### PR TITLE
Add chat tab management to MainWorkspaceView and ReasonDocs

### DIFF
--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -14,19 +14,51 @@ import 'easydrawer/styles.css';
 import 'katex/contrib/mhchem';
 
 export function MainWorkspaceView() {
-  const { activeView, filesSidebarRequestId } = useMainView();
+  const { activeView, toggleToDocs, toggleToResearch, filesSidebarRequestId } = useMainView();
+  const { chatTabs, activeChatId, openChat, newChat, closeChat } = useChatTabs();
 
   useEffect(() => {
     localeActions.setLang('en');
     themeActions.setColor('default');
   }, []);
 
+  const extraTabs = chatTabs.map((tab) => ({ id: tab.id, title: tab.title, kind: 'chat' as const }));
+
+  const handleExtraTabSelect = (id: string) => {
+    openChat(id);
+    toggleToResearch();
+  };
+
+  const handleExtraTabClose = (id: string) => {
+    const { closedWasActive, nextActiveId } = closeChat(id);
+    if (closedWasActive && !nextActiveId) toggleToDocs();
+  };
+
+  const handleExtraTabAdd = () => {
+    newChat();
+    toggleToResearch();
+  };
+
+  const extraTabProps = {
+    extraTabs,
+    activeExtraTabId: activeView === 'research' ? activeChatId ?? undefined : undefined,
+    onExtraTabSelect: handleExtraTabSelect,
+    onExtraTabClose: handleExtraTabClose,
+    onExtraTabAdd: handleExtraTabAdd,
+    onFileTabSelect: toggleToDocs,
+  };
+
   return activeView === 'docs' ? (
     <ReasonDocs
       belowMainContent={<ChatInputBox />}
       openFilesSidebarSignal={filesSidebarRequestId}
+      {...extraTabProps}
     />
   ) : (
-    <ReasonDocs mainContent={<ChatWindow />} openFilesSidebarSignal={filesSidebarRequestId} />
+    <ReasonDocs
+      mainContent={<ChatWindow />}
+      openFilesSidebarSignal={filesSidebarRequestId}
+      {...extraTabProps}
+    />
   );
 }

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -17,6 +17,7 @@ import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../utils/storage';
 import { Menu, PanelRight } from 'lucide-react';
+import type { OpenTabItem } from '../layout/sidebar/types';
 import '../app-styles/split-pane.css';
 
 /** A non-document tab (e.g. a chat conversation) supplied by the host app. */
@@ -41,6 +42,18 @@ interface ReasonDocsProps {
    * request the sidebar open.
    */
   openFilesSidebarSignal?: number | string;
+  /** Host-supplied non-document tabs (e.g. open chats) merged into the Open Tabs panel. */
+  extraTabs?: ReasonDocsExtraTab[];
+  /** ID of the currently active extra tab, if one is active instead of a document. */
+  activeExtraTabId?: string;
+  /** Called when an extra tab is selected from the Open Tabs panel. */
+  onExtraTabSelect?: (id: string) => void;
+  /** Called when an extra tab is closed from the Open Tabs panel. */
+  onExtraTabClose?: (id: string) => void;
+  /** Called when the "new chat" action is triggered from the Open Tabs panel header. */
+  onExtraTabAdd?: () => void;
+  /** Called whenever a document/file tab becomes active, so the host can switch away from an extra tab. */
+  onFileTabSelect?: () => void;
 }
 
 /**
@@ -48,7 +61,17 @@ interface ReasonDocsProps {
  * Uses `useReasonDocsState` for shared state and `next-themes` for theme control.
  * Renders a resizable panel layout on desktop and a stacked layout on mobile.
  */
-const Index = ({ mainContent, belowMainContent, openFilesSidebarSignal }: ReasonDocsProps) => {
+const Index = ({
+  mainContent,
+  belowMainContent,
+  openFilesSidebarSignal,
+  extraTabs,
+  activeExtraTabId,
+  onExtraTabSelect,
+  onExtraTabClose,
+  onExtraTabAdd,
+  onFileTabSelect,
+}: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState(openFilesSidebarSignal);
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -51,6 +51,8 @@ interface RightPanelProps {
   onReopenLastClosed?: () => void;
   canReopenLastClosed?: boolean;
   outlineRef?: RefObject<OutlineViewHandle | null>;
+  tabItems?: OpenTabItem[];
+  onNewChat?: () => void;
   aiProps: SidebarAiProps;
   /** Closes the panel by clearing the right sidebar's panel list. */
   onClose: () => void;
@@ -106,6 +108,8 @@ export function RightPanel({
   onReopenLastClosed,
   canReopenLastClosed,
   outlineRef,
+  tabItems,
+  onNewChat,
   aiProps,
   onClose,
   isMobile,
@@ -155,6 +159,8 @@ export function RightPanel({
           onReopenLastClosed={onReopenLastClosed}
           canReopenLastClosed={canReopenLastClosed}
           onNavigate={onNavigate}
+          tabItems={tabItems}
+          onNewChat={onNewChat}
           aiProps={aiProps}
         />
       </div>


### PR DESCRIPTION
## Summary
This PR integrates chat tab management into the main workspace view, allowing users to switch between document and chat views while maintaining multiple open chat conversations in the Open Tabs panel.

## Key Changes
- **MainWorkspaceView**: 
  - Added `useChatTabs()` hook to manage chat conversations
  - Implemented handlers for chat tab selection, creation, and closure
  - Added logic to toggle between 'docs' and 'research' views based on tab interactions
  - Passed chat tab data and handlers to ReasonDocs via new `extraTabProps`

- **ReasonDocs**:
  - Added new props to support extra tabs (chat conversations): `extraTabs`, `activeExtraTabId`, `onExtraTabSelect`, `onExtraTabClose`, `onExtraTabAdd`, and `onFileTabSelect`
  - Updated component signature to accept and destructure these new props
  - Imported `OpenTabItem` type for type safety

- **RightPanel**:
  - Added `tabItems` and `onNewChat` props to support chat tab UI in the sidebar
  - Passed these props down to child components for rendering and interaction

## Implementation Details
- Chat tabs are mapped to a consistent format with `id`, `title`, and `kind: 'chat'` for display in the Open Tabs panel
- View switching is coordinated: selecting a chat tab switches to 'research' view, selecting a file tab switches to 'docs' view
- When the last chat is closed and no other chats exist, the view automatically switches back to 'docs'
- The active extra tab ID is only set when in 'research' view to maintain proper UI state

https://claude.ai/code/session_01KVcQRbMevEASSrEr4pqgPh