### PR TITLE
Add trending news widget powered by Wikipedia and The News API

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",
@@ -106,6 +106,7 @@
     "react-reason-editor": "workspace:*",
     "react-textarea-autosize": "^8.5.9",
     "remark-gfm": "^4.0.1",
+    "trending-news-api": "workspace:*",
     "use-weather-forecast": "workspace:*",
     "research-agent-ui": "workspace:*",
     "scroll-into-view-if-needed": "^3.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -170,6 +170,7 @@
         "tailwind-merge": "^3.6.0",
         "tailwindcss-animate": "^1.0.7",
         "tldts": "^7.4.2",
+        "trending-news-api": "workspace:*",
         "use-sync-external-store": "^1.6.0",
         "use-weather-forecast": "workspace:*",
         "write-language": "workspace:*",
@@ -624,6 +625,7 @@
         "sonner": "^2.0.7",
         "streamdown": "^2.5.0",
         "tailwind-merge": "^3.6.0",
+        "trending-news-api": "workspace:*",
         "turndown": "^7.2.4",
         "use-weather-forecast": "workspace:*",
       },
@@ -735,6 +737,22 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18",
+      },
+    },
+    "packages/trending-news-api": {
+      "name": "trending-news-api",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250115.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "tsup": "^8.2.4",
+        "typescript": "^5.6.3",
+        "wrangler": "^3.88.0",
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19",
       },
     },
     "packages/use-voice-control": {
@@ -4953,6 +4971,8 @@
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
+    "trending-news-api": ["trending-news-api@workspace:packages/trending-news-api"],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
@@ -6037,6 +6057,8 @@
 
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
+    "trending-news-api/wrangler": ["wrangler@3.114.17", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250718.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250718.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA=="],
+
     "tsconfig-paths/strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "tsup/cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
@@ -6801,6 +6823,20 @@
 
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
+    "trending-news-api/wrangler/@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.3.4", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q=="],
+
+    "trending-news-api/wrangler/@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.0.2", "", { "peerDependencies": { "unenv": "2.0.0-rc.14", "workerd": "^1.20250124.0" }, "optionalPeers": ["workerd"] }, "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg=="],
+
+    "trending-news-api/wrangler/esbuild": ["esbuild@0.17.19", "", { "optionalDependencies": { "@esbuild/android-arm": "0.17.19", "@esbuild/android-arm64": "0.17.19", "@esbuild/android-x64": "0.17.19", "@esbuild/darwin-arm64": "0.17.19", "@esbuild/darwin-x64": "0.17.19", "@esbuild/freebsd-arm64": "0.17.19", "@esbuild/freebsd-x64": "0.17.19", "@esbuild/linux-arm": "0.17.19", "@esbuild/linux-arm64": "0.17.19", "@esbuild/linux-ia32": "0.17.19", "@esbuild/linux-loong64": "0.17.19", "@esbuild/linux-mips64el": "0.17.19", "@esbuild/linux-ppc64": "0.17.19", "@esbuild/linux-riscv64": "0.17.19", "@esbuild/linux-s390x": "0.17.19", "@esbuild/linux-x64": "0.17.19", "@esbuild/netbsd-x64": "0.17.19", "@esbuild/openbsd-x64": "0.17.19", "@esbuild/sunos-x64": "0.17.19", "@esbuild/win32-arm64": "0.17.19", "@esbuild/win32-ia32": "0.17.19", "@esbuild/win32-x64": "0.17.19" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw=="],
+
+    "trending-news-api/wrangler/miniflare": ["miniflare@3.20250718.3", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250718.0", "ws": "8.18.0", "youch": "3.3.4", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ=="],
+
+    "trending-news-api/wrangler/sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
+
+    "trending-news-api/wrangler/unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
+
+    "trending-news-api/wrangler/workerd": ["workerd@1.20250718.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250718.0", "@cloudflare/workerd-darwin-arm64": "1.20250718.0", "@cloudflare/workerd-linux-64": "1.20250718.0", "@cloudflare/workerd-linux-arm64": "1.20250718.0", "@cloudflare/workerd-windows-64": "1.20250718.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg=="],
+
     "tsup/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
     "tsup/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
@@ -7235,6 +7271,112 @@
 
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "trending-news-api/wrangler/@cloudflare/kv-asset-handler/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.17.19", "", { "os": "android", "cpu": "arm64" }, "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.17.19", "", { "os": "android", "cpu": "x64" }, "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.17.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.17.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.17.19", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.17.19", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.17.19", "", { "os": "linux", "cpu": "arm" }, "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.17.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.17.19", "", { "os": "linux", "cpu": "ia32" }, "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.17.19", "", { "os": "linux", "cpu": "ppc64" }, "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.17.19", "", { "os": "linux", "cpu": "s390x" }, "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.17.19", "", { "os": "linux", "cpu": "x64" }, "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.17.19", "", { "os": "none", "cpu": "x64" }, "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.17.19", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.17.19", "", { "os": "sunos", "cpu": "x64" }, "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.17.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.17.19", "", { "os": "win32", "cpu": "ia32" }, "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw=="],
+
+    "trending-news-api/wrangler/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.17.19", "", { "os": "win32", "cpu": "x64" }, "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA=="],
+
+    "trending-news-api/wrangler/miniflare/acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "trending-news-api/wrangler/miniflare/exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "trending-news-api/wrangler/miniflare/undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+
+    "trending-news-api/wrangler/miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "trending-news-api/wrangler/miniflare/youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
+
+    "trending-news-api/wrangler/miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "trending-news-api/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250718.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g=="],
+
+    "trending-news-api/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250718.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q=="],
+
+    "trending-news-api/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250718.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg=="],
+
+    "trending-news-api/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250718.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog=="],
+
+    "trending-news-api/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250718.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg=="],
+
     "typedoc/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "use-voice-control/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
