### PR TITLE
Replace ip-api.com with ipapi.co for geolocation

### DIFF
--- a/packages/react-weather-forecast/README.md
+++ b/packages/react-weather-forecast/README.md
@@ -1,6 +1,6 @@
 # use-weather-forecast
 
-React weather forecast component using Open-Meteo for current, hourly, and daily forecasts and Cloudflare/ip-api for IP geolocation.
+React weather forecast component using Open-Meteo for current, hourly, and daily forecasts and Cloudflare/ipapi.co for IP geolocation.
 
 ## Features
 
@@ -62,12 +62,14 @@ This package no longer uses ipinfo.io. Instead:
 
 - Pass `geoEndpoint` pointing at a deployed instance of the bundled Cloudflare Worker
   (`worker/geo-worker.ts`) for accurate results. The worker reads Cloudflare's built-in
-  geolocation (`request.cf`) for the visitor's own IP, and falls back to `ip-api.com`
+  geolocation (`request.cf`) for the visitor's own IP, and falls back to `ipapi.co`
   when a `?ip=` query param (or the `ip` prop) is supplied for an arbitrary address.
-- If `geoEndpoint` is omitted, the package falls back to calling `ip-api.com` directly
-  from the browser. **Note:** ip-api.com's free tier only serves plain HTTP, so this
-  fallback will be blocked as mixed content on pages served over HTTPS — deploy the
-  worker and pass `geoEndpoint` for any HTTPS site.
+- If `geoEndpoint` is omitted, the package falls back to calling `ipapi.co` directly
+  from the browser (`https://ipapi.co/json/`, or `https://ipapi.co/<ip>/json/` when an
+  `ip` is supplied). Unlike the previous ip-api.com fallback, this works over HTTPS with
+  no mixed-content issues, though ipapi.co's free tier is rate-limited (1,000
+  requests/day) — deploy the worker and pass `geoEndpoint` for higher-volume or
+  production use.
 
 ### Deploying the geo worker
 
@@ -82,4 +84,4 @@ This deploys `worker/geo-worker.ts` via Wrangler. Use the resulting `*.workers.d
 ## Notes
 
 - Open-Meteo powers the forecast data.
-- Cloudflare's `request.cf` and ip-api.com power IP geolocation (see above).
+- Cloudflare's `request.cf` and ipapi.co power IP geolocation (see above).

--- a/packages/react-weather-forecast/package.json
+++ b/packages/react-weather-forecast/package.json
@@ -2,7 +2,7 @@
   "name": "use-weather-forecast",
   "version": "0.1.0",
   "description": "React weather forecast component using Open-Meteo and IP geolocation",
-  "keywords": ["react", "weather", "forecast", "open-meteo", "cloudflare", "ip-api", "component-library"],
+  "keywords": ["react", "weather", "forecast", "open-meteo", "cloudflare", "ipapi", "component-library"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",

--- a/packages/react-weather-forecast/src/api/geolocation.ts
+++ b/packages/react-weather-forecast/src/api/geolocation.ts
@@ -1,19 +1,16 @@
 import type { WeatherLocation } from '../types';
 
-// ip-api.com's free tier only serves plain HTTP (HTTPS requires their paid plan),
-// so this default will be blocked as mixed content on pages served over HTTPS.
-// Deploy worker/geo-worker.ts and pass its URL as `geoEndpoint` to avoid that.
-const DEFAULT_IP_API_URL = 'http://ip-api.com/json/';
+const DEFAULT_IP_API_URL = 'https://ipapi.co';
 
 type IpApiResponse = {
-  status: 'success' | 'fail';
   city?: string;
-  regionName?: string;
-  country?: string;
+  region?: string;
+  country_name?: string;
   timezone?: string;
-  lat?: number;
-  lon?: number;
-  message?: string;
+  latitude?: number;
+  longitude?: number;
+  error?: boolean;
+  reason?: string;
 };
 
 type GeoWorkerResponse = {
@@ -42,20 +39,20 @@ export async function getClientLocation(geoEndpoint?: string, ip?: string): Prom
     };
   }
 
-  const res = await fetch(`${DEFAULT_IP_API_URL}${ip ? encodeURIComponent(ip) : ''}`);
-  if (!res.ok) throw new Error(`ip-api lookup failed: ${res.status}`);
+  const res = await fetch(`${DEFAULT_IP_API_URL}/${ip ? `${encodeURIComponent(ip)}/` : ''}json/`);
+  if (!res.ok) throw new Error(`ipapi.co lookup failed: ${res.status}`);
   const data: IpApiResponse = await res.json();
 
-  if (data.status === 'fail') {
-    throw new Error(`ip-api lookup failed: ${data.message ?? 'unknown error'}`);
+  if (data.error) {
+    throw new Error(`ipapi.co lookup failed: ${data.reason ?? 'unknown error'}`);
   }
 
   return {
     city: data.city,
-    region: data.regionName,
-    country: data.country,
+    region: data.region,
+    country: data.country_name,
     timezone: data.timezone,
-    latitude: Number(data.lat),
-    longitude: Number(data.lon),
+    latitude: Number(data.latitude),
+    longitude: Number(data.longitude),
   };
 }

--- a/packages/react-weather-forecast/worker/geo-worker.ts
+++ b/packages/react-weather-forecast/worker/geo-worker.ts
@@ -11,24 +11,23 @@ type CloudflareGeo = {
 };
 
 type IpApiResponse = {
-  status: 'success' | 'fail';
-  query?: string;
-  country?: string;
-  countryCode?: string;
-  regionName?: string;
+  ip?: string;
+  country_name?: string;
+  country_code?: string;
+  region?: string;
   city?: string;
-  lat?: number;
-  lon?: number;
+  latitude?: number;
+  longitude?: number;
   timezone?: string;
-  isp?: string;
   org?: string;
-  as?: string;
-  message?: string;
+  asn?: string;
+  error?: boolean;
+  reason?: string;
 };
 
 async function lookupIpApi(ip: string): Promise<IpApiResponse> {
-  const res = await fetch(`http://ip-api.com/json/${encodeURIComponent(ip)}`);
-  if (!res.ok) throw new Error(`ip-api HTTP ${res.status}`);
+  const res = await fetch(`https://ipapi.co/${encodeURIComponent(ip)}/json/`);
+  if (!res.ok) throw new Error(`ipapi.co HTTP ${res.status}`);
   return res.json() as Promise<IpApiResponse>;
 }
 
