### PR TITLE
Improve dropdown and panel positioning on mobile screens

### DIFF
--- a/packages/reason-editor/src/app-ui/dropdown-menu.tsx
+++ b/packages/reason-editor/src/app-ui/dropdown-menu.tsx
@@ -43,6 +43,8 @@ function DropdownMenuContent({
   return (
     <DropdownMenuPrimitive.Portal>
       <DropdownMenuPrimitive.Content
+        collisionPadding={8}
+        data-richtext-menu
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
@@ -232,6 +234,8 @@ function DropdownMenuSubContent({
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
     <DropdownMenuPrimitive.SubContent
+      collisionPadding={8}
+      data-richtext-menu
       data-slot="dropdown-menu-sub-content"
       className={cn(
         "bg-card text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-2xl border p-1 shadow-lg",

--- a/packages/reason-editor/src/components/ui/dropdown-menu.tsx
+++ b/packages/reason-editor/src/components/ui/dropdown-menu.tsx
@@ -10,6 +10,14 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Gutter Radix keeps between a menu and the viewport edge when it flips or
+ * shifts a menu back into view. Matches the toolbar's own panel margin, and
+ * pairs with the `[data-richtext-menu]` sizing rules in `styles/global.scss`
+ * that stop wide menus from being clipped on narrow screens.
+ */
+const MENU_COLLISION_PADDING = 8;
+
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
@@ -48,6 +56,8 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.SubContent
+    collisionPadding={MENU_COLLISION_PADDING}
+    data-richtext-menu
     data-richtext-portal
     ref={ref}
     className={cn(
@@ -65,6 +75,8 @@ const DropdownMenuContent = React.forwardRef<
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal data-richtext-portal>
     <DropdownMenuPrimitive.Content
+      collisionPadding={MENU_COLLISION_PADDING}
+      data-richtext-menu
       data-richtext-portal
       ref={ref}
       sideOffset={sideOffset}

--- a/packages/reason-editor/src/components/ui/popover.tsx
+++ b/packages/reason-editor/src/components/ui/popover.tsx
@@ -20,6 +20,8 @@ const PopoverContent = React.forwardRef<
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       align={align}
+      collisionPadding={8}
+      data-richtext-menu
       data-richtext-portal
       ref={ref}
       sideOffset={sideOffset}

--- a/packages/reason-editor/src/components/ui/select.tsx
+++ b/packages/reason-editor/src/components/ui/select.tsx
@@ -77,6 +77,8 @@ const SelectContent = React.forwardRef<
 >(({ className, children, position = 'popper', ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
+      collisionPadding={8}
+      data-richtext-menu
       data-richtext-portal
       position={position}
       ref={ref}

--- a/packages/reason-editor/src/editor-views/components/Toolbar.tsx
+++ b/packages/reason-editor/src/editor-views/components/Toolbar.tsx
@@ -2,7 +2,7 @@
  * Full formatting toolbar for the example editor, wiring each extension's RichText control together. Provides the top row of editing actions users interact with.
  */
 
-import { useCallback, useEffect, useState, useRef, useMemo } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useState, useRef, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import type { Editor } from '@tiptap/core';
 import { useCurrentEditor } from '@tiptap/react';
@@ -588,6 +588,91 @@ function ToolbarIconBtn({
 const panelCls =
   'fixed bg-white/70 dark:bg-slate-900/70 backdrop-blur-md border border-gray-200/60 dark:border-slate-700/60 rounded-lg shadow-xl py-1 z-50 min-w-[220px] dropdown-portal';
 
+/** Gutter kept clear between an open panel and every edge of the viewport. */
+const PANEL_MARGIN = 8;
+/** At or below this viewport width panels stop tracking the trigger. */
+const PANEL_MOBILE_BREAKPOINT = 640;
+
+/**
+ * Portal shell for the toolbar dropdowns. The panels are wider than a phone
+ * screen, so anchoring them to their trigger pushes them off the side; this
+ * clamps every panel into the viewport instead. On phone-width screens the
+ * trigger position is ignored horizontally and the panel spans the full width,
+ * centred between equal margins. Height is capped to what is left below the
+ * trigger so long menus scroll rather than run off the bottom.
+ */
+function MenuPanel({
+  top,
+  left,
+  right,
+  className = '',
+  children,
+}: {
+  top: number;
+  left?: number;
+  right?: number;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  // Rendered off-screen for one layout pass so the panel can be measured
+  // before it is placed.
+  const [style, setStyle] = useState<React.CSSProperties>({
+    top,
+    left: -9999,
+    visibility: 'hidden',
+  });
+
+  useLayoutEffect(() => {
+    const place = () => {
+      const el = ref.current;
+      if (!el) return;
+
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const maxHeight = Math.max(160, vh - top - PANEL_MARGIN);
+
+      if (vw <= PANEL_MOBILE_BREAKPOINT) {
+        setStyle({
+          top,
+          left: PANEL_MARGIN,
+          right: PANEL_MARGIN,
+          width: 'auto',
+          // The panels carry min-w-[300px]/min-w-[400px] for desktop; those
+          // would keep them wider than the screen and clip the right edge.
+          minWidth: 0,
+          maxWidth: 'none',
+          maxHeight,
+          overflowY: 'auto',
+        });
+        return;
+      }
+
+      const width = el.offsetWidth;
+      const desired = right != null ? vw - right - width : left ?? PANEL_MARGIN;
+      const clamped = Math.max(PANEL_MARGIN, Math.min(desired, vw - width - PANEL_MARGIN));
+
+      setStyle({
+        top,
+        left: clamped,
+        maxWidth: vw - PANEL_MARGIN * 2,
+        maxHeight,
+        overflowY: 'auto',
+      });
+    };
+
+    place();
+    window.addEventListener('resize', place);
+    return () => window.removeEventListener('resize', place);
+  }, [top, left, right]);
+
+  return (
+    <div className={`${panelCls} ${className}`} ref={ref} style={style}>
+      {children}
+    </div>
+  );
+}
+
 // ─── Document details modal (info + word count + sharing) ─────────────────────
 
 interface SharedUser {
@@ -1150,11 +1235,6 @@ export const RichTextToolbar = ({
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
-  const panelStyle = (rightAligned?: boolean) =>
-    rightAligned && pos?.right != null
-      ? { top: `${pos!.top}px`, right: `${pos!.right}px` }
-      : { top: `${pos!.top}px`, left: `${pos!.left}px` };
-
   return (
     <>
       <div className="flex items-center gap-0.5 border-b border-gray-200 dark:border-slate-700 px-2 py-1 flex-wrap">
@@ -1185,7 +1265,7 @@ export const RichTextToolbar = ({
             </svg>
           </ToolbarIconBtn>
           {open === 'block' && pos && createPortal(
-            <div className={`${panelCls} min-w-[400px]`} style={panelStyle()}>
+            <MenuPanel className="min-w-[400px]" left={pos.left} top={pos.top}>
               <div className="grid grid-cols-2 gap-0.5 px-1 py-1">
                 <div><HiddenControl icon="H1" label="Heading 1" shortcut="Ctrl+Alt+1"><RichTextHeading level={1} /></HiddenControl></div>
                 <div><HiddenControl icon="H2" label="Heading 2" shortcut="Ctrl+Alt+2"><RichTextHeading level={2} /></HiddenControl></div>
@@ -1216,7 +1296,7 @@ export const RichTextToolbar = ({
                 <Paintbrush size={14} className="text-gray-400 shrink-0" />
                 Customize default styles…
               </button>
-            </div>,
+            </MenuPanel>,
             document.body
           )}
         </div>
@@ -1227,7 +1307,7 @@ export const RichTextToolbar = ({
             <span className="text-sm font-mono">Tt</span>
           </ToolbarIconBtn>
           {open === 'textstyles' && pos && createPortal(
-            <div className={`${panelCls} min-w-[400px]`} style={panelStyle()}>
+            <MenuPanel className="min-w-[400px]" left={pos.left} top={pos.top}>
               <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Text Styles</div>
               <div className="grid grid-cols-2 gap-0.5 px-1 py-1">
                 <div className="col-span-2"><ToolbarMenuItem><RichTextFontFamily /></ToolbarMenuItem></div>
@@ -1240,7 +1320,7 @@ export const RichTextToolbar = ({
                 <div><ToolbarMenuItem label="Line Spacing"><RichTextLineHeight /></ToolbarMenuItem></div>
                 <div className="col-span-2"><ToolbarMenuItem label="Alignment"><RichTextAlign /></ToolbarMenuItem></div>
               </div>
-            </div>,
+            </MenuPanel>,
             document.body
           )}
         </div>
@@ -1251,7 +1331,7 @@ export const RichTextToolbar = ({
             <Plus size={16} />
           </ToolbarIconBtn>
           {open === 'insert' && pos && createPortal(
-            <div className={`${panelCls} min-w-[300px] max-h-[360px] overflow-y-auto`} style={panelStyle()}>
+            <MenuPanel className="min-w-[300px]" left={pos.left} top={pos.top}>
               <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Insert</div>
               <div className="grid grid-cols-2 gap-0.5 px-1">
                 <div><ToolbarMenuItem label="Link"><RichTextLink /></ToolbarMenuItem></div>
@@ -1284,7 +1364,7 @@ export const RichTextToolbar = ({
                   </div>
                 )}
               </div>
-            </div>,
+            </MenuPanel>,
             document.body
           )}
         </div>
@@ -1298,7 +1378,7 @@ export const RichTextToolbar = ({
             </svg>
           </ToolbarIconBtn>
           {open === 'tools' && pos && createPortal(
-            <div className={`${panelCls} max-h-[70vh] overflow-y-auto`} style={panelStyle()}>
+            <MenuPanel left={pos.left} top={pos.top}>
               <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Document</div>
               <MenuAction
                 icon={<FileText size={14} />}
@@ -1375,7 +1455,7 @@ export const RichTextToolbar = ({
               <ToolbarMenuItem label="Import Word"><RichTextImportWord /></ToolbarMenuItem>
               <ToolbarMenuItem label="Export Word"><RichTextExportWord /></ToolbarMenuItem>
               <ToolbarMenuItem label="Export PDF"><RichTextExportPdf /></ToolbarMenuItem>
-            </div>,
+            </MenuPanel>,
             document.body
           )}
         </div>
@@ -1403,9 +1483,10 @@ export const RichTextToolbar = ({
             <Settings size={16} />
           </button>
           {!configDriven && open === 'settings' && pos && createPortal(
-            <div
-              className="fixed bg-white/70 dark:bg-slate-900/70 backdrop-blur-md border border-gray-200/60 dark:border-slate-700/60 rounded-lg shadow-2xl p-2 z-50 w-[260px] dropdown-portal"
-              style={panelStyle(true)}
+            <MenuPanel
+              className="w-[260px] px-2 py-2 shadow-2xl"
+              right={pos.right}
+              top={pos.top}
             >
               <div className="text-[10px] font-semibold mb-1 text-gray-500 dark:text-gray-400 uppercase px-1">Theme</div>
               <div className="flex gap-1 mb-2 px-1">
@@ -1466,7 +1547,7 @@ export const RichTextToolbar = ({
                   </button>
                 ))}
               </div>
-            </div>,
+            </MenuPanel>,
             document.body
           )}
         </div>

--- a/packages/reason-editor/src/styles/global.scss
+++ b/packages/reason-editor/src/styles/global.scss
@@ -49,6 +49,25 @@
   --richtext-ring: 240 4.9% 83.9%;
 }
 
+// Dropdown menus, popovers and selects must never run off the side of the
+// screen. Radix already shifts them back into view (see MENU_COLLISION_PADDING),
+// but a menu that is intrinsically wider than the viewport still gets clipped,
+// so cap the width here. On phone-width screens the menus stretch across the
+// screen instead of hugging their trigger — with the width pinned to the
+// viewport, Radix's collision handling lands them centred.
+[data-richtext-menu] {
+  max-width: calc(100vw - 16px);
+}
+
+@media (max-width: 640px) {
+  [data-richtext-menu] {
+    width: calc(100vw - 16px) !important;
+    min-width: 0 !important;
+    max-height: 70vh;
+    overflow-y: auto;
+  }
+}
+
 // https://github.com/radix-ui/primitives/issues/1496
 html body[data-scroll-locked] {
   --removed-body-scroll-bar-size: 0 !important;


### PR DESCRIPTION
## Summary
This PR improves the positioning and responsiveness of dropdown menus and toolbar panels, particularly on mobile and narrow screens. It introduces a new `MenuPanel` component for toolbar dropdowns that intelligently clamps panels into the viewport and adapts their layout for phone-width screens.

## Key Changes

- **New `MenuPanel` component**: Replaces inline panel divs in the toolbar with a reusable component that:
  - Renders off-screen initially to measure dimensions before placement
  - Clamps panels horizontally into the viewport with an 8px margin
  - On screens ≤640px width, spans full width with equal side margins instead of tracking the trigger
  - Caps height to available space below the trigger with scrolling for overflow

- **Consistent collision padding**: Added `collisionPadding={8}` to all Radix UI dropdown, popover, and select components to match the toolbar's panel margin and prevent clipping

- **Mobile-specific styling**: Added `[data-richtext-menu]` CSS rules that:
  - Cap menu width to viewport minus 16px gutter on all screens
  - Force full-width layout on mobile (≤640px) with `!important` overrides
  - Cap height to 70vh with scrolling on mobile

- **Removed manual positioning logic**: Deleted the `panelStyle()` helper function that only handled left/right positioning, replacing it with the more sophisticated `MenuPanel` component

## Implementation Details

- Uses `useLayoutEffect` to ensure panel positioning happens before paint, preventing visual jumps
- Handles both left-aligned (default) and right-aligned panels via optional `left` and `right` props
- Responsive breakpoint at 640px matches Tailwind's `sm` breakpoint
- Maintains backward compatibility by keeping all existing className props and styling

https://claude.ai/code/session_01Ea8XRegWSBmeQUr7rDAL5Q