### PR TITLE
Enable chat/doc tabs as workspace tabs with URL sync

### DIFF
--- a/apps/qwksearch-web/app/library/page.tsx
+++ b/apps/qwksearch-web/app/library/page.tsx
@@ -293,7 +293,8 @@ function ChatRow({ chat, isPinned, onTogglePin, onDelete }: ChatRowProps) {
 
   return (
     <div className="group flex items-center gap-2 px-3 py-3 rounded-xl hover:bg-secondary transition-colors duration-200">
-      <Link href={`/c/${chat.id}`} className="flex-1 min-w-0">
+      {/* Chats open as a tab on the homepage workspace, not a dedicated `/c/<id>` page. */}
+      <Link href={`/?chat=${chat.id}`} className="flex-1 min-w-0">
         <p className="text-sm font-medium truncate">
           {isPinned && <Pin size={12} className="inline mr-1.5 text-primary" />}
           {chat.title}

--- a/apps/qwksearch-web/components/layout/CategoryDock.tsx
+++ b/apps/qwksearch-web/components/layout/CategoryDock.tsx
@@ -135,14 +135,28 @@ export function CategoryDock() {
     },
   ]
 
+  // The "Files" shortcut only makes sense on mobile, where REASON's file
+  // sidebar isn't otherwise reachable at a glance — on desktop it's always
+  // visible in the persistent sidebar, so the dock icon would be redundant.
+  const desktopItems = items.filter((item) => item.key !== "files")
+  const renderImage = (src: string, alt: string, size: number) => (
+    <Image src={src} alt={alt} width={size} height={size} unoptimized className="w-full h-full" />
+  )
+
   return (
-    <BaseCategoryDock
-      items={items}
-      enableKeyboardShortcuts
-      mobileAlign={activeView === "docs" ? "end" : "center"}
-      renderImage={(src, alt, size) => (
-        <Image src={src} alt={alt} width={size} height={size} unoptimized className="w-full h-full" />
-      )}
-    />
+    <>
+      <BaseCategoryDock
+        items={desktopItems}
+        enableKeyboardShortcuts
+        placements={{ desktop: true, mobile: false }}
+        renderImage={renderImage}
+      />
+      <BaseCategoryDock
+        items={items}
+        placements={{ desktop: false, mobile: true }}
+        mobileAlign={activeView === "docs" ? "end" : "center"}
+        renderImage={renderImage}
+      />
+    </>
   )
 }

--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
-import { ChatInputBox, ChatWindow } from 'research-agent-ui';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { ChatInputBox, ChatWindow, configureResearchAgentUI } from 'research-agent-ui';
 import { ReasonDocs } from 'react-reason-editor/reason-docs';
 import { themeActions } from 'react-reason-editor/theme';
 import { localeActions } from 'react-reason-editor/locale-bundle';
