### PR TITLE
Refactor theme tokens to inherit host application palette

### DIFF
--- a/packages/reason-editor/src/app-styles/split-pane.css
+++ b/packages/reason-editor/src/app-styles/split-pane.css
@@ -25,21 +25,21 @@
   transform: translateX(-50%);
   width: 2px;
   height: 100%;
-  background-color: hsl(var(--richtext-border));
+  background-color: var(--richtext-border);
   border-radius: 2px;
   transition: width 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .split-pane-divider.horizontal:hover,
 .split-pane-divider.horizontal.dragging {
-  background-color: hsl(var(--richtext-primary) / 0.08);
+  background-color: color-mix(in oklab, var(--richtext-primary) 8%, transparent);
 }
 
 .split-pane-divider.horizontal:hover::before,
 .split-pane-divider.horizontal.dragging::before {
   width: 3px;
-  background-color: hsl(var(--richtext-primary));
-  box-shadow: 0 0 8px hsl(var(--richtext-primary) / 0.45);
+  background-color: var(--richtext-primary);
+  box-shadow: 0 0 8px color-mix(in oklab, var(--richtext-primary) 45%, transparent);
 }
 
 /* ── Vertical split (top/bottom panes) ── horizontal bar ── */
@@ -56,19 +56,19 @@
   transform: translateY(-50%);
   height: 2px;
   width: 100%;
-  background-color: hsl(var(--richtext-border));
+  background-color: var(--richtext-border);
   border-radius: 2px;
   transition: height 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .split-pane-divider.vertical:hover,
 .split-pane-divider.vertical.dragging {
-  background-color: hsl(var(--richtext-primary) / 0.08);
+  background-color: color-mix(in oklab, var(--richtext-primary) 8%, transparent);
 }
 
 .split-pane-divider.vertical:hover::before,
 .split-pane-divider.vertical.dragging::before {
   height: 3px;
-  background-color: hsl(var(--richtext-primary));
-  box-shadow: 0 0 8px hsl(var(--richtext-primary) / 0.45);
+  background-color: var(--richtext-primary);
+  box-shadow: 0 0 8px color-mix(in oklab, var(--richtext-primary) 45%, transparent);
 }