@@ -7506,6 +7648,8 @@
     "qwksearch-web/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
     "research-agent-ui/wrangler/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "trending-news-api/wrangler/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
     "use-weather-forecast/wrangler/sharp/@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 

--- a/packages/research-agent-ui/package.json
+++ b/packages/research-agent-ui/package.json
@@ -100,6 +100,7 @@
     "react-icons": "^5.6.0",
     "react-native-app-buttons": "^0.1.4",
     "react-textarea-autosize": "^8.5.9",
+    "trending-news-api": "workspace:*",
     "use-weather-forecast": "workspace:*",
     "search-web-api": "workspace:*",
     "sonner": "^2.0.7",

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -9,6 +9,7 @@ import RecentHistoryChips from './RecentHistoryChips';
 import Footer from '../Footer';
 import DownloadsDialog from './DownloadsDialog';
 import { WeatherForecast, type WeatherLocationInput } from 'use-weather-forecast';
+import { TrendingNews } from 'trending-news-api';
 import { useChat } from '../../hooks/useChat';
 import { getBackgroundArtwork } from './background-art';
 import { researchAgentUIConfig } from '../../config';
@@ -60,12 +61,15 @@ export default function ChatHomepage() {
   const [fading, setFading] = useState(false);
   const [downloadsOpen, setDownloadsOpen] = useState(false);
   const [weatherLocations, setWeatherLocations] = useState<WeatherLocationInput[]>([]);
+  const [trendingNewsApiUrl, setTrendingNewsApiUrl] = useState<string | null>(null);
   const footerLinks = researchAgentUIConfig.footerLinks.map((link) =>
     link.url === '/#downloads' ? { ...link, onClick: () => setDownloadsOpen(true) } : link,
   );
   useEffect(() => {
-    const readLocations = () =>
+    const readLocations = () => {
       setWeatherLocations(parseWeatherLocations(localStorage.getItem('weatherLocations')));
+      setTrendingNewsApiUrl(localStorage.getItem('trendingNewsApiUrl'));
+    };
     readLocations();
     window.addEventListener('client-config-changed', readLocations);
     window.addEventListener('storage', readLocations);
@@ -142,20 +146,35 @@ export default function ChatHomepage() {
 
           <div className="w-full max-w-2xl mt-8 space-y-2">
             <RecentHistoryChips />
-            <WeatherForecast
-              compact
-              forecastDays={5}
-              forecastHours={12}
-              locations={weatherLocations.length > 0 ? weatherLocations : undefined}
-              className="rounded-2xl"
-              style={{
-                background: 'rgba(255,255,255,0.08)',
-                border: '1px solid rgba(255,255,255,0.15)',
-                color: 'inherit',
-                backdropFilter: 'blur(8px)',
-                maxWidth: '100%',
-              }}
-            />
+            <div className="flex flex-col md:flex-row gap-2 w-full">
+              <WeatherForecast
+                compact
+                forecastDays={5}
+                forecastHours={12}
+                locations={weatherLocations.length > 0 ? weatherLocations : undefined}
+                className="rounded-2xl md:flex-1"
+                style={{
+                  background: 'rgba(255,255,255,0.08)',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  color: 'inherit',
+                  backdropFilter: 'blur(8px)',
+                  maxWidth: '100%',
+                }}
+              />
+              <TrendingNews
+                compact
+                maxTopics={6}
+                apiEndpoint={trendingNewsApiUrl || undefined}
+                className="rounded-2xl md:flex-1"
+                style={{
+                  background: 'rgba(255,255,255,0.08)',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  color: 'inherit',
+                  backdropFilter: 'blur(8px)',
+                  maxWidth: '100%',
+                }}
+              />
+            </div>
             <ChatInputBox />
           </div>
         </div>

--- a/packages/research-agent-ui/src/settings/search.json
+++ b/packages/research-agent-ui/src/settings/search.json
@@ -129,5 +129,15 @@
     "placeholder": "Tokyo, 35.68, 139.69\nNew York, 40.71, -74.01",
     "scope": "client",
     "default": ""
+  },
+  {
+    "name": "Trending News API URL",
+    "key": "trendingNewsApiUrl",
+    "type": "string",
+    "required": false,
+    "description": "Show the homepage trending news widget. Enter the URL of your deployed trending-news-api Cloudflare Worker. Leave blank to hide the widget.",
+    "placeholder": "https://trending-news-api.your-subdomain.workers.dev",
+    "scope": "client",
+    "default": ""
   }
 ]

--- a/packages/trending-news-api/README.md
+++ b/packages/trending-news-api/README.md
@@ -1,0 +1,99 @@
+# trending-news-api
+
+React trending news widget: daily top Wikipedia pages (via the Wikimedia Pageviews API) matched
+against headlines from [The News API](https://www.thenewsapi.com/), served through a bundled
+Cloudflare Worker so the News API key never reaches the browser.
+
+## Features
+
+- Daily trending topics, ranked by Wikipedia pageviews.
+- Matching headlines per topic from The News API.
+- Single-topic headline lookup.
+- Compact card row or full article-list layouts.
+- `localStorage` response caching (10 minutes).
+- TypeScript + tsup library scaffold.
+
+## Install
+
+```bash
+npm install trending-news-api
+```
+
+## Usage
+
+```tsx
+import { TrendingNews } from 'trending-news-api';
+
+export default function App() {
+  return (
+    <TrendingNews
+      compact
+      maxTopics={8}
+      apiEndpoint="https://trending-news-api.your-subdomain.workers.dev"
+    />
+  );
+}
+```
+
+Pass `topic` to render headlines for a single topic instead of the daily trending list:
+
+```tsx
+<TrendingNews apiEndpoint="https://trending-news-api.your-subdomain.workers.dev" topic="Donald Trump" />
+```
+
+The widget renders nothing when `apiEndpoint` is unset, still loading, or errored — safe to drop
+into a layout unconditionally.
+
+## Direct API usage
+
+```ts
+import { getTrendingNews, getTrendingNewsForTopic } from 'trending-news-api';
+
+const trending = await getTrendingNews({
+  apiEndpoint: 'https://trending-news-api.your-subdomain.workers.dev',
+});
+
+const topicNews = await getTrendingNewsForTopic('Donald Trump', {
+  apiEndpoint: 'https://trending-news-api.your-subdomain.workers.dev',
+});
+```
+
+## Build
+
+```bash
+npm install
+npm run build
+```
+
+## The worker backend
+
+`worker/index.ts` is a Cloudflare Worker that:
+
+- Fetches yesterday's top Wikipedia pages by pageviews (Wikimedia REST API), filtering out
+  non-article pages (`Main_Page`, `Special:`, `Wikipedia:`, etc).
+- For each page, searches The News API for matching headlines.
+- Exposes:
+  - `GET /` — trending topics with headline counts and articles.
+  - `GET /?topic=...` — headlines for a specific topic.
+
+### Deploying the worker
+
+```bash
+cd packages/trending-news-api
+npm run worker:deploy
+npx wrangler secret put THENEWSAPI_API_KEY --config worker/wrangler.jsonc
+```
+
+Use the resulting `*.workers.dev` URL (or a custom route) as `apiEndpoint`.
+
+## Caching
+
+`getTrendingNews` / `getTrendingNewsForTopic` cache each response in `localStorage` for 10
+minutes, keyed by the exact request URL. Call `clearTrendingNewsCache()` to evict everything
+(e.g. in tests). The cache is a no-op in non-browser environments (SSR) or when `localStorage`
+is unavailable/full.
+
+## Notes
+
+- Wikimedia's Pageviews API powers the trending topic list.
+- The News API (thenewsapi.com) powers the headlines — you'll need a free or paid API key.

--- a/packages/trending-news-api/package.json
+++ b/packages/trending-news-api/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "trending-news-api",
+  "version": "0.1.0",
+  "description": "React trending news widget backed by Wikipedia pageviews and The News API, via a Cloudflare Worker proxy",
+  "keywords": ["react", "news", "trending", "wikipedia", "thenewsapi", "cloudflare", "component-library"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
+    "directory": "packages/trending-news-api"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18 || ^19",
+    "react-dom": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250115.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "tsup": "^8.2.4",
+    "typescript": "^5.6.3",
+    "wrangler": "^3.88.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "worker:typecheck": "tsc --noEmit -p worker/tsconfig.json",
+    "worker:dev": "wrangler dev --config worker/wrangler.jsonc",
+    "worker:deploy": "wrangler deploy --config worker/wrangler.jsonc"
+  }
+}

--- a/packages/trending-news-api/src/api/trending.ts
+++ b/packages/trending-news-api/src/api/trending.ts
@@ -1,0 +1,115 @@
+import type { NewsArticle, TrendingNewsData, TrendingNewsOptions, TrendingNewsTopicData } from '../types';
+import { readCachedTrendingNews, writeCachedTrendingNews } from '../lib/cache';
+
+type WorkerArticle = {
+  title?: string;
+  url?: string;
+  source?: string;
+  published_at?: string;
+};
+
+type WorkerTopic = {
+  topic: string;
+  wiki_rank?: number;
+  wiki_views?: number;
+  news_count: number;
+  articles: WorkerArticle[];
+};
+
+type WorkerTopicsResponse = {
+  date?: string;
+  topics: WorkerTopic[];
+  error?: string;
+};
+
+type WorkerTopicResponse = {
+  topic: string;
+  news_count: number;
+  articles: WorkerArticle[];
+  error?: string;
+};
+
+function mapArticles(articles: WorkerArticle[] = []): NewsArticle[] {
+  return articles.map((a) => ({
+    title: a.title ?? '',
+    url: a.url,
+    source: a.source,
+    publishedAt: a.published_at,
+  }));
+}
+
+function buildUrl(apiEndpoint: string, options: TrendingNewsOptions) {
+  const url = new URL(apiEndpoint);
+  if (options.topic) url.searchParams.set('topic', options.topic);
+  return url.toString();
+}
+
+/**
+ * Fetches trending topics (or, when `options.topic` is set, news for a
+ * single topic) from a deployed instance of `worker/index.ts`.
+ */
+export async function getTrendingNews(options: TrendingNewsOptions): Promise<TrendingNewsData> {
+  if (!options.apiEndpoint) {
+    throw new Error('trending-news-api: apiEndpoint is required');
+  }
+
+  const url = buildUrl(options.apiEndpoint, options);
+
+  const cached = readCachedTrendingNews<TrendingNewsData>(url);
+  if (cached) return cached;
+
+  const response = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
+  if (!response.ok) {
+    throw new Error(`Trending news request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as WorkerTopicsResponse;
+  if (data.error) throw new Error(data.error);
+
+  const limit = options.limit ?? 25;
+  const result: TrendingNewsData = {
+    date: data.date,
+    topics: (data.topics ?? []).slice(0, limit).map((t) => ({
+      topic: t.topic,
+      wikiRank: t.wiki_rank,
+      wikiViews: t.wiki_views,
+      newsCount: t.news_count,
+      articles: mapArticles(t.articles),
+    })),
+  };
+
+  writeCachedTrendingNews(url, result);
+  return result;
+}
+
+/** Fetches news articles for a single topic. */
+export async function getTrendingNewsForTopic(
+  topic: string,
+  options: Omit<TrendingNewsOptions, 'topic'>
+): Promise<TrendingNewsTopicData> {
+  if (!options.apiEndpoint) {
+    throw new Error('trending-news-api: apiEndpoint is required');
+  }
+
+  const url = buildUrl(options.apiEndpoint, { ...options, topic });
+
+  const cached = readCachedTrendingNews<TrendingNewsTopicData>(url);
+  if (cached) return cached;
+
+  const response = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
+  if (!response.ok) {
+    throw new Error(`Trending news request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const data = (await response.json()) as WorkerTopicResponse;
+  if (data.error) throw new Error(data.error);
+
+  const result: TrendingNewsTopicData = {
+    topic: data.topic,
+    newsCount: data.news_count,
+    articles: mapArticles(data.articles),
+  };
+
+  writeCachedTrendingNews(url, result);
+  return result;
+}

--- a/packages/trending-news-api/src/components/TrendingNews.tsx
+++ b/packages/trending-news-api/src/components/TrendingNews.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { useTrendingNews } from '../hooks/useTrendingNews';
+import type { TrendingNewsOptions } from '../types';
+
+type Props = TrendingNewsOptions & {
+  className?: string;
+  style?: React.CSSProperties;
+  compact?: boolean;
+  /** Max trending topics to render (default 8). */
+  maxTopics?: number;
+};
+
+const styles = {
+  root: {
+    fontFamily: 'system-ui, sans-serif',
+    border: '1px solid #e5e7eb',
+    borderRadius: 12,
+    padding: 16,
+    background: '#fff',
+    color: '#111827',
+    maxWidth: 640,
+  } as React.CSSProperties,
+  compactRoot: {
+    fontFamily: 'system-ui, sans-serif',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+    padding: '10px 14px',
+    borderRadius: 8,
+  } as React.CSSProperties,
+  compactHeader: {
+    fontSize: 11,
+    fontWeight: 600,
+    opacity: 0.75,
+    letterSpacing: 0.3,
+    textTransform: 'uppercase',
+  } as React.CSSProperties,
+  topicRow: { display: 'flex', gap: 10, overflowX: 'auto', paddingBottom: 2 } as React.CSSProperties,
+  topicCard: {
+    minWidth: 160,
+    maxWidth: 200,
+    padding: '8px 10px',
+    borderRadius: 8,
+    background: 'rgba(255,255,255,0.06)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    textDecoration: 'none',
+    color: 'inherit',
+  } as React.CSSProperties,
+  topicName: {
+    fontSize: 12,
+    fontWeight: 600,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  } as React.CSSProperties,
+  headline: {
+    fontSize: 11,
+    opacity: 0.8,
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  } as React.CSSProperties,
+  count: { fontSize: 10, opacity: 0.6 } as React.CSSProperties,
+  list: { display: 'flex', flexDirection: 'column', gap: 16 } as React.CSSProperties,
+  fullTopic: { display: 'flex', flexDirection: 'column', gap: 6 } as React.CSSProperties,
+  fullTopicHeader: { display: 'flex', alignItems: 'baseline', gap: 8 } as React.CSSProperties,
+  article: { fontSize: 13 } as React.CSSProperties,
+  articleLink: { color: 'inherit', textDecoration: 'none' } as React.CSSProperties,
+};
+
+/**
+ * Trending news widget. Requires `apiEndpoint` pointing at a deployed
+ * instance of the bundled Cloudflare Worker (`worker/index.ts`) — renders
+ * nothing when it's not configured, still loading, or errored, so it never
+ * disrupts the layout it's dropped into.
+ */
+export function TrendingNews(props: Props) {
+  const { className, style, compact, maxTopics = 8, ...options } = props;
+  const { data, loading, error } = useTrendingNews(options);
+
+  if (!options.apiEndpoint) return null;
+  if (loading && !data) return null;
+  if (error) return null;
+  if (!data || data.topics.length === 0) return null;
+
+  const topics = data.topics.slice(0, maxTopics);
+
+  if (compact) {
+    return (
+      <div className={className} style={{ ...styles.compactRoot, ...style }}>
+        <div style={styles.compactHeader}>Trending</div>
+        <div style={styles.topicRow}>
+          {topics.map((topic) => (
+            <a
+              key={topic.topic}
+              href={topic.articles[0]?.url}
+              target="_blank"
+              rel="noreferrer"
+              style={styles.topicCard}
+            >
+              <div style={styles.topicName}>{topic.topic}</div>
+              {topic.articles[0] && <div style={styles.headline}>{topic.articles[0].title}</div>}
+              <div style={styles.count}>
+                {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className} style={{ ...styles.root, ...styles.list, ...style }}>
+      {topics.map((topic) => (
+        <div key={topic.topic} style={styles.fullTopic}>
+          <div style={styles.fullTopicHeader}>
+            <strong>{topic.topic}</strong>
+            <span style={styles.count}>
+              {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
+            </span>
+          </div>
+          {topic.articles.slice(0, 5).map((article, i) => (
+            <div key={article.url ?? i} style={styles.article}>
+              {article.url ? (
+                <a href={article.url} target="_blank" rel="noreferrer" style={styles.articleLink}>
+                  {article.title}
+                </a>
+              ) : (
+                article.title
+              )}
+              {article.source && <span style={{ opacity: 0.6 }}> &middot; {article.source}</span>}
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/trending-news-api/src/hooks/useTrendingNews.ts
+++ b/packages/trending-news-api/src/hooks/useTrendingNews.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import type { TrendingNewsData, TrendingNewsOptions } from '../types';
+import { getTrendingNews } from '../api/trending';
+
+export function useTrendingNews(options: TrendingNewsOptions = {}) {
+  const [data, setData] = useState<TrendingNewsData | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [loading, setLoading] = useState(Boolean(options.apiEndpoint));
+
+  useEffect(() => {
+    if (!options.apiEndpoint) {
+      setLoading(false);
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+    setError(null);
+
+    getTrendingNews(options)
+      .then((result) => { if (active) setData(result); })
+      .catch((err) => { if (active) setError(err instanceof Error ? err : new Error('Unknown error')); })
+      .finally(() => { if (active) setLoading(false); });
+
+    return () => { active = false; };
+  }, [options.apiEndpoint, options.topic, options.limit]);
+
+  return { data, error, loading };
+}

--- a/packages/trending-news-api/src/index.ts
+++ b/packages/trending-news-api/src/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export { clearTrendingNewsCache } from './lib/cache';
+export * from './api/trending';
+export * from './hooks/useTrendingNews';
+export * from './components/TrendingNews';

--- a/packages/trending-news-api/src/lib/cache.ts
+++ b/packages/trending-news-api/src/lib/cache.ts
@@ -1,0 +1,57 @@
+const CACHE_PREFIX = 'trending-news-cache:';
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+type CacheEntry<T> = {
+  timestamp: number;
+  data: T;
+};
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  return window.localStorage;
+}
+
+/** Returns the cached value for `key` if it was written within the last 10 minutes. */
+export function readCachedTrendingNews<T>(key: string): T | null {
+  const storage = getStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+
+    const entry = JSON.parse(raw) as CacheEntry<T>;
+    if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+      storage.removeItem(CACHE_PREFIX + key);
+      return null;
+    }
+
+    return entry.data;
+  } catch {
+    return null;
+  }
+}
+
+export function writeCachedTrendingNews<T>(key: string, data: T): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  try {
+    const entry: CacheEntry<T> = { timestamp: Date.now(), data };
+    storage.setItem(CACHE_PREFIX + key, JSON.stringify(entry));
+  } catch {
+    // Storage full or unavailable (e.g. private browsing) — safe to ignore,
+    // the next call will simply hit the network again.
+  }
+}
+
+/** Clears all cached trending news responses. Mainly useful for tests/debugging. */
+export function clearTrendingNewsCache(): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  for (let i = storage.length - 1; i >= 0; i--) {
+    const key = storage.key(i);
+    if (key?.startsWith(CACHE_PREFIX)) storage.removeItem(key);
+  }
+}

--- a/packages/trending-news-api/src/types.ts
+++ b/packages/trending-news-api/src/types.ts
@@ -1,0 +1,34 @@
+export type NewsArticle = {
+  title: string;
+  url?: string;
+  source?: string;
+  publishedAt?: string;
+};
+
+export type TrendingTopic = {
+  topic: string;
+  wikiRank?: number;
+  wikiViews?: number;
+  newsCount: number;
+  articles: NewsArticle[];
+};
+
+export type TrendingNewsData = {
+  date?: string;
+  topics: TrendingTopic[];
+};
+
+export type TrendingNewsTopicData = {
+  topic: string;
+  newsCount: number;
+  articles: NewsArticle[];
+};
+
+export type TrendingNewsOptions = {
+  /** URL of a deployed instance of the bundled Cloudflare Worker (`worker/index.ts`). */
+  apiEndpoint?: string;
+  /** When set, fetches news for this single topic instead of the daily trending list. */
+  topic?: string;
+  /** Max trending topics to request from the worker (default 25). */
+  limit?: number;
+};

--- a/packages/trending-news-api/tsconfig.json
+++ b/packages/trending-news-api/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/trending-news-api/tsup.config.ts
+++ b/packages/trending-news-api/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  external: ['react', 'react-dom'],
+});

--- a/packages/trending-news-api/worker/index.ts
+++ b/packages/trending-news-api/worker/index.ts
@@ -1,0 +1,173 @@
+export interface Env {
+  THENEWSAPI_API_KEY: string;
+}
+
+type NewsApiArticle = {
+  title?: string;
+  description?: string;
+  source?: string;
+  url?: string;
+  published_at?: string;
+};
+
+type WikiTopPage = {
+  rank: number;
+  article: string;
+  views: number;
+};
+
+type TopicPayload = {
+  topic: string;
+  wiki_rank?: number;
+  wiki_views?: number;
+  news_count: number;
+  articles: Array<{
+    title: string;
+    url?: string;
+    source?: string;
+    published_at?: string;
+  }>;
+};
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'no-store',
+};
+
+// Wikipedia's daily "top viewed" list is dominated by navigation pages that
+// aren't real trending topics — filter those out rather than surfacing
+// "Main Page" as the #1 trend every day.
+const NON_ARTICLE_TITLE = /^(Main_Page|Special:|Wikipedia:|Portal:|File:|Talk:|Category:)/i;
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json', ...CORS_HEADERS },
+  });
+}
+
+/**
+ * Fetch daily top Wikipedia articles by pageviews for a given date, via the
+ * Wikimedia Analytics API.
+ */
+async function fetchWikipediaTopPages(
+  year: number,
+  month: number,
+  day: number,
+  limit = 25
+): Promise<WikiTopPage[]> {
+  const url = `https://wikimedia.org/api/rest_v1/metrics/pageviews/top-per-article/en.wikipedia.org/all-access/all-agents/${String(year).padStart(4, '0')}/${String(month).padStart(2, '0')}/${String(day).padStart(2, '0')}`;
+
+  const res = await fetch(url, { headers: { 'User-Agent': 'trending-news-api-worker' } });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch Wikipedia top pages: ${res.status}`);
+  }
+
+  const data = (await res.json()) as {
+    items?: Array<{ article: string; views: number; rank?: number }>;
+  };
+
+  const items = (data.items ?? []).filter((it) => !NON_ARTICLE_TITLE.test(it.article));
+
+  return items.slice(0, limit).map((it, i) => ({
+    rank: it.rank ?? i + 1,
+    article: decodeURIComponent(it.article.replace(/_/g, ' ')),
+    views: it.views,
+  }));
+}
+
+/**
+ * Search news for a given query using The News API (thenewsapi.com).
+ */
+async function searchNewsForTopic(
+  apiKey: string,
+  query: string,
+  limit = 20
+): Promise<NewsApiArticle[]> {
+  const url = new URL('https://api.thenewsapi.com/v1/news/search');
+  url.searchParams.set('api_token', apiKey);
+  url.searchParams.set('q', query);
+  url.searchParams.set('language', 'en');
+  url.searchParams.set('limit', String(limit));
+
+  const res = await fetch(url.toString());
+  if (!res.ok) return [];
+
+  const data = (await res.json()) as { data?: NewsApiArticle[] };
+  return data.data ?? [];
+}
+
+function toArticlePayload(articles: NewsApiArticle[]) {
+  return articles.map((a) => ({
+    title: a.title ?? '',
+    url: a.url,
+    source: a.source,
+    published_at: a.published_at,
+  }));
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const topic = url.searchParams.get('topic');
+
+    const apiKey = env.THENEWSAPI_API_KEY;
+    if (!apiKey) {
+      return jsonResponse({ error: 'THENEWSAPI_API_KEY is not configured' }, 500);
+    }
+
+    // A specific topic was requested: return news for that topic only.
+    if (topic) {
+      const articles = await searchNewsForTopic(apiKey, topic, 30);
+      return jsonResponse({
+        topic,
+        news_count: articles.length,
+        articles: toArticlePayload(articles),
+      });
+    }
+
+    // Otherwise: fetch Wikipedia's daily top pages and news for each.
+    // Pageviews data typically lags by ~1 day, so use yesterday's date.
+    const now = new Date();
+    const d = new Date(now);
+    d.setUTCDate(d.getUTCDate() - 1);
+    const year = d.getUTCFullYear();
+    const month = d.getUTCMonth() + 1;
+    const day = d.getUTCDate();
+
+    let wikiEntries: WikiTopPage[];
+    try {
+      wikiEntries = await fetchWikipediaTopPages(year, month, day, 25);
+    } catch (e) {
+      return jsonResponse(
+        {
+          error: 'Failed to fetch Wikipedia trends',
+          details: e instanceof Error ? e.message : String(e),
+        },
+        500
+      );
+    }
+
+    const results: TopicPayload[] = [];
+    for (const entry of wikiEntries) {
+      const articles = await searchNewsForTopic(apiKey, entry.article, 20);
+      if (!articles.length) continue;
+
+      results.push({
+        topic: entry.article,
+        wiki_rank: entry.rank,
+        wiki_views: entry.views,
+        news_count: articles.length,
+        articles: toArticlePayload(articles),
+      });
+    }
+
+    results.sort((a, b) => (a.wiki_rank ?? 999) - (b.wiki_rank ?? 999));
+
+    return jsonResponse({
+      source: 'wikipedia_daily_top',
+      date: `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`,
+      topics: results,
+    });
+  },
+} satisfies ExportedHandler<Env>;

--- a/packages/trending-news-api/worker/tsconfig.json
+++ b/packages/trending-news-api/worker/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/trending-news-api/worker/wrangler.jsonc
+++ b/packages/trending-news-api/worker/wrangler.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../node_modules/wrangler/config-schema.json",
+  "name": "trending-news-api",
+  "main": "index.ts",
+  "compatibility_date": "2026-07-06"
+}


### PR DESCRIPTION
## Summary

Introduces a new `trending-news-api` package that provides a React trending news widget component backed by Wikipedia's daily top pages and The News API, served through a Cloudflare Worker to keep API keys secure.

## Key Changes

- **New package: `trending-news-api`**
  - React component `TrendingNews` with compact and full-list layouts
  - Cloudflare Worker (`worker/index.ts`) that:
    - Fetches yesterday's top Wikipedia articles by pageviews via Wikimedia Analytics API
    - Filters out non-article pages (Main_Page, Special:, etc.)
    - Searches The News API for matching headlines per topic
    - Exposes endpoints for trending topics list and single-topic lookup
  - API client functions (`getTrendingNews`, `getTrendingNewsForTopic`) with localStorage caching (10-minute TTL)
  - Custom hook `useTrendingNews` for React integration
  - Full TypeScript support with type definitions

- **Integration into research-agent-ui**
  - Added `TrendingNews` widget to `ChatHomepage` alongside existing `WeatherForecast`
  - New settings option "Trending News API URL" to configure the worker endpoint
  - Widget renders nothing when unconfigured or errored, safe for unconditional layout placement

- **Configuration & Deployment**
  - Worker deployment via `npm run worker:deploy` with `THENEWSAPI_API_KEY` secret
  - Library build via tsup with ESM and CommonJS outputs
  - Comprehensive README with usage examples and deployment instructions

## Implementation Details

- **Caching**: Responses cached in `localStorage` with 10-minute TTL, keyed by request URL; gracefully degrades in SSR/private browsing
- **Error Handling**: Widget silently renders nothing on errors; API functions throw descriptive errors
- **Responsive Design**: Compact mode shows horizontal card row; full mode displays article lists per topic
- **Wikipedia Filtering**: Regex pattern excludes navigation/meta pages to surface real trending topics
- **Date Handling**: Worker uses yesterday's date for Wikipedia data (pageviews API lags ~1 day)

https://claude.ai/code/session_01MQMWWkVYgodaazd2yzQDsY