### PR TITLE
Move downloads section to modal dialog opened from footer

### DIFF
--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -7,12 +7,12 @@ import { GradientBlur } from '../../ui/gradient-blur';
 import ChatInputBox from '../MessageComposer/ChatInputBox';
 import RecentHistoryChips from './RecentHistoryChips';
 import Footer from '../Footer';
+import DownloadsDialog from './DownloadsDialog';
 import { WeatherForecast } from 'use-weather-forecast';
 import { useChat } from '../../hooks/useChat';
 import { getBackgroundArtwork } from './background-art';
 import { researchAgentUIConfig } from '../../config';
 import QuantumWaveOrbital from 'quantum-sphere-loading-icon/react';
-import { DownloadAppButton } from 'react-native-app-buttons';
 // Stylesheet is imported by the host app (globals.css) inside a named cascade
 // layer instead of here — it's a Tailwind v3 build with an unlayered `*`
 // reset that would otherwise beat every Tailwind v4 utility in the app.
@@ -27,6 +27,10 @@ export default function ChatHomepage() {
   const [backgroundUrl, setBackgroundUrl] = useState<string | null>(null);
   const [nextBackgroundUrl, setNextBackgroundUrl] = useState<string | null>(null);
   const [fading, setFading] = useState(false);
+  const [downloadsOpen, setDownloadsOpen] = useState(false);
+  const footerLinks = researchAgentUIConfig.footerLinks.map((link) =>
+    link.url === '/#downloads' ? { ...link, onClick: () => setDownloadsOpen(true) } : link,
+  );
   useEffect(() => {
     const showBg = localStorage.getItem('showBackgroundArt');
     if (showBg === 'false') return;
@@ -89,18 +93,6 @@ export default function ChatHomepage() {
             />
           </div>
 
-          <div id="downloads" className="flex items-center justify-center gap-3 mt-4">
-            <DownloadAppButton
-              platform="chrome-extension"
-              href={researchAgentUIConfig.downloadChromeUrl}
-              autoHighlight
-            />
-            <DownloadAppButton
-              platform="windows"
-              appId={researchAgentUIConfig.downloadWindowsStoreId}
-              autoHighlight
-            />
-          </div>
           <div className="w-full max-w-2xl mt-8 space-y-2">
             <RecentHistoryChips />
             <WeatherForecast
@@ -121,7 +113,8 @@ export default function ChatHomepage() {
         </div>
       </div>
 
-      <Footer listFooterLinks={researchAgentUIConfig.footerLinks} />
+      <Footer listFooterLinks={footerLinks} />
+      <DownloadsDialog open={downloadsOpen} onOpenChange={setDownloadsOpen} />
     </div>
   );
 }

--- a/packages/research-agent-ui/src/components/ChatConversation/DownloadsDialog.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/DownloadsDialog.tsx
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Popup dialog listing app download links (Chrome extension, Windows app), opened from the "Downloads" footer link instead of being shown inline on the homepage.
+ */
+'use client';
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '../../ui/dialog';
+import { researchAgentUIConfig } from '../../config';
+import { DownloadAppButton } from 'react-native-app-buttons';
+
+interface DownloadsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function DownloadsDialog({ open, onOpenChange }: DownloadsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-full max-w-md rounded-2xl bg-light-secondary dark:bg-dark-secondary border border-light-200 dark:border-dark-200 p-6 text-center align-middle shadow-xl">
+        <DialogTitle className="text-lg font-medium leading-6 dark:text-white">
+          Download QwkSearch
+        </DialogTitle>
+        <DialogDescription className="text-sm dark:text-white/70 text-black/70 mt-2">
+          Get QwkSearch on your browser or desktop.
+        </DialogDescription>
+        <div className="flex flex-wrap items-center justify-center gap-3 mt-6">
+          <DownloadAppButton
+            platform="chrome-extension"
+            href={researchAgentUIConfig.downloadChromeUrl}
+            autoHighlight
+          />
+          <DownloadAppButton
+            platform="windows"
+            appId={researchAgentUIConfig.downloadWindowsStoreId}
+            autoHighlight
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/research-agent-ui/src/components/Footer.tsx
+++ b/packages/research-agent-ui/src/components/Footer.tsx
@@ -10,6 +10,8 @@ interface FooterLink {
     url: string;
     text: string;
     icon?: string;
+    /** When set, clicking the link runs this instead of navigating to `url` (e.g. to open a popup). */
+    onClick?: () => void;
 }
 
 interface FooterProps {
@@ -52,7 +54,7 @@ export default function Footer({
     }, [open]);
 
     const renderLinks = () =>
-        listFooterLinks.map(({ url, text, icon }) => {
+        listFooterLinks.map(({ url, text, icon, onClick }) => {
             const IconComponent = icon ? (LucideIcons as any)[icon] : null;
 
             const isExternal = url.startsWith("http");
@@ -72,6 +74,19 @@ export default function Footer({
                     <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-current transition-all duration-300 group-hover:w-full group-hover:shadow-[0_0_8px_rgba(255,255,255,0.6)]" />
                 </>
             );
+
+            if (onClick) {
+                return (
+                    <button
+                        key={url}
+                        type="button"
+                        onClick={onClick}
+                        className="relative group inline-flex items-center gap-1 hover:text-white hover:drop-shadow-[0_0_8px_rgba(255,255,255,0.8)] transition-all duration-300 whitespace-nowrap"
+                    >
+                        {content}
+                    </button>
+                );
+            }
 
             return isExternal ? (
                 <a


### PR DESCRIPTION
## Summary
Refactored the downloads section from being displayed inline on the homepage to a modal dialog that opens when clicking the "Downloads" link in the footer.

## Key Changes
- **New component**: Created `DownloadsDialog.tsx` - a reusable dialog component that displays Chrome extension and Windows app download buttons
- **Updated ChatHomepage**: 
  - Removed inline downloads section from the homepage
  - Added state management for the downloads dialog (`downloadsOpen`)
  - Mapped footer links to intercept the downloads link and trigger the dialog instead of navigation
- **Enhanced Footer component**:
  - Added optional `onClick` callback to `FooterLink` interface
  - Added conditional rendering to support button elements with click handlers (in addition to existing link elements)
  - Maintains styling consistency with existing link hover effects

## Implementation Details
- The downloads dialog uses the existing Dialog UI component with consistent styling (rounded corners, dark mode support, shadow effects)
- The footer link interception is done via a map function that replaces the `/#downloads` URL with an `onClick` handler
- The dialog is rendered at the bottom of ChatHomepage alongside the Footer component
- All download configuration is sourced from `researchAgentUIConfig` for consistency

https://claude.ai/code/session_013CXwfGVtx5cw7hxCZDEY1e