@@ -16,11 +17,56 @@ import 'katex/contrib/mhchem';
 export function MainWorkspaceView() {
   const { activeView, toggleToDocs, toggleToResearch, filesSidebarRequestId } = useMainView();
   const { chatTabs, activeChatId, openChat, newChat, closeChat } = useChatTabs();
+  const searchParams = useSearchParams();
+  const [activeDocId, setActiveDocId] = useState<string | null>(null);
+  const [initialDocId, setInitialDocId] = useState<string | null>(null);
+  const [hasRestoredFromUrl, setHasRestoredFromUrl] = useState(false);
 
   useEffect(() => {
     localeActions.setLang('en');
     themeActions.setColor('default');
   }, []);
+
+  // Restore whichever tab (a chat or a REASON document) was active from the
+  // URL's `chat`/`docs` params on first load — the workspace itself never
+  // navigates away from `/`, so this is the only way a shared/bookmarked
+  // link reopens the right tab. Runs once; afterwards the effect below owns
+  // keeping the URL in sync with the live tab state.
+  const restoredFromUrlRef = useRef(false);
+  useEffect(() => {
+    if (restoredFromUrlRef.current) return;
+    restoredFromUrlRef.current = true;
+    const docsParam = searchParams.get('docs');
+    const chatParam = searchParams.get('chat');
+    if (docsParam) {
+      setInitialDocId(docsParam);
+      toggleToDocs();
+    } else if (chatParam) {
+      openChat(chatParam);
+      toggleToResearch();
+    }
+    setHasRestoredFromUrl(true);
+    // Runs once on mount only — later param changes come from our own sync below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Mirror the active chat/doc tab into `?chat=&docs=` without a Next.js
+  // route transition: chats and REASON docs are tabs within this one
+  // workspace route, not separate pages, so the URL only needs to record
+  // which tab is active for sharing/reload — not drive navigation. Waits for
+  // the restore effect above so it doesn't clobber the incoming URL with
+  // blanks before the restored tab's state has landed.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !hasRestoredFromUrl) return;
+    const url = new URL(window.location.href);
+    url.searchParams.set('chat', activeView === 'research' ? activeChatId ?? '' : '');
+    url.searchParams.set('docs', activeView === 'docs' ? activeDocId ?? '' : '');
+    const nextRelative = `${url.pathname}?${url.searchParams.toString()}${url.hash}`;
+    const currentRelative = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    if (nextRelative !== currentRelative) {
+      window.history.replaceState(null, '', nextRelative);
+    }
+  }, [activeView, activeChatId, activeDocId, hasRestoredFromUrl]);
 
   const extraTabs = chatTabs.map((tab) => ({ id: tab.id, title: tab.title, kind: 'chat' as const }));
 
@@ -39,6 +85,20 @@ export function MainWorkspaceView() {
     toggleToResearch();
   };
 
+  // Let chat-history links (research-agent-ui's history dropdown, recent
+  // chips, etc.) open a chat as a workspace tab in place instead of
+  // navigating to the `/c/<chatId>` route.
+  const handleOpenChat = useCallback((id: string) => {
+    openChat(id);
+    toggleToResearch();
+    return true;
+  }, [openChat, toggleToResearch]);
+
+  useEffect(() => {
+    configureResearchAgentUI({ onOpenChat: handleOpenChat });
+    return () => configureResearchAgentUI({ onOpenChat: undefined });
+  }, [handleOpenChat]);
+
   const extraTabProps = {
     extraTabs,
     activeExtraTabId: activeView === 'research' ? activeChatId ?? undefined : undefined,
@@ -46,6 +106,8 @@ export function MainWorkspaceView() {
     onExtraTabClose: handleExtraTabClose,
     onExtraTabAdd: handleExtraTabAdd,
     onFileTabSelect: toggleToDocs,
+    initialDocId,
+    onActiveDocumentChange: setActiveDocId,
   };
 
   return activeView === 'docs' ? (

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -12,7 +12,7 @@ import { useReasonDocsState } from './useReasonDocsState';
 import { DynamicIslandTOC } from '../search/DynamicIslandTOC';
 import { Button } from '../app-ui/button';
 import { useTheme } from 'next-themes';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../utils/storage';
@@ -54,6 +54,15 @@ interface ReasonDocsProps {
   onExtraTabAdd?: () => void;
   /** Called whenever a document/file tab becomes active, so the host can switch away from an extra tab. */
   onFileTabSelect?: () => void;
+  /**
+   * Document ID to open as the active document once (e.g. restored from a
+   * URL param on load). Applied only on the first render where the document
+   * exists — later changes to this prop are ignored, so it never fights with
+   * the user's own tab switching.
+   */
+  initialDocId?: string | null;
+  /** Called whenever the active document changes, so the host can mirror it (e.g. into a URL param). */
+  onActiveDocumentChange?: (docId: string | null) => void;
 }
 
 /**
@@ -71,10 +80,30 @@ const Index = ({
   onExtraTabClose,
   onExtraTabAdd,
   onFileTabSelect,
+  initialDocId,
+  onActiveDocumentChange,
 }: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState(openFilesSidebarSignal);
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
+
+  // Restore the active document from a host-supplied ID (e.g. a `?docs=`
+  // URL param) once, the first time it resolves to a real document.
+  const initialDocIdAppliedRef = useRef(false);
+  useEffect(() => {
+    if (initialDocIdAppliedRef.current || !initialDocId) return;
+    if (state.documents.some((doc) => doc.id === initialDocId)) {
+      initialDocIdAppliedRef.current = true;
+      if (initialDocId !== state.activeDocId) {
+        state.handleSelectDocument(initialDocId);
+      }
+    }
+  }, [initialDocId, state.documents, state.activeDocId, state.handleSelectDocument]);
+
+  // Mirror the active document back to the host so it can sync a URL param.
+  useEffect(() => {
+    onActiveDocumentChange?.(state.activeDocId);
+  }, [state.activeDocId, onActiveDocumentChange]);
 
   // Use persistence hook for sidebar sizes
   const [sidebarSizes, setSidebarSizes] = usePersistence({

--- a/packages/research-agent-ui/src/components/ChatConversation/RecentHistoryChips.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RecentHistoryChips.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { useHistoryState } from '../ChatHistoryDropdown/useHistoryState';
 import HistoryDropdown from '../ChatHistoryDropdown';
 import { formatRelativeTime } from '../../lib/relative-time';
+import { researchAgentUIConfig } from '../../config';
 
 /** Most recent activity timestamp for a chat, falling back to creation time. */
 const activityTime = (chat: { lastMessageAt?: string | null; createdAt: string }) =>
@@ -32,6 +33,9 @@ export default function RecentHistoryChips() {
           <Link
             key={chat.id}
             href={`/c/${chat.id}`}
+            onClick={(e) => {
+              if (researchAgentUIConfig.onOpenChat?.(chat.id)) e.preventDefault();
+            }}
             className="flex items-center gap-1.5 px-3 py-1 rounded-full text-xs text-muted-foreground bg-secondary hover:bg-secondary/80 hover:text-foreground transition-colors duration-150 max-w-[220px]"
             title={chat.title}
           >

--- a/packages/research-agent-ui/src/components/ChatHistoryDropdown/HistoryChatItem.tsx
+++ b/packages/research-agent-ui/src/components/ChatHistoryDropdown/HistoryChatItem.tsx
@@ -7,6 +7,7 @@ import { Trash, Pin } from 'lucide-react';
 import { Chat } from '../../types/research';
 import { formatTimeDifference } from '../../lib/utils';
 import { Badge } from '../../ui/badge';
+import { researchAgentUIConfig } from '../../config';
 import Link from 'next/link';
 
 interface HistoryChatItemProps {
@@ -20,7 +21,13 @@ export function HistoryChatItem({ chat, isPinned, onTogglePin, onDelete }: Histo
   const messageCount = chat.messageCount ?? 0;
   return (
     <div className="group flex items-center gap-1 px-2 py-1 rounded-lg hover:bg-secondary transition-colors duration-200">
-      <Link href={`/c/${chat.id}`} className="flex-1 min-w-0 flex items-center gap-1.5">
+      <Link
+        href={`/c/${chat.id}`}
+        onClick={(e) => {
+          if (researchAgentUIConfig.onOpenChat?.(chat.id)) e.preventDefault();
+        }}
+        className="flex-1 min-w-0 flex items-center gap-1.5"
+      >
         <span className="flex items-center gap-1 shrink-0">
           {messageCount > 0 && (
             <Badge className="px-1.5 py-0 text-[10px] font-medium bg-zinc-200 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-700 border-0 rounded-md">

--- a/packages/research-agent-ui/src/config.ts
+++ b/packages/research-agent-ui/src/config.ts
@@ -49,6 +49,15 @@ export interface ResearchAgentUIConfig {
    * optionally deep-links to a specific settings tab.
    */
   onOpenSettings?: (section?: string) => boolean;
+  /**
+   * Requests that a chat from history be opened in place. Lets the consuming
+   * app switch to the chat as a tab within its current workspace (e.g. on
+   * the homepage) instead of navigating to the `/c/<chatId>` route. Return
+   * `true` when handled — the caller then skips route navigation; return
+   * `false`/`undefined` (or leave unset) to fall back to navigating to
+   * `/c/<chatId>`.
+   */
+  onOpenChat?: (chatId: string) => boolean;
 }
 
 export const researchAgentUIConfig: ResearchAgentUIConfig = {

--- a/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
+++ b/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
@@ -178,9 +178,15 @@ export async function sendMessage(
   setLoading(true);
   setMessageAppeared(false);
 
-  // Update URL to include chat ID (for sharing/bookmarking)
-  if (messages.length <= 1) {
-    window.history.replaceState(null, "", `/c/${chatId}`);
+  // Reflect the chat ID in the URL as a `?chat=` param once the conversation
+  // starts (for sharing/bookmarking/reload), without changing the route:
+  // chats live as tabs within the current page, not a separate `/c/<id>`
+  // page. Skipped when the host app owns this itself (e.g. the tabbed
+  // workspace, which mirrors the active tab on every switch already).
+  if (messages.length <= 1 && !researchAgentUIConfig.onOpenChat) {
+    const url = new URL(window.location.href);
+    url.searchParams.set("chat", chatId);
+    window.history.replaceState(null, "", `${url.pathname}?${url.searchParams.toString()}${url.hash}`);
   }
 
   // Accumulator for streaming response


### PR DESCRIPTION
## Summary
This PR refactors the workspace to treat chats and REASON documents as tabs within a single workspace route (`/`) rather than separate pages, enabling URL-based sharing and restoration while maintaining a cohesive tabbed interface.

## Key Changes

- **Workspace URL synchronization**: Added logic to mirror the active chat/doc tab into `?chat=` and `?docs=` URL parameters without route transitions, allowing users to share and restore their workspace state via bookmarks or links.

- **Tab restoration on load**: Implemented URL parameter restoration that opens the correct chat or document tab when the workspace loads, using a one-time effect to avoid conflicts with user interactions.

- **Research agent UI configuration**: Extended `researchAgentUIConfig` with an `onOpenChat` callback that lets the workspace intercept chat history navigation (from dropdowns, recent chips, etc.) and open chats as tabs instead of navigating to `/c/<chatId>`.

- **ReasonDocs integration**: Added `initialDocId` and `onActiveDocumentChange` props to `ReasonDocs` component to support initial document restoration and active document tracking for URL synchronization.

- **Chat history link handling**: Updated `HistoryChatItem` and `RecentHistoryChips` components to use the new `onOpenChat` callback, allowing them to open chats within the workspace when configured.

- **Library page chat links**: Changed chat links on the library page to point to `/?chat=<id>` instead of `/c/<id>`, directing users to the workspace tabs.

- **CategoryDock responsive refinement**: Split the dock into separate desktop and mobile instances to hide the "Files" shortcut on desktop (where the file sidebar is always visible) while keeping it on mobile.

- **sendMessage URL handling**: Updated the chat initialization logic to set `?chat=` parameters only when the host app doesn't already manage chat URL state (via `onOpenChat` callback).

## Implementation Details

- Uses `useRef` to ensure one-time effects (URL restoration, initial doc ID application) don't re-run unnecessarily.
- Employs `window.history.replaceState` to update URLs without triggering navigation or page reloads.
- Carefully sequences effects: URL restoration runs first, then URL synchronization waits for restoration to complete before mirroring tab changes.
- Maintains backward compatibility: apps without `onOpenChat` configured continue to navigate to `/c/<chatId>` routes as before.

https://claude.ai/code/session_01WisEkdJzH6myJtSL4nmYYL