--- a/packages/reason-editor/src/components/ActionButton.tsx
+++ b/packages/reason-editor/src/components/ActionButton.tsx
@@ -51,7 +51,10 @@ const ActionButton = React.forwardRef<HTMLButtonElement, Partial<ActionButtonPro
   (props, ref) => {
     const {
       icon = undefined,
-      // title = undefined,
+      // Pulled out of `rest` so it never reaches the DOM as the `title`
+      // attribute: the browser would draw its own native tooltip on hover,
+      // overlapping and offset from the styled Radix one below.
+      title: _title = undefined,
       tooltip = undefined,
       disabled = false,
       customClass = '',
@@ -99,7 +102,7 @@ const ActionButton = React.forwardRef<HTMLButtonElement, Partial<ActionButtonPro
 
         {tooltip && (
           <TooltipContent {...tooltipOptions} className='richtext-tooltip'>
-            <div className='richtext-flex richtext-max-w-24 richtext-flex-col richtext-items-center richtext-text-center'>
+            <div className='richtext-flex richtext-flex-col richtext-items-center richtext-text-center'>
               <div>{tooltip}</div>
 
               {!!shortcutKeys?.length && <span>{getShortcutKeys(shortcutKeys)}</span>}

--- a/packages/reason-editor/src/components/ActionMenuButton.tsx
+++ b/packages/reason-editor/src/components/ActionMenuButton.tsx
@@ -40,6 +40,12 @@ const ActionMenuButton = React.forwardRef<HTMLButtonElement, ActionMenuButtonPro
     const Icon = icons[props.icon];
     const Comp = asChild ? Slot : Button;
 
+    // `title` is the button's visible label, rendered below. It must not reach
+    // the DOM as the `title` attribute: the browser would then draw its own
+    // native tooltip on hover on top of — and offset from — the styled Radix
+    // one, so every toolbar control showed two overlapping tooltips.
+    const { title, ...buttonProps } = props;
+
     return (
       <Tooltip>
         <TooltipTrigger asChild>
@@ -49,12 +55,12 @@ const ActionMenuButton = React.forwardRef<HTMLButtonElement, ActionMenuButtonPro
             disabled={props?.disabled}
             ref={ref}
             variant='ghost'
-            {...props}
+            {...buttonProps}
           >
             <div className='richtext-flex richtext-h-full richtext-items-center richtext-font-normal'>
-              {props?.title && (
+              {title && (
                 <div className='richtext-grow richtext-truncate richtext-text-left richtext-text-sm'>
-                  {props?.title}
+                  {title}
                 </div>
               )}
 
@@ -66,8 +72,8 @@ const ActionMenuButton = React.forwardRef<HTMLButtonElement, ActionMenuButtonPro
         </TooltipTrigger>
 
         {tooltip && (
-          <TooltipContent>
-            <div className='richtext-flex richtext-max-w-24 richtext-flex-col richtext-items-center richtext-text-center'>
+          <TooltipContent {...props?.tooltipOptions} className='richtext-tooltip'>
+            <div className='richtext-flex richtext-flex-col richtext-items-center richtext-text-center'>
               {tooltip && <div>{tooltip}</div>}
 
               <div className='richtext-flex'>

--- a/packages/reason-editor/src/components/Bubble/RichTextBubbleKatex.tsx
+++ b/packages/reason-editor/src/components/Bubble/RichTextBubbleKatex.tsx
@@ -95,7 +95,7 @@ function ModalEditKatex({ children, visible, toggleVisible }: any) {
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>{t('editor.formula.dialog.text')}</DialogTitle>
 
-        <div style={{ height: '100%', border: '1px solid hsl(var(--richtext-border))' }}>
+        <div style={{ height: '100%', border: '1px solid var(--richtext-border)' }}>
           <div className='richtext-flex richtext-gap-[10px] richtext-rounded-[10px] richtext-p-[10px]'>
             <div className='richtext-flex-1'>
               <Label className='mb-[6px]'>Expression</Label>
@@ -109,7 +109,7 @@ function ModalEditKatex({ children, visible, toggleVisible }: any) {
                 rows={10}
                 value={currentValue}
                 style={{
-                  color: 'hsl(var(--richtext-foreground))',
+                  color: 'var(--richtext-foreground)',
                 }}
               />
 
@@ -121,7 +121,7 @@ function ModalEditKatex({ children, visible, toggleVisible }: any) {
                 rows={10}
                 value={currentMacros}
                 style={{
-                  color: 'hsl(var(--richtext-foreground))',
+                  color: 'var(--richtext-foreground)',
                 }}
               />
             </div>

--- a/packages/reason-editor/src/components/ui/context-menu.tsx
+++ b/packages/reason-editor/src/components/ui/context-menu.tsx
@@ -48,7 +48,7 @@ const ContextMenuSubContent = React.forwardRef<
   <ContextMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-blue-400/30 bg-blue-500/15 backdrop-blur-md p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover backdrop-blur-md p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className,
     )}
     {...props}
@@ -64,7 +64,7 @@ const ContextMenuContent = React.forwardRef<
     <ContextMenuPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-blue-400/30 bg-blue-500/15 backdrop-blur-md p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover backdrop-blur-md p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/packages/reason-editor/src/components/ui/dropdown-menu.tsx
+++ b/packages/reason-editor/src/components/ui/dropdown-menu.tsx
@@ -61,7 +61,7 @@ const DropdownMenuSubContent = React.forwardRef<
     data-richtext-portal
     ref={ref}
     className={cn(
-      'richtext-z-50 richtext-min-w-[8rem] richtext-overflow-hidden richtext-rounded-md !richtext-border !richtext-border-blue-400/30 richtext-bg-blue-500/15 richtext-backdrop-blur-md richtext-p-1 richtext-text-popover-foreground richtext-shadow-lg data-[state=open]:richtext-animate-in data-[state=closed]:richtext-animate-out data-[state=closed]:richtext-fade-out-0 data-[state=open]:richtext-fade-in-0 data-[state=closed]:richtext-zoom-out-95 data-[state=open]:richtext-zoom-in-95 data-[side=bottom]:richtext-slide-in-from-top-2 data-[side=left]:richtext-slide-in-from-right-2 data-[side=right]:richtext-slide-in-from-left-2 data-[side=top]:richtext-slide-in-from-bottom-2',
+      'richtext-z-50 richtext-min-w-[8rem] richtext-overflow-hidden richtext-rounded-md !richtext-border !richtext-border-border richtext-bg-popover richtext-backdrop-blur-md richtext-p-1 richtext-text-popover-foreground richtext-shadow-lg data-[state=open]:richtext-animate-in data-[state=closed]:richtext-animate-out data-[state=closed]:richtext-fade-out-0 data-[state=open]:richtext-fade-in-0 data-[state=closed]:richtext-zoom-out-95 data-[state=open]:richtext-zoom-in-95 data-[side=bottom]:richtext-slide-in-from-top-2 data-[side=left]:richtext-slide-in-from-right-2 data-[side=right]:richtext-slide-in-from-left-2 data-[side=top]:richtext-slide-in-from-bottom-2',
       className
     )}
     {...props}
@@ -81,7 +81,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'richtext-z-50 richtext-min-w-[8rem] richtext-overflow-hidden richtext-rounded-md !richtext-border !richtext-border-blue-400/30 richtext-bg-blue-500/15 richtext-backdrop-blur-md richtext-p-1 richtext-text-popover-foreground richtext-shadow-md data-[state=open]:richtext-animate-in data-[state=closed]:richtext-animate-out data-[state=closed]:richtext-fade-out-0 data-[state=open]:richtext-fade-in-0 data-[state=closed]:richtext-zoom-out-95 data-[state=open]:richtext-zoom-in-95 data-[side=bottom]:richtext-slide-in-from-top-2 data-[side=left]:richtext-slide-in-from-right-2 data-[side=right]:richtext-slide-in-from-left-2 data-[side=top]:richtext-slide-in-from-bottom-2',
+        'richtext-z-50 richtext-min-w-[8rem] richtext-overflow-hidden richtext-rounded-md !richtext-border !richtext-border-border richtext-bg-popover richtext-backdrop-blur-md richtext-p-1 richtext-text-popover-foreground richtext-shadow-md data-[state=open]:richtext-animate-in data-[state=closed]:richtext-animate-out data-[state=closed]:richtext-fade-out-0 data-[state=open]:richtext-fade-in-0 data-[state=closed]:richtext-zoom-out-95 data-[state=open]:richtext-zoom-in-95 data-[side=bottom]:richtext-slide-in-from-top-2 data-[side=left]:richtext-slide-in-from-right-2 data-[side=right]:richtext-slide-in-from-left-2 data-[side=top]:richtext-slide-in-from-bottom-2',
         className
       )}
       {...props}

--- a/packages/reason-editor/src/editor-views/config/baseKit.ts
+++ b/packages/reason-editor/src/editor-views/config/baseKit.ts
@@ -24,7 +24,7 @@ export function buildBaseKit(): any[] {
     Text,
     Dropcursor.configure({
       class: 'react-reason-editor-theme',
-      color: 'hsl(var(--richtext-primary))',
+      color: 'var(--richtext-primary)',
       width: 2,
     }),
     Gapcursor,

--- a/packages/reason-editor/src/extensions/Attachment/components/NodeViewAttachment/index.module.scss
+++ b/packages/reason-editor/src/extensions/Attachment/components/NodeViewAttachment/index.module.scss
@@ -3,7 +3,7 @@
   /* for NodeView */
   border-width: 1px !important;
   border-radius: var(--richtext-radius) !important;
-  border-color: hsl(var(--richtext-border)) !important;
+  border-color: var(--richtext-border) !important;
   padding: 8px;
   display: flex;
   align-items: center;

--- a/packages/reason-editor/src/extensions/Drawio/components/NodeViewDrawio/index.module.scss
+++ b/packages/reason-editor/src/extensions/Drawio/components/NodeViewDrawio/index.module.scss
@@ -5,7 +5,7 @@
   line-height: 0;
 
   .renderWrap {
-    border: 1px dashed hsl(var(--richtext-border)) !important;
+    border: 1px dashed var(--richtext-border) !important;
     border-radius: 6px;
 
     &::after {
@@ -37,7 +37,7 @@
     bottom: 10px;
     z-index: 2;
     padding: 2px 4px;
-    border: 1px solid hsl(var(--richtext-border));
+    border: 1px solid var(--richtext-border);
     border-radius: 6px;
   }
 }
@@ -48,7 +48,7 @@
 
 .active {
   .renderWrap {
-    border-color: hsl(var(--richtext-primary)) !important;
-    box-shadow: 0 0 0 2px hsl(var(--richtext-primary) / 0.1);
+    border-color: var(--richtext-primary) !important;
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--richtext-primary) 10%, transparent);
   }
 }

--- a/packages/reason-editor/src/extensions/Iframe/components/index.module.scss
+++ b/packages/reason-editor/src/extensions/Iframe/components/index.module.scss
@@ -5,7 +5,7 @@
   overflow: hidden;
   line-height: 0;
   flex-direction: column;
-  border: 1px dashed hsl(var(--richtext-border)) !important;
+  border: 1px dashed var(--richtext-border) !important;
   border-radius: 6px;
 
   .handlerWrap {

--- a/packages/reason-editor/src/extensions/Katex/components/RichTextKatex.tsx
+++ b/packages/reason-editor/src/extensions/Katex/components/RichTextKatex.tsx
@@ -107,7 +107,7 @@ export function RichTextKatex() {
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>{t('editor.formula.dialog.text')}</DialogTitle>
 
-        <div style={{ height: '100%', border: '1px solid hsl(var(--richtext-border))' }}>
+        <div style={{ height: '100%', border: '1px solid var(--richtext-border)' }}>
           <div className='richtext-flex richtext-gap-[10px] richtext-rounded-[10px] richtext-p-[10px]'>
             <div className='richtext-flex-1'>
               <Label className='mb-[6px]'>Expression</Label>
@@ -121,7 +121,7 @@ export function RichTextKatex() {
                 rows={10}
                 value={currentValue}
                 style={{
-                  color: 'hsl(var(--richtext-foreground))',
+                  color: 'var(--richtext-foreground)',
                 }}
               />
 
@@ -136,7 +136,7 @@ export function RichTextKatex() {
                   setCurrentMacros(e.target.value);
                 }}
                 style={{
-                  color: 'hsl(var(--richtext-foreground))',
+                  color: 'var(--richtext-foreground)',
                 }}
               />
             </div>

--- a/packages/reason-editor/src/extensions/Mermaid/components/EditMermaidBlock.tsx
+++ b/packages/reason-editor/src/extensions/Mermaid/components/EditMermaidBlock.tsx
@@ -126,7 +126,7 @@ export const EditMermaidBlock: React.FC<IProps> = ({ editor, attrs, extension })
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>Edit Mermaid</DialogTitle>
 
-        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid hsl(var(--richtext-border))' }}>
+        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid var(--richtext-border)' }}>
           <div className='richtext-flex richtext-gap-[10px] richtext-rounded-[10px] richtext-p-[10px]'>
             <Textarea
               autoFocus
@@ -138,7 +138,7 @@ export const EditMermaidBlock: React.FC<IProps> = ({ editor, attrs, extension })
               rows={10}
               value={mermaidCode}
               style={{
-                color: 'hsl(var(--richtext-foreground))',
+                color: 'var(--richtext-foreground)',
               }}
             />
 
@@ -148,7 +148,7 @@ export const EditMermaidBlock: React.FC<IProps> = ({ editor, attrs, extension })
               ref={mermaidRef as any}
               style={{
                 height: '100%',
-                border: '1px solid hsl(var(--richtext-border))',
+                border: '1px solid var(--richtext-border)',
                 minHeight: 500,
               }}
             />

--- a/packages/reason-editor/src/extensions/Mermaid/components/RichTextMermaid.tsx
+++ b/packages/reason-editor/src/extensions/Mermaid/components/RichTextMermaid.tsx
@@ -141,7 +141,7 @@ export function RichTextMermaid() {
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>Mermaid</DialogTitle>
 
-        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid hsl(var(--richtext-border))' }}>
+        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid var(--richtext-border)' }}>
           {loading ? (
             <p>Loading...</p>
           ) : (
@@ -156,7 +156,7 @@ export function RichTextMermaid() {
                   rows={10}
                   value={mermaidCode}
                   style={{
-                    color: 'hsl(var(--richtext-foreground))',
+                    color: 'var(--richtext-foreground)',
                   }}
                 />
 

--- a/packages/reason-editor/src/novel/NovelEditor.tsx
+++ b/packages/reason-editor/src/novel/NovelEditor.tsx
@@ -215,7 +215,15 @@ export function NovelEditor({
             editable={current.editable}
             immediatelyRender={current.immediatelyRender}
             textDirection={current.textDirection}
-            editorContainerProps={contentClassName ? { className: contentClassName } : undefined}
+            // `reason-editor-surface` is the stylesheet's hook for stretching
+            // the contenteditable to fill this container (see
+            // `styles/editor.scss`); it is always present so the rule does not
+            // depend on what the host passes in `className`.
+            editorContainerProps={{
+              className: contentClassName
+                ? `reason-editor-surface ${contentClassName}`
+                : 'reason-editor-surface',
+            }}
             editorProps={{
               ...restEditorProps,
               handleDOMEvents: {

--- a/packages/reason-editor/src/store/ThemeColorReactive.tsx
+++ b/packages/reason-editor/src/store/ThemeColorReactive.tsx
@@ -7,6 +7,17 @@ import { useEffect } from 'react';
 import { THEME, useTheme } from '@/theme/theme';
 import { removeCSS, updateCSS } from '@/utils/dynamicCSS';
 
+/**
+ * Elements the theme tokens are applied to: the editor root, the standalone
+ * theme scope, and the portalled surfaces (tooltips, dropdowns, bubble menus)
+ * which render outside the editor's DOM subtree and so cannot inherit from it.
+ */
+const THEME_SCOPE = [
+  '.reactjs-tiptap-editor',
+  '.reactjs-tiptap-editor-theme',
+  'div[data-richtext-portal]',
+].join(', ');
+
 export function ThemeColorReactive() {
   const { theme, color, borderRadius } = useTheme();
 
@@ -14,35 +25,33 @@ export function ThemeColorReactive() {
     const themeValue = theme || 'light';
     const colorValue = color || 'default';
 
-    //@ts-ignore
-    let themeObject = THEME[themeValue][colorValue];
+    // @ts-ignore — indexed by the two signal values, both validated below.
+    const themeObject = THEME[themeValue]?.[colorValue] ?? THEME.light.default;
 
-    if (!themeObject) {
-      themeObject = THEME['light']['default'];
-      return;
+    const declarations: string[] = [
+      `--richtext-radius: ${typeof borderRadius === 'string' ? borderRadius : themeObject.radius};`,
+    ];
+
+    // `default` means "inherit the host application's theme". The static
+    // tokens in `styles/global.scss` already alias `--richtext-*` onto the
+    // app's own `--primary` / `--secondary` / `--background` / … so there is
+    // nothing to inject: writing the packaged shadcn greys here would paint
+    // over the product's palette (and its dark mode) with a fixed light one,
+    // which is what used to leave the editor stubbornly white inside a themed
+    // app. Only an explicitly chosen accent palette overrides the host.
+    if (colorValue !== 'default') {
+      for (const [key, value] of Object.entries(themeObject)) {
+        if (key === 'radius') continue;
+        // The palettes in `theme/theme.ts` store bare `H S L` channels, while
+        // the tokens hold complete colours (a host may theme in any colour
+        // space, so consumers can no longer wrap them in `hsl()`).
+        declarations.push(`--richtext-${key}: hsl(${value});`);
+      }
     }
 
-    updateCSS(
-      `
-      .reactjs-tiptap-editor, .reactjs-tiptap-editor *,
-      .reactjs-tiptap-editor-theme, .reactjs-tiptap-editor-theme *,
-      div[data-richtext-portal], div[data-richtext-portal] * {
-        ${Object.entries(themeObject)
-          .map(([key, value]) => {
-            if (typeof borderRadius === 'string' && key === 'radius') {
-              return `--${key}: ${borderRadius};`;
-            }
-
-            return `--${key}: ${value};`;
-          })
-          .join('\n')}
-      }
-      `,
-      'richtext-theme',
-      {
-        priority: 50,
-      }
-    );
+    updateCSS(`${THEME_SCOPE} {\n${declarations.join('\n')}\n}`, 'richtext-theme', {
+      priority: 50,
+    });
 
     return () => {
       removeCSS('richtext-theme');

--- a/packages/reason-editor/src/styles/columns.scss
+++ b/packages/reason-editor/src/styles/columns.scss
@@ -9,7 +9,7 @@
     padding: 12px;
     border-width: 1px;
     border-style: solid;
-    border-color: hsl(var(--richtext-border));
+    border-color: var(--richtext-border);
     border-radius: 2px;
     flex: 1 1 0%;
     box-sizing: border-box;

--- a/packages/reason-editor/src/styles/editor.scss
+++ b/packages/reason-editor/src/styles/editor.scss
@@ -1,7 +1,54 @@
+// ── Editable surface sizing ───────────────────────────────────────────────
+//
+// `.reason-editor-surface` is the container `NovelEditor` puts around the
+// contenteditable. @tiptap/react mounts ProseMirror inside an unclassed
+// wrapper div of its own, so without these rules the editable area is only as
+// tall as its text: a short document leaves dead space below it where clicks
+// do not reach the document and the host background shows through. Making the
+// chain a flex column lets the contenteditable claim the full height and width
+// the host gave the editor, while still growing past it (and scrolling, where
+// the host set `overflow-auto`) once the document is longer.
+.reason-editor-surface {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  > div:has(> .ProseMirror) {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+  }
+
+  .ProseMirror {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+}
+
+// The editable area is focusable, so the browser draws its default focus ring
+// (a solid blue box in Chrome) around the whole document as soon as the caret
+// is placed. A permanent border around the page is not wanted here — the caret
+// already shows focus — so suppress it on the editable surface and on the
+// wrappers that can take focus with it.
+.reason-editor-surface,
+.reason-editor-surface > div,
+.reactjs-tiptap-editor .ProseMirror,
+.reactjs-tiptap-editor .ProseMirror-focused,
+.reactjs-tiptap-editor [contenteditable='true'] {
+  &,
+  &:focus,
+  &:focus-visible,
+  &:focus-within {
+    outline: none !important;
+    box-shadow: none;
+  }
+}
 
 .reactjs-tiptap-editor {
-  background-color: hsl(var(--richtext-background));
-  color: hsl(var(--richtext-foreground));
+  background-color: var(--richtext-background);
+  color: var(--richtext-foreground);
   // Fill the host container so height constraints propagate to the editor.
   // Resolves to `auto` (content height) when the parent is auto-height, so the
   // common page-grows embedding is unaffected; when the parent is bounded (e.g.
@@ -19,6 +66,9 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  // Claim the host's full width for the same reason as the height above: as a
+  // flex item the wrapper would otherwise shrink to its content.
+  width: 100%;
 
   .ProseMirror.ProseMirror.ProseMirror {
     min-height: 180px;
@@ -72,7 +122,7 @@
         @apply richtext-bg-black/5 dark:richtext-bg-white/10;
 
         hr {
-          border-top-color: hsl(var(--richtext-foreground)) !important;
+          border-top-color: var(--richtext-foreground) !important;
         }
       }
 
@@ -88,7 +138,7 @@
 
     :not(.image-view)::selection,
     :not(.search-result)::selection {
-      background-color: hsl(var(--richtext-accent)) !important;
+      background-color: var(--richtext-accent) !important;
     }
 
     .is-empty::before {
@@ -167,7 +217,7 @@
 
         &--focused:hover,
         &--resizing:hover {
-          outline-color: hsl(var(--richtext-primary));
+          outline-color: var(--richtext-primary);
         }
 
         &__placeholder {
@@ -186,7 +236,7 @@
       }
 
       .image-view__body--focused {
-        outline-color: hsl(var(--richtext-primary)) !important;
+        outline-color: var(--richtext-primary) !important;
       }
 
       &.focus {
@@ -220,7 +270,7 @@
         height: 12px;
         border: 1px solid #fff;
         border-radius: 2px;
-        background-color: hsl(var(--richtext-primary));
+        background-color: var(--richtext-primary);
 
         &--tl {
           top: -6px;
@@ -266,12 +316,12 @@
   }
 
   .ProseMirror {
-    caret-color: hsl(var(--richtext-foreground)) !important;
+    caret-color: var(--richtext-foreground) !important;
   }
 }
 
 .bg-item-active.bg-item-active {
-  background-color: hsl(var(--richtext-accent)) !important;
+  background-color: var(--richtext-accent) !important;
 }
 
 .heading-1 {

--- a/packages/reason-editor/src/styles/global.scss
+++ b/packages/reason-editor/src/styles/global.scss
@@ -2,51 +2,116 @@
 @tailwind components;
 @tailwind utilities;
 
-// shadcn UI design tokens - light theme
+// ── Design tokens ─────────────────────────────────────────────────────────
+//
+// Every `--richtext-*` token is an alias for the *host application's* shadcn
+// token of the same name, so an app that themes itself by redefining
+// `--primary` / `--secondary` / `--background` / … themes the editor with it —
+// no per-package theme wiring, and no editor that stays stubbornly white while
+// the rest of the product is on a coloured theme.
+//
+// The second argument of each `var()` is the fallback used when the host does
+// not define that token (the standalone `bun run dev:editor` shell, Storybook,
+// or any consumer of the published package). Those fallbacks are the values
+// this file used to hard-code, so a bare embed looks exactly as it did before.
+//
+// Tokens hold *complete colours*, not the bare `H S L` channel triplets shadcn
+// v3 used, because host themes are free to express their palette in any colour
+// space (this product uses `oklch()`); `hsl(var(--x))` cannot wrap those. Every
+// consumer therefore reads `var(--richtext-x)` directly — see
+// `tailwind.config.js`, which no longer wraps these in `hsl()`. Alpha variants
+// use `color-mix()` rather than the `hsl(… / α)` slash syntax.
 :root {
-  --richtext-radius: 0.65rem;
-  --richtext-background: 0 0% 100%;
-  --richtext-foreground: 240 10% 3.9%;
-  --richtext-card: 0 0% 100%;
-  --richtext-card-foreground: 240 10% 3.9%;
-  --richtext-popover: 0 0% 100%;
-  --richtext-popover-foreground: 240 10% 3.9%;
-  --richtext-primary: 240 5.9% 10%;
-  --richtext-primary-foreground: 0 0% 98%;
-  --richtext-secondary: 240 4.8% 95.9%;
-  --richtext-secondary-foreground: 240 5.9% 10%;
-  --richtext-muted: 240 4.8% 95.9%;
-  --richtext-muted-foreground: 240 3.8% 46.1%;
-  --richtext-accent: 240 4.8% 95.9%;
-  --richtext-accent-foreground: 240 5.9% 10%;
-  --richtext-destructive: 0 84.2% 60.2%;
-  --richtext-destructive-foreground: 0 0% 98%;
-  --richtext-border: 240 5.9% 90%;
-  --richtext-input: 240 5.9% 90%;
-  --richtext-ring: 240 5.9% 10%;
+  --richtext-radius: var(--radius, 0.65rem);
+  // The editor canvas follows the host's dedicated editor surface colour when
+  // there is one, and its page background otherwise.
+  --richtext-background: var(--editor-bg, var(--background, hsl(0 0% 100%)));
+  --richtext-foreground: var(--foreground, hsl(240 10% 3.9%));
+  --richtext-card: var(--card, hsl(0 0% 100%));
+  --richtext-card-foreground: var(--card-foreground, hsl(240 10% 3.9%));
+  --richtext-popover: var(--popover, hsl(0 0% 100%));
+  --richtext-popover-foreground: var(--popover-foreground, hsl(240 10% 3.9%));
+  --richtext-primary: var(--primary, hsl(240 5.9% 10%));
+  --richtext-primary-foreground: var(--primary-foreground, hsl(0 0% 98%));
+  --richtext-secondary: var(--secondary, hsl(240 4.8% 95.9%));
+  --richtext-secondary-foreground: var(--secondary-foreground, hsl(240 5.9% 10%));
+  --richtext-muted: var(--muted, hsl(240 4.8% 95.9%));
+  --richtext-muted-foreground: var(--muted-foreground, hsl(240 3.8% 46.1%));
+  --richtext-accent: var(--accent, hsl(240 4.8% 95.9%));
+  --richtext-accent-foreground: var(--accent-foreground, hsl(240 5.9% 10%));
+  --richtext-destructive: var(--destructive, hsl(0 84.2% 60.2%));
+  --richtext-destructive-foreground: var(--destructive-foreground, hsl(0 0% 98%));
+  --richtext-border: var(--border, hsl(240 5.9% 90%));
+  --richtext-input: var(--input, hsl(240 5.9% 90%));
+  --richtext-ring: var(--ring, hsl(240 5.9% 10%));
 }
 
-// shadcn UI design tokens - dark theme
+// Dark theme.
+//
+// When the host toggles dark mode on `<html>` these aliases would already
+// resolve correctly — they are declared on `:root`, so they re-substitute
+// against the host's own dark values. The block is repeated here for the case
+// the host puts `.dark` on a *descendant* (a body wrapper, a preview pane): a
+// custom property is substituted on the element that declares it, so without
+// this the editor would keep the light values it inherited from `:root`. Only
+// the fallbacks differ from the block above.
 .dark {
-  --richtext-background: 240 10% 3.9%;
-  --richtext-foreground: 0 0% 98%;
-  --richtext-card: 240 10% 3.9%;
-  --richtext-card-foreground: 0 0% 98%;
-  --richtext-popover: 240 10% 3.9%;
-  --richtext-popover-foreground: 0 0% 98%;
-  --richtext-primary: 0 0% 98%;
-  --richtext-primary-foreground: 240 5.9% 10%;
-  --richtext-secondary: 240 3.7% 15.9%;
-  --richtext-secondary-foreground: 0 0% 98%;
-  --richtext-muted: 240 3.7% 15.9%;
-  --richtext-muted-foreground: 240 5% 64.9%;
-  --richtext-accent: 240 3.7% 15.9%;
-  --richtext-accent-foreground: 0 0% 98%;
-  --richtext-destructive: 0 62.8% 30.6%;
-  --richtext-destructive-foreground: 0 0% 98%;
-  --richtext-border: 240 3.7% 15.9%;
-  --richtext-input: 240 3.7% 15.9%;
-  --richtext-ring: 240 4.9% 83.9%;
+  --richtext-background: var(--editor-bg, var(--background, hsl(240 10% 3.9%)));
+  --richtext-foreground: var(--foreground, hsl(0 0% 98%));
+  --richtext-card: var(--card, hsl(240 10% 3.9%));
+  --richtext-card-foreground: var(--card-foreground, hsl(0 0% 98%));
+  --richtext-popover: var(--popover, hsl(240 10% 3.9%));
+  --richtext-popover-foreground: var(--popover-foreground, hsl(0 0% 98%));
+  --richtext-primary: var(--primary, hsl(0 0% 98%));
+  --richtext-primary-foreground: var(--primary-foreground, hsl(240 5.9% 10%));
+  --richtext-secondary: var(--secondary, hsl(240 3.7% 15.9%));
+  --richtext-secondary-foreground: var(--secondary-foreground, hsl(0 0% 98%));
+  --richtext-muted: var(--muted, hsl(240 3.7% 15.9%));
+  --richtext-muted-foreground: var(--muted-foreground, hsl(240 5% 64.9%));
+  --richtext-accent: var(--accent, hsl(240 3.7% 15.9%));
+  --richtext-accent-foreground: var(--accent-foreground, hsl(0 0% 98%));
+  --richtext-destructive: var(--destructive, hsl(0 62.8% 30.6%));
+  --richtext-destructive-foreground: var(--destructive-foreground, hsl(0 0% 98%));
+  --richtext-border: var(--border, hsl(240 3.7% 15.9%));
+  --richtext-input: var(--input, hsl(240 3.7% 15.9%));
+  --richtext-ring: var(--ring, hsl(240 4.9% 83.9%));
+}
+
+// ── Tooltips ──────────────────────────────────────────────────────────────
+//
+// Tooltip content is portalled to <body>, outside `.reactjs-tiptap-editor`, so
+// it picks up the host page's typography instead of the editor's and none of
+// the editor's own resets reach it. Pin the presentation here so a toolbar
+// tooltip reads the same whatever page it is portalled into, and keep it on the
+// theme tokens so it follows the host's palette in both light and dark.
+//
+// `:where()` keeps this at zero specificity: it is the base look, and any
+// utility class a caller passes through `tooltipOptions.className` still wins.
+:where([data-slot='tooltip-content'], .richtext-tooltip) {
+  z-index: 60;
+  // Wide enough for a label plus its shortcut on one line, capped so a long
+  // one wraps instead of stretching across the window.
+  max-width: 18rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--richtext-border);
+  border-radius: calc(var(--richtext-radius) - 2px);
+  background-color: var(--richtext-popover);
+  color: var(--richtext-popover-foreground);
+  font-size: 0.75rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  text-align: center;
+  white-space: normal;
+  overflow-wrap: break-word;
+  box-shadow: 0 4px 12px color-mix(in oklab, var(--richtext-foreground) 12%, transparent);
+  // A tooltip that swallowed pointer events would re-trigger its own trigger's
+  // hover state as it is placed under the cursor.
+  pointer-events: none;
+}
+
+// Radix renders the arrow as an <svg>; keep it on the popover surface.
+:where([data-slot='tooltip-content'], .richtext-tooltip) > svg {
+  fill: var(--richtext-popover);
 }
 
 // Dropdown menus, popovers and selects must never run off the side of the

--- a/packages/reason-editor/src/styles/mention.scss
+++ b/packages/reason-editor/src/styles/mention.scss
@@ -1,6 +1,6 @@
 [data-type='mention'] {
-  color: hsl(var(--richtext-primary));
-  background: hsl(var(--richtext-muted));
+  color: var(--richtext-primary);
+  background: var(--richtext-muted);
   padding: 2px 4px;
   border-radius: 6px;
 }

--- a/packages/reason-editor/tailwind.config.js
+++ b/packages/reason-editor/tailwind.config.js
@@ -1,5 +1,28 @@
 import tailwindcssAnimate from 'tailwindcss-animate';
 
+/**
+ * Reads a `--richtext-*` design token (see `src/styles/global.scss`) as a
+ * complete colour rather than the bare `H S L` triplet shadcn v3 assumes.
+ *
+ * The tokens alias the host application's own theme variables, and a host is
+ * free to express its palette in any colour space — this product uses
+ * `oklch()` — so the old `hsl(var(--token))` wrapper would produce an invalid
+ * declaration and the editor would fall back to unstyled white. Reading the
+ * token directly works whatever colour space the host themes in.
+ *
+ * Tailwind calls this with an explicit `opacityValue` for opacity modifiers
+ * (`bg-primary/90`), which `color-mix()` applies to the opaque token — what
+ * the `hsl(… / α)` slash syntax used to do. Without a modifier it instead
+ * threads its own `--tw-*-opacity` variable through `opacityVariable` (and
+ * pins it to 1 on the same rule), so the token is emitted unwrapped.
+ *
+ * @param {string} token CSS custom property name, e.g. `--richtext-primary`.
+ */
+const themeColor = (token) => ({ opacityValue, opacityVariable } = {}) =>
+  opacityValue === undefined || opacityVariable !== undefined
+    ? `var(${token})`
+    : `color-mix(in oklab, var(${token}) calc(${opacityValue} * 100%), transparent)`;
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ['class', "[class~='dark']"],
@@ -33,38 +56,38 @@ export default {
     },
     extend: {
       colors: {
-        border: 'hsl(var(--richtext-border))',
-        input: 'hsl(var(--richtext-input))',
-        ring: 'hsl(var(--richtext-ring))',
-        background: 'hsl(var(--richtext-background))',
-        foreground: 'hsl(var(--richtext-foreground))',
+        border: themeColor('--richtext-border'),
+        input: themeColor('--richtext-input'),
+        ring: themeColor('--richtext-ring'),
+        background: themeColor('--richtext-background'),
+        foreground: themeColor('--richtext-foreground'),
         primary: {
-          DEFAULT: 'hsl(var(--richtext-primary))',
-          foreground: 'hsl(var(--richtext-primary-foreground))',
+          DEFAULT: themeColor('--richtext-primary'),
+          foreground: themeColor('--richtext-primary-foreground'),
         },
         secondary: {
-          DEFAULT: 'hsl(var(--richtext-secondary))',
-          foreground: 'hsl(var(--richtext-secondary-foreground))',
+          DEFAULT: themeColor('--richtext-secondary'),
+          foreground: themeColor('--richtext-secondary-foreground'),
         },
         destructive: {
-          DEFAULT: 'hsl(var(--richtext-destructive))',
-          foreground: 'hsl(var(--richtext-destructive-foreground))',
+          DEFAULT: themeColor('--richtext-destructive'),
+          foreground: themeColor('--richtext-destructive-foreground'),
         },
         muted: {
-          DEFAULT: 'hsl(var(--richtext-muted))',
-          foreground: 'hsl(var(--richtext-muted-foreground))',
+          DEFAULT: themeColor('--richtext-muted'),
+          foreground: themeColor('--richtext-muted-foreground'),
         },
         accent: {
-          DEFAULT: 'hsl(var(--richtext-accent))',
-          foreground: 'hsl(var(--richtext-accent-foreground))',
+          DEFAULT: themeColor('--richtext-accent'),
+          foreground: themeColor('--richtext-accent-foreground'),
         },
         popover: {
-          DEFAULT: 'hsl(var(--richtext-popover))',
-          foreground: 'hsl(var(--richtext-popover-foreground))',
+          DEFAULT: themeColor('--richtext-popover'),
+          foreground: themeColor('--richtext-popover-foreground'),
         },
         card: {
-          DEFAULT: 'hsl(var(--richtext-card))',
-          foreground: 'hsl(var(--richtext-card-foreground))',
+          DEFAULT: themeColor('--richtext-card'),
+          foreground: themeColor('--richtext-card-foreground'),
         },
       },
       borderRadius: {


### PR DESCRIPTION
## Summary

This PR refactors the editor's theme system to inherit the host application's design tokens instead of hard-coding a fixed light theme. The editor now aliases its `--richtext-*` tokens to the host's own `--primary`, `--secondary`, `--background`, etc., allowing seamless theme synchronization without per-package wiring.

## Key Changes

- **Design Token Architecture**: Converted all `--richtext-*` tokens from hard-coded HSL values to CSS `var()` aliases that reference the host application's tokens, with fallback values for standalone usage
  - Tokens now hold complete colours (e.g., `hsl(240 10% 3.9%)`) rather than bare HSL channels, supporting any colour space the host uses (e.g., `oklch()`)
  - Added `--editor-bg` token for dedicated editor surface backgrounds when available

- **Tailwind Configuration**: Updated `tailwind.config.js` to read tokens as complete colours instead of wrapping them in `hsl()`
  - Implemented `themeColor()` helper function that uses `color-mix()` for opacity modifiers instead of the `hsl(… / α)` slash syntax
  - Ensures opacity variants work correctly with any colour space

- **Theme Injection Logic**: Simplified `ThemeColorReactive.tsx` to only inject custom tokens when an explicit accent palette is chosen
  - When `colorValue === 'default'`, the static token aliases in `global.scss` handle inheritance automatically
  - Reduces CSS injection overhead and prevents overriding the host's theme with packaged defaults

- **Tooltip Styling**: Added comprehensive tooltip styling rules that were previously missing
  - Tooltips are portalled outside the editor DOM, so they now receive explicit styling to match the editor's theme
  - Uses `:where()` for zero specificity to allow caller-provided classes to override

- **Editor Surface Sizing**: Added flex layout rules to make the contenteditable fill its container
  - Stretches the editable area to claim full height/width of the host container
  - Suppresses default browser focus rings on the editable surface and wrappers

- **CSS Variable Syntax**: Replaced all `hsl(var(--richtext-*))` patterns with direct `var(--richtext-*)` references throughout stylesheets
  - Updated opacity patterns from `hsl(… / α)` to `color-mix(in oklab, var(--token) α%, transparent)`

- **Component Fixes**: 
  - Prevented `title` prop from reaching DOM as `title` attribute in `ActionButton` and `ActionMenuButton` to avoid browser native tooltips conflicting with styled Radix tooltips
  - Added `reason-editor-surface` class to editor container in `NovelEditor.tsx` for stylesheet hooks

## Implementation Details

- The static token declarations in `styles/global.scss` now serve as the primary integration point—host applications theme the editor by defining their own `--primary`, `--secondary`, etc. tokens
- Dark mode support works whether the host toggles dark mode on `<html>` or applies `.dark` to a descendant element
- Fallback values preserve the original light theme appearance for standalone usage (dev shell, Storybook, published package consumers without host theming)
- All colour references now use the `oklab` colour space for `color-mix()` operations, ensuring consistent alpha blending across colour spaces

https://claude.ai/code/session_01V2WJYbzYCBQ1idJXRdDHDs