@@ -41,20 +40,19 @@ export default {
       const data = await lookupIpApi(ip);
       return Response.json(
         {
-          source: 'ip-api',
-          ip: data.query ?? ip,
-          country: data.country,
-          countryCode: data.countryCode,
-          region: data.regionName,
+          source: 'ipapi.co',
+          ip: data.ip ?? ip,
+          country: data.country_name,
+          countryCode: data.country_code,
+          region: data.region,
           city: data.city,
-          latitude: data.lat,
-          longitude: data.lon,
+          latitude: data.latitude,
+          longitude: data.longitude,
           timezone: data.timezone,
-          isp: data.isp,
           org: data.org,
-          as: data.as,
-          status: data.status,
-          message: data.message,
+          asn: data.asn,
+          error: data.error,
+          reason: data.reason,
         },
         { headers: { 'Cache-Control': 'no-store' } }
       );


### PR DESCRIPTION
## Summary
Migrates the IP geolocation service from ip-api.com to ipapi.co across the worker and client-side code. This change resolves HTTPS mixed-content issues and improves the default fallback experience.

## Key Changes
- **API Migration**: Updated `lookupIpApi()` in geo-worker.ts to call `https://ipapi.co/` instead of `http://ip-api.com/`
- **Response Type Updates**: Updated `IpApiResponse` type definitions to match ipapi.co's field names:
  - `query` → `ip`
  - `country` → `country_name`
  - `countryCode` → `country_code`
  - `regionName` → `region`
  - `lat`/`lon` → `latitude`/`longitude`
  - `status`/`message` → `error`/`reason`
  - Removed `isp` field; renamed `as` → `asn`
- **Client-side Fallback**: Updated `getClientLocation()` in geolocation.ts to use ipapi.co's HTTPS endpoint as the default fallback (previously required deploying the worker to avoid mixed-content errors)
- **Error Handling**: Changed error detection from `data.status === 'fail'` to `data.error` boolean flag
- **Documentation**: Updated README and package.json keywords to reflect the new service, including notes about ipapi.co's rate limits and improved HTTPS support

## Implementation Details
- The ipapi.co endpoint now works over HTTPS without requiring a deployed worker, eliminating the previous mixed-content blocker for HTTPS sites
- Rate limiting (1,000 requests/day on free tier) is documented as a trade-off; production deployments should still use the Cloudflare Worker for higher volume
- All field mappings have been updated consistently across both the worker and client code

https://claude.ai/code/session_018SsaLzxfJjfBuRTWeo9yHq