### PR TITLE
Add mobile drawer UI and files sidebar request signal

### DIFF
--- a/apps/qwksearch-web/components/layout/CategoryDock.tsx
+++ b/apps/qwksearch-web/components/layout/CategoryDock.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { Settings, LogIn, LogOut, Link2 } from "lucide-react"
+import { Settings, LogIn, LogOut, Link2, FileText } from "lucide-react"
 import * as LucideIcons from "lucide-react"
 import {
   CategoryDock as BaseCategoryDock,
@@ -37,7 +37,7 @@ export function CategoryDock() {
   const { isAuthenticated, signIn, signOut } = useSession()
   const { newChat } = useChat()
   const { openSettings } = useSettingsModal()
-  const { activeView, setActiveView } = useMainView()
+  const { activeView, setActiveView, requestFilesSidebar } = useMainView()
 
   const isOnResearch = pathname === "/" || pathname.startsWith("/c")
 
@@ -62,6 +62,15 @@ export function CategoryDock() {
         setActiveView("docs")
       },
     })),
+    {
+      key: "files",
+      label: "Files",
+      icon: <FileText className="w-full h-full p-1" />,
+      onClick: () => {
+        setActiveView("docs")
+        requestFilesSidebar()
+      },
+    },
     {
       key: "settings",
       label: "Settings",
@@ -130,6 +139,7 @@ export function CategoryDock() {
     <BaseCategoryDock
       items={items}
       enableKeyboardShortcuts
+      mobileAlign={activeView === "docs" ? "end" : "center"}
       renderImage={(src, alt, size) => (
         <Image src={src} alt={alt} width={size} height={size} unoptimized className="w-full h-full" />
       )}

--- a/apps/qwksearch-web/components/layout/MainViewProvider.tsx
+++ b/apps/qwksearch-web/components/layout/MainViewProvider.tsx
@@ -9,6 +9,9 @@ type MainViewContextValue = {
   setActiveView: (view: MainViewMode) => void
   toggleToDocs: () => void
   toggleToResearch: () => void
+  /** Bumped whenever the files sidebar should be opened (e.g. from a dock icon). */
+  filesSidebarRequestId: number
+  requestFilesSidebar: () => void
 }
 
 const MainViewContext = createContext<MainViewContextValue | null>(null)
@@ -17,6 +20,7 @@ const STORAGE_KEY = 'qwksearch-main-view'
 
 export function MainViewProvider({ children }: { children: React.ReactNode }) {
   const [activeView, setActiveView] = useState<MainViewMode>('research')
+  const [filesSidebarRequestId, setFilesSidebarRequestId] = useState(0)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -39,8 +43,10 @@ export function MainViewProvider({ children }: { children: React.ReactNode }) {
       setActiveView,
       toggleToDocs: () => setActiveView('docs'),
       toggleToResearch: () => setActiveView('research'),
+      filesSidebarRequestId,
+      requestFilesSidebar: () => setFilesSidebarRequestId((id) => id + 1),
     }),
-    [activeView],
+    [activeView, filesSidebarRequestId],
   )
 
   return <MainViewContext.Provider value={value}>{children}</MainViewContext.Provider>

--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { ChatWindow } from 'research-agent-ui';
+import { ChatInputBox, ChatWindow } from 'research-agent-ui';
 import { ReasonDocs } from 'react-reason-editor/reason-docs';
 import { themeActions } from 'react-reason-editor/theme';
 import { localeActions } from 'react-reason-editor/locale-bundle';
@@ -13,7 +13,7 @@ import 'easydrawer/styles.css';
 import 'katex/contrib/mhchem';
 
 export function MainWorkspaceView() {
-  const { activeView } = useMainView();
+  const { activeView, filesSidebarRequestId } = useMainView();
 
   useEffect(() => {
     localeActions.setLang('en');
@@ -21,8 +21,11 @@ export function MainWorkspaceView() {
   }, []);
 
   return activeView === 'docs' ? (
-    <ReasonDocs />
+    <ReasonDocs
+      belowMainContent={<ChatInputBox />}
+      openFilesSidebarSignal={filesSidebarRequestId}
+    />
   ) : (
-    <ReasonDocs mainContent={<ChatWindow />} />
+    <ReasonDocs mainContent={<ChatWindow />} openFilesSidebarSignal={filesSidebarRequestId} />
   );
 }

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -10,16 +10,31 @@ import { RightPanel } from './RightPanel';
 import { ReasonDocsDialogs } from './ReasonDocsDialogs';
 import { useReasonDocsState } from './useReasonDocsState';
 import { DynamicIslandTOC } from '../search/DynamicIslandTOC';
+import { Button } from '../app-ui/button';
 import { useTheme } from 'next-themes';
 import { useState, type ReactNode } from 'react';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../utils/storage';
+import { Menu, PanelRight } from 'lucide-react';
 import '../app-styles/split-pane.css';
 
 
 interface ReasonDocsProps {
   mainContent?: ReactNode;
+  /**
+   * Optional content rendered below `mainContent` (e.g. a compact chat
+   * input), stacked under the main area with minimal padding. On mobile
+   * widths with room to spare it shares the bottom row with the app dock
+   * instead of stacking above it.
+   */
+  belowMainContent?: ReactNode;
+  /**
+   * Changing this value (e.g. bumping a counter) opens the files sidebar.
+   * Lets chrome mounted outside this component — like an app dock icon —
+   * request the sidebar open.
+   */
+  openFilesSidebarSignal?: number | string;
 }
 
 /**
@@ -27,9 +42,9 @@ interface ReasonDocsProps {
  * Uses `useReasonDocsState` for shared state and `next-themes` for theme control.
  * Renders a resizable panel layout on desktop and a stacked layout on mobile.
  */
-const Index = ({ mainContent }: ReasonDocsProps) => {
+const Index = ({ mainContent, belowMainContent, openFilesSidebarSignal }: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
-  const state = useReasonDocsState();
+  const state = useReasonDocsState(openFilesSidebarSignal);
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
 
   // Use persistence hook for sidebar sizes
@@ -150,18 +165,53 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
         onAiRegenerate: state.handleAIRegenerate,
       }}
       onClose={() => state.setRightPanels([])}
+      isMobile={state.isMobile}
+      isOpen={state.isRightSidebarOpen}
+      onOpenChange={state.setIsRightSidebarOpen}
     />
   );
 
   return (
     <div className="h-screen w-screen flex flex-col overflow-hidden">
       {state.isMobile ? (
-        <div className="flex-1 flex overflow-hidden">
-          <Sidebar {...sidebarProps} headings={state.headings} />
-          <main className="flex-1 overflow-hidden flex flex-col">
-            {mainContent ?? <EditorArea {...editorProps} />}
-          </main>
-          {rightPanel}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {/* Hamburger bar: opens the left (files) and right sidebars as drawers. */}
+          <div className="flex items-center justify-between h-10 px-1 border-b border-sidebar-border/60 shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="size-8 p-0"
+              onClick={() => state.setIsSidebarOpen(true)}
+              aria-label="Open sidebar"
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+            {state.rightPanels.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="size-8 p-0"
+                onClick={() => state.setIsRightSidebarOpen(true)}
+                aria-label="Open right panel"
+              >
+                <PanelRight className="h-5 w-5" />
+              </Button>
+            )}
+          </div>
+          <div className="flex-1 flex overflow-hidden">
+            <Sidebar {...sidebarProps} headings={state.headings} />
+            <main className="flex-1 overflow-hidden flex flex-col">
+              <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+                {mainContent ?? <EditorArea {...editorProps} />}
+              </div>
+              {belowMainContent && (
+                <div className="shrink-0 px-2 pt-1 pb-[60px] sm:pb-2 sm:pr-56">
+                  {belowMainContent}
+                </div>
+              )}
+            </main>
+            {rightPanel}
+          </div>
         </div>
       ) : (
         <div className="flex-1 overflow-hidden">
@@ -175,11 +225,16 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
 
             {/* Main area */}
             <Pane>
-              <div className="h-screen flex bg-background">
-                <div className="flex-1 min-h-0 overflow-auto">
-                  {mainContent ?? <EditorArea {...editorProps} />}
+              <div className="h-screen flex flex-col bg-background">
+                <div className="flex-1 flex min-h-0">
+                  <div className="flex-1 min-h-0 overflow-auto">
+                    {mainContent ?? <EditorArea {...editorProps} />}
+                  </div>
+                  {rightPanel}
                 </div>
-                {rightPanel}
+                {belowMainContent && (
+                  <div className="shrink-0 px-2 pb-2">{belowMainContent}</div>
+                )}
               </div>
             </Pane>
           </SplitPane>

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -16,7 +16,13 @@ import type { OutlineViewHandle } from '../search/OutlineView';
 import type { TocEntry } from '../app-types/toc';
 import type { Document } from '../documents/DocumentTree';
 import { Button } from '../app-ui/button';
+import { Sheet, SheetContent } from '../app-ui/sheet';
+import { cn } from '../app-utils/utils';
 import { X } from 'lucide-react';
+
+/** Translucent, blurred glass background — matches the app dock and weather widget. */
+const SIDEBAR_GLASS_CLASSES =
+  'bg-white/10 dark:bg-black/20 backdrop-blur-md border-white/15 dark:border-white/10';
 
 /** Props for the {@link RightPanel} component. */
 interface RightPanelProps {
@@ -48,6 +54,12 @@ interface RightPanelProps {
   aiProps: SidebarAiProps;
   /** Closes the panel by clearing the right sidebar's panel list. */
   onClose: () => void;
+  /** Renders as a slide-in drawer instead of an inset resizable panel. */
+  isMobile?: boolean;
+  /** Whether the mobile drawer is open. Ignored when `isMobile` is false. */
+  isOpen?: boolean;
+  /** Called when the mobile drawer's open state should change. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const RESIZE_HANDLES = {
@@ -96,10 +108,68 @@ export function RightPanel({
   outlineRef,
   aiProps,
   onClose,
+  isMobile,
+  isOpen,
+  onOpenChange,
 }: RightPanelProps) {
   const [width, setWidth] = useState(320);
 
   const title = panels.length === 1 ? PANEL_LABELS[panels[0]] : 'Right Panel';
+
+  const body = (
+    <div className="h-full overflow-hidden flex flex-col">
+      <div className="px-3 py-2 border-b border-sidebar-border/60 flex items-center justify-between select-none shrink-0">
+        <h3 className="text-sm font-semibold text-sidebar-foreground">{title}</h3>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2"
+          onClick={onClose}
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="flex-1 min-h-0">
+        <SidebarContent
+          panels={panels}
+          split={split}
+          persistenceKey="right"
+          activeDocuments={documents}
+          activeId={activeId}
+          activeDocument={activeDocument}
+          headings={headings}
+          onSelect={onSelect}
+          onAdd={onAdd}
+          onDelete={onDelete}
+          onDuplicate={onDuplicate}
+          onMove={onMove}
+          onManageTags={onManageTags}
+          onRename={onRename}
+          outlineRef={outlineRef}
+          openTabs={openTabs}
+          activeTab={activeTab}
+          onTabChange={onTabChange}
+          onTabClose={onTabClose}
+          onTabRename={onTabRename}
+          onSplitRight={onSplitRight}
+          onReopenLastClosed={onReopenLastClosed}
+          canReopenLastClosed={canReopenLastClosed}
+          onNavigate={onNavigate}
+          aiProps={aiProps}
+        />
+      </div>
+    </div>
+  );
+
+  if (isMobile) {
+    return (
+      <Sheet open={isOpen} onOpenChange={onOpenChange}>
+        <SheetContent side="right" className={cn('w-80 p-0', SIDEBAR_GLASS_CLASSES)}>
+          <aside className="h-full flex flex-col">{body}</aside>
+        </SheetContent>
+      </Sheet>
+    );
+  }
 
   return (
     <Resizable
@@ -108,50 +178,9 @@ export function RightPanel({
       minWidth={260}
       maxWidth={640}
       enable={RESIZE_HANDLES}
-      className="h-full flex flex-col border-l border-sidebar-border/60 bg-sidebar-background shrink-0"
+      className={cn('h-full flex flex-col border-l shrink-0', SIDEBAR_GLASS_CLASSES)}
     >
-      <div className="h-full overflow-hidden flex flex-col">
-        <div className="px-3 py-2 border-b border-sidebar-border/60 flex items-center justify-between select-none shrink-0">
-          <h3 className="text-sm font-semibold text-sidebar-foreground">{title}</h3>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-7 px-2"
-            onClick={onClose}
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-        <div className="flex-1 min-h-0">
-          <SidebarContent
-            panels={panels}
-            split={split}
-            persistenceKey="right"
-            activeDocuments={documents}
-            activeId={activeId}
-            activeDocument={activeDocument}
-            headings={headings}
-            onSelect={onSelect}
-            onAdd={onAdd}
-            onDelete={onDelete}
-            onDuplicate={onDuplicate}
-            onMove={onMove}
-            onManageTags={onManageTags}
-            onRename={onRename}
-            outlineRef={outlineRef}
-            openTabs={openTabs}
-            activeTab={activeTab}
-            onTabChange={onTabChange}
-            onTabClose={onTabClose}
-            onTabRename={onTabRename}
-            onSplitRight={onSplitRight}
-            onReopenLastClosed={onReopenLastClosed}
-            canReopenLastClosed={canReopenLastClosed}
-            onNavigate={onNavigate}
-            aiProps={aiProps}
-          />
-        </div>
-      </div>
+      {body}
     </Resizable>
   );
 }

--- a/packages/reason-editor/src/editor/useReasonDocsState.ts
+++ b/packages/reason-editor/src/editor/useReasonDocsState.ts
@@ -23,12 +23,16 @@ import { toast } from "sonner";
 /**
  * Aggregates all Reason Docs application state into a single hook.
  *
+ * @param openFilesSidebarSignal - Optional value from the host app; changing
+ * it (e.g. bumping a counter) opens the files sidebar. Lets chrome mounted
+ * outside this component (like an app dock icon) request the sidebar open.
  * @returns An object containing reactive state values and handler callbacks
  * consumed by {@link Index} and its child components.
  */
-export function useReasonDocsState() {
+export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
   const isMobile = useIsMobile();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isRightSidebarOpen, setIsRightSidebarOpen] = useState(false);
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isTeamsOpen, setIsTeamsOpen] = useState(false);
@@ -441,6 +445,14 @@ export function useReasonDocsState() {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, []);
 
+  // Opens the files sidebar in response to an external trigger (e.g. an app
+  // dock icon mounted outside this component tree).
+  useEffect(() => {
+    if (!openFilesSidebarSignal) return;
+    setLeftPanels(["files"]);
+    setIsSidebarOpen(true);
+  }, [openFilesSidebarSignal]);
+
   // Apply default sidebar view on mount
   useEffect(() => {
     if (defaultSidebarView === "tree") {
@@ -738,6 +750,8 @@ export function useReasonDocsState() {
     isMobile,
     isSidebarOpen,
     setIsSidebarOpen,
+    isRightSidebarOpen,
+    setIsRightSidebarOpen,
     isSearchModalOpen,
     setIsSearchModalOpen,
     isSettingsOpen,

--- a/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
+++ b/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
@@ -13,6 +13,11 @@ import { FileManagerModal } from '../../dialogs/FileManagerModal';
 import { SidebarToolbar } from './SidebarToolbar';
 import { SidebarContent } from './SidebarContent';
 import type { SidebarProps } from './types';
+import { cn } from '../../app-utils/utils';
+
+/** Translucent, blurred glass background — matches the app dock and weather widget. */
+const SIDEBAR_GLASS_CLASSES =
+  'bg-white/10 dark:bg-black/20 backdrop-blur-md border-white/15 dark:border-white/10';
 
 export const Sidebar = ({
   documents,
@@ -205,8 +210,8 @@ export const Sidebar = ({
   if (isMobile) {
     return (
       <Sheet open={isOpen} onOpenChange={onOpenChange}>
-        <SheetContent side="left" className="w-80 p-0">
-          <aside className="h-full flex flex-col bg-sidebar-background">
+        <SheetContent side="left" className={cn('w-80 p-0', SIDEBAR_GLASS_CLASSES)}>
+          <aside className="h-full flex flex-col">
             <SidebarToolbar {...toolbarProps} />
             <div className="flex-1 min-h-0 overflow-hidden">
               <SidebarContent {...contentProps} />
@@ -220,7 +225,7 @@ export const Sidebar = ({
 
   // Desktop: render as sidebar, full height
   return (
-    <aside className="h-screen w-full flex flex-col bg-sidebar-background pt-14">
+    <aside className={cn('h-screen w-full flex flex-col pt-14', SIDEBAR_GLASS_CLASSES)}>
       <SidebarToolbar {...toolbarProps} />
       <div className="flex-1 min-h-0 overflow-hidden">
         <SidebarContent {...contentProps} />

--- a/packages/research-agent-ui/src/index.ts
+++ b/packages/research-agent-ui/src/index.ts
@@ -43,6 +43,7 @@ export type {
 
 // ============ Chat ============
 export { default as ChatWindow } from './components/ChatConversation/ChatWindow';
+export { default as ChatInputBox } from './components/MessageComposer/ChatInputBox';
 export type {
   Message,
   ChatTurn,

--- a/packages/shadcn-app-dock/src/shadcn-app-dock.tsx
+++ b/packages/shadcn-app-dock/src/shadcn-app-dock.tsx
@@ -47,6 +47,13 @@ export interface CategoryDockProps {
   className?: string
   /** Which fixed placements to render. Defaults to both. */
   placements?: { desktop?: boolean; mobile?: boolean }
+  /**
+   * Horizontal alignment of the mobile dock at `sm:` widths and up (it stays
+   * centered below that). `"end"` shifts it to the right, freeing the rest
+   * of the bottom row for other fixed bottom chrome (e.g. a chat input bar)
+   * to share the same row. Defaults to `"center"`.
+   */
+  mobileAlign?: "center" | "end"
 }
 
 const ICON_SIZE = 24
@@ -155,6 +162,7 @@ export function CategoryDock({
   enableKeyboardShortcuts = false,
   className,
   placements,
+  mobileAlign = "center",
 }: CategoryDockProps) {
   const showDesktop = placements?.desktop ?? true
   const showMobile = placements?.mobile ?? true
@@ -190,7 +198,10 @@ export function CategoryDock({
       {showMobile && (
         <div className={cn("md:hidden fixed bottom-0 left-0 right-0 z-50 pb-safe", className)}>
           <DockInstance
-            dockClassName="h-[52px] shrink-0 !mt-0 mx-auto w-max mb-2 !gap-1 !p-1"
+            dockClassName={cn(
+              "h-[52px] shrink-0 !mt-0 w-max mb-2 !gap-1 !p-1 mx-auto",
+              mobileAlign === "end" && "sm:ml-auto sm:mr-3",
+            )}
             side="top"
             items={items}
             renderImage={renderImage}


### PR DESCRIPTION
## Summary
This PR adds mobile-optimized drawer UI for the right panel and implements a signal-based mechanism to request the files sidebar open from external components. It also introduces a glass-morphism design for sidebars and adds support for content below the main editor area.

## Key Changes

- **Mobile drawer support**: `RightPanel` now renders as a slide-in `Sheet` drawer on mobile instead of a resizable panel, with new `isMobile`, `isOpen`, and `onOpenChange` props
- **Glass-morphism styling**: Extracted `SIDEBAR_GLASS_CLASSES` constant for translucent, blurred backgrounds matching the app dock, applied to both `Sidebar` and `RightPanel`
- **Files sidebar request signal**: Added `openFilesSidebarSignal` prop to `ReasonDocs` that triggers the files sidebar to open when the value changes, enabling external components (like dock icons) to request sidebar visibility
- **Mobile hamburger navigation**: Added a top bar on mobile with menu and panel icons to toggle sidebars as drawers
- **Below-main-content area**: New `belowMainContent` prop in `ReasonDocs` for rendering content (e.g., chat input) below the main editor, positioned to share the bottom row with the dock on mobile
- **Dock alignment control**: Added `mobileAlign` prop to `CategoryDock` to shift the mobile dock to the right (`"end"`) when other fixed bottom chrome needs space
- **Files dock button**: Added a "Files" button to the category dock that opens the docs view and requests the files sidebar
- **Chat input integration**: Exported `ChatInputBox` from research-agent-ui and integrated it into the workspace view

## Implementation Details

- Refactored `RightPanel` body into a reusable variable to avoid duplication between mobile and desktop renders
- `useReasonDocsState` now accepts and responds to `openFilesSidebarSignal` via a `useEffect` hook
- Mobile layout uses flexbox stacking with proper overflow handling for the new below-main-content area
- Desktop layout adjusted to accommodate the right panel within the main area flex container

https://claude.ai/code/session_01YPRqipJPKCMK7Gtt6LBgyU