### PR TITLE
Add cursor glow trail effect with toggle setting

### DIFF
--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -63,6 +63,8 @@ export default function ChatHomepage() {
   const [weatherLocations, setWeatherLocations] = useState<WeatherLocationInput[]>([]);
   const [trendingNewsApiUrl, setTrendingNewsApiUrl] = useState<string | null>(null);
   const [orbHoverGlow, setOrbHoverGlow] = useState(false);
+  // Off by default; enabled via the "Cursor Glow Trail" setting.
+  const [cursorGlowTrail, setCursorGlowTrail] = useState(false);
   const footerLinks = researchAgentUIConfig.footerLinks.map((link) =>
     link.url === '/#downloads' ? { ...link, onClick: () => setDownloadsOpen(true) } : link,
   );
@@ -71,6 +73,7 @@ export default function ChatHomepage() {
       setWeatherLocations(parseWeatherLocations(localStorage.getItem('weatherLocations')));
       setTrendingNewsApiUrl(localStorage.getItem('trendingNewsApiUrl'));
       setOrbHoverGlow(localStorage.getItem('orbHoverGlow') === 'true');
+      setCursorGlowTrail(localStorage.getItem('cursorGlowTrail') === 'true');
     };
     readLocations();
     window.addEventListener('client-config-changed', readLocations);
@@ -128,7 +131,7 @@ export default function ChatHomepage() {
       <div className="fixed inset-0 z-0">
         {backgroundUrl && renderBackground(backgroundUrl, fading ? 'opacity-0' : 'opacity-30')}
         {nextBackgroundUrl && renderBackground(nextBackgroundUrl, fading ? 'opacity-30' : 'opacity-0')}
-        <GradientBlur />
+        {cursorGlowTrail && <GradientBlur />}
       </div>
 
       <div className="relative z-10">

--- a/packages/research-agent-ui/src/settings/search.json
+++ b/packages/research-agent-ui/src/settings/search.json
@@ -18,6 +18,15 @@
     "scope": "client"
   },
   {
+    "name": "Cursor Glow Trail",
+    "key": "cursorGlowTrail",
+    "type": "switch",
+    "required": false,
+    "description": "Paint a colored glow trail that follows your cursor across the chat homepage background.",
+    "default": false,
+    "scope": "client"
+  },
+  {
     "name": "Search Result Glow Effect",
     "key": "searchResultGlow",
     "type": "switch",

--- a/packages/research-agent-ui/src/ui/gradient-blur.tsx
+++ b/packages/research-agent-ui/src/ui/gradient-blur.tsx
@@ -48,6 +48,8 @@ export function GradientBlur({
     const ctx = canvas.getContext("2d")
     if (!ctx) return
 
+    let frameId = 0
+
     const resizeCanvas = () => {
       canvas.width = window.innerWidth
       canvas.height = window.innerHeight
@@ -105,7 +107,7 @@ export function GradientBlur({
       }
 
       ctx.globalAlpha = 1
-      requestAnimationFrame(draw)
+      frameId = requestAnimationFrame(draw)
     }
 
     const handleMouseMove = (e: MouseEvent) => {
@@ -125,9 +127,11 @@ export function GradientBlur({
     draw()
 
     return () => {
+      cancelAnimationFrame(frameId)
       window.removeEventListener("mousemove", handleMouseMove)
       window.removeEventListener("touchmove", handleTouchMove)
       window.removeEventListener("resize", resizeCanvas)
+      circsRef.current = []
     }
   }, [radius, opacityDecay, backgroundColor, color, colorGenerator])
 


### PR DESCRIPTION
## Summary
This PR adds a new "Cursor Glow Trail" feature that allows users to enable a colored glow effect that follows their cursor across the chat homepage background. The feature is controlled via a new client-side setting and is disabled by default.

## Key Changes
- **New Setting**: Added "Cursor Glow Trail" toggle to `search.json` that controls whether the glow trail effect is rendered
- **State Management**: Added `cursorGlowTrail` state to `ChatHomepage` component that reads from localStorage and syncs with the client config
- **Conditional Rendering**: The `GradientBlur` component (which renders the cursor glow effect) is now only rendered when the `cursorGlowTrail` setting is enabled
- **Memory Leak Fixes**: Improved cleanup in `GradientBlur` component by:
  - Storing the `requestAnimationFrame` ID and properly canceling it on unmount
  - Clearing the circles array on cleanup to prevent memory accumulation

## Implementation Details
- The feature integrates with the existing settings system via localStorage and the `client-config-changed` event
- The `GradientBlur` component's animation loop is now properly managed with frame ID tracking and cancellation
- The setting is scoped to "client" and defaults to `false` for opt-in behavior

https://claude.ai/code/session_01R5oBYRVUdt4Qj5tdQ5cBrP