### PR TITLE
Fix import paths in auth test file

### DIFF
--- a/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
+++ b/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
@@ -6,19 +6,19 @@ vi.mock("better-auth", () => ({
   betterAuth: betterAuthMock,
 }));
 
-vi.mock("../database", () => ({
+vi.mock("../../database", () => ({
   getDB: () => ({})
 }));
 
-vi.mock("../cloudflare/context", () => ({
+vi.mock("../../cloudflare/context", () => ({
   getCloudflareContext: () => ({ env: {} }),
 }));
 
-vi.mock("../cloudflare/ip-geolocation", () => ({
+vi.mock("../../cloudflare/ip-geolocation", () => ({
   detectVpnAndLocation: vi.fn().mockResolvedValue({ city: null, state: null, isVpn: false }),
 }));
 
-vi.mock("../config/site", () => ({
+vi.mock("../../config/site", () => ({
   config: {
     appName: "Test App",
     appEmail: "noreply@example.com",


### PR DESCRIPTION
## Summary
Updated mock import paths in the auth test file to use correct relative paths from the test location.

## Key Changes
- Fixed all `vi.mock()` import paths from `../` to `../../` to correctly resolve from the test file's location in `lib/auth/__tests__/`
  - `../database` → `../../database`
  - `../cloudflare/context` → `../../cloudflare/context`
  - `../cloudflare/ip-geolocation` → `../../cloudflare/ip-geolocation`
  - `../config/site` → `../../config/site`

## Details
The test file is located at `apps/qwksearch-web/lib/auth/__tests__/index.test.ts`, so relative imports need to go up two directory levels (`../../`) to reach the `lib/` directory, not one level (`../`). This fix ensures the mocks correctly resolve to their target modules during test execution.

https://claude.ai/code/session_01GeBLD3URyqn8DBokDPAcZd