### PR TITLE
Move the font picker onto the REASON toolbar and stop menus dismissing themselves

### DIFF
--- a/packages/reason-editor/src/editor-views/components/Toolbar.tsx
+++ b/packages/reason-editor/src/editor-views/components/Toolbar.tsx
@@ -59,6 +59,8 @@ import { RichTextPagination } from '@/extensions/Pagination/components/RichTextP
 import { RichTextTableOfContentsPanel } from '@/extensions/TableOfContents';
 import { RichTextHarper } from '@/extensions/Harper';
 import { RichTextDrawio } from '@/extensions/Drawio';
+import { selectSimilarPluginKey, type SelectSimilarMode } from '@/extensions/SelectSimilar';
+import { shouldDismissPanel, shouldKeepEditorFocus } from './toolbarOverlays';
 import {
   Check,
   SpellCheck,
@@ -83,6 +85,10 @@ import {
   Lock,
   Globe,
   Mail,
+  Palette,
+  TextCursorInput,
+  TextSelect,
+  Type,
   Users,
   MessageSquare,
   MessageSquarePlus,
@@ -127,6 +133,33 @@ interface StylePreset {
 const STYLE_TAG_ID = 'rte-custom-styles';
 const STYLES_STORAGE_KEY = 'rte-custom-style-presets';
 const ACTIVE_STYLE_KEY = 'rte-active-style-preset';
+
+// ─── Keeping nested surfaces alive ────────────────────────────────────────────
+
+/** Suppresses the focus move a press on a toolbar control would otherwise make. */
+function keepEditorFocus(e: React.MouseEvent) {
+  if (shouldKeepEditorFocus(e.target)) e.preventDefault();
+}
+
+/**
+ * Backdrop dismissal that only fires when the press *started* on the backdrop.
+ * Without this, any drag begun inside the modal — selecting text, sweeping a
+ * colour slider — closes it as soon as the pointer is released past its edge.
+ */
+function useBackdropDismiss(onClose: () => void) {
+  const armed = useRef(false);
+
+  return {
+    onMouseDown: (e: React.MouseEvent) => {
+      armed.current = e.target === e.currentTarget;
+    },
+    onClick: (e: React.MouseEvent) => {
+      if (!armed.current || e.target !== e.currentTarget) return;
+      armed.current = false;
+      onClose();
+    },
+  };
+}
 
 // ─── CSS Editor Modal ─────────────────────────────────────────────────────────
 
@@ -254,9 +287,11 @@ function CssEditorModal({ onClose }: { onClose: () => void }) {
   const updateRule = (id: number, field: keyof Omit<CssRule, 'id'>, val: string) =>
     setRules(prev => prev.map(r => r.id === id ? { ...r, [field]: val } : r));
 
+  const backdrop = useBackdropDismiss(onClose);
+
   return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" {...backdrop} />
       <div className="relative bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl shadow-2xl w-[640px] max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-slate-700">
           <div className="flex items-center gap-2">
@@ -667,7 +702,7 @@ function MenuPanel({
   }, [top, left, right]);
 
   return (
-    <div className={`${panelCls} ${className}`} ref={ref} style={style}>
+    <div className={`${panelCls} ${className}`} onMouseDown={keepEditorFocus} ref={ref} style={style}>
       {children}
     </div>
   );
@@ -813,9 +848,11 @@ function DocumentDetailsModal({
         : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200'
     }`;
 
+  const backdrop = useBackdropDismiss(onClose);
+
   return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" {...backdrop} />
       <div className="relative bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl shadow-2xl w-[600px] max-h-[85vh] flex flex-col" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-700">
           <div className="flex items-center gap-3 min-w-0">
@@ -1035,9 +1072,11 @@ function FileRenameModal({ onClose, currentName }: { onClose: () => void; curren
     onClose();
   };
 
+  const backdrop = useBackdropDismiss(onClose);
+
   return createPortal(
     <div className="fixed inset-0 z-[100] flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" {...backdrop} />
       <div className="relative bg-white dark:bg-slate-900 border border-gray-200 dark:border-slate-700 rounded-xl shadow-2xl w-[400px]" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-slate-700">
           <h2 className="font-semibold text-gray-900 dark:text-white">Rename document</h2>
@@ -1180,6 +1219,46 @@ export const RichTextToolbar = ({
     editor?.commands.deleteSelection();
   }, [editor]);
 
+  // ─── Selection actions ──────────────────────────────────────────────────────
+
+  const handleSelectAll = useCallback(() => {
+    editor?.chain().focus().selectAll().run();
+  }, [editor]);
+
+  // Multi-selection: only offered when the extension is registered, since the
+  // plugin manager can switch it off.
+  const hasSelectSimilar = !!editor?.extensionManager.extensions.some(
+    (e) => e.name === 'selectSimilar',
+  );
+
+  // How many extra ranges the multi-selection currently holds, so the menu can
+  // report and clear them.
+  const [similarCount, setSimilarCount] = useState(0);
+  useEffect(() => {
+    if (!editor || !hasSelectSimilar) return;
+
+    const update = () =>
+      setSimilarCount(selectSimilarPluginKey.getState(editor.state)?.ranges.length ?? 0);
+
+    update();
+    editor.on('transaction', update);
+
+    return () => {
+      editor.off('transaction', update);
+    };
+  }, [editor, hasSelectSimilar]);
+
+  const handleSelectSimilar = useCallback(
+    (mode: SelectSimilarMode) => {
+      editor?.chain().focus().selectSimilar(mode).run();
+    },
+    [editor],
+  );
+
+  const handleClearSimilar = useCallback(() => {
+    editor?.chain().focus().clearSimilarSelection().run();
+  }, [editor]);
+
   // Re-apply saved CSS on mount
   useEffect(() => {
     try {
@@ -1221,23 +1300,22 @@ export const RichTextToolbar = ({
   const close = () => { setOpen(null); setPos(null); };
 
   useEffect(() => {
+    if (!open) return;
+
     const handler = (e: MouseEvent) => {
-      const t = e.target as HTMLElement;
-      if (
-        open &&
-        !t.closest('.dropdown-container') &&
-        !t.closest('.dropdown-portal') &&
-        !t.closest('[data-radix-popper-content-wrapper]') &&
-        !t.closest('[data-radix-portal]')
-      ) close();
+      if (shouldDismissPanel(e.target)) close();
     };
+
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
   return (
     <>
-      <div className="flex items-center gap-0.5 border-b border-gray-200 dark:border-slate-700 px-2 py-1 flex-wrap">
+      <div
+        className="flex items-center gap-0.5 border-b border-gray-200 dark:border-slate-700 px-2 py-1 flex-wrap"
+        onMouseDown={keepEditorFocus}
+      >
 
         {/* Undo / Redo — only rendered while the command is actually available */}
         <RichTextUndo hideWhenDisabled />
@@ -1248,11 +1326,12 @@ export const RichTextToolbar = ({
           <RichTextZoom />
         </div>
 
-        {/* Text styles — bold, italic, underline directly */}
+        {/* Font family and size, then bold / italic / underline directly */}
+        <RichTextFontFamily />
+        <RichTextFontSize />
         <RichTextBold />
         <RichTextItalic />
         <RichTextUnderline />
-        <RichTextFontSize />
         <RichTextHighlight />
 
         {/* ≡ — Block format */}
@@ -1310,7 +1389,6 @@ export const RichTextToolbar = ({
             <MenuPanel className="min-w-[400px]" left={pos.left} top={pos.top}>
               <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Text Styles</div>
               <div className="grid grid-cols-2 gap-0.5 px-1 py-1">
-                <div className="col-span-2"><ToolbarMenuItem><RichTextFontFamily /></ToolbarMenuItem></div>
                 <div><ToolbarMenuItem label="Strikethrough" shortcut="Ctrl+Shift+S"><RichTextStrike /></ToolbarMenuItem></div>
                 <div><ToolbarMenuItem label="Inline Code" shortcut="Ctrl+E"><RichTextCode /></ToolbarMenuItem></div>
                 <div><ToolbarMenuItem label="Text Color" shortcut="Alt+Shift+C"><RichTextColor /></ToolbarMenuItem></div>
@@ -1369,6 +1447,61 @@ export const RichTextToolbar = ({
           )}
         </div>
 
+        {/* Edit — clipboard and selection, split out of Tools so neither menu runs long */}
+        <div className="dropdown-container">
+          <ToolbarIconBtn name="edit" label="Edit" active={open === 'edit'} onClick={openMenu}>
+            <Clipboard size={16} />
+          </ToolbarIconBtn>
+          {open === 'edit' && pos && createPortal(
+            <MenuPanel left={pos.left} top={pos.top}>
+              <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Clipboard</div>
+              <MenuAction icon={<Scissors size={14} />} label="Cut" shortcut="Ctrl+X" onClick={() => { close(); handleCut(); }} />
+              <MenuAction icon={<Clipboard size={14} />} label="Copy" shortcut="Ctrl+C" onClick={() => { close(); handleCopy(); }} />
+              <MenuAction icon={<ClipboardPaste size={14} />} label="Paste" shortcut="Ctrl+V" onClick={() => { close(); handlePaste(); }} />
+              <MenuAction icon={<ClipboardType size={14} />} label="Paste Plain" shortcut="Ctrl+Shift+V" onClick={() => { close(); handlePastePlain(); }} />
+              <MenuAction icon={<Trash2 size={14} />} label="Delete" shortcut="Del" onClick={() => { close(); handleDelete(); }} />
+              <div className="my-1 border-t border-gray-100 dark:border-slate-700" />
+              <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Selection</div>
+              <MenuAction
+                icon={<TextCursorInput size={14} />}
+                label="Select All"
+                shortcut="Ctrl+A"
+                onClick={() => { close(); handleSelectAll(); }}
+              />
+              {hasSelectSimilar && (
+                <>
+                  <MenuAction
+                    icon={<Type size={14} />}
+                    label="Select All Similar Fonts"
+                    onClick={() => { close(); handleSelectSimilar('font'); }}
+                  />
+                  <MenuAction
+                    icon={<Palette size={14} />}
+                    label="Select All Similar Styles"
+                    onClick={() => { close(); handleSelectSimilar('style'); }}
+                  />
+                  <MenuAction
+                    icon={<TextSelect size={14} />}
+                    label="Select All Similar Formatting"
+                    onClick={() => { close(); handleSelectSimilar('formatting'); }}
+                  />
+                  <MenuAction
+                    disabled={similarCount === 0}
+                    icon={<X size={14} />}
+                    label={similarCount ? `Clear Multi-Selection (${similarCount})` : 'Clear Multi-Selection'}
+                    shortcut="Esc"
+                    onClick={() => { close(); handleClearSimilar(); }}
+                  />
+                  <div className="px-3 pb-1.5 pt-0.5 text-[10px] leading-snug text-gray-400 dark:text-gray-500">
+                    Formatting applied afterwards lands on every highlighted run at once.
+                  </div>
+                </>
+              )}
+            </MenuPanel>,
+            document.body
+          )}
+        </div>
+
         {/* Tools */}
         <div className="dropdown-container">
           <ToolbarIconBtn name="tools" label="Tools" active={open === 'tools'} onClick={openMenu}>
@@ -1407,12 +1540,6 @@ export const RichTextToolbar = ({
               />
               <div className="my-1 border-t border-gray-100 dark:border-slate-700" />
               <div className="px-2 py-1 text-[10px] font-semibold uppercase text-gray-400 tracking-wide">Tools</div>
-              <MenuAction icon={<Scissors size={14} />} label="Cut" shortcut="Ctrl+X" onClick={() => { close(); handleCut(); }} />
-              <MenuAction icon={<Clipboard size={14} />} label="Copy" shortcut="Ctrl+C" onClick={() => { close(); handleCopy(); }} />
-              <MenuAction icon={<ClipboardPaste size={14} />} label="Paste" shortcut="Ctrl+V" onClick={() => { close(); handlePaste(); }} />
-              <MenuAction icon={<ClipboardType size={14} />} label="Paste Plain" shortcut="Ctrl+Shift+V" onClick={() => { close(); handlePastePlain(); }} />
-              <MenuAction icon={<Trash2 size={14} />} label="Delete" shortcut="Del" onClick={() => { close(); handleDelete(); }} />
-              <div className="my-1 border-t border-gray-100 dark:border-slate-700" />
               {onToggleComments && (
                 <MenuToggle
                   icon={<MessageSquare size={14} />}

--- a/packages/reason-editor/src/editor-views/components/toolbarOverlays.ts
+++ b/packages/reason-editor/src/editor-views/components/toolbarOverlays.ts
@@ -1,0 +1,85 @@
+/**
+ * The rules that keep a toolbar dropdown — and everything it opens on top of
+ * itself — alive while the user is working in it.
+ *
+ * The toolbar's panels are portals of our own. The controls inside them open
+ * Radix popovers, menus, selects and dialogs, and Radix renders those in *its*
+ * own portals attached to `<body>`: outside the panel in the DOM, though still
+ * children of it in the React tree. So a naive "did the click land inside the
+ * panel element?" test reads every click on a colour swatch, a font name or a
+ * dialog field as being outside, closes the panel, and unmounts the surface the
+ * click landed in. These helpers answer that question in terms of the whole
+ * stack of surfaces instead of one element, and are kept apart from `Toolbar`
+ * itself so they can be tested without the extension graph it pulls in.
+ */
+
+/** Every surface a toolbar panel can put on screen, including the panels. */
+export const OVERLAY_SELECTOR = [
+  '.dropdown-container',
+  '.dropdown-portal',
+  // The marker this package's UI primitives stamp on their portalled content.
+  '[data-richtext-portal]',
+  '[data-radix-popper-content-wrapper]',
+  '[data-radix-portal]',
+  // Roles cover anything unstamped: Radix gives dialogs and popovers
+  // `role="dialog"`, menus `role="menu"` and selects `role="listbox"`.
+  '[role="dialog"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+].join(',');
+
+/**
+ * The subset that exists in the DOM only while a nested layer is open — Radix
+ * unmounts its content on close — so its presence answers "is something open on
+ * top of the panel right now?".
+ */
+export const NESTED_LAYER_SELECTOR = '[role="dialog"],[role="menu"],[role="listbox"]';
+
+/** Controls that legitimately need the caret, so must keep their native focus. */
+const TEXT_ENTRY_SELECTOR = 'input, textarea, select, [contenteditable="true"], [role="textbox"]';
+
+const CLICKABLE_SELECTOR =
+  'button, [role="button"], [role="menuitem"], [role="menuitemcheckbox"]';
+
+/**
+ * Whether a press at `target` should close the open toolbar panel.
+ *
+ * @param root the document the panel lives in, used to look for open layers
+ */
+export function shouldDismissPanel(
+  target: EventTarget | null,
+  root: Document = document,
+): boolean {
+  const element = target as HTMLElement | null;
+
+  // A control that re-renders on press reports a target already detached from
+  // the document, which matches no selector. That is not "outside".
+  if (!element?.isConnected) return false;
+
+  if (element.closest(OVERLAY_SELECTOR)) return false;
+
+  // A nested dialog/menu/popover is open on top of the panel, so this press
+  // belongs to that layer's own dismissal, not ours. The panel has to stay
+  // mounted: it owns the React tree the layer is rendered from, and closing it
+  // here would take the layer down mid-interaction.
+  if (root.querySelector(NESTED_LAYER_SELECTOR)) return false;
+
+  return true;
+}
+
+/**
+ * Whether pressing `target` should be stopped from moving focus.
+ *
+ * Pressing a toolbar control must not pull focus out of the document, or the
+ * command it fires has no selection left to act on — which is why formatting a
+ * selection from inside a menu used to clear it. Text fields and non-button
+ * targets (a panel's own scrollbar, for one) are left alone.
+ */
+export function shouldKeepEditorFocus(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+
+  if (!element?.closest) return false;
+  if (element.closest(TEXT_ENTRY_SELECTOR)) return false;
+
+  return !!element.closest(CLICKABLE_SELECTOR);
+}

--- a/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
+++ b/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
@@ -68,6 +68,7 @@ import { Drawio } from '@/extensions/Drawio';
 import { Harper } from '@/extensions/Harper';
 import { OfficePaste } from '@/extensions/OfficePaste';
 import { Pagination } from '@/extensions/Pagination';
+import { SelectSimilar } from '@/extensions/SelectSimilar';
 
 import { EMOJI_LIST } from '../emojis';
 import { convertBase64ToBlob, MOCK_USERS } from '../components/constants';
@@ -169,6 +170,14 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
     category: 'Editing',
     defaultEnabled: true,
     create: () => Clear,
+  },
+  {
+    key: 'selectSimilar',
+    label: 'Select Similar',
+    description: 'Select every run of text sharing the selection’s font or style, and format them together.',
+    category: 'Editing',
+    defaultEnabled: true,
+    create: () => SelectSimilar,
   },
 
   // ── Text formatting ──

--- a/packages/reason-editor/src/extensions/FontFamily/components/RichTextFontFamily.tsx
+++ b/packages/reason-editor/src/extensions/FontFamily/components/RichTextFontFamily.tsx
@@ -2,16 +2,15 @@
  * Toolbar control (React) for the FontFamily extension, which adds font-family selection. Renders the button and dispatches the matching editor command when activated.
  */
 
-import React, { Fragment, useMemo } from 'react';
+import { Search, Type } from 'lucide-react';
+import React, { useDeferredValue, useMemo, useRef, useState } from 'react';
 
 import {
+  ActionButton,
   ActionMenuButton,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
 } from '@/components';
 import { FontFamily } from '@/extensions/FontFamily/FontFamily';
 import { useActive } from '@/hooks/useActive';
@@ -33,7 +32,16 @@ export interface Item {
   default?: boolean;
 }
 
-export function RichTextFontFamily() {
+export interface RichTextFontFamilyProps {
+  /**
+   * `icon` is the compact "T" button the main toolbar uses; `label` keeps the
+   * older trigger that spells out the active font, for use inside menus where
+   * there is room for the name.
+   */
+  variant?: 'icon' | 'label';
+}
+
+export function RichTextFontFamily({ variant = 'icon' }: RichTextFontFamilyProps = {}) {
   const { t } = useLocale();
 
   const buttonProps = useButtonProps(FontFamily.name);
@@ -47,49 +55,117 @@ export function RichTextFontFamily() {
 
   const { disabled, dataState } = useActive(isActive);
 
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  // Typing filters a list of ~50 fonts, each rendered in its own face; letting
+  // the input update ahead of the list keeps the field responsive.
+  const deferredQuery = useDeferredValue(query);
+  const searchRef = useRef<HTMLInputElement>(null);
+
   const title = useMemo(() => {
     return dataState?.font || 'Inter';
   }, [dataState]);
+
+  const filtered = useMemo(() => {
+    const needle = deferredQuery.trim().toLowerCase();
+    if (!needle) return items as Item[];
+    return (items as Item[]).filter((item) => item.title?.toLowerCase().includes(needle));
+  }, [items, deferredQuery]);
 
   if (!buttonProps) {
     return <></>;
   }
 
+  const label = tooltip || 'Font';
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild disabled={disabled}>
-        <div className='richtext-w-full'>
-          <ActionMenuButton
+    <Popover
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setQuery('');
+      }}
+      open={open}
+    >
+      <PopoverTrigger asChild disabled={disabled}>
+        {variant === 'icon' ? (
+          // Same `ActionButton` every other single-icon control uses, so the
+          // font picker sits in the toolbar row looking like its neighbours.
+          // The trigger's own `data-state` is open/closed rather than the
+          // toggle's on/off, so the pressed look is keyed off that instead.
+          <ActionButton
+            aria-label={label}
+            customClass='data-[state=open]:richtext-bg-accent'
             disabled={disabled}
-            icon={icon}
-            title={title}
-            tooltip={tooltip}
-            // tooltipOptions={tooltipOptions}
+            tooltip={label}
+          >
+            <Type className='richtext-size-4' />
+          </ActionButton>
+        ) : (
+          <div className='richtext-w-full'>
+            <ActionMenuButton disabled={disabled} icon={icon} title={title} tooltip={tooltip} />
+          </div>
+        )}
+      </PopoverTrigger>
+
+      <PopoverContent
+        align='start'
+        className='richtext-w-[280px] !richtext-p-0'
+        // The picker lives inside the toolbar's own dropdown panels; pulling
+        // focus into the search box must not scroll or blur what is underneath.
+        onOpenAutoFocus={(event) => {
+          event.preventDefault();
+          searchRef.current?.focus({ preventScroll: true });
+        }}
+        side='bottom'
+      >
+        <div className='richtext-relative richtext-border-b richtext-border-border'>
+          <Search
+            className='richtext-pointer-events-none richtext-absolute richtext-left-3 richtext-top-1/2 -richtext-translate-y-1/2 richtext-text-muted-foreground'
+            size={15}
+          />
+
+          <input
+            className='richtext-w-full richtext-bg-transparent richtext-py-2.5 richtext-pl-9 richtext-pr-3 richtext-text-sm richtext-outline-none placeholder:richtext-text-muted-foreground'
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t('editor.fontFamily.search')}
+            ref={searchRef}
+            type='text'
+            value={query}
           />
         </div>
-      </DropdownMenuTrigger>
 
-      <DropdownMenuContent className='richtext-max-h-96 richtext-w-56 richtext-overflow-y-auto'>
-        <DropdownMenuLabel className='richtext-text-xs richtext-text-muted-foreground'>
-          Font Family
-        </DropdownMenuLabel>
-        {items?.map((item: any, index: any) => {
-          const style =
-            item.default ? {} : { fontFamily: item.font };
+        <div className='richtext-max-h-80 richtext-overflow-y-auto richtext-py-1'>
+          {filtered.length === 0 && (
+            <div className='richtext-px-3 richtext-py-6 richtext-text-center richtext-text-sm richtext-text-muted-foreground'>
+              {t('editor.fontFamily.empty')}
+            </div>
+          )}
 
-          return (
-            <Fragment key={`font-family-${index}`}>
-              <DropdownMenuCheckboxItem checked={title === item.font} onClick={item.action}>
-                <div className='richtext-truncate' style={style}>
-                  {item.title}
-                </div>
-              </DropdownMenuCheckboxItem>
+          {filtered.map((item, index) => {
+            const active = title === item.font;
 
-              {item.default && <DropdownMenuSeparator />}
-            </Fragment>
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
+            return (
+              <button
+                aria-pressed={active}
+                key={`font-family-${item.font ?? index}`}
+                onClick={() => {
+                  item.action?.();
+                  setOpen(false);
+                }}
+                // The default entry is the editor's own face, so it is left to
+                // inherit rather than being pinned to a named family.
+                style={item.default ? {} : { fontFamily: item.font }}
+                type='button'
+                className={`richtext-flex richtext-w-full richtext-items-center richtext-px-4 richtext-py-2 richtext-text-left richtext-text-base richtext-transition-colors hover:richtext-bg-accent ${
+                  active ? 'richtext-bg-accent richtext-font-medium' : ''
+                }`}
+              >
+                <span className='richtext-truncate'>{item.title}</span>
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/packages/reason-editor/src/extensions/SelectSimilar/SelectSimilar.ts
+++ b/packages/reason-editor/src/extensions/SelectSimilar/SelectSimilar.ts
@@ -1,0 +1,307 @@
+/**
+ * Defines the SelectSimilar Tiptap extension, which adds "select every run of
+ * text that is formatted like this one" to the editor.
+ *
+ * ProseMirror only ever has one real selection, so the extra runs are held as a
+ * list of ranges in plugin state, painted with a selection-like decoration, and
+ * kept in sync with edits through the transaction mapping. The pay-off is in
+ * `appendTransaction`: whenever a mark is added or removed inside the primary
+ * selection, the same step is replayed across every stored range, so the plain
+ * toolbar buttons (bold, colour, font, size, …) act on all of them at once
+ * without any of those extensions knowing this one exists.
+ */
+
+import { Extension } from '@tiptap/core';
+import { type Mark, type Node as PMNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey, type Transaction } from '@tiptap/pm/state';
+import { AddMarkStep, RemoveMarkStep } from '@tiptap/pm/transform';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+
+export type SelectSimilarMode = 'font' | 'style' | 'formatting';
+
+export interface SelectSimilarOptions {
+  /** Class applied to the decoration painted over each extra range. */
+  className: string;
+}
+
+export interface SimilarRange {
+  from: number;
+  to: number;
+}
+
+interface SelectSimilarState {
+  ranges: SimilarRange[];
+  mode: SelectSimilarMode | null;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    selectSimilar: {
+      /**
+       * Highlight every run of text formatted like the current selection.
+       * Subsequent mark changes apply to all of them.
+       */
+      selectSimilar: (mode: SelectSimilarMode) => ReturnType;
+      /** Drop the extra ranges, leaving only the real selection. */
+      clearSimilarSelection: () => ReturnType;
+    };
+  }
+}
+
+export const selectSimilarPluginKey = new PluginKey<SelectSimilarState>('selectSimilar');
+
+/** Marks the transactions this extension generates so they are never replayed. */
+const REPLAY_META = 'selectSimilarReplay';
+
+const EMPTY_STATE: SelectSimilarState = { ranges: [], mode: null };
+
+/** The textStyle attributes that make up "the same style". */
+const STYLE_ATTRS = ['fontFamily', 'fontSize', 'color', 'backgroundColor', 'lineHeight'] as const;
+
+function textStyleAttrs(marks: readonly Mark[]): Record<string, unknown> {
+  const mark = marks.find((m) => m.type.name === 'textStyle');
+  const attrs: Record<string, unknown> = {};
+
+  for (const key of STYLE_ATTRS) {
+    attrs[key] = mark?.attrs?.[key] ?? null;
+  }
+
+  return attrs;
+}
+
+function sameAttrs(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  return Object.keys(a).every((key) => a[key] === b[key]);
+}
+
+/** The full mark set, name + attrs, order-independent. */
+function markSignature(marks: readonly Mark[]): string {
+  return marks
+    .map((mark) => `${mark.type.name}:${JSON.stringify(mark.attrs ?? {})}`)
+    .sort()
+    .join('|');
+}
+
+function buildMatcher(mode: SelectSimilarMode, reference: readonly Mark[]) {
+  if (mode === 'font') {
+    const font = textStyleAttrs(reference).fontFamily ?? null;
+    return (marks: readonly Mark[]) => (textStyleAttrs(marks).fontFamily ?? null) === font;
+  }
+
+  if (mode === 'style') {
+    const attrs = textStyleAttrs(reference);
+    return (marks: readonly Mark[]) => sameAttrs(attrs, textStyleAttrs(marks));
+  }
+
+  const signature = markSignature(reference);
+  return (marks: readonly Mark[]) => markSignature(marks) === signature;
+}
+
+/**
+ * The marks that describe "how the selection is formatted". An empty selection
+ * reads the marks at the cursor; a real selection reads the first text node it
+ * covers, so selecting a whole paragraph and asking for its font works.
+ */
+function referenceMarks(state: { doc: PMNode; selection: any; storedMarks: readonly Mark[] | null }) {
+  const { selection } = state;
+
+  if (selection.empty) {
+    return state.storedMarks ?? selection.$from.marks();
+  }
+
+  let found: readonly Mark[] | null = null;
+
+  state.doc.nodesBetween(selection.from, selection.to, (node: PMNode) => {
+    if (found || !node.isText) return;
+    found = node.marks;
+  });
+
+  return found ?? selection.$from.marks();
+}
+
+/** Every contiguous run of text in the document whose marks satisfy `matches`. */
+function collectRanges(doc: PMNode, matches: (marks: readonly Mark[]) => boolean): SimilarRange[] {
+  const ranges: SimilarRange[] = [];
+
+  doc.descendants((node, pos) => {
+    if (!node.isText) return;
+    if (!matches(node.marks)) return;
+
+    const from = pos;
+    const to = pos + node.nodeSize;
+    const previous = ranges.at(-1);
+
+    // Adjacent text nodes (split by an unrelated mark boundary) read as one run.
+    if (previous && previous.to === from) {
+      previous.to = to;
+      return;
+    }
+
+    ranges.push({ from, to });
+  });
+
+  return ranges;
+}
+
+/** The stored ranges minus anything the user's own selection already covers. */
+function rangesOutside(ranges: SimilarRange[], from: number, to: number): SimilarRange[] {
+  const out: SimilarRange[] = [];
+
+  for (const range of ranges) {
+    if (range.to <= from || range.from >= to) {
+      out.push(range);
+      continue;
+    }
+
+    if (range.from < from) out.push({ from: range.from, to: from });
+    if (range.to > to) out.push({ from: to, to: range.to });
+  }
+
+  return out;
+}
+
+function isMarkStep(step: unknown): step is AddMarkStep | RemoveMarkStep {
+  return step instanceof AddMarkStep || step instanceof RemoveMarkStep;
+}
+
+/**
+ * Re-apply the mark steps a transaction performed inside the primary selection
+ * to every other range in the multi-selection.
+ *
+ * Only transactions made up entirely of mark steps are replayed. That is what
+ * every formatting command produces, and it means the step ranges are still
+ * valid against the new document (mark steps do not move positions), so no
+ * remapping is needed here. Typing, in contrast, is a replace step and must
+ * never be duplicated across the other ranges.
+ */
+function replayMarkSteps(
+  transactions: readonly Transaction[],
+  tr: Transaction,
+  ranges: SimilarRange[]
+): boolean {
+  let changed = false;
+
+  for (const transaction of transactions) {
+    if (transaction.getMeta(REPLAY_META)) continue;
+    if (transaction.steps.length === 0) continue;
+    if (!transaction.steps.every(isMarkStep)) continue;
+
+    for (const step of transaction.steps as (AddMarkStep | RemoveMarkStep)[]) {
+      const isAdd = step instanceof AddMarkStep;
+
+      // The step's own range was handled by the originating command; only the
+      // parts of the multi-selection it did not touch need the replay.
+      for (const range of rangesOutside(ranges, step.from, step.to)) {
+        if (isAdd) tr.addMark(range.from, range.to, step.mark);
+        else tr.removeMark(range.from, range.to, step.mark);
+
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+export const SelectSimilar = Extension.create<SelectSimilarOptions>({
+  name: 'selectSimilar',
+
+  addOptions() {
+    return {
+      className: 'similar-selection',
+    };
+  },
+
+  addCommands() {
+    return {
+      selectSimilar:
+        (mode) =>
+        ({ state, dispatch }) => {
+          const matches = buildMatcher(mode, referenceMarks(state as any));
+          const ranges = collectRanges(state.doc, matches);
+
+          if (dispatch) {
+            dispatch(
+              state.tr.setMeta(selectSimilarPluginKey, {
+                ranges,
+                mode,
+              } satisfies SelectSimilarState)
+            );
+          }
+
+          return ranges.length > 0;
+        },
+
+      clearSimilarSelection:
+        () =>
+        ({ state, dispatch }) => {
+          if (selectSimilarPluginKey.getState(state)?.ranges.length === 0) return false;
+
+          if (dispatch) {
+            dispatch(state.tr.setMeta(selectSimilarPluginKey, EMPTY_STATE));
+          }
+
+          return true;
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      Escape: () => this.editor.commands.clearSimilarSelection(),
+    };
+  },
+
+  addProseMirrorPlugins() {
+    const { className } = this.options;
+
+    return [
+      new Plugin<SelectSimilarState>({
+        key: selectSimilarPluginKey,
+
+        state: {
+          init: () => EMPTY_STATE,
+
+          apply(tr, value) {
+            const meta = tr.getMeta(selectSimilarPluginKey) as SelectSimilarState | undefined;
+
+            if (meta) return meta;
+            if (!tr.docChanged || value.ranges.length === 0) return value;
+
+            // Follow the text as it is edited; ranges that were deleted drop out.
+            const ranges = value.ranges
+              .map((range) => ({
+                from: tr.mapping.map(range.from, 1),
+                to: tr.mapping.map(range.to, -1),
+              }))
+              .filter((range) => range.to > range.from);
+
+            return { ranges, mode: value.mode };
+          },
+        },
+
+        appendTransaction(transactions, _oldState, newState) {
+          const ranges = selectSimilarPluginKey.getState(newState)?.ranges ?? [];
+
+          if (ranges.length === 0) return null;
+
+          const tr = newState.tr.setMeta(REPLAY_META, true);
+
+          return replayMarkSteps(transactions, tr, ranges) ? tr : null;
+        },
+
+        props: {
+          decorations(state) {
+            const { ranges } = selectSimilarPluginKey.getState(state) ?? EMPTY_STATE;
+
+            if (ranges.length === 0) return DecorationSet.empty;
+
+            return DecorationSet.create(
+              state.doc,
+              ranges.map((range) => Decoration.inline(range.from, range.to, { class: className }))
+            );
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/packages/reason-editor/src/extensions/SelectSimilar/index.ts
+++ b/packages/reason-editor/src/extensions/SelectSimilar/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Entry point for the SelectSimilar extension that re-exports the extension and its types. Lets the app import multi-range selection of similarly formatted text from a single, stable module path.
+ */
+
+export * from './SelectSimilar';

--- a/packages/reason-editor/src/locales/ar.ts
+++ b/packages/reason-editor/src/locales/ar.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'يرجى إدخال المحتوى',
   'editor.fontFamily.tooltip': 'عائلة الخط',
   'editor.fontFamily.default.tooltip': 'افتراضي',
+  'editor.fontFamily.search': 'ابحث عن الخطوط...',
+  'editor.fontFamily.empty': 'لا توجد خطوط مطابقة',
   'editor.moremark': 'المزيد من أنماط النص',
   'editor.size.small.tooltip': 'صغير',
   'editor.size.medium.tooltip': 'متوسط',

--- a/packages/reason-editor/src/locales/de.ts
+++ b/packages/reason-editor/src/locales/de.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Bitte Inhalt eingeben',
   'editor.fontFamily.tooltip': 'Schriftart',
   'editor.fontFamily.default.tooltip': 'Standard',
+  'editor.fontFamily.search': 'Schriftarten suchen...',
+  'editor.fontFamily.empty': 'Keine passenden Schriftarten',
   'editor.moremark': 'Weitere Textstile',
   'editor.size.small.tooltip': 'Klein',
   'editor.size.medium.tooltip': 'Mittel',

--- a/packages/reason-editor/src/locales/en.ts
+++ b/packages/reason-editor/src/locales/en.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Please input content',
   'editor.fontFamily.tooltip': 'Font Family',
   'editor.fontFamily.default.tooltip': 'Default',
+  'editor.fontFamily.search': 'Search fonts...',
+  'editor.fontFamily.empty': 'No matching fonts',
   'editor.moremark': 'More Text Styles',
   'editor.size.small.tooltip': 'Small',
   'editor.size.medium.tooltip': 'Medium',

--- a/packages/reason-editor/src/locales/es.ts
+++ b/packages/reason-editor/src/locales/es.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Por favor ingresa contenido',
   'editor.fontFamily.tooltip': 'Familia tipográfica',
   'editor.fontFamily.default.tooltip': 'Predeterminado',
+  'editor.fontFamily.search': 'Buscar fuentes...',
+  'editor.fontFamily.empty': 'No hay fuentes coincidentes',
   'editor.moremark': 'Más estilos de texto',
   'editor.size.small.tooltip': 'Pequeño',
   'editor.size.medium.tooltip': 'Mediano',

--- a/packages/reason-editor/src/locales/fa.ts
+++ b/packages/reason-editor/src/locales/fa.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'لطفاً محتوا وارد کنید',
   'editor.fontFamily.tooltip': 'فونت',
   'editor.fontFamily.default.tooltip': 'پیش‌فرض',
+  'editor.fontFamily.search': 'جستجوی فونت...',
+  'editor.fontFamily.empty': 'فونتی یافت نشد',
   'editor.moremark': 'بیشتر',
   'editor.size.small.tooltip': 'کوچک',
   'editor.size.medium.tooltip': 'متوسط',

--- a/packages/reason-editor/src/locales/fi.ts
+++ b/packages/reason-editor/src/locales/fi.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Syötä sisältö',
   'editor.fontFamily.tooltip': 'Fontti',
   'editor.fontFamily.default.tooltip': 'Oletus',
+  'editor.fontFamily.search': 'Hae fontteja...',
+  'editor.fontFamily.empty': 'Ei osuvia fontteja',
   'editor.moremark': 'Lisää tekstityylejä',
   'editor.size.small.tooltip': 'Pieni',
   'editor.size.medium.tooltip': 'Keskikokoinen',

--- a/packages/reason-editor/src/locales/fr.ts
+++ b/packages/reason-editor/src/locales/fr.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Veuillez saisir du contenu',
   'editor.fontFamily.tooltip': 'Police de caractères',
   'editor.fontFamily.default.tooltip': 'Par défaut',
+  'editor.fontFamily.search': 'Rechercher des polices...',
+  'editor.fontFamily.empty': 'Aucune police correspondante',
   'editor.moremark': 'Plus de styles de texte',
   'editor.size.small.tooltip': 'Petit',
   'editor.size.medium.tooltip': 'Moyen',

--- a/packages/reason-editor/src/locales/he.ts
+++ b/packages/reason-editor/src/locales/he.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'אנא הזן תוכן',
   'editor.fontFamily.tooltip': 'גופן',
   'editor.fontFamily.default.tooltip': 'ברירת מחדל',
+  'editor.fontFamily.search': 'חיפוש גופנים...',
+  'editor.fontFamily.empty': 'לא נמצאו גופנים תואמים',
   'editor.moremark': 'עוד סגנונות טקסט',
   'editor.size.small.tooltip': 'קטן',
   'editor.size.medium.tooltip': 'בינוני',

--- a/packages/reason-editor/src/locales/hi.ts
+++ b/packages/reason-editor/src/locales/hi.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'कृपया सामग्री दर्ज करें',
   'editor.fontFamily.tooltip': 'फ़ॉन्ट परिवार',
   'editor.fontFamily.default.tooltip': 'डिफ़ॉल्ट',
+  'editor.fontFamily.search': 'फ़ॉन्ट खोजें...',
+  'editor.fontFamily.empty': 'कोई मेल खाता फ़ॉन्ट नहीं',
   'editor.moremark': 'और टेक्स्ट स्टाइल',
   'editor.size.small.tooltip': 'छोटा',
   'editor.size.medium.tooltip': 'मध्यम',

--- a/packages/reason-editor/src/locales/hu.ts
+++ b/packages/reason-editor/src/locales/hu.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Írjon be tartalmat',
   'editor.fontFamily.tooltip': 'Betűtípus',
   'editor.fontFamily.default.tooltip': 'Alapértelmezett',
+  'editor.fontFamily.search': 'Betűtípusok keresése...',
+  'editor.fontFamily.empty': 'Nincs találat',
   'editor.moremark': 'Több betűstílus',
   'editor.size.small.tooltip': 'Kicsi',
   'editor.size.medium.tooltip': 'Közepes',

--- a/packages/reason-editor/src/locales/it.ts
+++ b/packages/reason-editor/src/locales/it.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Inserisci il contenuto',
   'editor.fontFamily.tooltip': 'Famiglia di caratteri',
   'editor.fontFamily.default.tooltip': 'Predefinito',
+  'editor.fontFamily.search': 'Cerca caratteri...',
+  'editor.fontFamily.empty': 'Nessun carattere corrispondente',
   'editor.moremark': 'Altri stili di testo',
   'editor.size.small.tooltip': 'Piccolo',
   'editor.size.medium.tooltip': 'Medio',

--- a/packages/reason-editor/src/locales/ja.ts
+++ b/packages/reason-editor/src/locales/ja.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': '内容を入力してください',
   'editor.fontFamily.tooltip': 'フォント',
   'editor.fontFamily.default.tooltip': 'デフォルト',
+  'editor.fontFamily.search': 'フォントを検索...',
+  'editor.fontFamily.empty': '一致するフォントがありません',
   'editor.moremark': 'その他のテキストスタイル',
   'editor.size.small.tooltip': '小',
   'editor.size.medium.tooltip': '中',

--- a/packages/reason-editor/src/locales/ko.ts
+++ b/packages/reason-editor/src/locales/ko.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': '내용을 입력하세요',
   'editor.fontFamily.tooltip': '글꼴',
   'editor.fontFamily.default.tooltip': '기본값',
+  'editor.fontFamily.search': '글꼴 검색...',
+  'editor.fontFamily.empty': '일치하는 글꼴 없음',
   'editor.moremark': '더 많은 텍스트 스타일',
   'editor.size.small.tooltip': '작게',
   'editor.size.medium.tooltip': '보통',

--- a/packages/reason-editor/src/locales/nl.ts
+++ b/packages/reason-editor/src/locales/nl.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Voer inhoud in',
   'editor.fontFamily.tooltip': 'Lettertype',
   'editor.fontFamily.default.tooltip': 'Standaard',
+  'editor.fontFamily.search': 'Lettertypen zoeken...',
+  'editor.fontFamily.empty': 'Geen overeenkomende lettertypen',
   'editor.moremark': 'Meer tekststijlen',
   'editor.size.small.tooltip': 'Klein',
   'editor.size.medium.tooltip': 'Middel',

--- a/packages/reason-editor/src/locales/pt-br.ts
+++ b/packages/reason-editor/src/locales/pt-br.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Por favor, insira o conteúdo',
   'editor.fontFamily.tooltip': 'Fonte',
   'editor.fontFamily.default.tooltip': 'Padrão',
+  'editor.fontFamily.search': 'Pesquisar fontes...',
+  'editor.fontFamily.empty': 'Nenhuma fonte correspondente',
   'editor.moremark': 'Mais estilos de texto',
   'editor.size.small.tooltip': 'Pequeno',
   'editor.size.medium.tooltip': 'Médio',

--- a/packages/reason-editor/src/locales/ru.ts
+++ b/packages/reason-editor/src/locales/ru.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Пожалуйста, введите содержимое',
   'editor.fontFamily.tooltip': 'Шрифт',
   'editor.fontFamily.default.tooltip': 'По умолчанию',
+  'editor.fontFamily.search': 'Поиск шрифтов...',
+  'editor.fontFamily.empty': 'Подходящих шрифтов нет',
   'editor.moremark': 'Больше стилей текста',
   'editor.size.small.tooltip': 'Маленький',
   'editor.size.medium.tooltip': 'Средний',

--- a/packages/reason-editor/src/locales/tr.ts
+++ b/packages/reason-editor/src/locales/tr.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Lütfen içerik girin',
   'editor.fontFamily.tooltip': 'Yazı tipi',
   'editor.fontFamily.default.tooltip': 'Varsayılan',
+  'editor.fontFamily.search': 'Yazı tipi ara...',
+  'editor.fontFamily.empty': 'Eşleşen yazı tipi yok',
   'editor.moremark': 'Daha fazla metin stili',
   'editor.size.small.tooltip': 'Küçük',
   'editor.size.medium.tooltip': 'Orta',

--- a/packages/reason-editor/src/locales/uk.ts
+++ b/packages/reason-editor/src/locales/uk.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': 'Будь ласка, введіть вміст',
   'editor.fontFamily.tooltip': 'Шрифт',
   'editor.fontFamily.default.tooltip': 'За замовчуванням',
+  'editor.fontFamily.search': 'Пошук шрифтів...',
+  'editor.fontFamily.empty': 'Відповідних шрифтів немає',
   'editor.moremark': 'Більше стилів тексту',
   'editor.size.small.tooltip': 'Малий',
   'editor.size.medium.tooltip': 'Середній',

--- a/packages/reason-editor/src/locales/vi.ts
+++ b/packages/reason-editor/src/locales/vi.ts
@@ -29,6 +29,8 @@ const locale = {
   'editor.size.small.tooltip': 'Nhỏ',
   'editor.fontFamily.tooltip': 'Phông chữ',
   'editor.fontFamily.default.tooltip': 'Mặc định',
+  'editor.fontFamily.search': 'Tìm phông chữ...',
+  'editor.fontFamily.empty': 'Không có phông chữ phù hợp',
   'editor.size.medium.tooltip': 'Trung bình',
   'editor.size.large.tooltip': 'Lớn',
   'editor.bold.tooltip': 'Đậm',

--- a/packages/reason-editor/src/locales/zh-cn.ts
+++ b/packages/reason-editor/src/locales/zh-cn.ts
@@ -27,6 +27,8 @@ const locale = {
   'editor.content': '请输入内容',
   'editor.fontFamily.tooltip': '字体',
   'editor.fontFamily.default.tooltip': '默认',
+  'editor.fontFamily.search': '搜索字体...',
+  'editor.fontFamily.empty': '没有匹配的字体',
   'editor.moremark': '更多文本样式',
   'editor.size.small.tooltip': '小',
   'editor.size.medium.tooltip': '中',

--- a/packages/reason-editor/src/styles/ProseMirror.scss
+++ b/packages/reason-editor/src/styles/ProseMirror.scss
@@ -195,6 +195,14 @@
   background-color: #0dff0080;
 }
 
+/* Extra ranges held by the "select similar formatting" multi-selection. Painted
+   like a selection so it reads as one, without being the real one. */
+.reactjs-tiptap-editor .ProseMirror .similar-selection {
+  background-color: rgb(59 130 246 / 22%);
+  box-shadow: inset 0 0 0 1px rgb(59 130 246 / 35%);
+  border-radius: 2px;
+}
+
 /* Harper proofing issue decorations */
 .reactjs-tiptap-editor .ProseMirror .harper-issue {
   text-decoration-line: underline;

--- a/packages/reason-editor/test/select-similar.test.ts
+++ b/packages/reason-editor/test/select-similar.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The SelectSimilar extension: which runs of text it gathers, and the replay
+ * that makes a single formatting command land on all of them at once.
+ */
+
+import { Editor } from '@tiptap/core';
+import { Bold } from '@tiptap/extension-bold';
+import { Document } from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { FontFamily, TextStyle } from '@tiptap/extension-text-style';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SelectSimilar, selectSimilarPluginKey } from '../src/extensions/SelectSimilar';
+
+let editor: Editor | null = null;
+
+/**
+ * A headless editor holding three paragraphs: two set in Georgia, one left in
+ * the default face, so "same font" has both a hit and a miss to distinguish.
+ */
+function createEditor() {
+  editor = new Editor({
+    extensions: [Document, Paragraph, Text, TextStyle, FontFamily, Bold, SelectSimilar],
+    content: [
+      '<p><span style="font-family: Georgia">alpha</span></p>',
+      '<p>beta</p>',
+      '<p><span style="font-family: Georgia">gamma</span></p>',
+    ].join(''),
+  });
+
+  return editor;
+}
+
+/** The ranges the multi-selection is currently holding. */
+function ranges(instance: Editor) {
+  return selectSimilarPluginKey.getState(instance.state)?.ranges ?? [];
+}
+
+/** The text each stored range covers, for readable assertions. */
+function selectedTexts(instance: Editor) {
+  return ranges(instance).map((range) => instance.state.doc.textBetween(range.from, range.to));
+}
+
+/** Places the cursor inside the first paragraph's Georgia run. */
+function putCursorInAlpha(instance: Editor) {
+  instance.commands.setTextSelection(2);
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe('selectSimilar', () => {
+  it('gathers every run sharing the font of the selection', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+
+    expect(instance.commands.selectSimilar('font')).toBe(true);
+    expect(selectedTexts(instance)).toEqual(['alpha', 'gamma']);
+  });
+
+  it('leaves out runs in a different font', () => {
+    const instance = createEditor();
+    instance.commands.setTextSelection(9); // inside "beta", the unstyled run
+
+    instance.commands.selectSimilar('font');
+
+    expect(selectedTexts(instance)).toEqual(['beta']);
+  });
+
+  it('matches the full mark set in formatting mode', () => {
+    const instance = createEditor();
+    // Bold only the first Georgia run, so the two no longer match on marks.
+    instance.commands.setTextSelection({ from: 1, to: 6 });
+    instance.commands.toggleBold();
+
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('formatting');
+
+    expect(selectedTexts(instance)).toEqual(['alpha']);
+  });
+
+  it('reports no match and stores nothing when the document has none', () => {
+    const instance = createEditor();
+    instance.commands.setTextSelection(2);
+    instance.commands.selectSimilar('font');
+    instance.commands.setContent('<p>plain</p>');
+
+    instance.commands.clearSimilarSelection();
+
+    expect(ranges(instance)).toEqual([]);
+  });
+});
+
+describe('replaying formatting across the multi-selection', () => {
+  it('applies a mark added to one range to all the others', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    // Bold only the first run; the third is a stored range, not the selection.
+    instance.commands.setTextSelection({ from: 1, to: 6 });
+    instance.commands.toggleBold();
+
+    expect(instance.state.doc.textBetween(0, instance.state.doc.content.size)).toContain('gamma');
+    expect(instance.getHTML()).toContain('<strong>gamma</strong>');
+    expect(instance.getHTML()).toContain('<strong>alpha</strong>');
+    expect(instance.getHTML()).not.toContain('<strong>beta</strong>');
+  });
+
+  it('removes a mark from the other ranges too', () => {
+    const instance = createEditor();
+    instance.commands.selectAll();
+    instance.commands.setBold();
+
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    instance.commands.setTextSelection({ from: 1, to: 6 });
+    instance.commands.unsetBold();
+
+    expect(instance.getHTML()).not.toContain('<strong>gamma</strong>');
+    expect(instance.getHTML()).toContain('<strong>beta</strong>');
+  });
+
+  it('does not replay typing', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    instance.commands.insertContentAt(6, '!');
+
+    expect(instance.state.doc.textContent).toBe('alpha!betagamma');
+  });
+
+  it('grows with text typed inside a range', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    instance.commands.insertContentAt(3, 'XX');
+
+    expect(selectedTexts(instance)).toEqual(['alXXpha', 'gamma']);
+  });
+
+  it('shifts later ranges along when earlier text grows', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    const before = ranges(instance).at(-1)!;
+    instance.commands.insertContentAt(3, 'XX');
+    const after = ranges(instance).at(-1)!;
+
+    // "gamma" itself is untouched, but its positions moved by the two
+    // characters inserted before it.
+    expect(after).toEqual({ from: before.from + 2, to: before.to + 2 });
+  });
+
+  it('drops ranges whose text was deleted', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    const [, gamma] = ranges(instance);
+    instance.commands.deleteRange({ from: gamma.from, to: gamma.to });
+
+    expect(selectedTexts(instance)).toEqual(['alpha']);
+  });
+});
+
+describe('clearSimilarSelection', () => {
+  it('empties the stored ranges', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+
+    expect(instance.commands.clearSimilarSelection()).toBe(true);
+    expect(ranges(instance)).toEqual([]);
+  });
+
+  it('reports nothing to do when there is no multi-selection', () => {
+    const instance = createEditor();
+
+    expect(instance.commands.clearSimilarSelection()).toBe(false);
+  });
+
+  it('stops formatting from spreading once cleared', () => {
+    const instance = createEditor();
+    putCursorInAlpha(instance);
+    instance.commands.selectSimilar('font');
+    instance.commands.clearSimilarSelection();
+
+    instance.commands.setTextSelection({ from: 1, to: 6 });
+    instance.commands.toggleBold();
+
+    expect(instance.getHTML()).not.toContain('<strong>gamma</strong>');
+  });
+});

--- a/packages/reason-editor/test/toolbar-overlays.test.ts
+++ b/packages/reason-editor/test/toolbar-overlays.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The toolbar's dismissal and focus rules — the ones that decide whether a
+ * press tears down an open dropdown, or belongs to something the dropdown
+ * itself put on screen.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  shouldDismissPanel,
+  shouldKeepEditorFocus,
+} from '../src/editor-views/components/toolbarOverlays';
+
+const created: Element[] = [];
+
+/** Appends an element to the document body and tracks it for cleanup. */
+function mount(html: string): HTMLElement {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  const element = host.firstElementChild as HTMLElement;
+  document.body.append(element);
+  created.push(element);
+  return element;
+}
+
+afterEach(() => {
+  created.splice(0).forEach((element) => element.remove());
+});
+
+describe('shouldDismissPanel', () => {
+  it('dismisses on a press somewhere unrelated', () => {
+    const outside = mount('<p>page content</p>');
+
+    expect(shouldDismissPanel(outside)).toBe(true);
+  });
+
+  it('keeps the panel open when the press is inside it', () => {
+    const panel = mount('<div class="dropdown-portal"><button>Cut</button></div>');
+
+    expect(shouldDismissPanel(panel.querySelector('button'))).toBe(false);
+  });
+
+  it('keeps the panel open when the press is on its trigger', () => {
+    const trigger = mount('<div class="dropdown-container"><button>Edit</button></div>');
+
+    expect(shouldDismissPanel(trigger.querySelector('button'))).toBe(false);
+  });
+
+  it('keeps the panel open for a press in a portalled Radix surface', () => {
+    // What the colour picker and the font list look like from the DOM's side:
+    // attached to <body>, nowhere near the panel that rendered them.
+    const popover = mount('<div data-richtext-portal><span>swatch</span></div>');
+
+    expect(shouldDismissPanel(popover.querySelector('span'))).toBe(false);
+  });
+
+  it('keeps the panel open for a press inside a dialog', () => {
+    const dialog = mount('<div role="dialog"><input /></div>');
+
+    expect(shouldDismissPanel(dialog.querySelector('input'))).toBe(false);
+  });
+
+  it('keeps the panel open while a dialog is on top of it, wherever the press lands', () => {
+    mount('<div role="dialog"><input /></div>');
+    const elsewhere = mount('<p>page content</p>');
+
+    // The press dismisses the dialog; the panel underneath renders it and must
+    // outlive it.
+    expect(shouldDismissPanel(elsewhere)).toBe(false);
+  });
+
+  it('dismisses again once the layer on top has closed', () => {
+    const dialog = mount('<div role="dialog"><input /></div>');
+    const elsewhere = mount('<p>page content</p>');
+
+    dialog.remove();
+
+    expect(shouldDismissPanel(elsewhere)).toBe(true);
+  });
+
+  it('ignores a press whose target has already left the document', () => {
+    const detached = document.createElement('button');
+
+    expect(shouldDismissPanel(detached)).toBe(false);
+  });
+
+  it('ignores a press with no target at all', () => {
+    expect(shouldDismissPanel(null)).toBe(false);
+  });
+});
+
+describe('shouldKeepEditorFocus', () => {
+  it('holds focus for a press on a toolbar button', () => {
+    const button = mount('<button>Bold</button>');
+
+    expect(shouldKeepEditorFocus(button)).toBe(true);
+  });
+
+  it('holds focus for a press on a button’s inner icon', () => {
+    const button = mount('<button><svg><title>B</title></svg></button>');
+
+    expect(shouldKeepEditorFocus(button.querySelector('svg'))).toBe(true);
+  });
+
+  it('holds focus for a press on a menu item', () => {
+    const item = mount('<div role="menuitemcheckbox">Table of Contents</div>');
+
+    expect(shouldKeepEditorFocus(item)).toBe(true);
+  });
+
+  it('lets a text field take the caret', () => {
+    const field = mount('<div class="dropdown-portal"><input placeholder="Search fonts..." /></div>');
+
+    expect(shouldKeepEditorFocus(field.querySelector('input'))).toBe(false);
+  });
+
+  it('lets a button-wrapped text field take the caret', () => {
+    // The style-preset rows in the CSS editor are an input inside a button.
+    const row = mount('<button><input value="Default" /></button>');
+
+    expect(shouldKeepEditorFocus(row.querySelector('input'))).toBe(false);
+  });
+
+  it('leaves a plain panel surface alone so its scrollbar still drags', () => {
+    const panel = mount('<div class="dropdown-portal"><span>Clipboard</span></div>');
+
+    expect(shouldKeepEditorFocus(panel)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Font picker on the main toolbar

The font family control was buried in the Text Styles overflow menu behind a plain name-and-chevron trigger. It now sits on the main toolbar next to the font size as a "T" button, and opens a searchable list that renders each font in its own face, so picking one out of the ~50 available no longer means scrolling a uniform list. It reuses `ActionButton`, so it matches its neighbours in the toolbar row.

## Dropdowns no longer tear themselves down

Any toolbar dropdown fell apart as soon as you used what it opened — the colour picker, the font list, the document info modal, every toolbar dialog.

**Root cause:** the panels close on a mousedown that lands outside their own element. But the controls inside them open Radix popovers, menus and dialogs, and Radix portals those to `<body>` — outside the panel in the DOM, though still children of it in the React tree. So a click on a colour swatch or a dialog field read as "outside", closed the panel, and unmounted the very surface the click had just landed in. The previous check only excused `[data-radix-popper-content-wrapper]`, which covers popovers but not dialogs.

The rules moved into `toolbarOverlays.ts` so they can be tested apart from the extension graph `Toolbar` pulls in:

- Dismissal now recognises the whole stack of surfaces — this package's `data-richtext-portal` marker plus the `dialog` / `menu` / `listbox` roles — and holds the panel open while any of them is on top of it, since the panel owns the React tree that layer renders from. It also ignores targets already detached from the document.
- Pressing a toolbar control no longer moves focus out of the editor, so the command it fires still has the selection it was meant to act on. Text fields and plain panel surfaces are exempt, so the font search box and the panels' scrollbars still behave natively.
- The three modal backdrops only dismiss when the press *started* on the backdrop, rather than when a drag begun inside happens to end past the edge.

## Tools menu split in two

Tools had become a catch-all. Clipboard and selection actions move to a new Edit menu; Tools keeps the document, view and import/export entries.

The Edit menu also gains **select all similar** — by font, by style, or by full formatting — with a live count and a clear action (also on Escape).

## SelectSimilar extension

ProseMirror only ever has one real selection, so the extra runs are held as ranges in plugin state, painted with a selection-like decoration, and mapped through edits. The pay-off is in `appendTransaction`: mark steps made in the primary selection are replayed across every stored range, so the existing bold / colour / font / size buttons format all matching runs at once without any of those extensions knowing this one exists. Only mark-only transactions are replayed — typing is a replace step and is deliberately left alone.

Registered in the plugin registry as `selectSimilar` (default on), so it can be switched off from Settings like any other plugin.

## Verification

- 412 tests pass; 28 are new — 13 covering the extension (range collection, replay, mapping through edits, clearing) and 15 covering the dismissal and focus rules.
- No new type errors (`tsc --noEmit`); the 5 remaining are pre-existing.
- `build:lib` succeeds and emits the new extension.
- Mounted the real toolbar in jsdom to confirm the font button lands on the main row and that both menus carry the right items.

Two suites (`adapter-parity`, `tiptap-editor-wrapper`) fail on a clean checkout because they need a built `dist/` for the package's self-referencing imports. That is pre-existing and unrelated — both pass once `build:lib` has run. It is also why the toolbar itself has no committed DOM test: it cannot be imported without a build.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UD6hmiG4TcxvGZ2MNgHRx2)_