### PR TITLE
Refactor config to use typed object instead of individual exports

### DIFF
--- a/apps/qwksearch-web/app/admin/config/page.tsx
+++ b/apps/qwksearch-web/app/admin/config/page.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import {
-  APP_NAME,
-  NEXT_PUBLIC_BASE_URL,
-  APP_EMAIL,
-  LAST_REVISED_DATE,
-  SubscriptionPlans,
-} from "@/lib/config/site";
+import { config as siteConfig, SubscriptionPlans } from "@/lib/config/site";
 
 interface ConfigField {
   name: string;
@@ -256,10 +250,10 @@ export default function AdminConfigPage() {
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
           {[
-            { label: "App Name", value: APP_NAME },
-            { label: "Base URL", value: NEXT_PUBLIC_BASE_URL },
-            { label: "Support Email", value: APP_EMAIL },
-            { label: "Terms Last Revised", value: LAST_REVISED_DATE },
+            { label: "App Name", value: siteConfig.appName },
+            { label: "Base URL", value: siteConfig.baseUrl },
+            { label: "Support Email", value: siteConfig.appEmail },
+            { label: "Terms Last Revised", value: siteConfig.lastRevisedDate },
           ].map(({ label, value }) => (
             <div key={label} className="bg-gray-50 dark:bg-gray-900 rounded px-3 py-2">
               <div className="text-xs text-gray-500 mb-0.5">{label}</div>

--- a/apps/qwksearch-web/app/api/docs/route.ts
+++ b/apps/qwksearch-web/app/api/docs/route.ts
@@ -3,14 +3,14 @@
  * Scalar API reference viewer powered by the OpenAPI spec.
  */
 import { NextResponse } from "next/server";
-import { APP_NAME } from "@/lib/config/site";
+import { config } from "@/lib/config/site";
 
 export async function GET() {
   const html = `
 <!DOCTYPE html>
 <html>
 <head>
-  <title>${APP_NAME} API Documentation</title>
+  <title>${config.appName} API Documentation</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 </head>

--- a/apps/qwksearch-web/app/layout.tsx
+++ b/apps/qwksearch-web/app/layout.tsx
@@ -5,11 +5,11 @@ import './globals.css';
 import 'shadcn-theme-menu/themes.css';
 import { cookies } from "next/headers"
 import { cn } from '@/lib/utils';
-import { APP_NAME } from '@/lib/config/site';
+import { config } from '@/lib/config/site';
 import { Providers } from '@/components/layout/Providers';
 
 export const metadata: Metadata = {
-  title: APP_NAME + ' - Reimagine the Web as a Self-Organizing Mind Map',
+  title: config.appName + ' - Reimagine the Web as a Self-Organizing Mind Map',
   description:
     "Search, extract, vectorize, outline graph, and monitor the web for a topic",
   icons: {

--- a/apps/qwksearch-web/app/legal/privacy/page.tsx
+++ b/apps/qwksearch-web/app/legal/privacy/page.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
 import './privacy.css';
-import { APP_NAME, APP_EMAIL, LAST_REVISED_DATE } from '@/lib/config/site';
+import { config } from '@/lib/config/site';
 
 export const metadata: Metadata = {
-    title: `${APP_NAME} Terms of Service and Privacy Policy`,
-    description: `Terms of Service and Privacy Policy for ${APP_NAME}`,
+    title: `${config.appName} Terms of Service and Privacy Policy`,
+    description: `Terms of Service and Privacy Policy for ${config.appName}`,
 };
 
 export default function PrivacyPage() {
@@ -17,13 +17,13 @@ export default function PrivacyPage() {
                 </Link>
             </div>
 
-            <h1>{APP_NAME} Terms of Service and Privacy Policy</h1>
-            <p><strong>Revised Date: {LAST_REVISED_DATE}</strong></p>
+            <h1>{config.appName} Terms of Service and Privacy Policy</h1>
+            <p><strong>Revised Date: {config.lastRevisedDate}</strong></p>
 
             <h2>1. Introduction</h2>
-            <p>These Terms of Service (&quot;Terms&quot;) govern your use of {APP_NAME}'s products and services, along with any associated apps, software, and websites (together, our &quot;Services&quot;). These Terms are a contract between you and {APP_NAME}, and they include our Acceptable Use Policy. By accessing our Services, you agree to these Terms.</p>
+            <p>These Terms of Service (&quot;Terms&quot;) govern your use of {config.appName}'s products and services, along with any associated apps, software, and websites (together, our &quot;Services&quot;). These Terms are a contract between you and {config.appName}, and they include our Acceptable Use Policy. By accessing our Services, you agree to these Terms.</p>
 
-            <p>This document also describes how {APP_NAME} (&quot;we&quot;, &quot;us,&quot; &quot;our&quot;) collects, uses and discloses information about individuals who use our websites, applications, services, tools and features, purchase our products or otherwise interact with us (collectively, the &quot;Services&quot;). For the purposes of this document, &quot;you&quot; and &quot;your&quot; means you as the user of the Services, whether you are a customer, website visitor, job applicant, representative of a company with whom we do business, or another individual whose information we have collected pursuant to this Privacy Policy. Please note that the Services are designed for users in the United States only and are not intended for users located outside the United States.</p>
+            <p>This document also describes how {config.appName} (&quot;we&quot;, &quot;us,&quot; &quot;our&quot;) collects, uses and discloses information about individuals who use our websites, applications, services, tools and features, purchase our products or otherwise interact with us (collectively, the &quot;Services&quot;). For the purposes of this document, &quot;you&quot; and &quot;your&quot; means you as the user of the Services, whether you are a customer, website visitor, job applicant, representative of a company with whom we do business, or another individual whose information we have collected pursuant to this Privacy Policy. Please note that the Services are designed for users in the United States only and are not intended for users located outside the United States.</p>
 
             <p>Please read this document carefully. By using any of the Services, you agree to the collection, use, and disclosure of your information as described in this document. If you do not agree to these terms, please do not use or access the Services.</p>
 
@@ -68,8 +68,8 @@ export default function PrivacyPage() {
             </ol>
 
             <h2>4. Account Creation and Access</h2>
-            <p><strong>Your {APP_NAME} Account:</strong> To access our Services, we may ask you to create an Account. You agree to provide correct, current, and complete Account information. You may not share your Account login information with anyone else. You are responsible for all activity occurring under your Account.</p>
-            <p>You may close your Account at any time by contacting us at {APP_EMAIL}.</p>
+            <p><strong>Your {config.appName} Account:</strong> To access our Services, we may ask you to create an Account. You agree to provide correct, current, and complete Account information. You may not share your Account login information with anyone else. You are responsible for all activity occurring under your Account.</p>
+            <p>You may close your Account at any time by contacting us at {config.appEmail}.</p>
 
             <h2>5. Use of Our Services</h2>
             <p>You may access and use our Services only in compliance with our Terms, our Acceptable Use Policy, and any guidelines or supplemental terms we may post on the Services (the &quot;Permitted Use&quot;).</p>
@@ -140,7 +140,7 @@ export default function PrivacyPage() {
             <h2>13. Data Security and Retention</h2>
             <p>Despite our reasonable efforts to protect your information, no security measures are impenetrable, and we cannot guarantee &quot;perfect security.&quot; Any information you send to us electronically, while using the Services or otherwise interacting with us, may not be secure while in transit. We recommend that you do not use unsecure channels to send us sensitive or confidential information.</p>
             <p>We retain your information for as long as is reasonably necessary for the purposes specified in this document. When determining the length of time to retain your information, we consider various criteria, including whether we need the information to continue to provide you the Services, resolve a dispute, enforce our contractual agreements, prevent harm, promote safety, security and integrity, or protect ourselves, including our rights, property or products.</p>
-            <p>You may opt out of information collection for AI, which would prohibit us from using your search information to improve our AI models in your settings page if you are logged into the Services. If you delete your account, we will delete your personal information from our servers within 30 days. Please contact us at {APP_EMAIL} to request deletion.</p>
+            <p>You may opt out of information collection for AI, which would prohibit us from using your search information to improve our AI models in your settings page if you are logged into the Services. If you delete your account, we will delete your personal information from our servers within 30 days. Please contact us at {config.appEmail} to request deletion.</p>
 
             <h2>14. California Residents</h2>
             <p>This section applies to you only if you are a California resident (&quot;resident&quot; or &quot;residents&quot;). For purposes of this section, references to &quot;personal information&quot; shall include &quot;sensitive personal information,&quot; as these terms are defined under the California Consumer Privacy Act (&quot;CCPA&quot;).</p>
@@ -190,14 +190,14 @@ export default function PrivacyPage() {
             <p>If you provide Feedback to us, you agree that we may use the Feedback however we choose without any obligation or payment to you.</p>
 
             <h2>16. Disclaimer of Warranties and Limitations of Liability</h2>
-            <p>The services are provided &quot;as is&quot; and &quot;as available&quot; without warranties of any kind. {APP_NAME} disclaims all warranties, express or implied.</p>
-            <p>To the fullest extent permissible under applicable law, {APP_NAME} shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues.</p>
+            <p>The services are provided &quot;as is&quot; and &quot;as available&quot; without warranties of any kind. {config.appName} disclaims all warranties, express or implied.</p>
+            <p>To the fullest extent permissible under applicable law, {config.appName} shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues.</p>
 
             <h2>17. Termination</h2>
             <p>We may suspend or terminate your access to the Services at any time if we believe that you have breached these Terms, or if we must do so to comply with law.</p>
 
             <h2>18. How to Contact Us</h2>
-            <p>Should you have any questions about our privacy practices, these Terms of Service, or this document, please email us at {APP_EMAIL}</p>
+            <p>Should you have any questions about our privacy practices, these Terms of Service, or this document, please email us at {config.appEmail}</p>
         </main>
     );
 }

--- a/apps/qwksearch-web/components/layout/CookieConsent.tsx
+++ b/apps/qwksearch-web/components/layout/CookieConsent.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
-import { listFooterLinks, APP_NAME } from '@/lib/config/site';
+import { listFooterLinks, config } from '@/lib/config/site';
 
 export function CookieConsent() {
   const [isVisible, setIsVisible] = useState(false);
@@ -50,7 +50,7 @@ export function CookieConsent() {
               Cookies & Privacy
             </h3>
             <p className="text-xs text-black/70 dark:text-white/70 mb-3">
-              {APP_NAME} uses cookies to enhance your research experience, analyze usage patterns, and improve our service. We respect your privacy and only use essential cookies by default.
+              {config.appName} uses cookies to enhance your research experience, analyze usage patterns, and improve our service. We respect your privacy and only use essential cookies by default.
             </p>
             <div className="flex flex-wrap gap-2 text-xs mb-3">
               {listFooterLinks.map((link) => (

--- a/apps/qwksearch-web/components/layout/LoginPage.tsx
+++ b/apps/qwksearch-web/components/layout/LoginPage.tsx
@@ -12,7 +12,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth/client"
-import { APP_NAME } from "@/lib/config/site"
+import { config } from "@/lib/config/site"
 
 // Google Sign In Button
 function GoogleSignIn() {
@@ -215,7 +215,7 @@ export default function LoginPage() {
                                 className="h-full w-full object-cover"
                             />
                         </div>
-                        <span className="text-2xl font-bold">{APP_NAME}</span>
+                        <span className="text-2xl font-bold">{config.appName}</span>
                     </div>
                     <div className="text-center">
                         <p className="text-sm text-muted-foreground">

--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -16,21 +16,14 @@ import { CookieConsent } from '@/components/layout/CookieConsent';
 import { useChunkErrorReload } from '@/components/layout/useChunkErrorReload';
 import { SettingsModalProvider } from '@/components/Settings/SettingsModal';
 import { MainViewProvider } from '@/components/layout/MainViewProvider';
-import {
-  APP_NAME,
-  DEFAULT_SUMMARIZE_PROMPT,
-  MAX_ARTICLE_LENGTH,
-  DOWNLOAD_CHROME_URL,
-  DOWNLOAD_WINDOWS_STORE_ID,
-  listFooterLinks,
-} from '@/lib/config/site';
+import { config, listFooterLinks } from '@/lib/config/site';
 
 configureResearchAgentUI({
-  appName: APP_NAME,
-  defaultSummarizePrompt: DEFAULT_SUMMARIZE_PROMPT,
-  maxArticleLength: MAX_ARTICLE_LENGTH,
-  downloadChromeUrl: DOWNLOAD_CHROME_URL,
-  downloadWindowsStoreId: DOWNLOAD_WINDOWS_STORE_ID,
+  appName: config.appName,
+  defaultSummarizePrompt: config.defaultSummarizePrompt,
+  maxArticleLength: config.maxArticleLength,
+  downloadChromeUrl: config.downloadChromeUrl,
+  downloadWindowsStoreId: config.downloadWindowsStoreId,
   footerLinks: listFooterLinks,
   googleApiKey: process.env.NEXT_PUBLIC_GOOGLE_API_KEY || '',
   getAutoMediaSearch: () => true,

--- a/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
+++ b/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
@@ -19,9 +19,11 @@ vi.mock("../cloudflare/ip-geolocation", () => ({
 }));
 
 vi.mock("../config/site", () => ({
-  APP_NAME: "Test App",
-  APP_EMAIL: "noreply@example.com",
-  NEXT_PUBLIC_BASE_URL: "http://localhost:3000",
+  config: {
+    appName: "Test App",
+    appEmail: "noreply@example.com",
+    baseUrl: "http://localhost:3000",
+  },
 }));
 
 describe("auth configuration", () => {

--- a/apps/qwksearch-web/lib/auth/client.ts
+++ b/apps/qwksearch-web/lib/auth/client.ts
@@ -4,10 +4,7 @@ import {
   magicLinkClient,
   anonymousClient,
 } from "better-auth/client/plugins";
-import {
-  NEXT_PUBLIC_BASE_URL,
-  NEXT_PUBLIC_GOOGLE_CLIENT_ID,
-} from "../config/site";
+import { config } from "../config/site";
 
 // Use the current browser origin so auth requests are always same-origin.
 // The app ships its own /api/auth routes on every deployment (qwksearch.com,
@@ -16,13 +13,13 @@ import {
 // preflight (no Access-Control-Allow-Origin header). Fall back to the
 // configured base URL during SSR, where `window` is undefined.
 const baseURL =
-  typeof window !== "undefined" ? window.location.origin : NEXT_PUBLIC_BASE_URL;
+  typeof window !== "undefined" ? window.location.origin : config.baseUrl;
 
 export const authClient = createAuthClient({
   baseURL,
   plugins: [
     oneTapClient({
-      clientId: NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
+      clientId: config.googleClientId!,
       additionalOptions: {
         use_fedcm_for_prompt: false,
       },

--- a/apps/qwksearch-web/lib/auth/index.ts
+++ b/apps/qwksearch-web/lib/auth/index.ts
@@ -5,7 +5,7 @@ import { getDB } from "../database";
 import * as schema from "../database/schema";
 import { getCloudflareContext } from "../cloudflare/context";
 import { detectVpnAndLocation } from "../cloudflare/ip-geolocation";
-import { APP_NAME, APP_EMAIL, NEXT_PUBLIC_BASE_URL } from "../config/site";
+import { config } from "../config/site";
 
 export interface Env {
   EMAIL: {
@@ -55,7 +55,7 @@ async function authBuilder() {
   const trustedOrigins = Array.from(
     new Set(
       [
-        NEXT_PUBLIC_BASE_URL,
+        config.baseUrl,
         "https://qwksearch.com",
         "https://*.qwksearch.com",
         "http://localhost:3000",
@@ -67,7 +67,7 @@ async function authBuilder() {
   );
 
   return betterAuth({
-    baseURL: NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
+    baseURL: config.baseUrl || "http://localhost:3000",
     trustedOrigins,
     database: drizzleAdapter(db, {
       provider: "sqlite",
@@ -149,10 +149,10 @@ async function authBuilder() {
             }
 
             await env.EMAIL.send({
-              from: APP_EMAIL || "noreply@example.com",
+              from: config.appEmail || "noreply@example.com",
               to: email,
-              subject: `Sign in to ${APP_NAME}`,
-              html: `<p>Click the link below to sign in to ${APP_NAME}:</p><p><a href="${url}">Sign in</a></p><p>This link expires in 5 minutes.</p>`,
+              subject: `Sign in to ${config.appName}`,
+              html: `<p>Click the link below to sign in to ${config.appName}:</p><p><a href="${url}">Sign in</a></p><p>This link expires in 5 minutes.</p>`,
             });
           } catch (error) {
             console.error("[auth] Magic link send failed:", error);

--- a/apps/qwksearch-web/lib/config/__tests__/site.test.ts
+++ b/apps/qwksearch-web/lib/config/__tests__/site.test.ts
@@ -1,32 +1,29 @@
 import { describe, expect, it } from 'vitest'
 import {
-  APP_NAME,
-  APP_EMAIL,
-  MAX_ARTICLE_LENGTH,
-  DEFAULT_SUMMARIZE_PROMPT,
+  config,
   listFooterLinks,
   SubscriptionPlans,
   SearchCategories,
 } from '../site'
 
 describe('scalar constants', () => {
-  it('APP_NAME is a non-empty string', () => {
-    expect(typeof APP_NAME).toBe('string')
-    expect(APP_NAME.length).toBeGreaterThan(0)
+  it('appName is a non-empty string', () => {
+    expect(typeof config.appName).toBe('string')
+    expect(config.appName.length).toBeGreaterThan(0)
   })
 
-  it('APP_EMAIL contains an @ sign', () => {
-    expect(APP_EMAIL).toMatch(/@/)
+  it('appEmail contains an @ sign', () => {
+    expect(config.appEmail).toMatch(/@/)
   })
 
-  it('MAX_ARTICLE_LENGTH is a positive integer', () => {
-    expect(Number.isInteger(MAX_ARTICLE_LENGTH)).toBe(true)
-    expect(MAX_ARTICLE_LENGTH).toBeGreaterThan(0)
+  it('maxArticleLength is a positive integer', () => {
+    expect(Number.isInteger(config.maxArticleLength)).toBe(true)
+    expect(config.maxArticleLength).toBeGreaterThan(0)
   })
 
-  it('DEFAULT_SUMMARIZE_PROMPT is a non-empty string', () => {
-    expect(typeof DEFAULT_SUMMARIZE_PROMPT).toBe('string')
-    expect(DEFAULT_SUMMARIZE_PROMPT.length).toBeGreaterThan(0)
+  it('defaultSummarizePrompt is a non-empty string', () => {
+    expect(typeof config.defaultSummarizePrompt).toBe('string')
+    expect(config.defaultSummarizePrompt.length).toBeGreaterThan(0)
   })
 })
 

--- a/apps/qwksearch-web/lib/config/site.ts
+++ b/apps/qwksearch-web/lib/config/site.ts
@@ -1,25 +1,38 @@
 // Icon components are no longer imported - we use string names instead
 // and resolve them dynamically in client components
 
-export const /** App Name in title case */
-  APP_NAME: string = "QwkSearch",
-  NEXT_PUBLIC_BASE_URL = "https://beta.qwksearch.com",
-  NEXT_PUBLIC_GOOGLE_CLIENT_ID =
-    "921732917742-79ql1h9hek2qsdn9f5vnk6lg26jq0vi2.apps.googleusercontent.com",
+export interface Config {
+  /** App Name in title case */
+  appName: string;
+  baseUrl: string;
+  googleClientId: string;
   /** App Email for support */
-  APP_EMAIL: string = "support@qwksearch.com",
+  appEmail: string;
   /** Terms & Privacy Last Revised Date */
-  LAST_REVISED_DATE: string = "2026-01-15",
+  lastRevisedDate: string;
   /** Windows product ID for native & URL links */
-  DOWNLOAD_WINDOWS_STORE_ID: string = "9PCGF9GNK460",
-  /** Download Button URL for Chrome extension  */
-  DOWNLOAD_CHROME_URL: string =
-    "https://chromewebstore.google.com/detail/tab-manager-ai/manhemnhmipdhdpabojcplebckhckeko",
+  downloadWindowsStoreId: string;
+  /** Download Button URL for Chrome extension */
+  downloadChromeUrl: string;
   /** Default prompt template for article */
-  DEFAULT_SUMMARIZE_PROMPT: string =
-    "Summarize in bullet points and bold topics",
+  defaultSummarizePrompt: string;
   /** Max char length for article body sent to the LLM */
-  MAX_ARTICLE_LENGTH: number = 1500;
+  maxArticleLength: number;
+}
+
+export const config: Config = {
+  appName: "QwkSearch",
+  baseUrl: process.env.NEXT_PUBLIC_BASE_URL || "https://beta.qwksearch.com",
+  googleClientId:
+    "921732917742-79ql1h9hek2qsdn9f5vnk6lg26jq0vi2.apps.googleusercontent.com",
+  appEmail: "support@qwksearch.com",
+  lastRevisedDate: "2026-01-15",
+  downloadWindowsStoreId: "9PCGF9GNK460",
+  downloadChromeUrl:
+    "https://chromewebstore.google.com/detail/tab-manager-ai/manhemnhmipdhdpabojcplebckhckeko",
+  defaultSummarizePrompt: "Summarize in bullet points and bold topics",
+  maxArticleLength: 1500,
+};
 
 export const listFooterLinks: FooterLink[] = [
   // {


### PR DESCRIPTION
## Summary
Refactored the site configuration from individual named exports to a single typed `config` object. This improves type safety, maintainability, and makes configuration management more scalable.

## Key Changes
- Created a `Config` interface defining all configuration properties with proper types and JSDoc comments
- Consolidated all configuration constants into a single `config` object export
- Converted SCREAMING_SNAKE_CASE exports to camelCase properties (e.g., `APP_NAME` → `config.appName`)
- Updated `baseUrl` to read from `process.env.NEXT_PUBLIC_BASE_URL` with a fallback value
- Updated all imports across the codebase to use the new `config` object:
  - `apps/qwksearch-web/lib/config/__tests__/site.test.ts`
  - `apps/qwksearch-web/app/legal/privacy/page.tsx`
  - `apps/qwksearch-web/components/layout/Providers.tsx`
  - `apps/qwksearch-web/app/admin/config/page.tsx`
  - `apps/qwksearch-web/lib/auth/index.ts`
  - `apps/qwksearch-web/lib/auth/client.ts`
  - `apps/qwksearch-web/lib/auth/__tests__/index.test.ts`
  - `apps/qwksearch-web/app/api/docs/route.ts`
  - `apps/qwksearch-web/app/layout.tsx`
  - `apps/qwksearch-web/components/layout/CookieConsent.tsx`
  - `apps/qwksearch-web/components/layout/LoginPage.tsx`

## Implementation Details
- All configuration properties are now accessed via `config.propertyName` instead of individual constant names
- The configuration object is centralized, making it easier to add, remove, or modify settings
- Environment variable support is properly integrated for the `baseUrl` property
- Test mocks were updated to reflect the new structure
- No functional changes to the actual configuration values

https://claude.ai/code/session_01Gz38bN5LifDhyE7rg1Vceu