### PR TITLE
Add chat tab management to workspace with unified Open Tabs panel

### DIFF
--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -6,6 +6,7 @@ import { ReasonDocs } from 'react-reason-editor/reason-docs';
 import { themeActions } from 'react-reason-editor/theme';
 import { localeActions } from 'react-reason-editor/locale-bundle';
 import { useMainView } from '@/components/layout/MainViewProvider';
+import { useChatTabs } from '@/components/layout/useChatTabs';
 
 import 'react-reason-editor/style.css';
 import 'katex/dist/katex.min.css';
@@ -13,16 +14,36 @@ import 'easydrawer/styles.css';
 import 'katex/contrib/mhchem';
 
 export function MainWorkspaceView() {
-  const { activeView } = useMainView();
+  const { activeView, setActiveView } = useMainView();
+  const { chatTabs, activeChatId, openChat, newChat, closeChat } = useChatTabs();
 
   useEffect(() => {
     localeActions.setLang('en');
     themeActions.setColor('default');
   }, []);
 
-  return activeView === 'docs' ? (
-    <ReasonDocs />
-  ) : (
-    <ReasonDocs mainContent={<ChatWindow />} />
+  const extraTabs = chatTabs.map((tab) => ({ id: tab.id, title: tab.title, kind: 'chat' as const }));
+
+  return (
+    <ReasonDocs
+      mainContent={activeView === 'docs' ? undefined : <ChatWindow />}
+      extraTabs={extraTabs}
+      activeExtraTabId={activeView === 'research' ? activeChatId : null}
+      onExtraTabSelect={(id) => {
+        openChat(id);
+        setActiveView('research');
+      }}
+      onExtraTabClose={(id) => {
+        const { closedWasActive, nextActiveId } = closeChat(id);
+        if (closedWasActive && !nextActiveId) {
+          setActiveView('docs');
+        }
+      }}
+      onExtraTabAdd={() => {
+        newChat();
+        setActiveView('research');
+      }}
+      onFileTabSelect={() => setActiveView('docs')}
+    />
   );
 }

--- a/apps/qwksearch-web/components/layout/useChatTabs.ts
+++ b/apps/qwksearch-web/components/layout/useChatTabs.ts
@@ -1,0 +1,116 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useChat } from 'research-agent-ui';
+
+export interface ChatTab {
+  id: string;
+  title: string;
+  /** Whether this chat has ever had a message sent. Empty/untouched "New
+   * Chat" tabs must be re-armed via `startNewChat` rather than
+   * `switchToChat` — the latter fetches the chat and would incorrectly
+   * report it "not found" since nothing was ever persisted for it. */
+  hasMessages?: boolean;
+}
+
+const STORAGE_KEY = 'qwksearch-open-chat-tabs';
+const MAX_TITLE_LENGTH = 50;
+
+function readStoredTabs(): ChatTab[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Tracks which chat conversations are "open" (shown as tabs in the
+ * workspace's Open Tabs sidebar panel) alongside REASON's document tabs.
+ * The active chat itself is owned by `ChatProvider`/`useChat()` — this hook
+ * only tracks the open-tab list and titles, and exposes helpers for
+ * switching, closing, and creating chat tabs without navigating away from
+ * the workspace route.
+ */
+export function useChatTabs() {
+  const { chatId, chatTurns, startNewChat, switchToChat } = useChat();
+  const [chatTabs, setChatTabs] = useState<ChatTab[]>(readStoredTabs);
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(chatTabs));
+  }, [chatTabs]);
+
+  // Keep the active chat represented as a tab, and keep its title/hasMessages
+  // in sync as the conversation gains its first message.
+  useEffect(() => {
+    if (!chatId) return;
+    const liveTitle = chatTurns[0]?.content?.slice(0, MAX_TITLE_LENGTH);
+    const hasMessages = chatTurns.length > 0;
+    setChatTabs((prev) => {
+      const existing = prev.find((t) => t.id === chatId);
+      if (!existing) {
+        return [...prev, { id: chatId, title: liveTitle || 'New Chat', hasMessages }];
+      }
+      if ((liveTitle && existing.title !== liveTitle) || existing.hasMessages !== hasMessages) {
+        return prev.map((t) => (
+          t.id === chatId ? { ...t, title: liveTitle || t.title, hasMessages } : t
+        ));
+      }
+      return prev;
+    });
+  }, [chatId, chatTurns]);
+
+  // Untouched "New Chat" tabs must be re-armed via `startNewChat` rather
+  // than fetched via `switchToChat`, which would otherwise report a
+  // real-but-empty chat as "not found".
+  const activateChat = useCallback((id: string, tabs: ChatTab[]) => {
+    const tab = tabs.find((t) => t.id === id);
+    if (tab && !tab.hasMessages) {
+      startNewChat(id);
+    } else {
+      switchToChat(id);
+    }
+  }, [startNewChat, switchToChat]);
+
+  const openChat = useCallback((id: string) => {
+    activateChat(id, chatTabs);
+  }, [activateChat, chatTabs]);
+
+  const newChat = useCallback(() => {
+    const id = crypto.randomUUID();
+    setChatTabs((prev) => [...prev, { id, title: 'New Chat' }]);
+    startNewChat(id);
+    return id;
+  }, [startNewChat]);
+
+  /**
+   * Closes a chat tab. If the closed tab was the active chat, switches to
+   * its nearest remaining neighbor and reports that in `nextActiveId`; if
+   * it was active and no chat tabs remain, `closedWasActive` is `true` and
+   * `nextActiveId` is `null` — the caller should fall back to a different
+   * view in that case. Closing an inactive tab never changes the active chat.
+   */
+  const closeChat = useCallback((id: string) => {
+    const index = chatTabs.findIndex((t) => t.id === id);
+    const remaining = chatTabs.filter((t) => t.id !== id);
+    setChatTabs(remaining);
+
+    const closedWasActive = id === chatId;
+    if (!closedWasActive) return { closedWasActive, nextActiveId: null };
+    if (remaining.length === 0) return { closedWasActive, nextActiveId: null };
+
+    const nextActiveId = remaining[Math.max(0, index - 1)]?.id ?? remaining[0].id;
+    activateChat(nextActiveId, remaining);
+    return { closedWasActive, nextActiveId };
+  }, [chatTabs, chatId, activateChat]);
+
+  return {
+    chatTabs,
+    activeChatId: chatId ?? null,
+    openChat,
+    newChat,
+    closeChat,
+  };
+}

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -11,15 +11,34 @@ import { ReasonDocsDialogs } from './ReasonDocsDialogs';
 import { useReasonDocsState } from './useReasonDocsState';
 import { DynamicIslandTOC } from '../search/DynamicIslandTOC';
 import { useTheme } from 'next-themes';
