### PR TITLE
Add offline library loading mode and Draw.io error handling

### DIFF
--- a/packages/reason-editor/src/editor-kit.ts
+++ b/packages/reason-editor/src/editor-kit.ts
@@ -16,3 +16,9 @@ export {
   createDefaultConfig,
   type EditorConfig,
 } from './editor-views/config/editorConfig';
+export {
+  useExternalLibsMode,
+  getExternalLibsMode,
+  externalLibsModeActions,
+  type ExternalLibsMode,
+} from './store/externalLibsMode';

--- a/packages/reason-editor/src/editor-views/App.tsx
+++ b/packages/reason-editor/src/editor-views/App.tsx
@@ -20,6 +20,7 @@ import {
 } from './config/editorConfig';
 import { localeActions } from 'react-reason-editor/locale-bundle';
 import { themeActions } from 'react-reason-editor/theme';
+import { externalLibsModeActions } from '@/store/externalLibsMode';
 import { DEFAULT_CONTENT, debounce } from './components/constants';
 
 import 'react-reason-editor/style.css';
@@ -47,6 +48,10 @@ function App() {
   useEffect(() => {
     themeActions.setColor(config.accentColor);
   }, [config.accentColor]);
+
+  useEffect(() => {
+    externalLibsModeActions.setMode(config.externalLibsMode);
+  }, [config.externalLibsMode]);
 
   useEffect(() => {
     setTheme(config.theme);

--- a/packages/reason-editor/src/editor-views/config/SettingsModal.tsx
+++ b/packages/reason-editor/src/editor-views/config/SettingsModal.tsx
@@ -13,6 +13,8 @@ import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Check,
+  CloudDownload,
+  HardDrive,
   Plus,
   Puzzle,
   RotateCcw,
@@ -254,6 +256,10 @@ export function SettingsModal({
     onConfigChange({ ...config, theme: mode });
   };
 
+  const setExternalLibsMode = (mode: EditorConfig['externalLibsMode']) => {
+    onConfigChange({ ...config, externalLibsMode: mode });
+  };
+
   const resetDefaults = () => {
     if (!confirm('Reset all editor settings and plugins to defaults?')) return;
     const fresh = createDefaultConfig();
@@ -359,6 +365,58 @@ export function SettingsModal({
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+          </section>
+
+          {/* External libraries loading mode */}
+          <section className="space-y-3">
+            <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+              Library Loading
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Controls how KaTeX and Mermaid are loaded when a plugin needs them.
+              Draw.io always opens diagrams.net in an embedded frame regardless of
+              this setting.
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <button
+                onClick={() => setExternalLibsMode('cdn')}
+                className={`flex items-start gap-2 text-left rounded-lg border p-3 transition-colors ${
+                  config.externalLibsMode !== 'bundled'
+                    ? 'border-blue-500 bg-blue-500/10'
+                    : 'border-gray-200 dark:border-slate-700 hover:border-blue-400'
+                }`}
+              >
+                <CloudDownload size={15} className="mt-0.5 text-blue-500 shrink-0" />
+                <span className="min-w-0">
+                  <span className="block text-xs font-medium text-gray-800 dark:text-gray-100">
+                    Lazy-load from CDN
+                  </span>
+                  <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                    Smallest bundle. Fetches libraries on first use — requires
+                    network access to the CDN.
+                  </span>
+                </span>
+              </button>
+              <button
+                onClick={() => setExternalLibsMode('bundled')}
+                className={`flex items-start gap-2 text-left rounded-lg border p-3 transition-colors ${
+                  config.externalLibsMode === 'bundled'
+                    ? 'border-blue-500 bg-blue-500/10'
+                    : 'border-gray-200 dark:border-slate-700 hover:border-blue-400'
+                }`}
+              >
+                <HardDrive size={15} className="mt-0.5 text-blue-500 shrink-0" />
+                <span className="min-w-0">
+                  <span className="block text-xs font-medium text-gray-800 dark:text-gray-100">
+                    Bundled (offline)
+                  </span>
+                  <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                    Ships the libraries with the app. Larger bundle, but works
+                    fully offline or behind restrictive firewalls.
+                  </span>
+                </span>
+              </button>
             </div>
           </section>
 

--- a/packages/reason-editor/src/editor-views/config/editorConfig.ts
+++ b/packages/reason-editor/src/editor-views/config/editorConfig.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ThemeColorType } from '@/theme/theme';
+import type { ExternalLibsMode } from '@/store/externalLibsMode';
 
 import {
   PLUGIN_BY_KEY,
@@ -31,6 +32,13 @@ export interface EditorConfig {
   theme: 'light' | 'dark';
   /** accent color preset */
   accentColor: ThemeColorType;
+  /**
+   * How heavy third-party libraries (KaTeX, Mermaid) are loaded: 'cdn' fetches
+   * them from a public CDN on first use, 'bundled' imports them from this
+   * package's own dependencies so the editor works offline. Does not affect
+   * Draw.io, which is always a remote embed. See `@/store/externalLibsMode`.
+   */
+  externalLibsMode: ExternalLibsMode;
   /** per-plugin enable flags and settings, keyed by plugin key */
   plugins: Record<string, PluginConfigEntry>;
 }
@@ -47,6 +55,7 @@ export function createDefaultConfig(): EditorConfig {
     language: 'en',
     theme: 'light',
     accentColor: 'default',
+    externalLibsMode: 'cdn',
     plugins,
   };
 }
@@ -73,6 +82,7 @@ export function normalizeConfig(saved: Partial<EditorConfig> | null | undefined)
     language: saved.language ?? base.language,
     theme: saved.theme === 'dark' ? 'dark' : 'light',
     accentColor: (saved.accentColor as ThemeColorType) ?? base.accentColor,
+    externalLibsMode: saved.externalLibsMode === 'bundled' ? 'bundled' : base.externalLibsMode,
     plugins,
   };
 }

--- a/packages/reason-editor/src/extensions/Drawio/components/RichTextDrawio.tsx
+++ b/packages/reason-editor/src/extensions/Drawio/components/RichTextDrawio.tsx
@@ -2,7 +2,7 @@
  * Toolbar control (React) for the Drawio extension, which adds draw.io / diagrams.net diagram embeds. Renders the button and dispatches the matching editor command when activated.
  */
 
-import { useCallback, useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 
 import { ActionButton } from '@/components/ActionButton';
 import { useListener } from '@/components/ReactBus';
@@ -18,9 +18,14 @@ import { useToggleActive } from '@/hooks/useActive';
 import { useButtonProps } from '@/hooks/useButtonProps';
 import { useExtension } from '@/hooks/useExtension';
 import { useEditorInstance } from '@/store/editor';
+import { useExternalLibsMode } from '@/store/externalLibsMode';
 import { EVENTS } from '@/utils/customEvents/events.constant';
 
 import { Drawio as DrawioExtension } from '../Drawio';
+
+const DRAWIO_EMBED_SRC =
+  'https://embed.diagrams.net/?embed=1&ui=minimal&spin=1&modified=unsaved&noExitBtn=1&proto=json';
+const DRAWIO_LOAD_TIMEOUT_MS = 15000;
 
 export function RichTextDrawio() {
   const editor = useEditorInstance();
@@ -37,11 +42,15 @@ export function RichTextDrawio() {
     return extension?.options || {};
   }, [extension]);
 
+  const externalLibsMode = useExternalLibsMode();
+
   const [iframeRef, setIframeRef] = useState<HTMLIFrameElement | null>(null);
   const [data, setData] = useState<string>('');
   const [visible, toggleVisible] = useState(false);
   const [loading, toggleLoading] = useState(true);
   const [error, setError] = useState<any>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const loadTimeoutRef = useRef<number | null>(null);
 
   const handleSave = useCallback(() => {
     if (!iframeRef) {
@@ -75,6 +84,10 @@ export function RichTextDrawio() {
       }
 
       if (message.event === 'init') {
+        if (loadTimeoutRef.current) {
+          window.clearTimeout(loadTimeoutRef.current);
+          loadTimeoutRef.current = null;
+        }
         toggleLoading(false);
         if (data) {
           iframeRef.contentWindow?.postMessage(
@@ -118,11 +131,29 @@ export function RichTextDrawio() {
   }, [handleMessage]);
 
   useEffect(() => {
-    if (visible) {
-      toggleLoading(true);
-      setError(null);
-    }
-  }, [visible]);
+    if (!visible) return;
+
+    toggleLoading(true);
+    setError(null);
+
+    loadTimeoutRef.current = window.setTimeout(() => {
+      setError(new Error('Timed out waiting for the Draw.io editor to load. Check your network connection and try again.'));
+      toggleLoading(false);
+    }, DRAWIO_LOAD_TIMEOUT_MS);
+
+    return () => {
+      if (loadTimeoutRef.current) {
+        window.clearTimeout(loadTimeoutRef.current);
+        loadTimeoutRef.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, retryCount]);
+
+  const retry = useCallback(() => {
+    setError(null);
+    setRetryCount((count) => count + 1);
+  }, []);
 
   return (
     <Dialog onOpenChange={toggleVisible} open={visible}>
@@ -145,12 +176,28 @@ export function RichTextDrawio() {
         <div style={{ height: '100%', borderWidth: 1 }}>
           {loading && <p>Loading editor...</p>}
 
-          {error && <p>{(error && error.message) || 'Error loading editor'}</p>}
+          {error && (
+            <div>
+              <p>{(error && error.message) || 'Error loading editor'}</p>
+              <Button onClick={retry} type='button'>
+                Retry
+              </Button>
+            </div>
+          )}
+
+          {externalLibsMode === 'bundled' && (loading || error) && (
+            <p style={{ opacity: 0.7, fontSize: 12 }}>
+              Draw.io always loads diagrams.net in an embedded frame and needs
+              network access, even with "Bundled (offline)" library loading
+              enabled — that setting only applies to KaTeX and Mermaid.
+            </p>
+          )}
 
           {!error && (
             <iframe
+              key={retryCount}
               ref={setIframeRef}
-              src='https://embed.diagrams.net/?embed=1&ui=minimal&spin=1&modified=unsaved&noExitBtn=1&proto=json'
+              src={DRAWIO_EMBED_SRC}
               style={{
                 width: '100%',
                 height: 600,

--- a/packages/reason-editor/src/index.ts
+++ b/packages/reason-editor/src/index.ts
@@ -10,3 +10,15 @@ export * from '@/components/RichTextProvider';
  * the whole editor experience directly instead of iframing the hosted demo.
  */
 export { default as ReasonDocs } from '@/editor/ReasonDocs';
+
+/**
+ * Controls whether heavy third-party libraries (KaTeX, Mermaid) load lazily
+ * from a CDN or from this package's own bundled dependencies. See
+ * `@/store/externalLibsMode` for details.
+ */
+export {
+  useExternalLibsMode,
+  getExternalLibsMode,
+  externalLibsModeActions,
+  type ExternalLibsMode,
+} from '@/store/externalLibsMode';

--- a/packages/reason-editor/src/store/externalLibsMode.ts
+++ b/packages/reason-editor/src/store/externalLibsMode.ts
@@ -1,0 +1,35 @@
+/**
+ * Global toggle controlling how heavy third-party libraries used by editor
+ * extensions (KaTeX, Mermaid) are loaded.
+ *
+ * - 'cdn': lazily fetch them from a public CDN the first time a plugin needs
+ *   them (`@/utils/cdn-loader`). Smallest initial bundle, but requires
+ *   outbound network access to the CDN at runtime.
+ * - 'bundled': import the same libraries from this package's own npm
+ *   dependencies instead. Still code-split / loaded on demand, but ships in
+ *   the build and works fully offline or behind restrictive firewalls.
+ *
+ * Draw.io's editor itself is always a remote embed (embed.diagrams.net) —
+ * there is no offline alternative for it, so this setting does not affect it.
+ */
+
+import { createSignal, getSignal, useSignalValue } from 'reactjs-signal';
+
+export type ExternalLibsMode = 'cdn' | 'bundled';
+
+const externalLibsModeSignal = createSignal<ExternalLibsMode>('cdn');
+
+export function useExternalLibsMode(): ExternalLibsMode {
+  return useSignalValue(externalLibsModeSignal);
+}
+
+/** Non-reactive read for use outside React components (e.g. cdn-loader.ts). */
+export function getExternalLibsMode(): ExternalLibsMode {
+  return getSignal(externalLibsModeSignal).value();
+}
+
+export const externalLibsModeActions = {
+  setMode: (mode: ExternalLibsMode) => {
+    getSignal(externalLibsModeSignal).setValue(mode);
+  },
+};

--- a/packages/reason-editor/src/utils/cdn-loader.ts
+++ b/packages/reason-editor/src/utils/cdn-loader.ts
@@ -1,6 +1,13 @@
 /**
- * Lazily loads external scripts and styles from a CDN at runtime. Used to defer heavy dependencies until a feature actually needs them.
+ * Lazily loads heavy third-party libraries used by editor extensions (KaTeX,
+ * Mermaid). By default these are fetched from a public CDN the first time a
+ * feature needs them; when `externalLibsMode` is set to 'bundled' (see
+ * `@/store/externalLibsMode`) this instead resolves them from the package's
+ * own npm dependencies via a code-split dynamic import, so the same
+ * `loadKatex()` / `loadMermaid()` callers work offline with no code changes.
  */
+
+import { getExternalLibsMode } from '@/store/externalLibsMode';
 
 const loadedScripts = new Set<string>();
 const loadingPromises = new Map<string, Promise<void>>();
@@ -62,7 +69,21 @@ export async function loadStylesheet(url: string): Promise<void> {
   return promise;
 }
 
+let bundledKatexPromise: Promise<any> | null = null;
+let bundledMermaidPromise: Promise<any> | null = null;
+
 export async function loadKatex() {
+  if (getExternalLibsMode() === 'bundled') {
+    if (!bundledKatexPromise) {
+      bundledKatexPromise = Promise.all([
+        import('katex'),
+        // @ts-ignore - side-effect CSS import, resolved by the bundler
+        import('katex/dist/katex.min.css'),
+      ]).then(([mod]) => mod.default ?? mod);
+    }
+    return bundledKatexPromise;
+  }
+
   await Promise.all([
     loadStylesheet('https://cdn.jsdelivr.net/npm/katex@0.16.47/dist/katex.min.css'),
     loadScript('https://cdn.jsdelivr.net/npm/katex@0.16.47/dist/katex.min.js'),
@@ -71,11 +92,13 @@ export async function loadKatex() {
 }
 
 export async function loadMermaid() {
+  if (getExternalLibsMode() === 'bundled') {
+    if (!bundledMermaidPromise) {
+      bundledMermaidPromise = import('mermaid').then((mod) => mod.default ?? mod);
+    }
+    return bundledMermaidPromise;
+  }
+
   await loadScript('https://cdnjs.cloudflare.com/ajax/libs/mermaid/11.12.0/mermaid.min.js');
   return (window as any).mermaid;
-}
-
-export async function loadDrawio() {
-  await loadScript('https://cdn.jsdelivr.net/npm/mxgraph@4.10.38/javascript/mxClient.min.js');
-  return (window as any).mxGraph ? { mxGraph: (window as any).mxGraph } : null;
 }


### PR DESCRIPTION
## Summary
This PR adds support for offline library loading of KaTeX and Mermaid, and improves error handling and user experience for the Draw.io extension.

## Key Changes

### Library Loading Mode
- **New `externalLibsMode` store** (`@/store/externalLibsMode.ts`): Global signal-based state to control how heavy third-party libraries (KaTeX, Mermaid) are loaded
  - `'cdn'` (default): Lazily fetch from public CDN on first use (smallest bundle)
  - `'bundled'`: Import from package's own npm dependencies (works offline, larger bundle)
- **Updated `cdn-loader.ts`**: Modified `loadKatex()` and `loadMermaid()` to check the mode and either fetch from CDN or dynamically import bundled versions
- **Settings UI**: Added "Library Loading" section in `SettingsModal.tsx` with two button options to toggle between CDN and bundled modes
- **Config persistence**: Added `externalLibsMode` field to `EditorConfig` with proper normalization and defaults
- **Exports**: Exposed new store functions in public API (`index.ts` and `editor-kit.ts`)

### Draw.io Improvements
- **Load timeout handling**: Added 15-second timeout for Draw.io iframe initialization with user-friendly error message
- **Retry mechanism**: Users can now retry loading if the editor fails to initialize
- **Better error UI**: Improved error display with retry button
- **Informational message**: Added note explaining that Draw.io always requires network access even in bundled mode
- **Constants**: Extracted Draw.io embed URL and timeout value to named constants for maintainability
- **Iframe key**: Added `key={retryCount}` to force iframe remount on retry

### App Integration
- **Config synchronization**: Added effect in `App.tsx` to sync `externalLibsMode` config changes to the global store

## Implementation Details
- Uses `reactjs-signal` for reactive state management in the new store
- Caches bundled library promises to avoid re-importing
- Maintains backward compatibility with existing CDN-based loading as the default
- Draw.io embed URL and timeout are now configurable constants
- Cleanup of unused `loadDrawio()` function from cdn-loader

https://claude.ai/code/session_01RqdLzskD4Y1iUHGQpKy7t2