### PR TITLE
Add toggleable glow effect setting for search result cards

### DIFF
--- a/packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx
+++ b/packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx
@@ -34,10 +34,25 @@ const MessageSources = ({
   const [currentPage, setCurrentPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [isDesktop, setIsDesktop] = useState(false);
+  const [glowEnabled, setGlowEnabled] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const wasOpenRef = useRef(false);
   const userClosedPanelRef = useRef(false);
   const { openPanel, isOpen } = useExtractPanel();
+
+  // Off by default; enabled via the "Search Result Glow Effect" setting.
+  useEffect(() => {
+    const readGlowSetting = () => {
+      setGlowEnabled(localStorage.getItem('searchResultGlow') === 'true');
+    };
+    readGlowSetting();
+    window.addEventListener('client-config-changed', readGlowSetting);
+    window.addEventListener('storage', readGlowSetting);
+    return () => {
+      window.removeEventListener('client-config-changed', readGlowSetting);
+      window.removeEventListener('storage', readGlowSetting);
+    };
+  }, []);
 
   // Track article loading/loaded states
   const [articleStates, setArticleStates] = useState<Record<string, 'loading' | 'loaded'>>({});
@@ -297,7 +312,7 @@ const MessageSources = ({
           <GlowingEffect
             spread={40}
             glow={true}
-            disabled={false}
+            disabled={!glowEnabled}
             proximity={64}
             inactiveZone={0.01}
             borderWidth={2}
@@ -335,7 +350,7 @@ const MessageSources = ({
         <GlowingEffect
           spread={40}
           glow={true}
-          disabled={false}
+          disabled={!glowEnabled}
           proximity={64}
           inactiveZone={0.01}
           borderWidth={2}

--- a/packages/research-agent-ui/src/settings/search.json
+++ b/packages/research-agent-ui/src/settings/search.json
@@ -18,6 +18,15 @@
     "scope": "client"
   },
   {
+    "name": "Search Result Glow Effect",
+    "key": "searchResultGlow",
+    "type": "switch",
+    "required": false,
+    "description": "Add a cursor-following glow border to source cards in the search results panel.",
+    "default": false,
+    "scope": "client"
+  },
+  {
     "name": "TTS Voice",
     "key": "ttsSpeaker",
     "type": "select",


### PR DESCRIPTION
## Summary
This PR adds a new user-configurable setting to enable/disable a cursor-following glow border effect on source cards in the search results panel.

## Key Changes
- Added `searchResultGlow` client-side setting in `search.json` with a switch toggle (default: disabled)
- Implemented state management in `MessageSources.tsx` to read and sync the glow setting from localStorage
- Connected the setting to the existing `GlowingEffect` components by binding their `disabled` prop to the setting state
- Added event listeners for `client-config-changed` and `storage` events to reactively update the glow effect when the setting changes

## Implementation Details
- The glow effect is **off by default** and must be explicitly enabled via the "Search Result Glow Effect" setting
- Uses `localStorage` to persist the user's preference with key `searchResultGlow`
- Listens to both custom `client-config-changed` events and native `storage` events to ensure the UI stays in sync when settings are modified
- Properly cleans up event listeners on component unmount to prevent memory leaks
- The setting applies to both desktop and mobile layouts of the search results panel

https://claude.ai/code/session_01CHSzhVKrts3QRJaFcgC96o