-import { useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../utils/storage';
+import type { OpenTabItem } from '../layout/sidebar/types';
 import '../app-styles/split-pane.css';
 
+/** A non-document tab (e.g. a chat conversation) supplied by the host app. */
+export interface ReasonDocsExtraTab {
+  id: string;
+  title: string;
+  kind: 'chat';
+}
 
 interface ReasonDocsProps {
   mainContent?: ReactNode;
+  /** Extra (non-document) tabs to interleave into the "Open Tabs" panel, e.g. open chat conversations. */
+  extraTabs?: ReasonDocsExtraTab[];
+  /** ID of the currently active extra tab, if any. When set, this tab is highlighted instead of the active document. */
+  activeExtraTabId?: string | null;
+  /** Called when an extra tab is clicked/activated. */
+  onExtraTabSelect?: (id: string) => void;
+  /** Called when an extra tab's close button is clicked. */
+  onExtraTabClose?: (id: string) => void;
+  /** Called from the "Open Tabs" panel header to create a new extra tab (e.g. "New Chat"). Omit to hide the control. */
+  onExtraTabAdd?: () => void;
+  /** Called whenever a document tab is selected, so the host app can switch away from an extra tab's view. */
+  onFileTabSelect?: () => void;
 }
 
 /**
@@ -27,7 +46,15 @@ interface ReasonDocsProps {
  * Uses `useReasonDocsState` for shared state and `next-themes` for theme control.
  * Renders a resizable panel layout on desktop and a stacked layout on mobile.
  */
-const Index = ({ mainContent }: ReasonDocsProps) => {
+const Index = ({
+  mainContent,
+  extraTabs,
+  activeExtraTabId,
+  onExtraTabSelect,
+  onExtraTabClose,
+  onExtraTabAdd,
+  onFileTabSelect,
+}: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState();
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
@@ -43,12 +70,61 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
     setTheme(theme === 'dark' ? 'light' : 'dark');
   };
 
+  // Merge document tabs with host-supplied extra tabs (e.g. open chats) into
+  // a single ordered list for the "Open Tabs" panel.
+  const tabItems: OpenTabItem[] = useMemo(() => {
+    const fileItems: OpenTabItem[] = state.openTabs.map((id) => ({
+      id,
+      title: state.documents.find((d) => d.id === id)?.title || 'Untitled',
+      kind: 'file' as const,
+    }));
+    const chatItems: OpenTabItem[] = (extraTabs ?? []).map((t) => ({
+      id: t.id,
+      title: t.title,
+      kind: t.kind,
+    }));
+    return [...fileItems, ...chatItems];
+  }, [state.openTabs, state.documents, extraTabs]);
+
+  const activeTabId = activeExtraTabId ?? state.activeDocId;
+
+  const handleTabChange = (id: string) => {
+    if (extraTabs?.some((t) => t.id === id)) {
+      onExtraTabSelect?.(id);
+    } else {
+      state.handleTabChange(id);
+      onFileTabSelect?.();
+    }
+  };
+
+  const handleTabClose = (id: string) => {
+    if (extraTabs?.some((t) => t.id === id)) {
+      onExtraTabClose?.(id);
+    } else {
+      state.handleTabClose(id);
+    }
+  };
+
+  // Creating a note (not a folder) opens it as the active document, so
+  // switch away from whatever extra tab (e.g. a chat) was showing.
+  const handleAdd = (parentId: string | null, isFolder?: boolean) => {
+    state.handleAddDocument(parentId, isFolder);
+    if (!isFolder) onFileTabSelect?.();
+  };
+
+  // Selecting a document (e.g. from the file tree) should also switch away
+  // from an active chat/extra tab, since it opens as the active document.
+  const handleSelect = (id: string) => {
+    state.handleSelectDocument(id);
+    onFileTabSelect?.();
+  };
+
   const sidebarProps = {
     documents: state.documents,
     activeId: state.activeDocId,
     activeDocument: state.activeDocument,
-    onSelect: state.handleSelectDocument,
-    onAdd: state.handleAddDocument,
+    onSelect: handleSelect,
+    onAdd: handleAdd,
     onDelete: state.handleDeleteDocument,
     onDuplicate: state.handleDuplicateDocument,
     onToggleExpand: state.handleToggleExpand,
@@ -81,13 +157,15 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
     onFileSourceChange: state.handleFileSourceChange,
     onNavigate: (key: string) => state.editorRef.current?.scrollToHeading(key),
     openTabs: state.openTabs,
-    activeTab: state.activeDocId,
-    onTabChange: state.handleTabChange,
-    onTabClose: state.handleTabClose,
+    activeTab: activeTabId,
+    onTabChange: handleTabChange,
+    onTabClose: handleTabClose,
     onTabRename: (id: string, title: string) => state.handleUpdateDocument(id, { title }),
     onSplitRight: state.handleSplitRight,
     onReopenLastClosed: state.handleReopenLastClosed,
     canReopenLastClosed: state.closedTabsHistory.length > 0,
+    tabItems,
+    onNewChat: onExtraTabAdd,
     aiProps: {
       isAiLoading: state.isAiLoading,
       aiSuggestion: state.aiSuggestion,
@@ -125,8 +203,8 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
       documents={state.documents}
       activeId={state.activeDocId}
       activeDocument={state.activeDocument}
-      onSelect={state.handleSelectDocument}
-      onAdd={state.handleAddDocument}
+      onSelect={handleSelect}
+      onAdd={handleAdd}
       onDelete={state.handleDeleteDocument}
       onDuplicate={state.handleDuplicateDocument}
       onMove={state.handleMoveDocument}
@@ -135,13 +213,15 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
       headings={state.headings}
       onNavigate={(key) => state.editorRef.current?.scrollToHeading(key)}
       openTabs={state.openTabs}
-      activeTab={state.activeDocId}
-      onTabChange={state.handleTabChange}
-      onTabClose={state.handleTabClose}
+      activeTab={activeTabId}
+      onTabChange={handleTabChange}
+      onTabClose={handleTabClose}
       onTabRename={(id: string, title: string) => state.handleUpdateDocument(id, { title })}
       onSplitRight={state.handleSplitRight}
       onReopenLastClosed={state.handleReopenLastClosed}
       canReopenLastClosed={state.closedTabsHistory.length > 0}
+      tabItems={tabItems}
+      onNewChat={onExtraTabAdd}
       aiProps={{
         isAiLoading: state.isAiLoading,
         aiSuggestion: state.aiSuggestion,
@@ -214,7 +294,7 @@ const Index = ({ mainContent }: ReasonDocsProps) => {
         enableDatabaseSync={state.enableDatabaseSync}
         setEnableDatabaseSync={state.setEnableDatabaseSync}
         setDocuments={state.setDocuments}
-        onSelectDocument={state.handleSelectDocument}
+        onSelectDocument={handleSelect}
         onToggleTheme={handleToggleTheme}
         currentTheme={theme}
         onUpdateTags={state.handleUpdateTags}

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -11,7 +11,7 @@ import { RefObject, useState } from 'react';
 import { Resizable } from 're-resizable';
 import { SidebarContent } from '../layout/sidebar/SidebarContent';
 import { PANEL_OPTIONS } from '../layout/sidebar/panelOptions';
-import type { SidebarPanelType, SidebarAiProps } from '../layout/sidebar/types';
+import type { SidebarPanelType, SidebarAiProps, OpenTabItem } from '../layout/sidebar/types';
 import type { OutlineViewHandle } from '../search/OutlineView';
 import type { TocEntry } from '../app-types/toc';
 import type { Document } from '../documents/DocumentTree';
@@ -48,6 +48,10 @@ interface RightPanelProps {
   aiProps: SidebarAiProps;
   /** Closes the panel by clearing the right sidebar's panel list. */
   onClose: () => void;
+  /** Unified tab list (files + chats). Overrides file-only tab derivation when set. */
+  tabItems?: OpenTabItem[];
+  /** Opens a new chat tab from the "Open Tabs" panel header. */
+  onNewChat?: () => void;
 }
 
 const RESIZE_HANDLES = {
@@ -96,6 +100,8 @@ export function RightPanel({
   outlineRef,
   aiProps,
   onClose,
+  tabItems,
+  onNewChat,
 }: RightPanelProps) {
   const [width, setWidth] = useState(320);
 
@@ -149,6 +155,8 @@ export function RightPanel({
             canReopenLastClosed={canReopenLastClosed}
             onNavigate={onNavigate}
             aiProps={aiProps}
+            tabItems={tabItems}
+            onNewChat={onNewChat}
           />
         </div>
       </div>

--- a/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
+++ b/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
@@ -55,6 +55,8 @@ export const Sidebar = ({
   onReopenLastClosed,
   canReopenLastClosed = false,
   aiProps,
+  tabItems,
+  onNewChat,
 }: SidebarProps) => {
   const deletedDocs = documents.filter(doc => doc.isDeleted);
 
@@ -168,6 +170,7 @@ export const Sidebar = ({
     onTabChange,
     onTabClose,
     documents,
+    tabItems,
   };
 
   const contentProps = {
@@ -199,6 +202,8 @@ export const Sidebar = ({
     canReopenLastClosed,
     onNavigate,
     aiProps,
+    tabItems,
+    onNewChat,
   };
 
   // Mobile: render in a drawer

--- a/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -12,12 +12,12 @@ import { OutlineView, type OutlineViewHandle } from '../../search/OutlineView';
 import { AIRewriteSuggestion } from '../../features/ai-rewrite/AIRewriteSuggestion';
 import { Input } from '../../app-ui/input';
 import { Document } from '../../documents/DocumentTree';
-import type { SidebarPanelType, SidebarAiProps } from './types';
+import type { SidebarPanelType, SidebarAiProps, OpenTabItem } from './types';
 import type { TocEntry } from '../../app-types/toc';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../../utils/storage';
-import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search } from 'lucide-react';
+import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus } from 'lucide-react';
 import { FileTypeIcon } from '../../app-ui/FileTypeIcon';
 import { cn } from '../../app-utils/utils';
 import {
@@ -36,7 +36,7 @@ const PANEL_TITLES: Record<SidebarPanelType, string> = {
   ai: 'AI Suggestions',
   files: 'Files',
   outline: 'Outline',
-  openTabs: 'Open Files',
+  openTabs: 'Open Tabs',
 };
 
 /** Props for the {@link SidebarContent} component. */
@@ -97,6 +97,10 @@ interface SidebarContentProps {
   onNavigate?: (key: string) => void;
   /** AI suggestion state/handlers (used by the "ai" panel). */
   aiProps?: SidebarAiProps;
+  /** Unified tab list (files + chats). Overrides file-only tab derivation when set. */
+  tabItems?: OpenTabItem[];
+  /** Opens a new chat tab from the "Open Tabs" panel header. */
+  onNewChat?: () => void;
 }
 
 /**
@@ -132,6 +136,8 @@ export const SidebarContent = ({
   canReopenLastClosed = false,
   onNavigate,
   aiProps,
+  tabItems,
+  onNewChat,
 }: SidebarContentProps) => {
   // Track copied document for copy/paste operations
   const [copiedDocId, setCopiedDocId] = useState<string | null>(null);
@@ -200,17 +206,44 @@ export const SidebarContent = ({
     storage: ssrSafeLocalStorage,
   });
 
+  // Fall back to file-only tabs derived from `openTabs`/`activeDocuments`
+  // when the host app hasn't supplied a unified `tabItems` list.
+  const resolvedTabItems: OpenTabItem[] = tabItems ?? openTabs.map((tabId) => ({
+    id: tabId,
+    title: activeDocuments.find(d => d.id === tabId)?.title || 'Untitled',
+    kind: 'file' as const,
+  }));
+
   const renderOpenTabs = () => (
     <div className="h-full overflow-auto">
       <div className="px-1 py-1">
-        <p className="px-2 py-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">Open Files</p>
-        {openTabs.length === 0 ? (
-          <div className="px-2 py-3 text-xs text-muted-foreground">No open files</div>
+        <div className="flex items-center justify-between px-2 py-1">
+          <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Open Tabs</p>
+          <div className="flex items-center gap-0.5">
+            <button
+              className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+              title="New File"
+              onClick={() => onAdd(null, false)}
+            >
+              <FilePlus2 className="h-3.5 w-3.5" />
+            </button>
+            {onNewChat && (
+              <button
+                className="h-5 w-5 flex items-center justify-center rounded text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
+                title="New Chat"
+                onClick={onNewChat}
+              >
+                <MessageSquarePlus className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+        </div>
+        {resolvedTabItems.length === 0 ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">No open tabs</div>
         ) : (
-          openTabs.map((tabId) => {
-            const doc = activeDocuments.find(d => d.id === tabId);
-            const title = doc?.title || 'Untitled';
+          resolvedTabItems.map(({ id: tabId, title, kind }) => {
             const isActive = tabId === activeTab;
+            const isChat = kind === 'chat';
             return (
               <ContextMenu key={tabId}>
                 <ContextMenuTrigger>
@@ -221,7 +254,11 @@ export const SidebarContent = ({
                     )}
                     onClick={() => onTabChange?.(tabId)}
                   >
-                    <FileTypeIcon filename={title} size={16} />
+                    {isChat ? (
+                      <MessageSquare className="shrink-0 h-4 w-4 text-blue-500" />
+                    ) : (
+                      <FileTypeIcon filename={title} size={16} />
+                    )}
                     <span className="flex-1 truncate text-sm">{title}</span>
                     {onTabClose && (
                       <button
@@ -237,7 +274,7 @@ export const SidebarContent = ({
                   </div>
                 </ContextMenuTrigger>
                 <ContextMenuContent>
-                  {onTabRename && (
+                  {onTabRename && !isChat && (
                     <ContextMenuItem onClick={() => {
                       const newTitle = window.prompt('Rename document', title);
                       if (newTitle?.trim()) onTabRename(tabId, newTitle.trim());
@@ -255,14 +292,14 @@ export const SidebarContent = ({
                       Close
                     </ContextMenuItem>
                   )}
-                  <ContextMenuSeparator />
-                  {onSplitRight && (
+                  {!isChat && (onSplitRight || onReopenLastClosed) && <ContextMenuSeparator />}
+                  {onSplitRight && !isChat && (
                     <ContextMenuItem onClick={() => onSplitRight(tabId)}>
                       <SplitSquareVertical className="mr-2 h-4 w-4" />
                       Split Right
                     </ContextMenuItem>
                   )}
-                  {onReopenLastClosed && (
+                  {onReopenLastClosed && !isChat && (
                     <ContextMenuItem
                       onClick={onReopenLastClosed}
                       disabled={!canReopenLastClosed}

--- a/packages/reason-editor/src/layout/sidebar/SidebarToolbar.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarToolbar.tsx
@@ -8,15 +8,16 @@ import { RefObject } from 'react';
 import { Button } from '../../app-ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../../app-ui/tooltip';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger, DropdownMenuSeparator } from '../../app-ui/dropdown-menu';
-import { Search, FilePlus, FolderPlus, ChevronsDownUp, ChevronsUpDown, Check, Folders, Trash2, RotateCcw, MoreHorizontal, X } from 'lucide-react';
+import { Search, FilePlus, FolderPlus, ChevronsDownUp, ChevronsUpDown, Check, Folders, Trash2, RotateCcw, MoreHorizontal, X, MessageSquare } from 'lucide-react';
 import { AnyFileSource } from '../../app-types/fileSource';
 import { getSourceIcon, getSourceTypeLabel } from './fileSourceUtils';
 import type { DocumentTreeHandle } from '../../file-tree/filetree';
 import type { OutlineViewHandle } from '../../search/OutlineView';
-import type { SidebarPanelType } from './types';
+import type { SidebarPanelType, OpenTabItem } from './types';
 import { SidebarViewMenu } from './SidebarViewMenu';
 import { cn } from '../../app-utils/utils';
 import { Document } from '../../documents/DocumentTree';
+import { FileTypeIcon } from '../../app-ui/FileTypeIcon';
 
 /** Props for the {@link SidebarToolbar} component. */
 interface SidebarToolbarProps {
@@ -88,6 +89,8 @@ interface SidebarToolbarProps {
   onTabClose?: (id: string) => void;
   /** All documents (used for tab title lookup). */
   documents?: Document[];
+  /** Unified tab list (files + chats). Overrides file-only tab derivation when set. */
+  tabItems?: OpenTabItem[];
 }
 
 /**
@@ -131,8 +134,14 @@ export const SidebarToolbar = ({
   onTabChange,
   onTabClose,
   documents = [],
+  tabItems,
 }: SidebarToolbarProps) => {
   const getDocTitle = (id: string) => documents.find(d => d.id === id)?.title || 'Untitled';
+  const resolvedTabItems: OpenTabItem[] = tabItems ?? openTabs.map((tabId) => ({
+    id: tabId,
+    title: getDocTitle(tabId),
+    kind: 'file' as const,
+  }));
   return (
     <div className="flex flex-wrap items-center gap-0.5 px-2 py-1.5 border-b border-sidebar-border">
         <TooltipProvider delayDuration={300}>
@@ -328,7 +337,7 @@ export const SidebarToolbar = ({
               </DropdownMenu>
 
               {/* All Tabs Dropdown */}
-              {openTabs.length > 0 && onTabChange && (
+              {resolvedTabItems.length > 0 && onTabChange && (
                 <DropdownMenu>
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -347,7 +356,7 @@ export const SidebarToolbar = ({
                     </TooltipContent>
                   </Tooltip>
                   <DropdownMenuContent align="end" className="w-56 max-h-80 overflow-y-auto">
-                    {openTabs.map((tabId) => (
+                    {resolvedTabItems.map(({ id: tabId, title, kind }) => (
                       <DropdownMenuItem
                         key={tabId}
                         className={cn(
@@ -356,7 +365,14 @@ export const SidebarToolbar = ({
                         )}
                         onSelect={() => onTabChange(tabId)}
                       >
-                        <span className="truncate flex-1 text-sm">{getDocTitle(tabId)}</span>
+                        <span className="flex items-center gap-2 flex-1 min-w-0">
+                          {kind === 'chat' ? (
+                            <MessageSquare className="shrink-0 h-3.5 w-3.5 text-blue-500" />
+                          ) : (
+                            <FileTypeIcon filename={title} size={14} />
+                          )}
+                          <span className="truncate text-sm">{title}</span>
+                        </span>
                         {onTabClose && (
                           <button
                             className="shrink-0 h-5 w-5 flex items-center justify-center rounded hover:bg-destructive/10 hover:text-destructive"

--- a/packages/reason-editor/src/layout/sidebar/types.ts
+++ b/packages/reason-editor/src/layout/sidebar/types.ts
@@ -10,6 +10,20 @@ import type { TocEntry } from "../../app-types/toc";
 /** A single togglable panel kind that can appear in the left or right sidebar. */
 export type SidebarPanelType = "ai" | "files" | "outline" | "openTabs";
 
+/** The kind of resource a tab in the "Open Tabs" panel represents. */
+export type OpenTabKind = "file" | "chat";
+
+/**
+ * A single entry in the unified "Open Tabs" list. When provided, this
+ * overrides the legacy document-only tab rendering so tabs for other
+ * resource kinds (e.g. chat conversations) can be interleaved with files.
+ */
+export interface OpenTabItem {
+  id: string;
+  title: string;
+  kind: OpenTabKind;
+}
+
 /** Shared AI-suggestion props needed to render an "ai" panel. */
 export interface SidebarAiProps {
   isAiLoading?: boolean;
@@ -87,6 +101,13 @@ export interface SidebarProps {
   onSplitRight?: (id: string) => void;
   onReopenLastClosed?: () => void;
   canReopenLastClosed?: boolean;
+  // Unified tab list (files + chats, etc.) for the "Open Tabs" panel. When
+  // omitted, the panel falls back to deriving file-only tabs from
+  // `openTabs`/`documents`.
+  tabItems?: OpenTabItem[];
+  // Opens a new chat tab from the "Open Tabs" panel. Omitted when the host
+  // app has no chat feature to offer.
+  onNewChat?: () => void;
   // AI panel data (used by the "ai" panel)
   aiProps?: SidebarAiProps;
 }

--- a/packages/research-agent-ui/src/hooks/useChat/ChatContext.tsx
+++ b/packages/research-agent-ui/src/hooks/useChat/ChatContext.tsx
@@ -130,6 +130,22 @@ export interface ChatContextValue {
   newChat: () => void;
 
   /**
+   * Starts a brand-new chat session with a caller-supplied ID, without
+   * navigating away from the current route. Unlike `newChat`, this does not
+   * push to `/` — useful for hosts that render `ChatWindow` inline (e.g. as
+   * a tab) and want to control the new chat's ID up front.
+   * @param id - The ID to assign to the new chat session.
+   */
+  startNewChat: (id: string) => void;
+
+  /**
+   * Switches the active chat to an existing chat ID and loads its messages,
+   * without navigating away from the current route.
+   * @param id - The ID of the existing chat session to switch to.
+   */
+  switchToChat: (id: string) => void;
+
+  /**
    * Whether incognito mode is active.
    * When true, messages are not saved to history or cloud.
    */
@@ -184,6 +200,8 @@ export const chatContext = createContext<ChatContextValue>({
   setChatModelProvider: () => { },
   stopStreaming: () => { },
   newChat: () => { },
+  startNewChat: () => { },
+  switchToChat: () => { },
   incognito: false,
   setIncognito: () => { },
 });

--- a/packages/research-agent-ui/src/hooks/useChat/ChatProvider.tsx
+++ b/packages/research-agent-ui/src/hooks/useChat/ChatProvider.tsx
@@ -404,6 +404,41 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     router.push('/');
   }, [handleStopStreaming, router]);
 
+  /**
+   * Starts a brand-new chat session with a caller-supplied ID, without
+   * navigating away from the current route (`newChat` pushes to `/`).
+   * Skips the message-loading fetch entirely since the ID is known to be
+   * unused, avoiding a spurious "not found" round-trip.
+   */
+  const handleStartNewChat = useCallback((id: string) => {
+    handleStopStreaming();
+    setters.setMessages([]);
+    setters.setChatHistory([]);
+    setters.setFiles([]);
+    setters.setFileIds([]);
+    setters.setNotFound(false);
+    setters.setNewChatCreated(true);
+    setters.setIsMessagesLoaded(true);
+    setters.setChatId(id);
+  }, [handleStopStreaming]);
+
+  /**
+   * Switches the active chat to an existing chat ID and loads its messages,
+   * without navigating away from the current route.
+   */
+  const handleSwitchToChat = useCallback((id: string) => {
+    if (id === state.chatId) return;
+    handleStopStreaming();
+    setters.setMessages([]);
+    setters.setChatHistory([]);
+    setters.setFiles([]);
+    setters.setFileIds([]);
+    setters.setIsMessagesLoaded(false);
+    setters.setNotFound(false);
+    setters.setNewChatCreated(false);
+    setters.setChatId(id);
+  }, [handleStopStreaming, state.chatId]);
+
   // ============ Context Value ============
 
   /** The complete context value provided to consumers */
@@ -439,6 +474,8 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
     setChatModelProvider: setters.setChatModelProvider,
     stopStreaming: handleStopStreaming,
     newChat: handleNewChat,
+    startNewChat: handleStartNewChat,
+    switchToChat: handleSwitchToChat,
     setIncognito,
   };
 


### PR DESCRIPTION
## Summary
This PR adds support for managing multiple chat conversations as tabs alongside document tabs in the workspace. Chat tabs are now integrated into the "Open Tabs" panel, allowing users to switch between open chats and documents seamlessly without navigating away from the workspace.

## Key Changes

### New Chat Tab Management (`useChatTabs` hook)
- Created `useChatTabs.ts` hook to manage open chat conversations as persistent tabs
- Tracks chat tab state (id, title, hasMessages) with localStorage persistence
- Provides methods to open, create, and close chat tabs
- Distinguishes between "touched" chats (with messages) and untouched "New Chat" tabs to avoid spurious "not found" errors when switching

### Chat Context Enhancements
- Added `startNewChat(id)` method to create a new chat with a caller-supplied ID without navigating
- Added `switchToChat(id)` method to switch to an existing chat without navigating
- These complement the existing `newChat()` which navigates to the home route

### Unified Open Tabs Panel
- Introduced `OpenTabItem` and `OpenTabKind` types to represent both file and chat tabs uniformly
- Modified `ReasonDocs` to accept `extraTabs`, `activeExtraTabId`, and callbacks for managing non-document tabs
- Updated `SidebarContent` to render a unified tab list merging files and chats
- Added "New Chat" button to the Open Tabs panel header (when `onNewChat` is provided)
- Chat tabs display with a message icon and cannot be renamed or split

### Workspace Integration
- Updated `MainWorkspaceView` to use `useChatTabs` and pass chat tabs to `ReasonDocs`
- Switching to a chat tab activates the research view; switching to a file tab activates the docs view
- Creating a new document or selecting a file automatically switches away from any active chat tab

### UI/UX Improvements
- Renamed "Open Files" panel to "Open Tabs" to reflect the unified content
- Added "New File" button to the Open Tabs panel header
- Chat tabs show a blue message icon instead of file type icons
- Context menu for chat tabs omits file-specific options (rename, split, reopen)

## Implementation Details
- Chat tab titles are derived from the first message content (truncated to 50 chars)
- Empty "New Chat" tabs use `startNewChat()` instead of `switchToChat()` to avoid fetch errors
- Tab state is persisted to localStorage and restored on page reload
- The unified tab list gracefully falls back to file-only tabs when `tabItems` is not provided, maintaining backward compatibility

https://claude.ai/code/session_01KuyjJjkMaLT9grZc7RbTwB