### PR TITLE
Add Claude skill documentation for QwkSearch customization

### DIFF
--- a/.claude/skills/qwksearch-customize/SKILL.md
+++ b/.claude/skills/qwksearch-customize/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: qwksearch-customize
+description: Guides modifying and extending the QwkSearch research-agent monorepo (OpenSourceAGI/qwksearch-research-agent) — the Next.js web app, chat/search UI, REASON editor, browser extension, desktop app, VS Code extension, and the ~20 workspace packages behind them (search aggregation, PDF/YouTube/webpage extraction, multi-provider LLM toolkit, API clients). Use this whenever the user wants to add a feature, restyle or rewire the web UI, add a new search engine or LLM provider, add an editor extension, or otherwise "try different ideas" against this codebase's source — even if they only name one app or package, since most features cut across several. Also use it just to figure out where a given piece of behavior lives before touching code.
+---
+
+# Customizing QwkSearch Research Agent
+
+QwkSearch is a bun/turbo monorepo: a research assistant that searches 100+
+sites, extracts and cites articles/PDFs/YouTube, and writes into a
+Lexical-based document editor. It ships as a Next.js web app, a browser
+extension, a desktop app, and a VS Code extension, all built from shared
+`packages/*`. This skill orients you before you edit so changes land in the
+right package instead of being re-implemented in the wrong layer.
+
+## Before changing anything: find the right layer
+
+The single biggest way to waste time here is editing UI in the wrong repo
+location because three things look similar:
+
+- **`apps/qwksearch-web`** is the deployed product (routes, API, auth, DB).
+  It mostly *wires together* packages — it rarely contains the component or
+  business logic itself.
+- **`packages/research-agent-ui`** is the actual chat/search UI (message
+  composer, article reader, search config, voice, file upload). If the
+  request is "change how search results look" or "add a button to the chat
+  toolbar," it almost always belongs here, not in `apps/qwksearch-web`.
+- **`packages/reason-editor`** is the separate writing/notes editor (Tiptap
+  extensions, document tree, locales). Don't confuse it with
+  `research-agent-ui` — they are two different UIs.
+
+Read `references/architecture.md` first for the full map, then jump to the
+reference file for the area you're touching:
+
+| You want to... | Read | Then edit |
+|---|---|---|
+| Understand the monorepo, dev/build/test commands, deploy targets | `references/architecture.md` | — |
+| Change the chat/search UI, article reader, search config, voice, or the web app's routes/API/auth/DB | `references/web-ui.md` | `packages/research-agent-ui`, `apps/qwksearch-web` |
+| Change the REASON writing editor (toolbar, extensions, document tree) | `references/web-ui.md` | `packages/reason-editor` |
+| Change the desktop app, browser extension, or VS Code extension | `references/other-apps.md` | `apps/qwksearch-desktop`, `apps/qwksearch-ext`, `apps/qwk-vscode-ext` |
+| Add/modify a search engine, content extractor (PDF/webpage/YouTube), or page renderer | `references/search-and-extraction.md` | `packages/search-web-api`, `packages/extract-*`, `packages/render-url-to-html` |
+| Add/modify an LLM provider, agent behavior, memory, MCP tools, or the generated API client | `references/ai-and-data.md` | `packages/chat-agent-toolkit`, `packages/write-language`, `packages/qwksearch-mcp-server`, `packages/qwksearch-api-client` |
+| Reuse or change a standalone shadcn-style widget (dock, settings panel, weather, voice hook) | `references/ui-widgets.md` | `packages/shadcn-app-dock`, `packages/shadcn-settings`, `packages/react-weather-forecast`, `packages/use-voice-control` |
+
+Each reference file lists concrete file paths, the dev/build command for
+that piece, and the pattern to follow when adding something new (e.g. the
+exact shape of a new search engine adapter, or how a new LLM provider gets
+registered). Only load the ones relevant to the task — that's the point of
+splitting them out.
+
+## Working in this monorepo
+
+- **Package manager is bun**, not npm/yarn — use `bun install`, `bun run <script>`, `bun x <pkg>`. Workspaces are `packages/*` and `apps/*` (root `package.json`).
+- **Turbo** orchestrates cross-package builds (`turbo build`, `turbo dev --filter=<name>`). If you change a package that another app imports as a workspace dependency (e.g. `research-agent-ui` → `qwksearch-web`), you generally need to *build* that package (`bun run build` inside it, or let `qwksearch-web`'s `prebuild` script do it) before the consuming app picks up the change — dev-mode hot reload across workspace packages is not guaranteed everywhere.
+- **Tests**: `bun run test` at the root runs the Vitest workspace (`vitest.workspace.ts`) across all packages that define `vitest.config.ts`. Run a single package's tests with `cd packages/<name> && bun run test` — faster feedback while iterating.
+- **This app has its own unrelated "Skills & Memory" feature** (a Perplexity-style per-user skill toggle system, `docs/SKILLS_AND_MEMORY.md`, surfaced in Settings). Don't confuse it with this Claude Code skill — if the user says "add a new skill" they likely mean a new tool/capability in `chat-agent-toolkit` or a new entry in that in-app skills panel, not a `.claude/skills/*` folder.
+- **Don't reinvent an adapter pattern.** Most "add a new X" tasks in this repo (search engine, extractor, LLM provider, MCP tool) already have 10-70 existing examples to copy. Find the closest existing one in the relevant package and follow its shape exactly — the reference files point to where these live.
+- **Root `README.md` and each package's own `README.md`** are usually more up to date on public API/usage than any doc here — cross-check them when a package's shape has clearly moved on.

--- a/.claude/skills/qwksearch-customize/references/ai-and-data.md
+++ b/.claude/skills/qwksearch-customize/references/ai-and-data.md
@@ -1,0 +1,78 @@
+# AI Agent, LLM Providers, and API Clients
+
+## packages/chat-agent-toolkit — the agent orchestration layer
+
+Integrates the Vercel AI SDK, the Mastra framework, and MCP to run research
+agent workflows across 10+ LLM providers. This is the highest-leverage
+package to understand before adding new agent *behavior* (as opposed to UI).
+
+- `src/config/` — `model-registry.ts` + `language-models-database.ts` (which models exist per provider), `provider-ui-config.ts` (how providers show up in UI pickers — pairs with `research-agent-ui`'s settings), `mcp-server-registry.ts`, `config-manager.ts`/`config-types.ts` (runtime config shape), `environment-variables.ts` (which env vars each provider needs).
+- `src/models/` — `providers.ts`, `registry.ts`, `types.ts`: the provider abstraction itself.
+- `src/mastra/` — `agents.ts`, `workflows.ts`, `rag.ts`, `model-routing.ts`, `evals.ts`, `telemetry.ts`: Mastra-specific agent/workflow definitions. If the task is "change how the agent decides what to search next" or "add a workflow step," it's likely here.
+- `src/tools/` — `qwksearch-api-tools.ts`, `qwksearch-mcp-tools.ts`, `open-connector-mastra.ts`, `open-connector-mcp.ts`, plus a `search/` subfolder. Tools the agent can call are defined here.
+- `src/memory/` — persistent agent memory manager (`agent-memory-manager.ts`, `storage/`, own `ARCHITECTURE.md`/`MASTRA_INTEGRATION.md`/`README.md` worth reading directly if working on memory).
+- `src/connectors/` — third-party service connectors (OAuth-style "open connectors"); has its own `README.md`, `catalog.json`, and a small local server (`server.ts`) for testing — see the package-level `CONNECTORS_INTEGRATION.md` and `QUICK_START_CONNECTORS.md` at the package root for the full guide.
+- `src/prompts/` — `search-prompts.ts`, `meta-search-types.ts`: prompt templates for search-related agent steps.
+- `src/provider-logos/` — logo assets for each provider, used by UI provider pickers; add one when adding a new provider if it should show a logo.
+
+**Recipe: add a new LLM provider.** Register it in `src/models/providers.ts`
++ `src/config/model-registry.ts` (or `language-models-database.ts` for its
+model list), add required env vars to `src/config/environment-variables.ts`,
+and add a `provider-ui-config.ts` entry so it surfaces in settings. Compare
+against an existing similar provider (e.g. one already on the Vercel AI SDK)
+rather than starting blank — `write-language` (below) has the actual
+generation-side provider factory this toolkit builds on.
+
+## packages/write-language — text generation across providers
+
+Lower-level than `chat-agent-toolkit`: a focused multi-provider generation
+toolkit on the Vercel AI SDK. `src/provider-factory.ts` (constructs a model
+client per provider), `src/generate-response.ts` (streaming/non-streaming
+generation entry points), `src/language-model-registry.ts` +
+`src/language-model-families.ts` (provider/model metadata),
+`src/rewrite-modes.ts` + `src/prompt-templates.ts` (the "AI Rewriting"
+feature mentioned in the root README, also used by `reason-editor`'s
+`features/ai-rewrite/`). If `chat-agent-toolkit`'s provider abstraction
+feels like too much for a simple "just generate text" need, this package is
+the simpler layer underneath it.
+
+## packages/qwksearch-mcp-server — MCP server
+
+Exposes QwkSearch capabilities as MCP tools for external MCP clients
+(Claude Desktop, other agents). `bin/` — CLI entry; `src/index.ts` — server
+setup; `src/tools/web-search.ts`, `src/tools/extract-page.ts`,
+`src/tools/render-page.ts` — one file per exposed tool, each presumably
+wrapping `search-web-api`/`extract-webpage`/`render-url-to-html`
+respectively. **Recipe: add a new MCP tool** — add a file in `src/tools/`
+following the shape of an existing one, then register it in `src/index.ts`.
+
+## packages/qwksearch-api-client — generated backend client
+
+Auto-generated from an OpenAPI spec — **do not hand-edit the generated
+files** (`src/client.gen.ts`, `src/types.gen.ts`, `src/sdk.gen.ts`).
+`qwksearch-openapi.json` is the spec; `openapi-ts.config.js` configures the
+generator (`@hey-api/openapi-ts` style codegen, run via the `build:api`
+script). If the backend API shape changes, update the OpenAPI spec (or
+regenerate it from `qwksearch-web`'s route definitions if that's the source
+of truth — check `app/api/openapi` in `qwksearch-web` first) and rerun
+`build:api`, rather than editing generated output directly. `src/index.ts`
+re-exports the generated surface; `baseurl.ts` at the package root
+configures the default API base URL.
+
+## packages/notebooklm-api-client
+
+Currently a placeholder (`src/index.ts` only) for a future Google NotebookLM
+integration — has a `container/` + `Dockerfile` suggesting the eventual
+implementation will run as a small service, not a pure client library. Low
+priority unless the task specifically asks for NotebookLM integration.
+
+## packages/language-model-training
+
+Mostly independent of the web product: a from-scratch GPT-style transformer
+(Tinygrad) with a Wikipedia data pipeline, FastAPI control API
+(`webui/` for a Next.js training dashboard), and Docker Compose
+orchestration (`docker/`). Python-based (`pyproject.toml`,
+`requirements.txt`, `pytest.ini`), not part of the bun/turbo JS build. Only
+relevant if the task is specifically about training or fine-tuning a model
+from scratch, not about using an LLM provider in the product (that's
+`chat-agent-toolkit`/`write-language`).

--- a/.claude/skills/qwksearch-customize/references/architecture.md
+++ b/.claude/skills/qwksearch-customize/references/architecture.md
@@ -1,0 +1,90 @@
+# Architecture & Workflow
+
+## Monorepo shape
+
+```
+qwksearch-research-agent/
+├── apps/
+│   ├── qwksearch-web/       Next.js web app — the deployed product
+│   ├── qwksearch-desktop/   Tauri + Svelte desktop app
+│   ├── qwksearch-ext/       WXT-based browser extension (tab manager)
+│   ├── qwk-vscode-ext/      VS Code extension (sidebar + editor webview)
+│   └── test-reports/        Static host for the Vitest HTML report (Cloudflare Worker)
+├── packages/                ~20 publishable/shared packages, see table below
+├── turbo.json                Turbo task graph (build/test/dev)
+├── vitest.workspace.ts       Aggregates every package's vitest.config.ts
+└── package.json              Root scripts, bun workspaces
+```
+
+Root `package.json` workspaces: `packages/*` and `apps/*`. Package manager
+is **bun** (`packageManager: bun@1.3.11`).
+
+## Root scripts (run from repo root)
+
+- `bun run dev` → `turbo dev --filter=qwksearch-web` (the web app dev server)
+- `bun run dev:editor` → `turbo dev --filter=react-reason-editor` (REASON editor standalone dev)
+- `bun run build` → `turbo build` (builds every package/app, respecting dependency order)
+- `bun run build:web` → `turbo build --filter=qwksearch-web`
+- `bun run test` → `vitest run` across the whole workspace
+- `bun run test:ui` → Vitest UI
+- `bun run test:report` → generates an HTML test report into `apps/test-reports/dist`
+
+`turbo.json` declares three tasks: `build` (depends on `^build`, i.e. builds
+dependencies first — this is why `qwksearch-web`'s own `prebuild` script
+also manually chains several packages), `test` (depends on `^build`, not
+cached), and `dev` (not cached, persistent/long-running).
+
+## Package group map
+
+| Package | Role |
+|---|---|
+| `research-agent-ui` | The chat/search UI dropped into `qwksearch-web` |
+| `reason-editor` | The REASON writing/notes editor (Tiptap) |
+| `chat-agent-toolkit` | Multi-provider LLM agent orchestration (Mastra, MCP, memory) |
+| `write-language` | Multi-provider text generation via Vercel AI SDK |
+| `search-web-api` | 70+ search engine adapters + Hono HTTP API |
+| `searxng-search-cloudflare` | Self-hosted SearXNG meta-search deployment config |
+| `domain-rank` | Domain reputation/favicon lookup (Tranco + CommonCrawl) |
+| `extract-pdf`, `extract-pdf-docling` | PDF → structured HTML |
+| `extract-webpage` | Full research pipeline: search → extract → cite → outline |
+| `extract-youtube` | YouTube transcript extraction, no headless browser |
+| `render-url-to-html` | JS-rendered page → HTML (Puppeteer/JSDOM/Cloudflare Browser Rendering) |
+| `qwksearch-api-client` | Auto-generated TS client for the QwkSearch backend OpenAPI spec |
+| `qwksearch-mcp-server` | MCP server exposing search/extract/render as tools |
+| `notebooklm-api-client` | Placeholder client for Google NotebookLM |
+| `shadcn-app-dock`, `shadcn-settings` | Standalone shadcn-style UI widgets |
+| `react-weather-forecast` | Standalone weather widget + Cloudflare Worker API |
+| `use-voice-control` | Speech/voice control hook used by `research-agent-ui` |
+| `language-model-training` | From-scratch GPT training pipeline (Python/Tinygrad), mostly independent of the web product |
+
+## Cross-package dependency chain (why build order matters)
+
+`apps/qwksearch-web`'s `prebuild` script shows the real dependency order,
+because these are workspace packages consumed as built artifacts, not
+live-transpiled source:
+
+```
+extract-pdf → shadcn-app-dock → shadcn-settings → react-weather-forecast
+  → chat-agent-toolkit → research-agent-ui → reason-editor (build:lib)
+```
+
+Practical effect: if you edit `packages/research-agent-ui/src/...` and the
+change doesn't show up in `apps/qwksearch-web`, run `bun run build` inside
+`packages/research-agent-ui` (or rerun the web app's `prebuild` chain)
+before assuming something is broken.
+
+## Testing
+
+- Each package that needs tests has its own `vitest.config.ts`; the root
+  `vitest.workspace.ts` aggregates them so `bun run test` at the root runs
+  everything.
+- Iterate faster by running tests inside the specific package:
+  `cd packages/search-web-api && bun run test`.
+- `language-model-training` (Python) has its own `pytest.ini` / `requirements.txt` — it is not part of the JS/TS Vitest workspace.
+
+## Deployment targets (for context, rarely something you need to touch)
+
+- `qwksearch-web` deploys to Cloudflare Workers via `vinext` + `wrangler.jsonc`, with D1 (`drizzle/` migrations) for the database.
+- `research-agent-ui` can run its own Cloudflare Worker (`src/cloudflare/worker.ts`, `wrangler.local.jsonc`) when embedded standalone.
+- `qwksearch-desktop` builds native binaries via Tauri (`src-tauri/`) and has Docker-based cross-compilation scripts for Linux/Windows.
+- `qwksearch-ext` builds via WXT (`wxt.config.ts`) to a loadable Chrome/Firefox extension.

--- a/.claude/skills/qwksearch-customize/references/other-apps.md
+++ b/.claude/skills/qwksearch-customize/references/other-apps.md
@@ -1,0 +1,59 @@
+# Desktop, Browser Extension, VS Code Extension
+
+These three all reuse backend packages (`search-web-api`, `chat-agent-toolkit`,
+`qwksearch-api-client`, etc.) but each has its own UI shell. None of them
+share UI code with `research-agent-ui` directly — they call the same QwkSearch
+API instead.
+
+## apps/qwksearch-desktop — Tauri + Svelte
+
+"Select any text on screen, press \`\` ` \`\` to instantly search" (from the
+root README). Svelte app (`svelte.config.js`, `vite.config.js`) with a Rust
+Tauri shell (`src-tauri/`).
+
+- `src/routes/+page.svelte`, `src/routes/+layout.js` — SvelteKit routing (small surface — this is a lightweight quick-search popup, not the full web UI).
+- `src-tauri/` — native Rust side: window management, global hotkey registration, OS integration. Changes to hotkey behavior, tray icon, or OS-level permissions happen here, not in `src/`.
+- Scripts are mostly packaging: `tauri`, `tauri:macos`, `docker:build:linux`, `docker:build:windows` (cross-compilation via Docker, since Tauri builds are OS-specific).
+- Dependencies: `@tauri-apps/plugin-autostart`, `plugin-clipboard-manager`, `plugin-shell` — these map directly to Tauri capabilities the app uses (autostart on login, clipboard access for the "select text → search" flow, shelling out).
+
+**When to edit here**: global hotkey behavior, native OS integration, the minimal quick-search popup UI. For anything resembling the full chat/search experience, that logic likely belongs in `research-agent-ui` and this app should just be calling the API.
+
+## apps/qwksearch-ext — Browser extension (WXT)
+
+"AI-powered tab manager" — separate from the "guest sidebar" concept in the
+VS Code extension. Built with [WXT](https://wxt.dev), dev via `bun x wxt`
+(root script: `bun run dev` inside this app), builds via `bun x wxt build`.
+
+- `entrypoints/` — one folder/file per extension surface: `background.ts` (service worker), `content.ts` (content script injected into pages), `popup/` (toolbar popup UI), `sidepanel/` (browser side panel UI), `offscreen/` (offscreen document, typically for DOM/audio work service workers can't do directly).
+- `components/`, `lib/`, `styles/` — shared UI (React + Tailwind, per `tailwind.config.ts`/`postcss.config.js`) and helpers used across entrypoints.
+- `background/`, `content/` (top-level dirs alongside `entrypoints/`) — supporting logic split out from the entrypoint files themselves.
+- `public/` — static assets (icons, manifest pieces WXT merges in).
+
+**When to edit here**: tab management logic → `background.ts` + `lib/`; anything visible in the popup or side panel → `popup/`/`sidepanel/` + `components/`; page-level interaction (e.g. reading selected text, injecting UI into pages) → `content.ts`.
+
+Note: this app has its own `pnpm-workspace.yaml` and `bun.lock` — it's
+effectively a semi-independent workspace nested inside the monorepo; don't
+assume root-level `bun install` alone wires up all of its dependencies if
+things look missing, run install inside `apps/qwksearch-ext` too.
+
+## apps/qwk-vscode-ext — VS Code extension
+
+"Ask cited research questions from a sidebar in your editor... Sign in with
+your account's API key, or use it signed-out as a guest." Two separate
+embedded webview apps plus the extension host code:
+
+- `src/extension.ts` — activation entry point, command registration.
+- `src/panel.ts`, `src/reasonEditorProvider.ts` — manage the sidebar chat panel and a custom editor provider (for opening REASON documents inside VS Code).
+- `src/apiProxy.ts`, `src/auth.ts` — talk to the QwkSearch backend and handle the API-key / guest auth flow mentioned in the README.
+- `src/webviewHtml.ts`, `src/nonce.ts` — webview HTML scaffolding and CSP nonce generation (VS Code webviews require a strict CSP).
+- `webview-ui/` — the **chat sidebar** webview app (its own `package.json`, Vite build). Build: `bun run build:webview`.
+- `webview-ui-editor/` — the **REASON document editor** webview app, separate bundle. Build: `bun run build:webview-editor`.
+- Root build (`bun run build` → `compile`) builds both webviews then runs `esbuild.mjs` to bundle the extension host itself. `bun run watch` runs esbuild in watch mode for host-code iteration; webview changes need their own rebuild (or run their dev server directly inside `webview-ui`/`webview-ui-editor` if one exists).
+
+**When to edit here**: sidebar chat UI → `webview-ui/`; embedded document editor → `webview-ui-editor/` (likely wraps `reason-editor` or a subset of it — check its `package.json` dependencies before assuming it's a from-scratch editor); extension activation, commands, auth, or the API proxy → `src/`.
+
+## apps/test-reports
+
+Not a product surface — just a Cloudflare Worker (`wrangler.jsonc`) that
+hosts the static Vitest HTML report produced by `bun run test:report` at
+the root. Only relevant if you're changing CI/test-reporting infrastructure.

--- a/.claude/skills/qwksearch-customize/references/search-and-extraction.md
+++ b/.claude/skills/qwksearch-customize/references/search-and-extraction.md
@@ -1,0 +1,73 @@
+# Search & Content Extraction
+
+## packages/search-web-api — adding or changing a search engine
+
+Hono-based HTTP server exposing 70+ engines across 10 categories. Dev:
+`bun run dev` inside the package.
+
+- `src/sources/<category>/<engine>.ts` — one file per engine adapter, grouped into category folders: `general`, `news`, `academic`, `videos`, `images`, `shopping`, `social`, `specialized`, `it`, `maps`, `torrents`. E.g. `src/sources/general/google.ts`, `src/sources/general/baidu.ts`, `src/sources/news/*.ts`.
+- **Adapter shape** (every engine follows this — copy the closest existing one in the same category rather than writing from scratch): an exported `const <engine>: EngineFunction = async (query, page) => {...}` (type from `src/types/search-engine-interface.js`) that fetches the engine's search results page or API, parses it (commonly with `linkedom`'s `parseHTML`), and returns an array of `{ url, title, content, engine }` objects (or `[]` on failure — adapters fail soft, they don't throw for a bad response).
+- `src/registry/search-engine-category-registry.ts` — registers which engines belong to which category; a new adapter must be added here to be reachable.
+- `src/registry/search-engine-descriptions.ts` — human-readable name/description shown in UI pickers (`research-agent-ui`'s `SearchConfig` reads from something derived from this).
+- `src/registry/search-engine-status-tracker.ts` — tracks engine health/failures (used to deprioritize or skip consistently-failing engines).
+- `src/result-container.ts`, `src/engine.ts` — result merging/deduplication and the top-level dispatch that calls engines per category.
+- `src/autocomplete/`, `src/suggest-next-words/` — query suggestion logic, separate from result search itself.
+
+**Recipe: add a new search engine.** Pick the right category folder, copy
+the adapter closest in behavior (simple HTML scrape vs. JSON API — e.g.
+`baidu.ts` scrapes HTML with `linkedom`), implement the `EngineFunction`,
+then register it in `search-engine-category-registry.ts` and add an entry
+in `search-engine-descriptions.ts`. Test with the package's own `bun run test`.
+
+## packages/extract-pdf and packages/extract-pdf-docling
+
+Two different PDF strategies:
+
+- `extract-pdf` — zero-runtime-dependency PDF→HTML using `pdfjs-serverless`, works in Node/Workers/browser. `src/pdf-to-html.ts` is the entry; `src/transforms/` holds structural transforms (headings, lists, footnotes, code blocks — see root README's "Tractor" section for the exact feature list); `src/detect-needs-ocr.ts` decides whether a PDF needs OCR fallback.
+- `extract-pdf-docling` — heavier, OCR-capable path using IBM's granite-docling model via Hugging Face Transformers, served over its own Hono HTTP API (`src/routes.js`, `src/pdf2html.js`, `src/model.js`, `src/schemas.js`). Has a `pdf-to-html-docling-python/` subfolder for the Python side. Use this one when layout/OCR fidelity matters more than portability.
+
+## packages/extract-webpage — the research pipeline
+
+Combines search, extraction, citation, and outlining into one flow (this is
+the package behind "Article Preview" in the root README). `src/index.ts` is
+the entry; `src/html-to-content/` (Readability/Mercury-style main-content
+detection), `src/html-to-cite/` (citation metadata extraction — author/date
+matched against a name database, per the README), `src/url-to-content/`,
+`src/seektopic/` (topic-directed extraction), `src/tokenize/`. If a
+citation is formatted wrong or main-content detection picks the wrong DOM
+node, this is the package to check first.
+
+## packages/extract-youtube
+
+No headless browser — fetches captions/subtitles directly. `src/fetchers/`,
+`src/parsers/`, `src/proxies/` (for regions/rate-limit avoidance),
+`src/formatters/` (SRT/WebVTT output), `src/cli.ts` (usable standalone via
+CLI, see `build:cli`/`build:bundle` scripts).
+
+## packages/render-url-to-html
+
+Not a package.json-having TS package in the usual sense — it's a
+collection of rendering *strategies* (`scraper-jsdom/`, `scraper-puppeteer/`
+subfolders), each a different tradeoff: JSDOM is fast but doesn't run
+JS-heavy pages; Puppeteer (with stealth plugins) handles JS-rendered/
+bot-protected pages but is heavier; Cloudflare Browser Rendering is the
+serverless-friendly middle ground mentioned in the root README. Pick the
+strategy folder matching your constraint (speed vs. JS-rendering vs.
+serverless-compatible) rather than assuming one file does everything.
+
+## packages/searxng-search-cloudflare
+
+Not application code — a Docker deployment (`Dockerfile`, `Dockerfile.redis`,
+`searxng-settings.yml`, `searxng-engines.yml`) for self-hosting a private
+SearXNG meta-search proxy. Edit `searxng-engines.yml`/`searxng-settings.yml`
+to change which upstream engines SearXNG itself queries — this is a
+different mechanism from adding an adapter in `search-web-api`.
+
+## packages/domain-rank
+
+Looks up domain reputation/favicon from Tranco List + CommonCrawl data.
+`src/domain-api.ts` (lookup API), `src/domain-name-formatter.ts`
+(human-readable source labels), `src/scripts/` + `src/data/` (the
+`download`/`merge`/`favicons` npm scripts regenerate the underlying dataset
+— only needed if you're refreshing the ranking data itself, not for normal
+feature work).

--- a/.claude/skills/qwksearch-customize/references/ui-widgets.md
+++ b/.claude/skills/qwksearch-customize/references/ui-widgets.md
@@ -1,0 +1,42 @@
+# Standalone UI Widgets
+
+Small, independently publishable components used across the apps. Good
+candidates to reuse rather than reimplement when a task needs "a settings
+panel," "a dock/launcher," "a weather widget," or "voice input."
+
+## packages/shadcn-app-dock
+
+macOS-style category dock: icon magnification on hover, built-in shadcn
+theme switcher (light/dark via `next-themes`), animated with Framer Motion.
+`src/shadcn-app-dock.tsx` (main component), `src/shadcn-app-dock-context.tsx`
+(context/provider), `src/theme-menu.tsx`, `src/components/`. Prop-driven —
+check `src/index.ts` for the exported API before assuming you need to fork
+it; used by `qwksearch-web` for its category dock.
+
+## packages/shadcn-settings
+
+Generic settings-panel primitives (sections, forms) — `src/components/`,
+`src/types.ts` for the shape settings sections must conform to. Note
+`research-agent-ui` has its *own* `src/settings/` (JSON-driven, `search.json`
++ `sections.json`) — check whether a settings change belongs in this shared
+package (reusable across apps) or in `research-agent-ui`'s app-specific
+settings config before picking one.
+
+## packages/react-weather-forecast
+
+Self-contained weather widget with its own tiny backend: `src/components/`,
+`src/hooks/`, `src/api/` (client calling a weather provider), `src/icons/`,
+`src/weatherCodes.ts` (weather condition → icon/label mapping), plus a
+`worker/` Cloudflare Worker proxy (scripts `worker:dev`/`worker:deploy`) —
+the worker likely exists to hide an API key from the client bundle. Used
+where the product shows weather info inline in search/answers.
+
+## packages/use-voice-control
+
+Speech/voice control hook, backed by `speech/` (check for
+provider-specific code, e.g. Whisper/Web Speech API/Kokoro — `KOKORO_INTEGRATION.md`
+in `research-agent-ui` references Kokoro TTS, and `research-agent-ui/src/lib/kokoro.ts`
++ `src/hooks/voice/` consume this hook). This is the shared hook;
+`research-agent-ui`'s `VoiceSettings` component and `use-voice-control`
+together form the full voice feature — check both when changing voice
+input/output behavior.

--- a/.claude/skills/qwksearch-customize/references/web-ui.md
+++ b/.claude/skills/qwksearch-customize/references/web-ui.md
@@ -1,0 +1,75 @@
+# Web UI: qwksearch-web, research-agent-ui, reason-editor
+
+This is where most "add a feature" or "restyle the UI" requests land. Three
+distinct pieces, easy to confuse:
+
+## apps/qwksearch-web — the Next.js shell
+
+Dev: `bun run dev` (root) or `cd apps/qwksearch-web && npx open-ready next dev`.
+Build/deploy: `vinext build` / `vinext deploy` (Cloudflare Workers target),
+`wrangler dev --local` for a local Workers runtime via `dev:cf`.
+
+Next.js App Router layout (`apps/qwksearch-web/app/`):
+
+- `app/page.tsx`, `app/c/[chatId]` — the main chat/search screen and per-conversation route. These mostly *instantiate* components from `research-agent-ui`.
+- `app/api/agent`, `app/api/search`, `app/api/scraper`, `app/api/speech`, `app/api/config`, `app/api/user`, `app/api/auth`, `app/api/admin`, `app/api/docs`, `app/api/openapi`, `app/api/notebooklm` — backend routes. Adding a new backend capability usually means a new route here calling into a `packages/*` library, not new business logic inline.
+- `app/settings/[[...section]]` — settings UI (includes the Skills & Memory panel, see `docs/SKILLS_AND_MEMORY.md`).
+- `app/admin/*` — admin dashboard (users, freekeys, config).
+- `app/login`, `app/library`, `app/news`, `app/docs`, `app/enterprise`, `app/legal` — supporting pages.
+- `worker/index.ts` — the Cloudflare Worker entry (routes/middleware around the Next.js app when deployed to Workers).
+- `drizzle/*.sql` — D1 database migrations; `db:generate`/`db:push`/`db:migrate`/`db:studio` scripts manage schema.
+- Auth is Better Auth (`BETTER_AUTH_SECRET`, Discord OAuth, etc. — see `.env.example` for the full env var list before running locally).
+
+**When to edit here**: new page/route, new API endpoint, auth/session behavior, DB schema changes, admin features. **Not** for chat UI component behavior — that's `research-agent-ui`.
+
+## packages/research-agent-ui — the actual chat/search UI
+
+This is a standalone package (own `package.json`, builds to `dist/`) designed
+to "drop into a Next.js app behind a small config/injection surface." Built
+with `bun run build` (vite + tsc), has its own Storybook (`bun run storybook`,
+see `STORYBOOK.md`) for isolated component development — prefer Storybook
+over the full web app when iterating on a single component's look.
+
+Key exports (see `package.json` `exports` map): `.` (main), `./config`,
+`./api`, `./file-sources`, `./settings`, `./settings/*`.
+
+`src/` layout:
+
+- `src/components/` — `ChatConversation`, `MessageComposer`, `MessageActions`, `ArticleReader`, `SearchConfig`, `SearchResults`, `FileUpload`, `ChatHistoryDropdown`, `VoiceSettings`, `Footer`, `ConfigError`. Each is a folder with the component + likely a `.stories.tsx` — check for an existing story before writing a manual test harness.
+- `src/hooks/` — `useChat/`, `useSession.tsx`, `voice/`. Chat state and streaming logic lives here, not in the components.
+- `src/config.ts` and `src/settings/` (`sections.json`, `search.json`) — the "injection surface" mentioned in the root README: branding, auth wiring, and media-search preferences are configured here rather than hardcoded in components.
+- `src/api/` — typed handlers/types for talking to the backend; `src/api/handlers/`.
+- `src/icons/` — category search icons (academic, files, images, news, tech, videos, web) as both `.tsx` and `.svg` — add both when adding a new search category icon.
+- `src/lib/` — assorted utilities: `chatTitle.ts`, `composer.ts`, `export.ts`, `guest.ts`, `kokoro.ts` (voice), `suggestions.ts`, `url-autolink.ts`.
+- `src/ui/` — small shared primitives (button, dialog, dropdown-menu, popover, tooltip, badge, live-waveform, glowing-effect) — Radix + Tailwind style, check here before adding a new low-level UI primitive; one may already exist.
+- `src/cloudflare/worker.ts` — lets this package run standalone as its own Worker (`dev:cloudflare`/`deploy:cloudflare` scripts) independent of `qwksearch-web`.
+
+**When to edit here**: anything about how the conversation looks or behaves, search config UI, article preview, file upload, voice settings, chat history — i.e. almost every "change the UI" request that mentions chat/search.
+
+## packages/reason-editor — the REASON writing editor
+
+A separate product surface: a Lexical/Tiptap-based rich text editor with a
+document tree, not the chat UI. Dev: `bun run dev:editor` from root, or
+`cd packages/reason-editor && ...` (check `package.json` for the exact
+script name — `vite.config.ts` in this package drives standalone dev via
+`index.html`). Build: `bun run build:lib`.
+
+`src/` layout highlights:
+
+- `src/extensions/` — one folder per Tiptap extension (Table, CodeBlock, Mermaid, Katex, Mention, SlashCommand, ExportPdf, ExportWord, ImportWord, Comment, Drawio, Twitter, Video, Image, etc). **Adding editor functionality (new block type, new toolbar action) means adding a new folder here following an existing extension's shape**, then registering it (check `src/editor-kit.ts` and `src/reason-docs.ts` for where extensions are assembled).
+- `src/components/`, `src/editor-views/`, `src/editor/` — toolbar, editor area, right panel, and the standalone app shell (`editor-views/App.tsx`, `main.tsx`) used when running the editor outside the full product.
+- `src/documents/`, `src/file-tree/` — the nested document organizer (drag-and-drop, context menu) mentioned in the root README.
+- `src/locales/` — one file per language (20+ languages); add a new key to `en.ts` first, then mirror it across the others (or at minimum add the English fallback).
+- `src/features/` — `ai-rewrite/`, `settings/`, `tags/`, `team/` — larger vertical features, each self-contained.
+- `src/store/` — editor state (`store.ts`, `editor.ts`) plus reactive bridges (`EditorEditableReactive.tsx`, `ThemeColorReactive.tsx`).
+- `src/comments/` — commenting/annotation system (`CommentsSidebar.tsx`, `commentMarks.ts`).
+
+**When to edit here**: rich text editor behavior, new document/formatting feature, export/import formats, editor localization, collaborative editing (Yjs) behavior.
+
+## Shared styling
+
+Both `research-agent-ui` and `reason-editor` use Tailwind + shadcn-style
+primitives; `qwksearch-web` also pulls in `shadcn-app-dock` for its
+category dock. If a component looks inconsistent across surfaces, check
+whether the same primitive exists in more than one package's `src/ui` or
+`src/app-ui` before creating a third copy.

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,8 @@ pnpm-lock*
 apps/qwksearch-web/.open-next
 .dev.vars
 packages/reason-editor/demo
-.claude
+.claude/*
+!.claude/skills
 .turbo
 
 yarn.lock


### PR DESCRIPTION
## Summary

This PR adds comprehensive Claude skill documentation for the QwkSearch research-agent monorepo, enabling Claude to effectively guide users through modifying and extending the codebase. The documentation provides a structured reference system that maps user requests to the correct packages and files.

## Key Changes

- **Added `SKILL.md`**: Main entry point defining the skill's purpose and providing a quick reference table mapping common tasks to relevant documentation files and packages
- **Added `references/architecture.md`**: Complete monorepo structure guide including:
  - Workspace layout (apps, packages, turbo/vitest configuration)
  - Root scripts and development commands
  - Package group map with 20+ workspace packages and their roles
  - Cross-package dependency chain and build order
  - Testing strategy and deployment targets

- **Added `references/web-ui.md`**: Guide to the three main UI surfaces:
  - `apps/qwksearch-web` (Next.js shell, routes, auth, DB)
  - `packages/research-agent-ui` (chat/search UI components)
  - `packages/reason-editor` (Tiptap-based document editor)
  - Shared styling patterns

- **Added `references/ai-and-data.md`**: LLM and agent integration guide covering:
  - `packages/chat-agent-toolkit` (agent orchestration, provider registry, tools, memory)
  - `packages/write-language` (multi-provider text generation)
  - `packages/qwksearch-mcp-server` (MCP tool exposure)
  - `packages/qwksearch-api-client` (auto-generated backend client)
  - `packages/language-model-training` (Python-based model training)

- **Added `references/search-and-extraction.md`**: Content discovery and processing guide:
  - `packages/search-web-api` (70+ search engine adapters with recipes)
  - PDF extraction strategies (pdfjs vs. docling)
  - `packages/extract-webpage` (research pipeline)
  - YouTube transcript extraction
  - Page rendering strategies
  - Domain reputation lookup

- **Added `references/other-apps.md`**: Non-web product surfaces:
  - `apps/qwksearch-desktop` (Tauri + Svelte quick-search)
  - `apps/qwksearch-ext` (WXT browser extension, tab manager)
  - `apps/qwk-vscode-ext` (VS Code sidebar and editor integration)
  - `apps/test-reports` (test infrastructure)

- **Added `references/ui-widgets.md`**: Reusable component library guide:
  - `packages/shadcn-app-dock` (macOS-style category dock)
  - `packages/shadcn-settings` (settings panel primitives)
  - `packages/react-weather-forecast` (weather widget)
  - `packages/use-voice-control` (voice input hook)

- **Updated `.gitignore`**: Modified to preserve `.claude/skills` directory while ignoring other `.claude` contents

## Notable Implementation Details

- Each reference file includes concrete file paths, dev/build commands, and "recipe" patterns for common tasks (e.g., adding a new search engine, LLM provider, or editor extension)
- Documentation emphasizes the monorepo's key architectural patterns: workspace packages as built artifacts (not live-transpiled), turbo task orchestration, and the distinction between the web app shell and reusable UI packages
- Cross-references between files guide users to the right documentation based on their task type
- Includes practical warnings about common mistakes (e.g., editing UI in the wrong package, confusing `research-agent-ui` with `reason-editor`)

https://claude.ai/code/session_0119fUUaRhzkZdmw4h3xqmqZ