### PR TITLE
Add LiteParse WASM parsing method for cross-platform PDF extraction

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -282,6 +282,9 @@
     "packages/extract-pdf": {
       "name": "extract-pdf",
       "version": "0.1.104",
+      "dependencies": {
+        "@llamaindex/liteparse-wasm": "^2.11.0",
+      },
       "devDependencies": {
         "terser": "^5.46.0",
         "typescript": "^5.9.3",
@@ -1353,6 +1356,8 @@
     "@llamaindex/liteparse-linux-x64-gnu": ["@llamaindex/liteparse-linux-x64-gnu@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-O5Ep8Ykpb4caJsIP3/ohdyWQiXMhjfkxI1oVW7UtnBG8iDsqjQCTYSvcOmnRib7E4ud1dqy+T8m5vAtUcTwA4w=="],
 
     "@llamaindex/liteparse-linux-x64-musl": ["@llamaindex/liteparse-linux-x64-musl@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-3BMr+6a7YBBtD1kiBQR9VAroqWP9iBzuCX3H9CCkwxL61j+ldPbpdTzf75jhXo1/KkDN6eP6A9ntKDfZX1I0dg=="],
+
+    "@llamaindex/liteparse-wasm": ["@llamaindex/liteparse-wasm@2.11.0", "", {}, "sha512-V9EKjrOC3wI8bHXeGFcSkOxpih1dAYzkz85ruN2WJkAV/bZq02iD9cqNsGMnlvADB9ARAGXcEWRph2mlXSeWxA=="],
 
     "@llamaindex/liteparse-win32-arm64-msvc": ["@llamaindex/liteparse-win32-arm64-msvc@2.10.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-eFzr8i8XaiMJ/jaKr3IeGVnpxoF2dcG5BhMkmf1VfuYSxTEFYKa6i+0tMbfdiiPlLBrOsJl2zw8YVr4jydeQmw=="],
 

--- a/packages/extract-pdf/README.md
+++ b/packages/extract-pdf/README.md
@@ -58,8 +58,8 @@ const { html } = await convertPDFToHTML(buffer, { addPageNumbers: true });
 | ----------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
 | `addPageNumbers`  | `false`                | Inserts `[n]` markers at each page boundary                                                |
 | `addCitation`     | `true`                 | Reads PDF metadata and first-page heading to populate `title`/`author` in the return value |
-| `method`          | `"ts-block-algorithm"` | Parsing engine — `"ts-block-algorithm"` or `"liteparse"` (see below)                       |
-| `liteParseOptions`| `{}`                   | Passed through to LiteParse's constructor when `method: "liteparse"`                       |
+| `method`          | `"ts-block-algorithm"` | Parsing engine — `"ts-block-algorithm"`, `"liteparse"`, or `"liteparse-wasm"` (see below)   |
+| `liteParseOptions`| `{}`                   | Passed through to LiteParse's constructor when `method` is `"liteparse"` or `"liteparse-wasm"` |
 
 ### Return value
 
@@ -69,17 +69,21 @@ const { html } = await convertPDFToHTML(buffer, { addPageNumbers: true });
 
 ## Parse methods
 
-`convertPDFToHTML` supports two interchangeable parsing engines via `options.method`:
+`convertPDFToHTML` supports three interchangeable parsing engines via `options.method`:
 
 | Method                              | Engine                                                              | Environments                       | OCR |
 | ------------------------------------ | -------------------------------------------------------------------- | ----------------------------------- | --- |
 | `"ts-block-algorithm"` (default)     | The pure-TS pipeline documented below (this package)                  | Node.js, Cloudflare Workers, browser | No  |
 | `"liteparse"`                        | [LiteParse](https://github.com/run-llama/liteparse) (native, `@llamaindex/liteparse`) | Node.js only                        | Optional |
+| `"liteparse-wasm"`                   | [LiteParse](https://github.com/run-llama/liteparse) (WASM, `@llamaindex/liteparse-wasm`) | Node.js, Cloudflare Workers, browser | Optional (via callback) |
 
 ```ts
 import { convertPDFToHTML } from "extract-pdf";
 
 const { html } = await convertPDFToHTML(buffer, { method: "liteparse" });
+
+// Or the WASM build, which also runs in browsers and Cloudflare Workers:
+const { html } = await convertPDFToHTML(buffer, { method: "liteparse-wasm" });
 ```
 
 LiteParse ships a native (napi) addon, so `method: "liteparse"` only runs in
@@ -88,7 +92,15 @@ it explicitly (`bun add @llamaindex/liteparse`) since it's an optional
 dependency; if it isn't installed, `convertPDFToHTML` returns `{ error }`
 instead of throwing.
 
-By default the LiteParse path runs with OCR disabled (`ocrEnabled: false`) —
+`method: "liteparse-wasm"` delegates to LiteParse's WebAssembly build instead,
+which runs anywhere WASM does — browsers, Cloudflare Workers, and Node.js.
+Install it explicitly (`bun add @llamaindex/liteparse-wasm`) since it's also
+an optional dependency; if it isn't installed, `convertPDFToHTML` returns
+`{ error }` instead of throwing. The WASM build has no OCR engine built in —
+pass a `liteParseOptions.ocrEngine` callback (e.g. backed by `tesseract-js`)
+to enable OCR.
+
+By default both LiteParse paths run with OCR disabled (`ocrEnabled: false`) —
 matching this package's "instant, no backend" philosophy. Use
 `detectPdfNeedsOcr` (below) to decide when a document is worth re-parsing with
 `liteParseOptions: { ocrEnabled: true }`.
@@ -149,6 +161,8 @@ Raw pdfjs text spans
 ```
 src/
   pdf-to-html.ts          — main entry point (convertPDFToHTML)
+  liteparse-to-html.ts    — "liteparse" method (native napi addon)
+  liteparse-wasm-to-html.ts — "liteparse-wasm" method (WASM, browser/edge)
   models/                 — data classes: Page, ParseResult, TextItem,
   │                         LineItem, LineItemBlock, Word, BlockType, …
   transforms/

--- a/packages/extract-pdf/package.json
+++ b/packages/extract-pdf/package.json
@@ -28,7 +28,8 @@
   },
   "dependencies": {},
   "optionalDependencies": {
-    "@llamaindex/liteparse": "^2.10.0"
+    "@llamaindex/liteparse": "^2.10.0",
+    "@llamaindex/liteparse-wasm": "^2.11.0"
   },
   "devDependencies": {
     "terser": "^5.46.0",

--- a/packages/extract-pdf/src/liteparse-wasm-to-html.ts
+++ b/packages/extract-pdf/src/liteparse-wasm-to-html.ts
@@ -1,35 +1,53 @@
 /**
- * Alternate `ParseMethod` for convertPDFToHTML that delegates to
- * [LiteParse](https://github.com/run-llama/liteparse) instead of the built-in
- * ts-block-algorithm pipeline. LiteParse ships a native (napi) addon, so this
- * path is Node.js only — it will not run in Cloudflare Workers or browsers —
- * and requires the optional `@llamaindex/liteparse` dependency to be installed.
+ * Alternate `ParseMethod` for convertPDFToHTML that delegates to LiteParse's
+ * [WASM build](https://github.com/run-llama/liteparse/blob/main/packages/wasm/README.md)
+ * instead of the native napi addon. Unlike `"liteparse"`, this path runs
+ * anywhere WebAssembly does — browsers, Cloudflare Workers, and Node.js — and
+ * requires the optional `@llamaindex/liteparse-wasm` dependency to be
+ * installed. OCR is not built in; pass `liteParseOptions.ocrEngine` (e.g.
+ * backed by tesseract-js) to enable it.
  */
 import { grab } from "./utils/grab";
 import { escapeHtml } from "./utils/string-functions";
-import type { LiteParseConfig } from "@llamaindex/liteparse";
+import type { LiteParseInit } from "@llamaindex/liteparse-wasm";
 
-export interface LiteParseHTMLOptions {
+export interface LiteParseWasmHTMLOptions {
   addPageNumbers?: boolean;
   addCitation?: boolean;
-  liteParseOptions?: Partial<LiteParseConfig>;
+  liteParseOptions?: Partial<LiteParseInit>;
+}
+
+// wasm-bindgen's `init()` locates and instantiates the .wasm binary itself
+// (relative to the package, via fetch in the browser or Node.js's file
+// loader); it only needs to run once per process, so the promise is cached
+// at module scope and reused by every call.
+let wasmInitPromise: Promise<unknown> | undefined;
+
+async function ensureWasmInit(
+  liteParseWasm: typeof import("@llamaindex/liteparse-wasm"),
+): Promise<void> {
+  if (!wasmInitPromise) {
+    wasmInitPromise = liteParseWasm.default();
+  }
+  await wasmInitPromise;
 }
 
 /**
- * Converts a PDF (URL or ArrayBuffer) into HTML using LiteParse's spatial text
- * extraction, mirroring the return shape of `convertPDFToHTML`.
+ * Converts a PDF (URL or ArrayBuffer) into HTML using LiteParse's WASM build,
+ * mirroring the return shape of `convertPDFToHTML`.
  * @param pdfURLOrBuffer - URL to a PDF file or buffer from fs.readFile
  * @param options.addPageNumbers default=false - Adds `[n]` markers at each page boundary
  * @param options.addCitation default=true - Populates `title`/`author` from PDF metadata
  * @param options.liteParseOptions - Passed through to the `LiteParse` constructor;
  *   defaults to `{ ocrEnabled: false, ocrFailureFatal: false }` (use detectPdfNeedsOcr
- *   to decide when a document is worth re-parsing with `ocrEnabled: true`)
+ *   to decide when a document is worth re-parsing with `ocrEnabled: true`, or pass
+ *   `ocrEngine` to run OCR in-process, e.g. via tesseract-js)
  * @returns `{ html, title, author, format: "pdf" }`, or `{ error }` on failure
  * @category Extract
  */
-export async function convertPDFToHTMLWithLiteParse(
+export async function convertPDFToHTMLWithLiteParseWasm(
   pdfURLOrBuffer: any,
-  options: LiteParseHTMLOptions = {},
+  options: LiteParseWasmHTMLOptions = {},
 ) {
   const { addPageNumbers = false, addCitation = true, liteParseOptions = {} } = options;
 
@@ -38,24 +56,19 @@ export async function convertPDFToHTMLWithLiteParse(
       ? await grab(pdfURLOrBuffer, { responseType: "arraybuffer", timeout: 10 })
       : pdfURLOrBuffer;
 
-  let LiteParse: typeof import("@llamaindex/liteparse").LiteParse;
+  let liteParseWasm: typeof import("@llamaindex/liteparse-wasm");
   try {
-    ({ LiteParse } = await import("@llamaindex/liteparse"));
+    liteParseWasm = await import("@llamaindex/liteparse-wasm");
+    await ensureWasmInit(liteParseWasm);
   } catch (e: any) {
     return {
       error:
-        "method: 'liteparse' requires the optional @llamaindex/liteparse dependency " +
-        `(Node.js only): ${e.message}`,
+        "method: 'liteparse-wasm' requires the optional @llamaindex/liteparse-wasm " +
+        `dependency: ${e.message}`,
     };
   }
 
-  // Default to no OCR: this method exists for the fast/local path (see
-  // detectPdfNeedsOcr for routing scanned/complex pages elsewhere), and OCR
-  // requires downloading tessdata on first use, which is slow and can fail
-  // offline. `ocrFailureFatal: false` keeps already-recovered native text
-  // instead of discarding the whole parse if a caller opts OCR back in and it
-  // fails on some pages.
-  const parser = new LiteParse({
+  const parser = new liteParseWasm.LiteParse({
     quiet: true,
     ocrEnabled: false,
     ocrFailureFatal: false,

--- a/packages/extract-pdf/src/pdf-to-html.ts
+++ b/packages/extract-pdf/src/pdf-to-html.ts
@@ -29,6 +29,10 @@ import {
   convertPDFToHTMLWithLiteParse,
   type LiteParseHTMLOptions,
 } from "./liteparse-to-html";
+import {
+  convertPDFToHTMLWithLiteParseWasm,
+  type LiteParseWasmHTMLOptions,
+} from "./liteparse-wasm-to-html";
 
 /**
  * Which parsing engine {@link convertPDFToHTML} runs.
@@ -38,8 +42,12 @@ import {
  * - `"liteparse"` — delegates to [LiteParse](https://github.com/run-llama/liteparse),
  *   a native/OCR-capable parser. Node.js only (ships a napi addon), and requires
  *   the optional `@llamaindex/liteparse` dependency to be installed.
+ * - `"liteparse-wasm"` — delegates to LiteParse's WebAssembly build. Runs
+ *   anywhere WASM does — browsers, Cloudflare Workers, and Node.js — and
+ *   requires the optional `@llamaindex/liteparse-wasm` dependency to be
+ *   installed. OCR requires passing an `ocrEngine` callback (e.g. tesseract-js).
  */
-export type ParseMethod = "ts-block-algorithm" | "liteparse";
+export type ParseMethod = "ts-block-algorithm" | "liteparse" | "liteparse-wasm";
 
 /**
  * Extracts formatted text from PDF with parsing of linebreaks ,
@@ -74,6 +82,14 @@ export async function convertPDFToHTML(
   if (options.method === "liteparse") {
     const { method: _method, ...liteParseOptions } = options;
     return convertPDFToHTMLWithLiteParse(pdfURLOrBuffer, liteParseOptions);
+  }
+
+  if (options.method === "liteparse-wasm") {
+    const { method: _method, ...liteParseOptions } = options;
+    return convertPDFToHTMLWithLiteParseWasm(
+      pdfURLOrBuffer,
+      liteParseOptions as unknown as LiteParseWasmHTMLOptions,
+    );
   }
 
   // try {
@@ -223,6 +239,8 @@ export async function convertPDFToHTML(
 
 export { convertPDFToHTMLWithLiteParse };
 export type { LiteParseHTMLOptions } from "./liteparse-to-html";
+export { convertPDFToHTMLWithLiteParseWasm };
+export type { LiteParseWasmHTMLOptions } from "./liteparse-wasm-to-html";
 export { detectPdfNeedsOcr } from "./detect-needs-ocr";
 export type {
   DetectPdfNeedsOcrOptions,

--- a/packages/extract-pdf/src/utils/string-functions.ts
+++ b/packages/extract-pdf/src/utils/string-functions.ts
@@ -115,6 +115,10 @@ export function isNumberedListItem(string: string): boolean {
   return /^[\s]*[\d]*[.][\s].*$/g.test(string)
 }
 
+export function escapeHtml(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
 export function wordMatch(string1: string, string2: string): number {
   const words1 = new Set(string1.toUpperCase().split(' '))
   const words2 = new Set(string2.toUpperCase().split(' '))

--- a/packages/extract-pdf/test/liteparse-wasm.test.ts
+++ b/packages/extract-pdf/test/liteparse-wasm.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "bun:test";
+import { convertPDFToHTML } from "../src/pdf-to-html";
+import { convertPDFToHTMLWithLiteParseWasm } from "../src/liteparse-wasm-to-html";
+import { minimalPDFBuffer } from "./helpers/minimal-pdf";
+
+const TIMEOUT = 30_000;
+
+describe("convertPDFToHTMLWithLiteParseWasm", () => {
+  it("returns html and format fields from a buffer", async () => {
+    const result = (await convertPDFToHTMLWithLiteParseWasm(minimalPDFBuffer())) as any;
+    expect(result.error).toBeUndefined();
+    expect(result.format).toBe("pdf");
+    expect(typeof result.html).toBe("string");
+    expect(result.html.length).toBeGreaterThan(0);
+  }, TIMEOUT);
+
+  it("html contains text extracted from the PDF", async () => {
+    const result = (await convertPDFToHTMLWithLiteParseWasm(minimalPDFBuffer())) as any;
+    expect(result.html).toContain("Test Document");
+    expect(result.html).toContain("sample paragraph");
+  }, TIMEOUT);
+
+  it("addPageNumbers inserts [1] marker", async () => {
+    const result = (await convertPDFToHTMLWithLiteParseWasm(minimalPDFBuffer(), {
+      addPageNumbers: true,
+    })) as any;
+    expect(result.html).toMatch(/\[1\]/);
+  }, TIMEOUT);
+
+  it("addCitation: false returns html without extracting metadata", async () => {
+    const result = (await convertPDFToHTMLWithLiteParseWasm(minimalPDFBuffer(), {
+      addCitation: false,
+    })) as any;
+    expect(typeof result.html).toBe("string");
+    expect(result.author).toBeUndefined();
+    expect(result.title).toBeUndefined();
+  }, TIMEOUT);
+
+  it("returns error object for an invalid buffer", async () => {
+    const bad = new Uint8Array([0x00, 0x01, 0x02, 0x03]).buffer;
+    const result = await convertPDFToHTMLWithLiteParseWasm(bad);
+    expect(result).toHaveProperty("error");
+  }, TIMEOUT);
+});
+
+describe("convertPDFToHTML method dispatch", () => {
+  it("method: 'liteparse-wasm' delegates to convertPDFToHTMLWithLiteParseWasm", async () => {
+    const result = (await convertPDFToHTML(minimalPDFBuffer(), {
+      method: "liteparse-wasm",
+    })) as any;
+    expect(result.error).toBeUndefined();
+    expect(result.format).toBe("pdf");
+    expect(result.html).toContain("Test Document");
+  }, TIMEOUT);
+});

--- a/packages/extract-pdf/vite.config.ts
+++ b/packages/extract-pdf/vite.config.ts
@@ -17,10 +17,11 @@ export default defineConfig({
       format: { comments: false },
     },
     rollupOptions: {
-      // @llamaindex/liteparse ships a native (napi) addon — never inline it,
-      // keep it as a runtime dependency resolved by Node.js when the
-      // "liteparse" ParseMethod is actually used.
-      external: ["@llamaindex/liteparse"],
+      // @llamaindex/liteparse ships a native (napi) addon, and
+      // @llamaindex/liteparse-wasm ships a .wasm binary — never inline either,
+      // keep them as runtime dependencies resolved by the consuming app when
+      // the "liteparse" / "liteparse-wasm" ParseMethods are actually used.
+      external: ["@llamaindex/liteparse", "@llamaindex/liteparse-wasm"],
     },
   },
   plugins: [
@@ -30,6 +31,7 @@ export default defineConfig({
       include: [
         "src/pdf-to-html.ts",
         "src/liteparse-to-html.ts",
+        "src/liteparse-wasm-to-html.ts",
         "src/detect-needs-ocr.ts",
         "src/models/**/*.ts",
         "src/transforms/**/*.ts",


### PR DESCRIPTION
## Summary
This PR adds support for LiteParse's WebAssembly build as an alternative PDF parsing engine, enabling PDF extraction in browsers, Cloudflare Workers, and Node.js environments without requiring native addons.

## Key Changes
- **New parsing method**: Added `"liteparse-wasm"` as a third option for `convertPDFToHTML`'s `method` parameter, alongside the existing `"ts-block-algorithm"` and `"liteparse"` methods
- **New module**: Created `liteparse-wasm-to-html.ts` implementing `convertPDFToHTMLWithLiteParseWasm()` that delegates to the WASM build of LiteParse
- **WASM initialization**: Implemented lazy initialization and caching of the WASM module at module scope to ensure efficient reuse across multiple calls
- **Shared utilities**: Extracted `escapeHtml()` function to `utils/string-functions.ts` for reuse between native and WASM implementations
- **Updated exports**: Added new function and type exports to the main `pdf-to-html.ts` entry point
- **Build configuration**: Updated `vite.config.ts` to mark `@llamaindex/liteparse-wasm` as external, preventing bundling of the WASM binary
- **Documentation**: Updated README with the new parsing method, environment support matrix, and usage examples
- **Tests**: Added comprehensive test suite covering buffer parsing, page numbers, citation extraction, error handling, and method dispatch
- **Dependencies**: Added `@llamaindex/liteparse-wasm` as an optional dependency in `package.json`

## Notable Implementation Details
- The WASM module initialization is cached at module scope to avoid redundant initialization across multiple function calls
- OCR is not built into the WASM build; users can optionally pass an `ocrEngine` callback (e.g., tesseract-js) via `liteParseOptions`
- Error handling gracefully returns an error object if the optional dependency is not installed, maintaining consistency with the native LiteParse method
- HTML generation mirrors the existing implementation with proper escaping and page number insertion
- Metadata extraction (title/author) follows the same pattern as the native implementation

https://claude.ai/code/session_01PNkVbmThUsNodKfjS19Dn5