### PR TITLE
Add voice input and read-aloud features with Tiptap extensions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -639,6 +639,7 @@
         "tailwind-scrollbar-hide": "^4.0.0",
         "tiptap-pagination-plus": "^3.1.0",
         "use-sync-external-store": "^1.6.0",
+        "use-voice-control": "^0.1.37",
         "y-indexeddb": "^9.0.12",
         "y-protocols": "^1.0.7",
         "y-webrtc": "10.3.0",
@@ -724,6 +725,7 @@
         "tailwind-merge": "^3.6.0",
         "trending-news-api": "workspace:*",
         "turndown": "^7.2.4",
+        "use-voice-control": "^0.1.37",
         "use-weather-forecast": "workspace:*",
       },
       "devDependencies": {
@@ -866,13 +868,14 @@
         "@huggingface/transformers": "^3.8.1",
         "@moonshine-ai/moonshine-js": "^0.1.29",
         "lucide-react": "^0.344.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
       },
       "devDependencies": {
-        "@types/react": "^18.0.0",
-        "@types/react-dom": "^18.0.0",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^4.0.18",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "typescript": "^5.3.3",
         "vite": "^5.0.0",
         "vite-plugin-dts": "^5.0.0",
@@ -882,8 +885,8 @@
         "@huggingface/transformers": "^3.0.0",
       },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
       },
     },
     "packages/write-language": {
@@ -1122,6 +1125,10 @@
     "@babel/plugin-syntax-top-level-await": ["@babel/plugin-syntax-top-level-await@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw=="],
 
     "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.29.7", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
 
@@ -2594,8 +2601,6 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@22.20.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q=="],
-
-    "@types/prop-types": ["@types/prop-types@15.7.15", "", {}, "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -5123,6 +5128,8 @@
 
     "react-reason-editor": ["react-reason-editor@workspace:packages/reason-editor"],
 
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -6831,15 +6838,9 @@
 
     "uri-js/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "use-voice-control/@types/react": ["@types/react@18.3.31", "", { "dependencies": { "@types/prop-types": "*", "csstype": "^3.2.2" } }, "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw=="],
-
-    "use-voice-control/@types/react-dom": ["@types/react-dom@18.3.7", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ=="],
+    "use-voice-control/@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "use-voice-control/lucide-react": ["lucide-react@0.344.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0" } }, "sha512-6YyBnn91GB45VuVT96bYCOKElbJzUHqp65vX8cDcu55MQL9T969v4dhGClpljamuI/+KMO9P6w9Acq1CVQGvIQ=="],
-
-    "use-voice-control/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
-
-    "use-voice-control/react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "use-voice-control/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
@@ -7717,7 +7718,9 @@
 
     "typedoc/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
-    "use-voice-control/react-dom/scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
+    "use-voice-control/@vitejs/plugin-react/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "use-voice-control/lucide-react/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "use-voice-control/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/packages/reason-editor/package.json
+++ b/packages/reason-editor/package.json
@@ -937,6 +937,7 @@
     "tailwind-scrollbar-hide": "^4.0.0",
     "tiptap-pagination-plus": "^3.1.0",
     "use-sync-external-store": "^1.6.0",
+    "use-voice-control": "^0.1.37",
     "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.7",
     "y-webrtc": "10.3.0",

--- a/packages/reason-editor/src/components/icons/icons.ts
+++ b/packages/reason-editor/src/components/icons/icons.ts
@@ -50,6 +50,7 @@ import {
   ListTodo,
   LoaderCircle,
   Maximize,
+  Mic,
   Minimize,
   Minus,
   PaintRoller,
@@ -79,6 +80,7 @@ import {
   Undo2,
   Unlink,
   Video,
+  Volume2,
   ZoomIn,
   ZoomOut,
   PencilRuler,
@@ -231,4 +233,6 @@ export const icons = {
   Html,
   ExternalLink,
   Callout: NotebookPen,
+  Mic,
+  Volume2,
 } as any;

--- a/packages/reason-editor/src/editor-views/components/Toolbar.tsx
+++ b/packages/reason-editor/src/editor-views/components/Toolbar.tsx
@@ -59,6 +59,12 @@ import { RichTextPagination } from '@/extensions/Pagination/components/RichTextP
 import { RichTextTableOfContentsPanel } from '@/extensions/TableOfContents';
 import { RichTextHarper } from '@/extensions/Harper';
 import { RichTextDrawio } from '@/extensions/Drawio';
+import { getReadAloudText, useReadAloudState } from '@/extensions/ReadAloud';
+import {
+  TranscribeOverlay,
+  isTranscriptionSupported,
+  useTranscribeState,
+} from '@/extensions/Transcribe';
 import { selectSimilarPluginKey, type SelectSimilarMode } from '@/extensions/SelectSimilar';
 import { shouldDismissPanel, shouldKeepEditorFocus } from './toolbarOverlays';
 import {
@@ -92,6 +98,9 @@ import {
   Users,
   MessageSquare,
   MessageSquarePlus,
+  Mic,
+  Volume2,
+  VolumeX,
 } from 'lucide-react';
 
 interface ToolbarProps {
@@ -1154,6 +1163,16 @@ export const RichTextToolbar = ({
     }
   }, [harperOn, editor, hasHarper]);
 
+  // Voice tools: both are optional extensions, so surface each entry only when
+  // its extension is registered. Their live state (speaking / listening) comes
+  // from the extension storage rather than the transaction stream, since neither
+  // changes the document while it runs.
+  const readAloud = useReadAloudState(editor ?? null);
+  const transcribe = useTranscribeState(editor ?? null);
+  // Recomputed per render so the label follows the selection as it changes.
+  const readAloudScope = editor && !editor.state.selection.empty ? 'selection' : 'document';
+  const canReadAloud = !!editor && getReadAloudText(editor).length > 0;
+
   // Page layout: only surface the Web ↔ A4 switch when the Pagination
   // extension is registered on the current editor.
   const hasPagination = !!editor?.extensionManager.extensions.some(
@@ -1568,6 +1587,44 @@ export const RichTextToolbar = ({
                   onChange={setHarperOn}
                 />
               )}
+              {(readAloud.available || transcribe.available) && (
+                <div className="my-1 border-t border-gray-100 dark:border-slate-700" />
+              )}
+              {readAloud.available && (
+                <MenuAction
+                  disabled={!readAloud.isActive && !canReadAloud}
+                  icon={readAloud.isActive ? <VolumeX size={14} /> : <Volume2 size={14} />}
+                  label={
+                    readAloud.isActive
+                      ? 'Stop reading'
+                      : readAloudScope === 'selection'
+                        ? 'Read selection aloud'
+                        : 'Read document aloud'
+                  }
+                  shortcut="Ctrl+Shift+S"
+                  onClick={() => {
+                    close();
+                    editor?.commands.toggleReadAloud();
+                  }}
+                />
+              )}
+              {transcribe.available && (
+                <MenuToggle
+                  icon={<Mic size={14} />}
+                  label={
+                    isTranscriptionSupported()
+                      ? transcribe.isListening
+                        ? 'Dictating — click to stop'
+                        : 'Dictate into the document'
+                      : 'Dictation unavailable in this browser'
+                  }
+                  checked={transcribe.isListening}
+                  onChange={() => {
+                    if (!isTranscriptionSupported()) return;
+                    editor?.commands.toggleTranscribe();
+                  }}
+                />
+              )}
               <div className="my-1 border-t border-gray-100 dark:border-slate-700" />
               {hasPagination && (
                 <MenuToggle
@@ -1685,6 +1742,8 @@ export const RichTextToolbar = ({
         <RichTextTableOfContentsPanel editor={editor} onClose={() => setShowToc(false)} />
       )}
       {hasHarper && harperOn && editor && <RichTextHarper editor={editor} />}
+      {/* Echoes each dictated phrase in the middle of the screen while listening. */}
+      {transcribe.available && <TranscribeOverlay editor={editor ?? null} />}
       {showRename && <FileRenameModal onClose={() => setShowRename(false)} currentName={documentTitle} />}
       {detailsTab && (
         <DocumentDetailsModal

--- a/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
+++ b/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
@@ -68,7 +68,9 @@ import { Drawio } from '@/extensions/Drawio';
 import { Harper } from '@/extensions/Harper';
 import { OfficePaste } from '@/extensions/OfficePaste';
 import { Pagination } from '@/extensions/Pagination';
+import { ReadAloud } from '@/extensions/ReadAloud';
 import { SelectSimilar } from '@/extensions/SelectSimilar';
+import { Transcribe } from '@/extensions/Transcribe';
 
 import { EMOJI_LIST } from '../emojis';
 import { convertBase64ToBlob, MOCK_USERS } from '../components/constants';
@@ -553,6 +555,55 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
     category: 'Tools',
     defaultEnabled: true,
     create: () => ExportPdf,
+  },
+  {
+    key: 'readAloud',
+    label: 'Read Aloud',
+    description:
+      'Speak the selected text, or the whole document when nothing is selected.',
+    category: 'Tools',
+    defaultEnabled: true,
+    settings: [
+      {
+        key: 'voice',
+        label: 'Voice',
+        type: 'text',
+        default: 'af_heart',
+        placeholder: 'af_heart',
+        help: 'Kokoro voice id, e.g. af_heart (warm) or am_michael (clear).',
+      },
+      {
+        key: 'endpoint',
+        label: 'Speech endpoint',
+        type: 'text',
+        default: '/api/speech/tts',
+        help: "Route that synthesizes text. Falls back to the browser's own voice when unreachable.",
+      },
+    ],
+    create: (s) =>
+      ReadAloud.configure({
+        voice: s.voice || 'af_heart',
+        endpoint: s.endpoint || '/api/speech/tts',
+      }),
+  },
+  {
+    key: 'transcribe',
+    label: 'Dictate',
+    description:
+      'Type what you say into the document, with each phrase shown on screen as it lands.',
+    category: 'Tools',
+    defaultEnabled: true,
+    settings: [
+      {
+        key: 'language',
+        label: 'Language',
+        type: 'text',
+        default: 'en-US',
+        placeholder: 'en-US',
+        help: 'BCP-47 tag used by the browser recognizer, e.g. en-US or es-ES.',
+      },
+    ],
+    create: (s) => Transcribe.configure({ language: s.language || 'en-US' }),
   },
   {
     key: 'pagination',

--- a/packages/reason-editor/src/extensions/ReadAloud/ReadAloud.ts
+++ b/packages/reason-editor/src/extensions/ReadAloud/ReadAloud.ts
@@ -1,0 +1,222 @@
+/**
+ * Defines the ReadAloud Tiptap extension, which speaks the document out loud. It
+ * reads the current selection when there is one and the whole document otherwise,
+ * driving playback through `use-voice-control`'s `ReadAloudController` (Kokoro by
+ * default, with the browser's own synthesizer as a fallback).
+ *
+ * Playback state lives in the extension's storage rather than in a React component,
+ * so the toolbar, a slash command and a keyboard shortcut all control one shared
+ * utterance. `subscribeReadAloud` lets UI subscribe to that state.
+ */
+
+import { type Editor, Extension } from '@tiptap/core';
+import {
+  ReadAloudController,
+  type ReadAloudChunk,
+  type ReadAloudState,
+  type TTSProvider,
+} from 'use-voice-control/client';
+
+import type { GeneralOptions } from '@/types';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    readAloud: {
+      /** Speak the selection, or the whole document when nothing is selected. */
+      readAloud: () => ReturnType;
+      /** Stop playback and drop anything still queued. */
+      stopReadAloud: () => ReturnType;
+      /** Start speaking, or stop if already speaking. */
+      toggleReadAloud: () => ReturnType;
+      /** Pause playback, keeping the queue intact. */
+      pauseReadAloud: () => ReturnType;
+      /** Resume paused playback. */
+      resumeReadAloud: () => ReturnType;
+    };
+  }
+}
+
+export interface ReadAloudOptions extends GeneralOptions<ReadAloudOptions> {
+  /** TTS provider to synthesize with. */
+  provider: TTSProvider;
+  /** Provider-specific voice id. */
+  voice: string;
+  /** HTTP route that turns text into audio. */
+  endpoint: string;
+  /**
+   * Target size of each synthesized chunk, in characters. Playback starts after
+   * the first chunk, so a smaller value means the document starts talking sooner.
+   */
+  maxChunkLength: number;
+}
+
+export interface ReadAloudStorage {
+  controller: ReadAloudController | null;
+  state: ReadAloudState;
+  /** The chunk currently being spoken, or `null` between utterances. */
+  currentChunk: ReadAloudChunk | null;
+  error: Error | null;
+  /** UI subscribers, notified on every state or chunk change. */
+  listeners: Set<() => void>;
+}
+
+/** Text the tool would speak right now: the selection, else the whole document. */
+export function getReadAloudText(editor: Editor): string {
+  const { from, to, empty } = editor.state.selection;
+  // Blank lines between blocks keep the synthesizer from running paragraphs
+  // together into one breathless sentence.
+  const range = empty ? { from: 0, to: editor.state.doc.content.size } : { from, to };
+  return editor.state.doc.textBetween(range.from, range.to, '\n\n', ' ').trim();
+}
+
+/** Whether the current selection (rather than the whole document) would be read. */
+export function isReadAloudSelectionScoped(editor: Editor): boolean {
+  return !editor.state.selection.empty;
+}
+
+function getStorage(editor: Editor): ReadAloudStorage | undefined {
+  return (editor.storage as any)?.readAloud;
+}
+
+export function getReadAloudStorage(editor: Editor): ReadAloudStorage | undefined {
+  return getStorage(editor);
+}
+
+/**
+ * Subscribe to playback state. Returns an unsubscribe function, so it pairs
+ * directly with React's `useSyncExternalStore`.
+ */
+export function subscribeReadAloud(editor: Editor, listener: () => void): () => void {
+  const storage = getStorage(editor);
+  if (!storage) return () => undefined;
+  storage.listeners.add(listener);
+  return () => storage.listeners.delete(listener);
+}
+
+/**
+ * The playback controller, built on first use. Creating it lazily rather than in
+ * `onCreate` keeps it available to a command fired the instant the editor mounts —
+ * Tiptap emits `create` a tick later — and avoids spinning one up for a document
+ * that is never read aloud.
+ */
+function ensureController(
+  storage: ReadAloudStorage,
+  options: ReadAloudOptions
+): ReadAloudController {
+  if (storage.controller) return storage.controller;
+
+  const notify = () => storage.listeners.forEach((listener) => listener());
+
+  storage.controller = new ReadAloudController({
+    provider: options.provider,
+    voice: options.voice,
+    endpoint: options.endpoint,
+    maxChunkLength: options.maxChunkLength,
+    onStateChange: (state) => {
+      storage.state = state;
+      notify();
+    },
+    onChunk: (chunk) => {
+      storage.currentChunk = chunk;
+      notify();
+    },
+    onEnd: () => {
+      storage.currentChunk = null;
+      notify();
+    },
+    onError: (error) => {
+      storage.error = error;
+      notify();
+    },
+  });
+
+  return storage.controller;
+}
+
+export const ReadAloud = Extension.create<ReadAloudOptions, ReadAloudStorage>({
+  name: 'readAloud',
+
+  //@ts-expect-error — `button` is supplied by GeneralOptions' parent defaults
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      provider: 'kokoro',
+      voice: 'af_heart',
+      endpoint: '/api/speech/tts',
+      maxChunkLength: 240,
+      button: ({ editor, t }) => ({
+        componentProps: {
+          action: () => {
+            (editor.commands as any).toggleReadAloud?.();
+          },
+          icon: 'Volume2',
+          tooltip: t('editor.readAloud.tooltip'),
+          isActive: () => getStorage(editor as Editor)?.state !== 'idle',
+          disabled: false,
+        },
+      }),
+    };
+  },
+
+  addStorage() {
+    return {
+      controller: null,
+      state: 'idle',
+      currentChunk: null,
+      error: null,
+      listeners: new Set(),
+    };
+  },
+
+  onDestroy() {
+    this.storage.controller?.stop();
+    this.storage.controller = null;
+    this.storage.listeners.clear();
+  },
+
+  addCommands() {
+    return {
+      readAloud:
+        () =>
+        ({ editor }) => {
+          const text = getReadAloudText(editor as Editor);
+          if (!text) return false;
+
+          this.storage.error = null;
+          void ensureController(this.storage, this.options).speak(text);
+          return true;
+        },
+
+      stopReadAloud: () => () => {
+        this.storage.controller?.stop();
+        return true;
+      },
+
+      toggleReadAloud:
+        () =>
+        ({ commands }) => {
+          if (this.storage.controller?.isActive()) {
+            this.storage.controller.stop();
+            return true;
+          }
+          return commands.readAloud();
+        },
+
+      pauseReadAloud: () => () => {
+        this.storage.controller?.pause();
+        return true;
+      },
+
+      resumeReadAloud: () => () => {
+        this.storage.controller?.resume();
+        return true;
+      },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-s': () => this.editor.commands.toggleReadAloud(),
+    };
+  },
+});

--- a/packages/reason-editor/src/extensions/ReadAloud/components/RichTextReadAloud.tsx
+++ b/packages/reason-editor/src/extensions/ReadAloud/components/RichTextReadAloud.tsx
@@ -1,0 +1,46 @@
+/**
+ * Toolbar control (React) for the ReadAloud extension, which speaks the selection —
+ * or the whole document when nothing is selected — out loud. The button doubles as
+ * a stop control while audio is playing, and its active state comes from the
+ * extension's storage rather than the editor's transaction stream, since playback
+ * progresses without the document changing.
+ */
+
+import { useCurrentEditor } from '@tiptap/react';
+
+import { ActionButton } from '@/components';
+import { ReadAloud, getReadAloudText, isReadAloudSelectionScoped } from '@/extensions/ReadAloud';
+import { useReadAloudState } from '@/extensions/ReadAloud/hooks/useReadAloudState';
+import { useButtonProps } from '@/hooks/useButtonProps';
+
+export function RichTextReadAloud() {
+  const buttonProps = useButtonProps(ReadAloud.name);
+  const { editor } = useCurrentEditor();
+  const { isActive } = useReadAloudState(editor ?? null);
+
+  const {
+    icon = 'Volume2',
+    tooltip = undefined,
+    shortcutKeys = undefined,
+    tooltipOptions = {},
+  } = buttonProps?.componentProps ?? {};
+
+  if (!buttonProps || !editor) {
+    return <></>;
+  }
+
+  const hasText = getReadAloudText(editor).length > 0;
+  const scopeLabel = isReadAloudSelectionScoped(editor) ? 'selection' : 'document';
+
+  return (
+    <ActionButton
+      action={() => editor.commands.toggleReadAloud()}
+      dataState={isActive}
+      disabled={!isActive && !hasText}
+      icon={isActive ? 'X' : icon}
+      shortcutKeys={shortcutKeys}
+      tooltip={isActive ? 'Stop reading' : (tooltip ?? `Read ${scopeLabel} aloud`)}
+      tooltipOptions={tooltipOptions}
+    />
+  );
+}

--- a/packages/reason-editor/src/extensions/ReadAloud/hooks/useReadAloudState.ts
+++ b/packages/reason-editor/src/extensions/ReadAloud/hooks/useReadAloudState.ts
@@ -1,0 +1,69 @@
+/**
+ * React binding for the ReadAloud extension's playback state.
+ *
+ * Playback lives in the extension's storage so every entry point (toolbar, command,
+ * shortcut) drives one utterance; this hook subscribes a component to that store
+ * and re-renders it whenever the state or the chunk being spoken changes.
+ */
+
+import { useCallback, useSyncExternalStore } from 'react';
+import type { Editor } from '@tiptap/core';
+import type { ReadAloudChunk, ReadAloudState } from 'use-voice-control/client';
+
+import { getReadAloudStorage, subscribeReadAloud } from '../ReadAloud';
+
+export interface ReadAloudSnapshot {
+  /** False when the ReadAloud extension is not registered on this editor. */
+  available: boolean;
+  state: ReadAloudState;
+  isActive: boolean;
+  isSpeaking: boolean;
+  isPaused: boolean;
+  currentChunk: ReadAloudChunk | null;
+  error: Error | null;
+}
+
+const IDLE: ReadAloudSnapshot = {
+  available: false,
+  state: 'idle',
+  isActive: false,
+  isSpeaking: false,
+  isPaused: false,
+  currentChunk: null,
+  error: null,
+};
+
+export function useReadAloudState(editor: Editor | null): ReadAloudSnapshot {
+  const subscribe = useCallback(
+    (listener: () => void) => (editor ? subscribeReadAloud(editor, listener) : () => undefined),
+    [editor]
+  );
+
+  // `useSyncExternalStore` compares snapshots by identity, so the pieces that
+  // actually change are serialized into a string and the object is rebuilt from
+  // it — cheaper than memoizing a new object on every notification.
+  const key = useSyncExternalStore(
+    subscribe,
+    () => {
+      const storage = editor ? getReadAloudStorage(editor) : undefined;
+      if (!storage) return 'none';
+      return `${storage.state}|${storage.currentChunk?.index ?? -1}|${storage.error?.message ?? ''}`;
+    },
+    () => 'none'
+  );
+
+  if (key === 'none' || !editor) return IDLE;
+
+  const storage = getReadAloudStorage(editor);
+  if (!storage) return IDLE;
+
+  return {
+    available: true,
+    state: storage.state,
+    isActive: storage.state !== 'idle',
+    isSpeaking: storage.state === 'speaking',
+    isPaused: storage.state === 'paused',
+    currentChunk: storage.currentChunk,
+    error: storage.error,
+  };
+}

--- a/packages/reason-editor/src/extensions/ReadAloud/index.ts
+++ b/packages/reason-editor/src/extensions/ReadAloud/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Entry point for the ReadAloud extension that re-exports the extension and its
+ * React components. Lets the app import speaking the document out loud from a
+ * single, stable module path.
+ */
+
+export * from './ReadAloud';
+export * from './components/RichTextReadAloud';
+export * from './hooks/useReadAloudState';

--- a/packages/reason-editor/src/extensions/Transcribe/Transcribe.ts
+++ b/packages/reason-editor/src/extensions/Transcribe/Transcribe.ts
@@ -1,0 +1,328 @@
+/**
+ * Defines the Transcribe Tiptap extension, which types dictated speech straight
+ * into the document. It drives `use-voice-control`'s `LiveTranscriber`, writing the
+ * recognizer's in-progress guess at the cursor and rewriting it in place on every
+ * update, so words appear as they are being said rather than in one lump when the
+ * speaker stops.
+ *
+ * Only settled phrases enter the undo history: the interim churn is written with
+ * history disabled and removed again before the committed phrase is inserted, so a
+ * single undo takes back one phrase rather than one word.
+ *
+ * Listening state lives in the extension's storage so the toolbar, a command and a
+ * keyboard shortcut all drive one microphone session; `subscribeTranscribe` lets UI
+ * follow it, including the `lastPhrase`/`phraseId` pair the on-screen phrase
+ * display reads.
+ */
+
+import { type Editor, Extension } from '@tiptap/core';
+import { TextSelection } from '@tiptap/pm/state';
+import {
+  LiveTranscriber,
+  isTranscriptionSupported,
+  type TranscriberEngine,
+} from 'use-voice-control/client';
+
+import type { GeneralOptions } from '@/types';
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    transcribe: {
+      /** Start dictating into the document at the cursor. */
+      startTranscribe: () => ReturnType;
+      /** Stop dictating, discarding any unfinished phrase. */
+      stopTranscribe: () => ReturnType;
+      /** Start dictating, or stop if already listening. */
+      toggleTranscribe: () => ReturnType;
+    };
+  }
+}
+
+export interface TranscribeOptions extends GeneralOptions<TranscribeOptions> {
+  /** Which recognizer to use: browser-native, on-device Moonshine, or auto. */
+  engine: TranscriberEngine;
+  /** BCP-47 language tag for the browser recognizer. */
+  language: string;
+  /** Moonshine model name, used when that engine is selected. */
+  model: string;
+}
+
+export interface TranscribeStorage {
+  transcriber: LiveTranscriber | null;
+  listening: boolean;
+  /** The phrase currently being spoken; empty between phrases. */
+  partial: string;
+  /** The most recent thing heard, partial or settled — what the overlay shows. */
+  lastPhrase: string;
+  /** Increments on every `lastPhrase` update so repeats still re-trigger the UI. */
+  phraseId: number;
+  error: Error | null;
+  /** Document range holding the in-progress phrase, or `null` between phrases. */
+  interimFrom: number | null;
+  interimTo: number | null;
+  /** Leading space inserted ahead of a phrase that starts mid-sentence. */
+  interimPrefix: string;
+  listeners: Set<() => void>;
+}
+
+function getStorage(editor: Editor): TranscribeStorage | undefined {
+  return (editor.storage as any)?.transcribe;
+}
+
+export function getTranscribeStorage(editor: Editor): TranscribeStorage | undefined {
+  return getStorage(editor);
+}
+
+/** True when this browser can dictate at all. */
+export { isTranscriptionSupported };
+
+/**
+ * Subscribe to dictation state. Returns an unsubscribe function, so it pairs
+ * directly with React's `useSyncExternalStore`.
+ */
+export function subscribeTranscribe(editor: Editor, listener: () => void): () => void {
+  const storage = getStorage(editor);
+  if (!storage) return () => undefined;
+  storage.listeners.add(listener);
+  return () => storage.listeners.delete(listener);
+}
+
+/** A phrase starting straight after a word needs a space in front of it. */
+function needsLeadingSpace(editor: Editor, pos: number): boolean {
+  if (pos <= 0) return false;
+  const before = editor.state.doc.textBetween(Math.max(0, pos - 1), pos, '', '');
+  return before.length > 0 && !/\s/.test(before);
+}
+
+/** Discard a stored range that a concurrent edit may have pushed out of the document. */
+function resolveInterimRange(
+  docSize: number,
+  storage: TranscribeStorage
+): { from: number; to: number } | null {
+  const { interimFrom, interimTo } = storage;
+  if (interimFrom === null || interimTo === null) return null;
+  if (interimFrom > docSize || interimTo > docSize || interimFrom > interimTo) return null;
+  return { from: interimFrom, to: interimTo };
+}
+
+/** Write the in-progress phrase at the cursor, replacing whatever it wrote last. */
+function writeInterim(editor: Editor, storage: TranscribeStorage, text: string): void {
+  const existing = resolveInterimRange(editor.state.doc.content.size, storage);
+
+  let from: number;
+  if (existing) {
+    from = existing.from;
+  } else {
+    from = Math.min(editor.state.selection.head, editor.state.doc.content.size);
+    storage.interimPrefix = needsLeadingSpace(editor, from) ? ' ' : '';
+  }
+  const to = existing ? existing.to : from;
+
+  const body = `${storage.interimPrefix}${text}`;
+  const tr = editor.state.tr;
+  if (body) {
+    tr.insertText(body, from, to);
+  } else if (from !== to) {
+    tr.delete(from, to);
+  } else {
+    return;
+  }
+
+  // Interim text is rewritten on every recognizer update; keeping it out of the
+  // history means undo steps through phrases, not keystrokes.
+  tr.setMeta('addToHistory', false);
+  const end = Math.min(from + body.length, tr.doc.content.size);
+  tr.setSelection(TextSelection.create(tr.doc, end));
+  editor.view.dispatch(tr);
+
+  storage.interimFrom = from;
+  storage.interimTo = end;
+}
+
+/**
+ * Replace the in-progress phrase with the settled one. The interim text is removed
+ * without touching the history first, so the recorded insertion is a clean one that
+ * a single undo takes back whole.
+ */
+function commitPhrase(editor: Editor, storage: TranscribeStorage, text: string): void {
+  const prefix = storage.interimPrefix;
+  const existing = resolveInterimRange(editor.state.doc.content.size, storage);
+
+  storage.interimFrom = null;
+  storage.interimTo = null;
+  storage.interimPrefix = '';
+
+  let insertAt: number;
+  if (existing) {
+    if (existing.from !== existing.to) {
+      const clearTr = editor.state.tr.delete(existing.from, existing.to);
+      clearTr.setMeta('addToHistory', false);
+      editor.view.dispatch(clearTr);
+    }
+    insertAt = existing.from;
+  } else {
+    insertAt = Math.min(editor.state.selection.head, editor.state.doc.content.size);
+  }
+
+  const lead = existing ? prefix : needsLeadingSpace(editor, insertAt) ? ' ' : '';
+  const body = `${lead}${text} `;
+  const tr = editor.state.tr.insertText(body, insertAt, insertAt);
+  const end = Math.min(insertAt + body.length, tr.doc.content.size);
+  tr.setSelection(TextSelection.create(tr.doc, end));
+  editor.view.dispatch(tr);
+}
+
+/**
+ * The recognizer, built on first use. Creating it lazily rather than in `onCreate`
+ * keeps it available to a command fired the instant the editor mounts — Tiptap
+ * emits `create` a tick later — and avoids asking for a microphone in documents
+ * nobody dictates into.
+ */
+function ensureTranscriber(
+  editor: Editor,
+  storage: TranscribeStorage,
+  options: TranscribeOptions
+): LiveTranscriber {
+  if (storage.transcriber) return storage.transcriber;
+
+  const notify = () => storage.listeners.forEach((listener) => listener());
+
+  storage.transcriber = new LiveTranscriber({
+    engine: options.engine,
+    language: options.language,
+    model: options.model,
+    onStateChange: (listening) => {
+      storage.listening = listening;
+      notify();
+    },
+    onPartial: (text) => {
+      if (editor.isDestroyed) return;
+      storage.partial = text;
+      if (text) {
+        storage.lastPhrase = text;
+        storage.phraseId += 1;
+      }
+      writeInterim(editor, storage, text);
+      notify();
+    },
+    onCommit: (text) => {
+      if (editor.isDestroyed) return;
+      storage.partial = '';
+      storage.lastPhrase = text;
+      storage.phraseId += 1;
+      commitPhrase(editor, storage, text);
+      notify();
+    },
+    onError: (error) => {
+      storage.error = error;
+      notify();
+    },
+  });
+
+  return storage.transcriber;
+}
+
+export const Transcribe = Extension.create<TranscribeOptions, TranscribeStorage>({
+  name: 'transcribe',
+
+  //@ts-expect-error — `button` is supplied by GeneralOptions' parent defaults
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      engine: 'auto',
+      language: 'en-US',
+      model: 'model/small',
+      button: ({ editor, t }) => ({
+        componentProps: {
+          action: () => {
+            (editor.commands as any).toggleTranscribe?.();
+          },
+          icon: 'Mic',
+          tooltip: t('editor.transcribe.tooltip'),
+          isActive: () => !!getStorage(editor as Editor)?.listening,
+          disabled: false,
+        },
+      }),
+    };
+  },
+
+  addStorage() {
+    return {
+      transcriber: null,
+      listening: false,
+      partial: '',
+      lastPhrase: '',
+      phraseId: 0,
+      error: null,
+      interimFrom: null,
+      interimTo: null,
+      interimPrefix: '',
+      listeners: new Set(),
+    };
+  },
+
+  onDestroy() {
+    void this.storage.transcriber?.stop();
+    this.storage.transcriber = null;
+    this.storage.listeners.clear();
+  },
+
+  addCommands() {
+    return {
+      startTranscribe:
+        () =>
+        ({ editor }) => {
+          const transcriber = ensureTranscriber(
+            editor as Editor,
+            this.storage,
+            this.options
+          );
+          if (transcriber.isListening()) return false;
+          this.storage.error = null;
+          // Dictation lands wherever the caret is, so make sure there is one.
+          if (!editor.isFocused) editor.commands.focus();
+          void transcriber.start();
+          return true;
+        },
+
+      stopTranscribe:
+        () =>
+        ({ tr, dispatch }) => {
+          const transcriber = this.storage.transcriber;
+          if (!transcriber) return false;
+          void transcriber.stop();
+
+          // Drop the half-heard phrase rather than leaving a guess in the text.
+          // The edit rides on the command's own transaction: dispatching a
+          // separate one built from `editor.state` would be applied against a
+          // state the command has already moved past.
+          const range = resolveInterimRange(tr.doc.content.size, this.storage);
+          if (dispatch && range && range.from !== range.to) {
+            tr.delete(range.from, range.to);
+            tr.setMeta('addToHistory', false);
+          }
+
+          this.storage.interimFrom = null;
+          this.storage.interimTo = null;
+          this.storage.interimPrefix = '';
+          this.storage.partial = '';
+          this.storage.listeners.forEach((listener) => listener());
+          return true;
+        },
+
+      toggleTranscribe:
+        () =>
+        ({ commands }) => {
+          return this.storage.transcriber?.isListening()
+            ? commands.stopTranscribe()
+            : commands.startTranscribe();
+        },
+    };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-d': () => this.editor.commands.toggleTranscribe(),
+    };
+  },
+});

--- a/packages/reason-editor/src/extensions/Transcribe/components/RichTextTranscribe.tsx
+++ b/packages/reason-editor/src/extensions/Transcribe/components/RichTextTranscribe.tsx
@@ -1,0 +1,50 @@
+/**
+ * Toolbar control (React) for the Transcribe extension, which types dictated speech
+ * into the document at the cursor. The button toggles the microphone and reflects
+ * the live listening state from the extension's storage; the phrase overlay that
+ * accompanies dictation is rendered by `TranscribeOverlay`.
+ */
+
+import { useCurrentEditor } from '@tiptap/react';
+
+import { ActionButton } from '@/components';
+import { Transcribe, isTranscriptionSupported } from '@/extensions/Transcribe';
+import { useTranscribeState } from '@/extensions/Transcribe/hooks/useTranscribeState';
+import { useButtonProps } from '@/hooks/useButtonProps';
+
+export function RichTextTranscribe() {
+  const buttonProps = useButtonProps(Transcribe.name);
+  const { editor } = useCurrentEditor();
+  const { isListening } = useTranscribeState(editor ?? null);
+
+  const {
+    icon = 'Mic',
+    tooltip = undefined,
+    shortcutKeys = undefined,
+    tooltipOptions = {},
+  } = buttonProps?.componentProps ?? {};
+
+  if (!buttonProps || !editor) {
+    return <></>;
+  }
+
+  const supported = isTranscriptionSupported();
+
+  return (
+    <ActionButton
+      action={() => editor.commands.toggleTranscribe()}
+      dataState={isListening}
+      disabled={!supported}
+      icon={icon}
+      shortcutKeys={shortcutKeys}
+      tooltip={
+        !supported
+          ? 'Dictation is not supported in this browser'
+          : isListening
+            ? 'Stop dictation'
+            : (tooltip ?? 'Dictate into the document')
+      }
+      tooltipOptions={tooltipOptions}
+    />
+  );
+}

--- a/packages/reason-editor/src/extensions/Transcribe/components/TranscribeOverlay.tsx
+++ b/packages/reason-editor/src/extensions/Transcribe/components/TranscribeOverlay.tsx
@@ -1,0 +1,32 @@
+/**
+ * Renders the phrase that was just dictated in large type at the centre of the
+ * screen, fading out two seconds after the last word. Dictation types into the
+ * document wherever the caret happens to be, which is easy to lose track of while
+ * speaking, so this echoes what was heard where it cannot be missed.
+ *
+ * Mount it once alongside the editor; it draws nothing unless dictation is running.
+ */
+
+import type { Editor } from '@tiptap/core';
+import { SpokenPhraseOverlay } from 'use-voice-control/react';
+
+import { useTranscribeState } from '@/extensions/Transcribe/hooks/useTranscribeState';
+
+export interface TranscribeOverlayProps {
+  editor: Editor | null;
+  /** How long the phrase stays up after the last update. Default 2000ms. */
+  durationMs?: number;
+}
+
+export function TranscribeOverlay({ editor, durationMs = 2000 }: TranscribeOverlayProps) {
+  const { isListening, lastPhrase, phraseId } = useTranscribeState(editor);
+
+  return (
+    <SpokenPhraseOverlay
+      durationMs={durationMs}
+      phrase={lastPhrase}
+      phraseId={phraseId}
+      visible={isListening}
+    />
+  );
+}

--- a/packages/reason-editor/src/extensions/Transcribe/hooks/useTranscribeState.ts
+++ b/packages/reason-editor/src/extensions/Transcribe/hooks/useTranscribeState.ts
@@ -1,0 +1,68 @@
+/**
+ * React binding for the Transcribe extension's dictation state.
+ *
+ * The microphone session lives in the extension's storage so every entry point
+ * drives one session; this hook subscribes a component to that store and re-renders
+ * it as phrases arrive, exposing the `lastPhrase`/`phraseId` pair that the
+ * on-screen phrase display reads.
+ */
+
+import { useCallback, useSyncExternalStore } from 'react';
+import type { Editor } from '@tiptap/core';
+
+import { getTranscribeStorage, subscribeTranscribe } from '../Transcribe';
+
+export interface TranscribeSnapshot {
+  /** False when the Transcribe extension is not registered on this editor. */
+  available: boolean;
+  isListening: boolean;
+  /** The phrase currently being spoken; empty between phrases. */
+  partial: string;
+  /** The most recent thing heard, partial or settled. */
+  lastPhrase: string;
+  /** Increments on every `lastPhrase` update, repeats included. */
+  phraseId: number;
+  error: Error | null;
+}
+
+const IDLE: TranscribeSnapshot = {
+  available: false,
+  isListening: false,
+  partial: '',
+  lastPhrase: '',
+  phraseId: 0,
+  error: null,
+};
+
+export function useTranscribeState(editor: Editor | null): TranscribeSnapshot {
+  const subscribe = useCallback(
+    (listener: () => void) => (editor ? subscribeTranscribe(editor, listener) : () => undefined),
+    [editor]
+  );
+
+  // Snapshots are compared by identity, so track a cheap string key and rebuild
+  // the object from storage only when something has actually moved.
+  const key = useSyncExternalStore(
+    subscribe,
+    () => {
+      const storage = editor ? getTranscribeStorage(editor) : undefined;
+      if (!storage) return 'none';
+      return `${storage.listening}|${storage.phraseId}|${storage.error?.message ?? ''}`;
+    },
+    () => 'none'
+  );
+
+  if (key === 'none' || !editor) return IDLE;
+
+  const storage = getTranscribeStorage(editor);
+  if (!storage) return IDLE;
+
+  return {
+    available: true,
+    isListening: storage.listening,
+    partial: storage.partial,
+    lastPhrase: storage.lastPhrase,
+    phraseId: storage.phraseId,
+    error: storage.error,
+  };
+}

--- a/packages/reason-editor/src/extensions/Transcribe/index.ts
+++ b/packages/reason-editor/src/extensions/Transcribe/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Entry point for the Transcribe extension that re-exports the extension, its React
+ * components and the centred phrase overlay. Lets the app import dictation from a
+ * single, stable module path.
+ */
+
+export * from './Transcribe';
+export * from './components/RichTextTranscribe';
+export * from './components/TranscribeOverlay';
+export * from './hooks/useTranscribeState';

--- a/packages/reason-editor/src/locales/en.ts
+++ b/packages/reason-editor/src/locales/en.ts
@@ -159,6 +159,8 @@ const locale = {
   'Frequently used': 'Frequently used',
   'editor.formula.dialog.text': 'Formula',
   'editor.katex.tooltip': 'Math Formula',
+  'editor.readAloud.tooltip': 'Read Aloud',
+  'editor.transcribe.tooltip': 'Dictate',
   'editor.exportPdf.tooltip': 'Export PDF',
   'editor.exportWord.tooltip': 'Export Word',
   'editor.importWord.tooltip': 'Import Word',

--- a/packages/reason-editor/test/helpers/vitest.setup.ts
+++ b/packages/reason-editor/test/helpers/vitest.setup.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared test setup.
+ *
+ * ProseMirror's `DOMObserver.stop()` schedules one final `flush()` 20ms out when
+ * the view still has pending DOM mutations, and nothing cancels that timer — so a
+ * test file that destroys or unmounts an editor at the very end leaves a callback
+ * queued past its own lifetime. Vitest tears the jsdom environment down first, and
+ * the callback then reaches for `document` from whatever file happens to be running
+ * next, surfacing as an unhandled "document is not defined" that fails the run
+ * without failing any test.
+ *
+ * Holding the file open a beat longer lets that flush land while its own jsdom is
+ * still standing.
+ */
+import { afterAll } from 'vitest';
+
+/** Comfortably past ProseMirror's own 20ms flush delay. */
+const PENDING_FLUSH_MS = 30;
+
+afterAll(async () => {
+  await new Promise((resolve) => setTimeout(resolve, PENDING_FLUSH_MS));
+});

--- a/packages/reason-editor/test/read-aloud.test.ts
+++ b/packages/reason-editor/test/read-aloud.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The ReadAloud extension: which text it hands to the synthesizer — the selection
+ * when there is one, the whole document otherwise — and how its commands drive
+ * playback.
+ */
+
+import { Editor } from '@tiptap/core';
+import { Document } from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ReadAloud,
+  getReadAloudStorage,
+  getReadAloudText,
+  isReadAloudSelectionScoped,
+} from '../src/extensions/ReadAloud';
+
+let editor: Editor | null = null;
+
+function createEditor(content: string) {
+  editor = new Editor({
+    extensions: [Document, Paragraph, Text, ReadAloud],
+    content,
+  });
+  return editor;
+}
+
+/** Swap the real controller for a recorder so no audio or network is involved. */
+function stubController(instance: Editor) {
+  const controller = {
+    speak: vi.fn(async () => undefined),
+    stop: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    isActive: vi.fn(() => false),
+  };
+  getReadAloudStorage(instance)!.controller = controller as any;
+  return controller;
+}
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+describe('ReadAloud', () => {
+  it('reads the whole document when nothing is selected', () => {
+    const instance = createEditor('<p>First line.</p><p>Second line.</p>');
+
+    expect(isReadAloudSelectionScoped(instance)).toBe(false);
+    // Blank lines between blocks stop the synthesizer running paragraphs together.
+    expect(getReadAloudText(instance)).toBe('First line.\n\nSecond line.');
+  });
+
+  it('reads only the selection when there is one', () => {
+    const instance = createEditor('<p>First line.</p><p>Second line.</p>');
+    instance.commands.setTextSelection({ from: 1, to: 6 });
+
+    expect(isReadAloudSelectionScoped(instance)).toBe(true);
+    expect(getReadAloudText(instance)).toBe('First');
+  });
+
+  it('speaks the current text on command', () => {
+    const instance = createEditor('<p>Speak this.</p>');
+    const controller = stubController(instance);
+
+    expect(instance.commands.readAloud()).toBe(true);
+    expect(controller.speak).toHaveBeenCalledWith('Speak this.');
+  });
+
+  it('refuses to speak an empty document', () => {
+    const instance = createEditor('<p></p>');
+    const controller = stubController(instance);
+
+    expect(instance.commands.readAloud()).toBe(false);
+    expect(controller.speak).not.toHaveBeenCalled();
+  });
+
+  it('toggles between speaking and stopping', () => {
+    const instance = createEditor('<p>Speak this.</p>');
+    const controller = stubController(instance);
+
+    instance.commands.toggleReadAloud();
+    expect(controller.speak).toHaveBeenCalledTimes(1);
+    expect(controller.stop).not.toHaveBeenCalled();
+
+    controller.isActive.mockReturnValue(true);
+    instance.commands.toggleReadAloud();
+    expect(controller.stop).toHaveBeenCalledTimes(1);
+    expect(controller.speak).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes pause and resume through to the controller', () => {
+    const instance = createEditor('<p>Speak this.</p>');
+    const controller = stubController(instance);
+
+    instance.commands.pauseReadAloud();
+    instance.commands.resumeReadAloud();
+
+    expect(controller.pause).toHaveBeenCalledTimes(1);
+    expect(controller.resume).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies subscribers of playback state', () => {
+    const instance = createEditor('<p>Speak this.</p>');
+    const storage = getReadAloudStorage(instance)!;
+    const listener = vi.fn();
+    storage.listeners.add(listener);
+
+    // The real controller reports state through the callbacks wired in onCreate.
+    storage.state = 'speaking';
+    storage.listeners.forEach((fn) => fn());
+
+    expect(listener).toHaveBeenCalled();
+  });
+});

--- a/packages/reason-editor/test/transcribe.test.ts
+++ b/packages/reason-editor/test/transcribe.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The Transcribe extension: how dictated speech lands in the document — the
+ * in-progress phrase rewritten in place at the cursor, the settled phrase replacing
+ * it, and what happens to a half-heard phrase when the microphone is switched off.
+ */
+
+import { Editor } from '@tiptap/core';
+import { Document } from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Transcribe, getTranscribeStorage } from '../src/extensions/Transcribe';
+
+/** Stand-in for the Web Speech API recognizer, driven manually from each test. */
+class FakeRecognition {
+  static instances: FakeRecognition[] = [];
+  continuous = false;
+  interimResults = false;
+  lang = '';
+  onstart: (() => void) | null = null;
+  onresult: ((event: any) => void) | null = null;
+  onerror: ((event: any) => void) | null = null;
+  onend: (() => void) | null = null;
+
+  constructor() {
+    FakeRecognition.instances.push(this);
+  }
+
+  start() {
+    this.onstart?.();
+  }
+
+  stop() {
+    /* the extension drives `onend` itself where a test needs it */
+  }
+}
+
+let editor: Editor | null = null;
+
+function createEditor(content: string) {
+  editor = new Editor({
+    extensions: [Document, Paragraph, Text, Transcribe],
+    content,
+  });
+  return editor;
+}
+
+/** Speak a phrase: `final` false is the recognizer's in-progress guess. */
+function say(text: string, final: boolean) {
+  const recognition = FakeRecognition.instances[0];
+  recognition.onresult?.({
+    resultIndex: 0,
+    results: [{ 0: { transcript: text }, isFinal: final }],
+  });
+}
+
+beforeEach(() => {
+  FakeRecognition.instances = [];
+  (window as any).SpeechRecognition = FakeRecognition;
+});
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+  delete (window as any).SpeechRecognition;
+});
+
+describe('Transcribe', () => {
+  it('rewrites the in-progress phrase in place as it is spoken', () => {
+    const instance = createEditor('<p>Hello</p>');
+    instance.commands.focus('end');
+    instance.commands.startTranscribe();
+
+    say('world', false);
+    expect(instance.getText()).toBe('Hello world');
+
+    // The next update replaces the guess rather than appending to it.
+    say('world peace', false);
+    expect(instance.getText()).toBe('Hello world peace');
+
+    say('world peace now', false);
+    expect(instance.getText()).toBe('Hello world peace now');
+  });
+
+  it('settles a phrase and leaves the cursor ready for the next one', () => {
+    const instance = createEditor('<p>Hello</p>');
+    instance.commands.focus('end');
+    instance.commands.startTranscribe();
+
+    say('wor', false);
+    say('world', true);
+
+    expect(instance.getText()).toBe('Hello world ');
+    expect(instance.state.selection.head).toBe(instance.state.doc.content.size - 1);
+
+    // A second phrase continues after the first without running the words together.
+    say('again', true);
+    expect(instance.getText()).toBe('Hello world again ');
+  });
+
+  it('does not add a leading space at the start of an empty block', () => {
+    const instance = createEditor('<p></p>');
+    instance.commands.focus('end');
+    instance.commands.startTranscribe();
+
+    say('first words', true);
+    expect(instance.getText()).toBe('first words ');
+  });
+
+  it('drops the unfinished phrase when dictation stops', () => {
+    const instance = createEditor('<p>Hello</p>');
+    instance.commands.focus('end');
+    instance.commands.startTranscribe();
+
+    say('settled', true);
+    say('half heard', false);
+    expect(instance.getText()).toBe('Hello settled half heard');
+
+    instance.commands.stopTranscribe();
+    expect(instance.getText()).toBe('Hello settled ');
+    expect(getTranscribeStorage(instance)?.listening).toBe(false);
+  });
+
+  it('keeps interim churn out of the undo history and records settled phrases', () => {
+    const instance = createEditor('<p>Hello</p>');
+    instance.commands.focus('end');
+    instance.commands.startTranscribe();
+
+    const history: (boolean | undefined)[] = [];
+    const dispatch = instance.view.dispatch.bind(instance.view);
+    instance.view.dispatch = (tr) => {
+      history.push(tr.getMeta('addToHistory'));
+      dispatch(tr);
+    };
+
+    say('one', false);
+    say('one two', false);
+    expect(history.every((value) => value === false)).toBe(true);
+
+    history.length = 0;
+    say('one two three', true);
+    // The interim is cleared silently, then the settled phrase is recorded, so a
+    // single undo takes back the whole phrase.
+    expect(history).toEqual([false, undefined]);
+  });
+
+  it('tracks the phrase the overlay displays', () => {
+    const instance = createEditor('<p></p>');
+    instance.commands.focus('end');
+    instance.commands.startTranscribe();
+
+    say('hello there', false);
+    const storage = getTranscribeStorage(instance)!;
+    expect(storage.lastPhrase).toBe('hello there');
+    expect(storage.listening).toBe(true);
+
+    const before = storage.phraseId;
+    say('hello there friend', true);
+    expect(storage.lastPhrase).toBe('hello there friend');
+    expect(storage.phraseId).toBeGreaterThan(before);
+    // The overlay's own phrase is cleared from the interim display on commit.
+    expect(storage.partial).toBe('');
+  });
+
+  it('toggles the microphone off and on', () => {
+    const instance = createEditor('<p></p>');
+    instance.commands.focus('end');
+
+    instance.commands.toggleTranscribe();
+    expect(getTranscribeStorage(instance)?.listening).toBe(true);
+
+    instance.commands.toggleTranscribe();
+    expect(getTranscribeStorage(instance)?.listening).toBe(false);
+  });
+});

--- a/packages/reason-editor/vite.config.ts
+++ b/packages/reason-editor/vite.config.ts
@@ -310,6 +310,16 @@ export default defineConfig(async ({ mode }) => {
           // use-sync-external-store shim above (same dynamic-require issue),
           // so it must stay external too rather than get re-bundled here.
           'grab-url',
+          // The voice engines behind the ReadAloud/Transcribe extensions. Left
+          // external so the host resolves the real package: bundling them drags
+          // in Moonshine's on-device speech model runtime as a 2 MB chunk, and
+          // that recognizer is only ever a fallback for browsers with no native
+          // one. `@moonshine-ai/moonshine-js` is named too so the lazy import
+          // inside it stays a runtime resolution even if the engines are reached
+          // by some other path.
+          'use-voice-control/client',
+          'use-voice-control/react',
+          '@moonshine-ai/moonshine-js',
           'katex',
           'docx',
           '@radix-ui/react-dropdown-menu',

--- a/packages/reason-editor/vitest.config.ts
+++ b/packages/reason-editor/vitest.config.ts
@@ -49,6 +49,9 @@ export default defineConfig({
     // The utilities under test touch localStorage, navigator and Blob/File.
     environment: 'jsdom',
     include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+    // Keeps a destroyed editor's last ProseMirror flush from outliving its own
+    // jsdom environment — see the file for the full story.
+    setupFiles: ['./test/helpers/vitest.setup.ts'],
     testTimeout: 20000,
     restoreMocks: true,
     unstubGlobals: true,

--- a/packages/research-agent-ui/package.json
+++ b/packages/research-agent-ui/package.json
@@ -106,7 +106,8 @@
     "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",
-    "turndown": "^7.2.4"
+    "turndown": "^7.2.4",
+    "use-voice-control": "^0.1.37"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250115.0",

--- a/packages/research-agent-ui/src/components/MessageComposer/ChatInputBox.tsx
+++ b/packages/research-agent-ui/src/components/MessageComposer/ChatInputBox.tsx
@@ -14,6 +14,7 @@ import { FilePreviewCard } from "../FileUpload/FilePreviewCard";
 import { PastedContentCard } from "./PastedContentCard";
 import { useChat } from '../../hooks/useChat';
 import { useSpeechInput } from '../../hooks/voice/useSpeechToTranscript';
+import { SpokenPhraseOverlay } from 'use-voice-control/react';
 import { useFileHandling } from '../FileUpload/useFileHandling';
 import FileUploadDropdown from '../FileUpload/FileUploadDropdown';
 import { LiveWaveform } from '../../ui/live-waveform';
@@ -96,8 +97,25 @@ const ChatInputBox = ({ onNewChat }: ChatInputBoxProps) => {
         if (textareaRef.current) textareaRef.current.style.height = "auto";
     };
 
-    const { isListening, toggleSpeech, isSpeechSupported } = useSpeechInput(
-        (transcript) => setMessage(transcript),
+    // Text the input held before the phrase currently being dictated. Each
+    // recognizer update rewrites only what comes after it, so the in-progress
+    // words appear (and correct themselves) live without eating what was typed
+    // or dictated earlier.
+    const dictationBaseRef = useRef("");
+
+    const appendToBase = (base: string, phrase: string) =>
+        base && !/\s$/.test(base) ? `${base} ${phrase}` : `${base}${phrase}`;
+
+    const { isListening, toggleSpeech, isSpeechSupported, lastPhrase, phraseId } = useSpeechInput(
+        (phrase) => {
+            // A settled phrase becomes part of the base, so the next one lands
+            // after it rather than replacing it.
+            setMessage(() => {
+                const next = `${appendToBase(dictationBaseRef.current, phrase)} `;
+                dictationBaseRef.current = next;
+                return next;
+            });
+        },
         () => {
             setMessage(prev => {
                 if (prev.trim()) {
@@ -108,8 +126,19 @@ const ChatInputBox = ({ onNewChat }: ChatInputBoxProps) => {
                 }
                 return prev;
             });
+        },
+        {
+            onPartial: (text) =>
+                setMessage(text ? appendToBase(dictationBaseRef.current, text) : dictationBaseRef.current),
         }
     );
+
+    // Anything already in the box when the mic opens is kept and dictated onto.
+    useEffect(() => {
+        if (isListening) dictationBaseRef.current = message;
+        // Only when listening starts — `message` changes constantly while dictating.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isListening]);
 
     const [placeholderIndex, setPlaceholderIndex] = useState(0);
     const [showPlaceholder, setShowPlaceholder] = useState(true);
@@ -347,6 +376,14 @@ const ChatInputBox = ({ onNewChat }: ChatInputBoxProps) => {
                         />
                     </div>
                 )}
+
+                {/* Echoes each dictated phrase in the middle of the screen, so what
+                    was heard is readable without watching the input box. */}
+                <SpokenPhraseOverlay
+                    phrase={lastPhrase}
+                    phraseId={phraseId}
+                    visible={isListening}
+                />
 
                 {/* Input Row */}
                 <div className="flex items-center gap-2 p-3">

--- a/packages/research-agent-ui/src/hooks/voice/useSpeechToTranscript.ts
+++ b/packages/research-agent-ui/src/hooks/voice/useSpeechToTranscript.ts
@@ -1,42 +1,108 @@
 /**
- * @fileoverview Hook providing `toggleSpeech` for voice input: uses the Web Speech API when available, falling back to
- * MediaRecorder + server-side transcription endpoint. Exposes `isListening` and `isSpeechSupported`.
- * Global Ctrl+` shortcut toggles listening while the hook is mounted.
+ * @fileoverview Hook providing `toggleSpeech` for voice input.
+ *
+ * Dictation runs through `use-voice-control`'s shared `LiveTranscriber`, which
+ * streams the recognizer's in-progress guess through `onPartial` and each settled
+ * phrase through `onTranscript` — so the composer can type words into the input as
+ * they are being said instead of waiting for the speaker to stop. Browsers without
+ * a native recognizer (Firefox) keep the previous behaviour: record with
+ * MediaRecorder and transcribe server-side once, which yields no partials.
+ *
+ * Exposes `isListening`, `isSpeechSupported`, and the `lastPhrase`/`phraseId` pair
+ * that the on-screen phrase display reads. Global Ctrl+` toggles listening while
+ * the hook is mounted.
  */
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
 import { toast } from "sonner";
 import grab from "grab-url";
+import { LiveTranscriber } from "use-voice-control/client";
+
+export interface SpeechInputOptions {
+  /** The in-progress phrase, replacing whatever was reported before it. */
+  onPartial?: (text: string) => void;
+  /** BCP-47 language tag for the browser recognizer. */
+  language?: string;
+}
+
+export interface SpeechInputReturn {
+  isListening: boolean;
+  toggleSpeech: () => Promise<void>;
+  isSpeechSupported: boolean;
+  /** The phrase currently being spoken; empty between phrases. */
+  partial: string;
+  /** The most recent thing heard, partial or settled. */
+  lastPhrase: string;
+  /** Increments on every `lastPhrase` update, repeats included. */
+  phraseId: number;
+}
+
+function hasNativeRecognizer(): boolean {
+  if (typeof window === "undefined") return false;
+  return !!(
+    (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+  );
+}
 
 export function useSpeechInput(
+  /** Called once per settled phrase — append it, do not replace the input. */
   onTranscript: (transcript: string) => void,
   onEnd: () => void,
-) {
+  options: SpeechInputOptions = {},
+): SpeechInputReturn {
   const [isListening, setIsListening] = useState(false);
-  const recognitionRef = useRef<any>(null);
+  const [partial, setPartial] = useState("");
+  const [lastPhrase, setLastPhrase] = useState("");
+  const [phraseId, setPhraseId] = useState(0);
+
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
   const chunksRef = useRef<BlobPart[]>([]);
-  const transcriptReceivedRef = useRef(false);
-  const fallbackFromRecognitionRef = useRef(false);
 
-  const SpeechRecognition =
-    typeof window !== "undefined"
-      ? (window as any).SpeechRecognition ||
-        (window as any).webkitSpeechRecognition
-      : null;
+  // Callers pass inline closures; hold them in a ref so the transcriber is built
+  // once rather than on every render.
+  const callbacksRef = useRef({ onTranscript, onEnd, onPartial: options.onPartial });
+  callbacksRef.current = { onTranscript, onEnd, onPartial: options.onPartial };
 
-  const stopFallbackRecorder = () => {
+  const transcriber = useMemo(
+    () =>
+      new LiveTranscriber({
+        // Pinned to the browser's own recognizer: the MediaRecorder path below
+        // already covers browsers without one, and it does not make the user
+        // wait on a model download.
+        engine: "webspeech",
+        language: options.language ?? "en-US",
+        onStateChange: setIsListening,
+        onPartial: (text) => {
+          setPartial(text);
+          if (text) {
+            setLastPhrase(text);
+            setPhraseId((id) => id + 1);
+          }
+          callbacksRef.current.onPartial?.(text);
+        },
+        onCommit: (text) => {
+          setPartial("");
+          setLastPhrase(text);
+          setPhraseId((id) => id + 1);
+          callbacksRef.current.onTranscript(text);
+        },
+        onError: () => {
+          toast.error("Speech recognition stopped unexpectedly.");
+        },
+      }),
+    [options.language],
+  );
+
+  const stopFallbackRecorder = useCallback(() => {
     const mediaRecorder = mediaRecorderRef.current;
     if (mediaRecorder && mediaRecorder.state !== "inactive") {
       mediaRecorder.stop();
-    } else {
-      mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
-      mediaStreamRef.current = null;
-      mediaRecorderRef.current = null;
-      setIsListening(false);
-      onEnd();
+      return;
     }
-  };
+    mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
+    mediaStreamRef.current = null;
+    mediaRecorderRef.current = null;
+  }, []);
 
   const transcribeAudio = async (audioBlob: Blob): Promise<string> => {
     const formData = new FormData();
@@ -50,7 +116,7 @@ export function useSpeechInput(
     return (data?.text ?? "").trim();
   };
 
-  const startFallbackRecording = async () => {
+  const startFallbackRecording = useCallback(async () => {
     if (
       typeof navigator === "undefined" ||
       !navigator.mediaDevices?.getUserMedia ||
@@ -60,7 +126,7 @@ export function useSpeechInput(
         duration: 5000,
       });
       setIsListening(false);
-      onEnd();
+      callbacksRef.current.onEnd();
       return;
     }
 
@@ -83,30 +149,27 @@ export function useSpeechInput(
 
       recorder.onstop = async () => {
         try {
-          const audioBlob = new Blob(chunksRef.current, {
-            type: "audio/webm",
-          });
+          const audioBlob = new Blob(chunksRef.current, { type: "audio/webm" });
           chunksRef.current = [];
           mediaStreamRef.current?.getTracks().forEach((track) => track.stop());
           mediaStreamRef.current = null;
           mediaRecorderRef.current = null;
           setIsListening(false);
 
-          if (audioBlob.size === 0) {
-            onEnd();
-            return;
-          }
+          if (audioBlob.size === 0) return;
 
           const transcript = await transcribeAudio(audioBlob);
           if (transcript) {
-            onTranscript(transcript);
+            setLastPhrase(transcript);
+            setPhraseId((id) => id + 1);
+            callbacksRef.current.onTranscript(transcript);
           } else {
             toast.error("No speech detected. Please try again.");
           }
         } catch {
           toast.error("Unable to transcribe audio.");
         } finally {
-          onEnd();
+          callbacksRef.current.onEnd();
         }
       };
 
@@ -114,73 +177,32 @@ export function useSpeechInput(
     } catch {
       toast.error("Microphone access is required for speech input.");
       setIsListening(false);
-      onEnd();
+      callbacksRef.current.onEnd();
     }
-  };
+  }, []);
 
-  const toggleSpeech = async () => {
-    if (isListening) {
-      recognitionRef.current?.stop();
+  const toggleSpeech = useCallback(async () => {
+    if (transcriber.isListening()) {
+      await transcriber.stop();
+      setPartial("");
+      callbacksRef.current.onEnd();
+      return;
+    }
+
+    if (mediaRecorderRef.current) {
       stopFallbackRecorder();
       return;
     }
 
-    fallbackFromRecognitionRef.current = false;
-    transcriptReceivedRef.current = false;
-
-    if (!SpeechRecognition) {
-      await startFallbackRecording();
+    if (hasNativeRecognizer()) {
+      await transcriber.start();
       return;
     }
 
-    const recognition = new SpeechRecognition();
-    recognition.continuous = false;
-    recognition.interimResults = false;
-    recognition.lang = "en-US";
+    await startFallbackRecording();
+  }, [transcriber, startFallbackRecording, stopFallbackRecorder]);
 
-    recognition.onstart = () => setIsListening(true);
-
-    recognition.onresult = (event: any) => {
-      const transcript = event.results[0][0].transcript;
-      transcriptReceivedRef.current = true;
-      onTranscript(transcript);
-    };
-
-    recognition.onend = async () => {
-      setIsListening(false);
-      recognitionRef.current = null;
-      if (fallbackFromRecognitionRef.current) {
-        fallbackFromRecognitionRef.current = false;
-        return;
-      }
-      onEnd();
-    };
-
-    recognition.onerror = async (event: any) => {
-      setIsListening(false);
-      recognitionRef.current = null;
-      const errorCode = event?.error;
-      const shouldFallback =
-        !transcriptReceivedRef.current && errorCode !== "aborted";
-
-      if (shouldFallback) {
-        fallbackFromRecognitionRef.current = true;
-        await startFallbackRecording();
-        return;
-      }
-    };
-
-    recognitionRef.current = recognition;
-    try {
-      recognition.start();
-    } catch {
-      recognitionRef.current = null;
-      setIsListening(false);
-      await startFallbackRecording();
-    }
-  };
-
-  // Global Ctrl+` shortcut for mic
+  // Global Ctrl+` shortcut for the mic.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.ctrlKey && e.key === "`") {
@@ -189,12 +211,15 @@ export function useSpeechInput(
       }
     };
     window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [toggleSpeech]);
+
+  useEffect(() => {
     return () => {
-      window.removeEventListener("keydown", onKeyDown);
-      recognitionRef.current?.stop();
+      void transcriber.stop();
       stopFallbackRecorder();
     };
-  }, [isListening]);
+  }, [transcriber, stopFallbackRecorder]);
 
   const hasFallbackSupport =
     typeof navigator !== "undefined" &&
@@ -204,6 +229,9 @@ export function useSpeechInput(
   return {
     isListening,
     toggleSpeech,
-    isSpeechSupported: !!SpeechRecognition || hasFallbackSupport,
+    isSpeechSupported: hasNativeRecognizer() || hasFallbackSupport,
+    partial,
+    lastPhrase,
+    phraseId,
   };
 }

--- a/packages/use-voice-control/README.md
+++ b/packages/use-voice-control/README.md
@@ -118,6 +118,79 @@ export function VoiceOutput() {
 
 ---
 
+## 🗣️ Read Aloud & Live Dictation
+
+Two ready-made browser engines ship from `use-voice-control/client` (framework
+agnostic) and `use-voice-control/react` (hooks plus an on-screen phrase display).
+They back the **Read aloud** and **Dictate** tools in the REASON editor and the
+chat composer.
+
+### Read aloud
+
+`ReadAloudController` chunks text along sentence and paragraph boundaries,
+synthesizes each chunk (Kokoro via `POST /api/speech/tts` by default) and plays
+them back-to-back while pre-fetching the next — so playback starts after the first
+short chunk instead of after the whole document. If no TTS route answers, it falls
+back to the browser's built-in `speechSynthesis` rather than failing.
+
+```tsx
+import { useReadAloud } from 'use-voice-control/react';
+
+function ReadButton({ text }: { text: string }) {
+  const { toggle, isActive, currentChunk } = useReadAloud({ voice: 'af_heart' });
+
+  return (
+    <button onClick={() => toggle(text)}>
+      {isActive ? `Stop (${currentChunk?.index ?? 0})` : 'Read aloud'}
+    </button>
+  );
+}
+```
+
+Options: `provider`, `voice`, `endpoint`, `maxChunkLength`, and `synthesize` to
+plug in your own TTS. Controls: `speak`, `pause`, `resume`, `stop`, `toggle`.
+
+### Live dictation
+
+`LiveTranscriber` reports two streams: `onPartial`, the guess that keeps changing
+while a phrase is being spoken, and `onCommit`, the phrase the recognizer settled
+on. The first is what lets you type words into an input *as they are said*. It
+prefers the browser's own `SpeechRecognition` (no model download) and falls back to
+on-device Moonshine; Chromium's recognizer stops itself after a pause, so sessions
+restart automatically.
+
+```tsx
+import { useLiveTranscription, SpokenPhraseOverlay } from 'use-voice-control/react';
+
+function Dictate() {
+  const [text, setText] = useState('');
+  const base = useRef('');
+
+  const { toggle, isListening, lastPhrase, phraseId } = useLiveTranscription({
+    onPartial: (phrase) => setText(`${base.current}${phrase}`),
+    onCommit: (phrase) => {
+      base.current = `${base.current}${phrase} `;
+      setText(base.current);
+    },
+  });
+
+  return (
+    <>
+      <textarea value={text} onChange={(e) => setText(e.target.value)} />
+      <button onClick={toggle}>{isListening ? 'Stop' : 'Dictate'}</button>
+      <SpokenPhraseOverlay phrase={lastPhrase} phraseId={phraseId} visible={isListening} />
+    </>
+  );
+}
+```
+
+`<SpokenPhraseOverlay />` shows the latest phrase in large type at the centre of the
+viewport and fades out two seconds after the last update, so you can confirm you
+were heard without watching the input. It renders through a portal with pointer
+events disabled and is styled inline, so it looks the same in any app.
+
+---
+
 ## 📚 API Reference
 
 ### Hooks
@@ -471,6 +544,10 @@ const SpeechWorker = require('use-voice-control/speech/worker.js');
 ## 📦 Exports
 
 ```ts
+// Read aloud & live dictation (implemented)
+export { ReadAloudController, LiveTranscriber, isTranscriptionSupported } from 'use-voice-control/client';
+export { useReadAloud, useLiveTranscription, SpokenPhraseOverlay } from 'use-voice-control/react';
+
 // Hooks
 export { useSpeechRecognition } from 'use-voice-control/hooks';
 export { useSpeechSynthesis } from 'use-voice-control/hooks';

--- a/packages/use-voice-control/package.json
+++ b/packages/use-voice-control/package.json
@@ -15,6 +15,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./client": {
+      "types": "./dist/client/index.d.ts",
+      "import": "./dist/client.js"
+    },
+    "./react": {
+      "types": "./dist/react/index.d.ts",
+      "import": "./dist/react.js"
+    },
     "./api-client": {
       "types": "./speech/api-client.ts",
       "import": "./speech/api-client.ts"
@@ -35,13 +43,14 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "lucide-react": "^0.344.0",
-    "@moonshine-ai/moonshine-js": "^0.1.29",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "@moonshine-ai/moonshine-js": "^0.1.29"
   },
   "devDependencies": {
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
+    "@types/react": "^19.2.17",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "@vitest/coverage-v8": "^4.0.18",
     "typescript": "^5.3.3",
     "vite": "^5.0.0",
@@ -49,8 +58,8 @@
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "optionalDependencies": {
     "@huggingface/transformers": "^3.0.0"

--- a/packages/use-voice-control/speech/client/index.ts
+++ b/packages/use-voice-control/speech/client/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Public entry point for the framework-agnostic browser engines:
+ * read-aloud playback and live dictation. React callers should prefer the hooks in
+ * `use-voice-control/react`, which wrap these.
+ */
+export {
+  ReadAloudController,
+  type ReadAloudChunk,
+  type ReadAloudOptions,
+  type ReadAloudState,
+  type SynthesizeFn,
+} from "./read-aloud";
+
+export {
+  LiveTranscriber,
+  isTranscriptionSupported,
+  type LiveTranscriberOptions,
+  type TranscriberEngine,
+} from "./live-transcriber";
+
+export type { TTSProvider, KokoroVoice, DeepgramSpeaker } from "../types/types";

--- a/packages/use-voice-control/speech/client/live-transcriber.ts
+++ b/packages/use-voice-control/speech/client/live-transcriber.ts
@@ -1,0 +1,216 @@
+/**
+ * @fileoverview Browser-side live dictation engine.
+ *
+ * `LiveTranscriber` streams microphone audio to a recognizer and reports two kinds
+ * of text: `onPartial`, the in-progress guess that keeps changing while a phrase is
+ * being spoken, and `onCommit`, a phrase the recognizer has settled on. Callers use
+ * the first to type text into an input as it is being said, and the second to
+ * finalize it.
+ *
+ * Two engines are supported. The browser's own `SpeechRecognition` is preferred when
+ * present because it needs no model download; otherwise the package's bundled
+ * Moonshine model runs the recognition entirely on-device. Chromium's recognizer
+ * stops itself after a pause, so a session that is still meant to be listening is
+ * restarted automatically.
+ */
+
+export type TranscriberEngine = "auto" | "webspeech" | "moonshine";
+
+export interface LiveTranscriberOptions {
+  /** Which recognizer to use. Default `auto` (browser first, Moonshine as fallback). */
+  engine?: TranscriberEngine;
+  /** BCP-47 language tag for the browser recognizer. Default `en-US`. */
+  language?: string;
+  /** Moonshine model name. Default `model/small`. */
+  model?: string;
+  /** Fires continuously with the current in-progress phrase. */
+  onPartial?: (text: string) => void;
+  /** Fires once per phrase the recognizer has settled on. */
+  onCommit?: (text: string) => void;
+  /** Fires whenever the microphone starts or stops. */
+  onStateChange?: (listening: boolean) => void;
+  onError?: (error: Error) => void;
+}
+
+type SpeechRecognitionCtor = new () => any;
+
+function getSpeechRecognition(): SpeechRecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as any).SpeechRecognition ||
+    (window as any).webkitSpeechRecognition ||
+    null
+  );
+}
+
+/** True when this browser can dictate at all (either engine). */
+export function isTranscriptionSupported(): boolean {
+  if (typeof window === "undefined") return false;
+  if (getSpeechRecognition()) return true;
+  return !!navigator.mediaDevices?.getUserMedia;
+}
+
+export class LiveTranscriber {
+  private options: LiveTranscriberOptions;
+  private listening = false;
+  /** Distinguishes a deliberate `stop()` from Chromium's idle auto-stop. */
+  private stopRequested = false;
+  private recognition: any = null;
+  private moonshine: any = null;
+
+  constructor(options: LiveTranscriberOptions = {}) {
+    this.options = options;
+  }
+
+  setOptions(options: LiveTranscriberOptions): void {
+    this.options = options;
+  }
+
+  isListening(): boolean {
+    return this.listening;
+  }
+
+  async start(): Promise<void> {
+    if (this.listening) return;
+    this.stopRequested = false;
+
+    const engine = this.options.engine ?? "auto";
+    const Recognition = getSpeechRecognition();
+
+    try {
+      if (engine !== "moonshine" && Recognition) {
+        this.startWebSpeech(Recognition);
+        return;
+      }
+      if (engine === "webspeech") {
+        throw new Error("Speech recognition is not available in this browser");
+      }
+      await this.startMoonshine();
+    } catch (error) {
+      this.setListening(false);
+      this.options.onError?.(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopRequested = true;
+
+    if (this.recognition) {
+      try {
+        this.recognition.stop();
+      } catch {
+        /* already stopped */
+      }
+      this.recognition = null;
+    }
+
+    if (this.moonshine) {
+      try {
+        await this.moonshine.stop?.();
+      } catch {
+        /* already stopped */
+      }
+      this.moonshine = null;
+    }
+
+    this.setListening(false);
+  }
+
+  async toggle(): Promise<void> {
+    if (this.listening) {
+      await this.stop();
+    } else {
+      await this.start();
+    }
+  }
+
+  private setListening(listening: boolean): void {
+    if (this.listening === listening) return;
+    this.listening = listening;
+    this.options.onStateChange?.(listening);
+  }
+
+  private startWebSpeech(Recognition: SpeechRecognitionCtor): void {
+    const recognition = new Recognition();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = this.options.language ?? "en-US";
+
+    recognition.onstart = () => this.setListening(true);
+
+    recognition.onresult = (event: any) => {
+      let interim = "";
+      for (let i = event.resultIndex; i < event.results.length; i += 1) {
+        const result = event.results[i];
+        const text = String(result[0]?.transcript ?? "").trim();
+        if (!text) continue;
+        if (result.isFinal) {
+          // No `onPartial("")` first: a commit supersedes the interim phrase, and
+          // clearing it separately would make consumers that write the interim
+          // into a document erase and re-insert the same words.
+          this.options.onCommit?.(text);
+        } else {
+          interim += `${interim ? " " : ""}${text}`;
+        }
+      }
+      if (interim) this.options.onPartial?.(interim);
+    };
+
+    recognition.onerror = (event: any) => {
+      const code = event?.error;
+      // `no-speech` and `aborted` are routine during a long dictation session;
+      // `onend` restarts the recognizer for us.
+      if (code === "no-speech" || code === "aborted") return;
+      this.stopRequested = true;
+      this.options.onError?.(new Error(`Speech recognition error: ${code}`));
+    };
+
+    recognition.onend = () => {
+      if (this.stopRequested || this.recognition !== recognition) {
+        this.recognition = null;
+        this.setListening(false);
+        return;
+      }
+      // Chromium ends the session after a pause — start a fresh one so the user
+      // can keep dictating without touching the button again.
+      try {
+        recognition.start();
+      } catch {
+        this.recognition = null;
+        this.setListening(false);
+      }
+    };
+
+    this.recognition = recognition;
+    recognition.start();
+  }
+
+  private async startMoonshine(): Promise<void> {
+    const Moonshine = await import("@moonshine-ai/moonshine-js");
+
+    const transcriber = new Moonshine.MicrophoneTranscriber(
+      this.options.model ?? "model/small",
+      {
+        onTranscriptionUpdated: (text: string) => {
+          this.options.onPartial?.(String(text ?? "").trim());
+        },
+        onTranscriptionCommitted: (text: string) => {
+          const committed = String(text ?? "").trim();
+          if (committed) this.options.onCommit?.(committed);
+          else this.options.onPartial?.("");
+        },
+      },
+      false // streaming mode
+    );
+
+    this.moonshine = transcriber;
+    await transcriber.start();
+    if (this.stopRequested) {
+      await this.stop();
+      return;
+    }
+    this.setListening(true);
+  }
+}

--- a/packages/use-voice-control/speech/client/read-aloud.ts
+++ b/packages/use-voice-control/speech/client/read-aloud.ts
@@ -1,0 +1,305 @@
+/**
+ * @fileoverview Browser-side "read aloud" playback engine.
+ *
+ * `ReadAloudController` takes a block of text, chunks it along sentence/paragraph
+ * boundaries with `splitTextSmart`, synthesizes each chunk (Kokoro by default, via
+ * the package's `/api/speech/tts` route) and plays the chunks back-to-back while
+ * pre-fetching the next one, so playback starts after the first short chunk rather
+ * than after the whole document. Pause/resume/stop are supported throughout, and
+ * each chunk is reported to `onChunk` so callers can highlight what is being spoken.
+ *
+ * When no TTS endpoint is reachable — a host app that has not mounted the route, or
+ * an offline build — the controller falls back to the browser's built-in
+ * `speechSynthesis` rather than failing, so the feature still works everywhere.
+ */
+import type { TTSProvider } from "../types/types";
+import { splitTextSmart } from "../utils/semantic-split.js";
+
+export type ReadAloudState = "idle" | "loading" | "speaking" | "paused";
+
+export interface ReadAloudChunk {
+  /** The text of the chunk currently being spoken. */
+  text: string;
+  /** Zero-based position of this chunk in the queue. */
+  index: number;
+  /** Total number of chunks queued for this utterance. */
+  total: number;
+}
+
+/** Turns a chunk of text into playable audio. Return `null` to defer to `speechSynthesis`. */
+export type SynthesizeFn = (
+  text: string,
+  signal: AbortSignal
+) => Promise<Blob | null>;
+
+export interface ReadAloudOptions {
+  /** TTS provider passed to the endpoint. Default `kokoro`. */
+  provider?: TTSProvider;
+  /** Provider-specific voice id. Default `af_heart`. */
+  voice?: string;
+  /** HTTP route that synthesizes text. Default `/api/speech/tts`. */
+  endpoint?: string;
+  /**
+   * Target chunk size in characters. Smaller starts talking sooner but makes the
+   * seams between chunks more audible. Default 240.
+   */
+  maxChunkLength?: number;
+  /** Override synthesis entirely (tests, a bring-your-own-TTS host app). */
+  synthesize?: SynthesizeFn;
+  /** Called as each chunk starts playing. */
+  onChunk?: (chunk: ReadAloudChunk) => void;
+  /** Called on every state transition. */
+  onStateChange?: (state: ReadAloudState) => void;
+  /** Called when playback ends, either by running out of chunks or by `stop()`. */
+  onEnd?: (reason: "finished" | "stopped") => void;
+  /** Called when synthesis or playback fails irrecoverably. */
+  onError?: (error: Error) => void;
+}
+
+const DEFAULT_ENDPOINT = "/api/speech/tts";
+const DEFAULT_VOICE = "af_heart";
+const DEFAULT_MAX_CHUNK = 240;
+
+/** Resolves once `signal` aborts. Used to race playback against `stop()`. */
+function abortPromise(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+export class ReadAloudController {
+  private options: ReadAloudOptions;
+  private state: ReadAloudState = "idle";
+  private abortController: AbortController | null = null;
+  private audio: HTMLAudioElement | null = null;
+  private objectUrl: string | null = null;
+  /** Set once the endpoint has proved unreachable, so later chunks skip the retry. */
+  private endpointUnavailable = false;
+
+  constructor(options: ReadAloudOptions = {}) {
+    this.options = options;
+  }
+
+  /** Replace the options (voice, callbacks, …) without discarding playback state. */
+  setOptions(options: ReadAloudOptions): void {
+    this.options = options;
+  }
+
+  getState(): ReadAloudState {
+    return this.state;
+  }
+
+  isActive(): boolean {
+    return this.state === "speaking" || this.state === "paused" || this.state === "loading";
+  }
+
+  /**
+   * Speak `text`, cancelling anything already playing. Resolves when playback
+   * finishes or is stopped — it never rejects; failures go to `onError`.
+   */
+  async speak(text: string): Promise<void> {
+    this.stop();
+
+    const maxChunkLength = this.options.maxChunkLength ?? DEFAULT_MAX_CHUNK;
+    const chunks = splitTextSmart(text ?? "", maxChunkLength)
+      .map((chunk) => chunk.trim())
+      .filter((chunk) => chunk.length > 0);
+
+    if (chunks.length === 0) return;
+
+    const abortController = new AbortController();
+    this.abortController = abortController;
+    const { signal } = abortController;
+    this.setState("loading");
+
+    try {
+      // Kick off the first chunk, then always keep exactly one chunk in flight
+      // ahead of the one playing.
+      let upcoming = this.synthesize(chunks[0], signal);
+
+      for (let index = 0; index < chunks.length; index += 1) {
+        const current = upcoming;
+        upcoming =
+          index + 1 < chunks.length
+            ? this.synthesize(chunks[index + 1], signal)
+            : Promise.resolve(null);
+
+        const blob = await current;
+        if (signal.aborted) return;
+
+        // Announce the state before the chunk so a listener reacting to
+        // `onChunk` sees the controller already speaking.
+        this.setState("speaking");
+        this.options.onChunk?.({ text: chunks[index], index, total: chunks.length });
+        if (signal.aborted) return;
+        await this.playChunk(blob, chunks[index], signal);
+        if (signal.aborted) return;
+      }
+
+      this.cleanup();
+      this.setState("idle");
+      this.options.onEnd?.("finished");
+    } catch (error) {
+      if (signal.aborted) return;
+      this.cleanup();
+      this.setState("idle");
+      this.options.onError?.(
+        error instanceof Error ? error : new Error(String(error))
+      );
+      this.options.onEnd?.("stopped");
+    } finally {
+      if (this.abortController === abortController) {
+        this.abortController = null;
+      }
+    }
+  }
+
+  pause(): void {
+    if (this.state !== "speaking") return;
+    if (this.audio) {
+      this.audio.pause();
+    } else if (typeof speechSynthesis !== "undefined") {
+      speechSynthesis.pause();
+    }
+    this.setState("paused");
+  }
+
+  resume(): void {
+    if (this.state !== "paused") return;
+    if (this.audio) {
+      void this.audio.play().catch(() => undefined);
+    } else if (typeof speechSynthesis !== "undefined") {
+      speechSynthesis.resume();
+    }
+    this.setState("speaking");
+  }
+
+  /** Stop playback and drop any queued chunks. Safe to call when already idle. */
+  stop(): void {
+    const wasActive = this.isActive();
+    this.abortController?.abort();
+    this.abortController = null;
+    this.cleanup();
+    if (wasActive) {
+      this.setState("idle");
+      this.options.onEnd?.("stopped");
+    }
+  }
+
+  private setState(state: ReadAloudState): void {
+    if (this.state === state) return;
+    this.state = state;
+    this.options.onStateChange?.(state);
+  }
+
+  private cleanup(): void {
+    if (this.audio) {
+      this.audio.pause();
+      this.audio.src = "";
+      this.audio = null;
+    }
+    if (this.objectUrl) {
+      URL.revokeObjectURL(this.objectUrl);
+      this.objectUrl = null;
+    }
+    if (typeof speechSynthesis !== "undefined") {
+      speechSynthesis.cancel();
+    }
+  }
+
+  private synthesize(text: string, signal: AbortSignal): Promise<Blob | null> {
+    const promise = this.options.synthesize
+      ? this.options.synthesize(text, signal)
+      : this.fetchAudio(text, signal);
+    // Pre-fetched chunks are awaited a beat later; mark them handled now so a
+    // stop() mid-flight does not surface as an unhandled rejection.
+    promise.catch(() => undefined);
+    return promise;
+  }
+
+  private async fetchAudio(text: string, signal: AbortSignal): Promise<Blob | null> {
+    if (this.endpointUnavailable) return null;
+
+    const endpoint = this.options.endpoint ?? DEFAULT_ENDPOINT;
+    try {
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text,
+          provider: this.options.provider ?? "kokoro",
+          voice: this.options.voice ?? DEFAULT_VOICE,
+        }),
+        signal,
+      });
+
+      if (!response.ok) throw new Error(`TTS failed: ${response.status}`);
+
+      const contentType = response.headers.get("Content-Type") || "audio/wav";
+      return new Blob([await response.arrayBuffer()], { type: contentType });
+    } catch (error) {
+      if (signal.aborted) throw error;
+      // No usable endpoint in this host app — remember it and let every
+      // remaining chunk go straight to the browser's own synthesizer.
+      this.endpointUnavailable = true;
+      return null;
+    }
+  }
+
+  private playChunk(
+    blob: Blob | null,
+    text: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    return blob
+      ? this.playAudioBlob(blob, signal)
+      : this.playWithSpeechSynthesis(text, signal);
+  }
+
+  private async playAudioBlob(blob: Blob, signal: AbortSignal): Promise<void> {
+    const url = URL.createObjectURL(blob);
+    const audio = new Audio(url);
+    this.audio = audio;
+    this.objectUrl = url;
+
+    const finished = new Promise<void>((resolve, reject) => {
+      audio.addEventListener("ended", () => resolve(), { once: true });
+      audio.addEventListener(
+        "error",
+        () => reject(new Error("Audio playback failed")),
+        { once: true }
+      );
+    });
+
+    try {
+      await audio.play();
+      await Promise.race([finished, abortPromise(signal)]);
+    } finally {
+      if (this.audio === audio) this.audio = null;
+      if (this.objectUrl === url) this.objectUrl = null;
+      audio.pause();
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  private async playWithSpeechSynthesis(
+    text: string,
+    signal: AbortSignal
+  ): Promise<void> {
+    if (typeof speechSynthesis === "undefined" || typeof SpeechSynthesisUtterance === "undefined") {
+      throw new Error("No speech synthesis available in this browser");
+    }
+
+    const utterance = new SpeechSynthesisUtterance(text);
+    const finished = new Promise<void>((resolve, reject) => {
+      utterance.onend = () => resolve();
+      // `cancel()` fires an error event; a stop is not a failure.
+      utterance.onerror = () =>
+        signal.aborted ? resolve() : reject(new Error("Speech synthesis failed"));
+    });
+
+    speechSynthesis.speak(utterance);
+    await Promise.race([finished, abortPromise(signal)]);
+  }
+}

--- a/packages/use-voice-control/speech/react/SpokenPhraseOverlay.tsx
+++ b/packages/use-voice-control/speech/react/SpokenPhraseOverlay.tsx
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview Full-screen display of the phrase that was just spoken.
+ *
+ * While dictating, the words land in whatever input has focus — which is easy to
+ * lose track of when you are looking away from the screen. This overlay echoes the
+ * latest phrase in large type at the centre of the viewport and fades out two
+ * seconds after the last update, so a glance confirms you were heard correctly.
+ *
+ * It renders into `document.body` through a portal with pointer events disabled, so
+ * it never intercepts clicks or gets clipped by the host app's layout, and it is
+ * styled inline so it looks the same in every app that mounts it regardless of the
+ * CSS framework in play.
+ */
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
+
+export interface SpokenPhraseOverlayProps {
+  /** The words to display. An empty string hides the overlay. */
+  phrase: string;
+  /**
+   * Bump this whenever `phrase` is refreshed to restart the hide timer, including
+   * when the same words are repeated. `useLiveTranscription` supplies it.
+   */
+  phraseId?: number;
+  /** How long the phrase stays up after the last update. Default 2000ms. */
+  durationMs?: number;
+  /** Set false to suppress the overlay entirely (e.g. once dictation stops). */
+  visible?: boolean;
+  /** Stacking order. Default 2147483000, above typical app chrome and modals. */
+  zIndex?: number;
+  className?: string;
+}
+
+const HIDE_AFTER_MS = 2000;
+
+export function SpokenPhraseOverlay({
+  phrase,
+  phraseId,
+  durationMs = HIDE_AFTER_MS,
+  visible = true,
+  zIndex = 2147483000,
+  className,
+}: SpokenPhraseOverlayProps) {
+  const [mounted, setMounted] = useState(false);
+  const [shown, setShown] = useState(false);
+  // Held separately from `phrase` so the text stays put while fading out rather
+  // than blanking the moment the transcript clears.
+  const [displayed, setDisplayed] = useState("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    const text = phrase.trim();
+    if (!visible || !text) {
+      if (!visible) setShown(false);
+      return;
+    }
+
+    setDisplayed(text);
+    setShown(true);
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setShown(false), durationMs);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [phrase, phraseId, visible, durationMs]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  if (!mounted || !displayed) return null;
+
+  const containerStyle: CSSProperties = {
+    position: "fixed",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    pointerEvents: "none",
+    padding: "6vw",
+    zIndex,
+    opacity: shown ? 1 : 0,
+    transition: "opacity 320ms ease-out",
+  };
+
+  const textStyle: CSSProperties = {
+    maxWidth: "min(1100px, 90vw)",
+    textAlign: "center",
+    // Scales with the viewport so a short phrase fills the screen on a laptop
+    // and still fits on a phone.
+    fontSize: "clamp(2rem, 7vw, 6rem)",
+    fontWeight: 700,
+    lineHeight: 1.1,
+    letterSpacing: "-0.02em",
+    color: "#ffffff",
+    // A dark pill keeps the words readable over light and dark pages alike.
+    background: "rgba(15, 23, 42, 0.82)",
+    borderRadius: "1.5rem",
+    padding: "0.6em 0.8em",
+    boxShadow: "0 25px 80px rgba(0, 0, 0, 0.45)",
+    backdropFilter: "blur(8px)",
+    transform: shown ? "scale(1)" : "scale(0.96)",
+    transition: "transform 320ms ease-out",
+    overflowWrap: "anywhere",
+  };
+
+  return createPortal(
+    <div
+      aria-hidden="true"
+      className={className}
+      data-spoken-phrase-overlay=""
+      style={containerStyle}
+    >
+      <div style={textStyle}>{displayed}</div>
+    </div>,
+    document.body
+  );
+}
+
+export default SpokenPhraseOverlay;

--- a/packages/use-voice-control/speech/react/index.ts
+++ b/packages/use-voice-control/speech/react/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Public entry point for the React layer: the read-aloud and live
+ * dictation hooks, plus the centred overlay that echoes the phrase just spoken.
+ */
+export { useReadAloud, type UseReadAloudOptions, type UseReadAloudReturn } from "./useReadAloud";
+
+export {
+  useLiveTranscription,
+  type UseLiveTranscriptionOptions,
+  type UseLiveTranscriptionReturn,
+} from "./useLiveTranscription";
+
+export {
+  SpokenPhraseOverlay,
+  type SpokenPhraseOverlayProps,
+} from "./SpokenPhraseOverlay";
+
+export {
+  ReadAloudController,
+  LiveTranscriber,
+  isTranscriptionSupported,
+  type ReadAloudChunk,
+  type ReadAloudOptions,
+  type ReadAloudState,
+  type LiveTranscriberOptions,
+  type TranscriberEngine,
+} from "../client";

--- a/packages/use-voice-control/speech/react/useLiveTranscription.ts
+++ b/packages/use-voice-control/speech/react/useLiveTranscription.ts
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview React binding for `LiveTranscriber`.
+ *
+ * Exposes the two streams a dictation UI needs: `partial`, which changes on every
+ * word while a phrase is in progress, and the committed phrases delivered through
+ * `onCommit`. `lastPhrase` carries whatever was most recently heard — partial or
+ * committed — along with a monotonically increasing `phraseId` so a display can
+ * re-trigger its own timeout even when the same words are said twice in a row.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  LiveTranscriber,
+  isTranscriptionSupported,
+  type LiveTranscriberOptions,
+} from "../client/live-transcriber";
+
+export interface UseLiveTranscriptionOptions
+  extends Omit<LiveTranscriberOptions, "onStateChange"> {}
+
+export interface UseLiveTranscriptionReturn {
+  isListening: boolean;
+  /** True when this browser can dictate at all. */
+  isSupported: boolean;
+  /** The in-progress phrase, updating as it is spoken. Empty between phrases. */
+  partial: string;
+  /** The most recent thing heard, partial or committed. */
+  lastPhrase: string;
+  /** Increments on every `lastPhrase` update, including repeats of the same words. */
+  phraseId: number;
+  error: Error | null;
+  start: () => Promise<void>;
+  stop: () => Promise<void>;
+  toggle: () => Promise<void>;
+}
+
+export function useLiveTranscription(
+  options: UseLiveTranscriptionOptions = {}
+): UseLiveTranscriptionReturn {
+  const [isListening, setIsListening] = useState(false);
+  const [isSupported, setIsSupported] = useState(false);
+  const [partial, setPartial] = useState("");
+  const [lastPhrase, setLastPhrase] = useState("");
+  const [phraseId, setPhraseId] = useState(0);
+  const [error, setError] = useState<Error | null>(null);
+
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  // Support depends on `window`, so it can only be settled after hydration.
+  useEffect(() => setIsSupported(isTranscriptionSupported()), []);
+
+  const transcriber = useMemo(
+    () =>
+      new LiveTranscriber({
+        onStateChange: setIsListening,
+        onPartial: (text) => {
+          setPartial(text);
+          if (text) {
+            setLastPhrase(text);
+            setPhraseId((id) => id + 1);
+          }
+          optionsRef.current.onPartial?.(text);
+        },
+        onCommit: (text) => {
+          setPartial("");
+          setLastPhrase(text);
+          setPhraseId((id) => id + 1);
+          optionsRef.current.onCommit?.(text);
+        },
+        onError: (err) => {
+          setError(err);
+          optionsRef.current.onError?.(err);
+        },
+      }),
+    []
+  );
+
+  // Engine/language changes take effect on the next `start()`.
+  useEffect(() => {
+    transcriber.setOptions({
+      engine: options.engine,
+      language: options.language,
+      model: options.model,
+      onStateChange: setIsListening,
+      onPartial: (text) => {
+        setPartial(text);
+        if (text) {
+          setLastPhrase(text);
+          setPhraseId((id) => id + 1);
+        }
+        optionsRef.current.onPartial?.(text);
+      },
+      onCommit: (text) => {
+        setPartial("");
+        setLastPhrase(text);
+        setPhraseId((id) => id + 1);
+        optionsRef.current.onCommit?.(text);
+      },
+      onError: (err) => {
+        setError(err);
+        optionsRef.current.onError?.(err);
+      },
+    });
+  }, [transcriber, options.engine, options.language, options.model]);
+
+  useEffect(() => {
+    return () => {
+      void transcriber.stop();
+    };
+  }, [transcriber]);
+
+  const start = useCallback(async () => {
+    setError(null);
+    await transcriber.start();
+  }, [transcriber]);
+
+  const stop = useCallback(async () => {
+    await transcriber.stop();
+    setPartial("");
+  }, [transcriber]);
+
+  const toggle = useCallback(async () => {
+    if (transcriber.isListening()) {
+      await stop();
+    } else {
+      await start();
+    }
+  }, [transcriber, start, stop]);
+
+  return {
+    isListening,
+    isSupported,
+    partial,
+    lastPhrase,
+    phraseId,
+    error,
+    start,
+    stop,
+    toggle,
+  };
+}

--- a/packages/use-voice-control/speech/react/useReadAloud.ts
+++ b/packages/use-voice-control/speech/react/useReadAloud.ts
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview React binding for `ReadAloudController`.
+ *
+ * Keeps one controller alive for the lifetime of the component, mirrors its state
+ * into React state, and stops playback on unmount so navigating away never leaves
+ * audio running.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  ReadAloudController,
+  type ReadAloudChunk,
+  type ReadAloudOptions,
+  type ReadAloudState,
+} from "../client/read-aloud";
+
+export interface UseReadAloudOptions
+  extends Omit<ReadAloudOptions, "onStateChange" | "onChunk"> {
+  /** Called as each chunk starts playing (e.g. to highlight it in the document). */
+  onChunk?: (chunk: ReadAloudChunk) => void;
+}
+
+export interface UseReadAloudReturn {
+  state: ReadAloudState;
+  /** True while loading, speaking, or paused. */
+  isActive: boolean;
+  isSpeaking: boolean;
+  isPaused: boolean;
+  /** The chunk currently being spoken, or `null` between utterances. */
+  currentChunk: ReadAloudChunk | null;
+  error: Error | null;
+  speak: (text: string) => Promise<void>;
+  pause: () => void;
+  resume: () => void;
+  stop: () => void;
+  /** Speak `text`, or stop if something is already playing. */
+  toggle: (text: string) => void;
+}
+
+export function useReadAloud(options: UseReadAloudOptions = {}): UseReadAloudReturn {
+  const [state, setState] = useState<ReadAloudState>("idle");
+  const [currentChunk, setCurrentChunk] = useState<ReadAloudChunk | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Callers routinely pass inline callbacks; hold them in a ref so the controller
+  // is never rebuilt mid-playback.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const controller = useMemo(
+    () =>
+      new ReadAloudController({
+        onStateChange: setState,
+        onChunk: (chunk) => {
+          setCurrentChunk(chunk);
+          optionsRef.current.onChunk?.(chunk);
+        },
+        onEnd: (reason) => {
+          setCurrentChunk(null);
+          optionsRef.current.onEnd?.(reason);
+        },
+        onError: (err) => {
+          setError(err);
+          optionsRef.current.onError?.(err);
+        },
+      }),
+    []
+  );
+
+  // Re-apply the caller's settings (voice, endpoint, …) whenever they change,
+  // preserving the callback wiring above.
+  useEffect(() => {
+    const { onChunk, onEnd, onError, ...rest } = options;
+    controller.setOptions({
+      ...rest,
+      onStateChange: setState,
+      onChunk: (chunk) => {
+        setCurrentChunk(chunk);
+        optionsRef.current.onChunk?.(chunk);
+      },
+      onEnd: (reason) => {
+        setCurrentChunk(null);
+        optionsRef.current.onEnd?.(reason);
+      },
+      onError: (err) => {
+        setError(err);
+        optionsRef.current.onError?.(err);
+      },
+    });
+  }, [
+    controller,
+    options.provider,
+    options.voice,
+    options.endpoint,
+    options.maxChunkLength,
+    options.synthesize,
+  ]);
+
+  useEffect(() => () => controller.stop(), [controller]);
+
+  const speak = useCallback(
+    async (text: string) => {
+      setError(null);
+      await controller.speak(text);
+    },
+    [controller]
+  );
+
+  const stop = useCallback(() => controller.stop(), [controller]);
+  const pause = useCallback(() => controller.pause(), [controller]);
+  const resume = useCallback(() => controller.resume(), [controller]);
+
+  const toggle = useCallback(
+    (text: string) => {
+      if (controller.isActive()) {
+        controller.stop();
+      } else {
+        void speak(text);
+      }
+    },
+    [controller, speak]
+  );
+
+  return {
+    state,
+    isActive: state !== "idle",
+    isSpeaking: state === "speaking",
+    isPaused: state === "paused",
+    currentChunk,
+    error,
+    speak,
+    pause,
+    resume,
+    stop,
+    toggle,
+  };
+}

--- a/packages/use-voice-control/speech/utils/semantic-split.d.ts
+++ b/packages/use-voice-control/speech/utils/semantic-split.d.ts
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview Type declarations for the JavaScript chunker in `semantic-split.js`,
+ * so TypeScript callers under `speech/client` can import it directly.
+ */
+
+/** Split text into TTS-sized chunks along paragraph, sentence, comma, and word boundaries. */
+export function splitTextSmart(text: string, maxChunkLength?: number): string[];
+
+/** Break a single oversized sentence down along commas, then words. */
+export function splitLongSentence(sentence: string, maxLen: number): string[];

--- a/packages/use-voice-control/speech/utils/sentence-detector.d.ts
+++ b/packages/use-voice-control/speech/utils/sentence-detector.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @fileoverview Type declarations for the JavaScript helpers in `sentence-detector.js`,
+ * so TypeScript callers under `speech/client` can import it directly.
+ */
+
+/** True when the text reads as a finished sentence (or is long enough to speak anyway). */
+export function isCompleteSentence(text: string): boolean;
+
+/** Split an accumulator + new chunk into speakable sentences plus the leftover remainder. */
+export function processStreamingText(
+  accumulator: string,
+  newContent: string
+): { sentences: string[]; remainder: string };

--- a/packages/use-voice-control/test/live-transcriber.test.ts
+++ b/packages/use-voice-control/test/live-transcriber.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Tests for `LiveTranscriber` against a stubbed browser recognizer:
+ * interim vs. committed text, the auto-restart after Chromium's idle stop, and that
+ * a deliberate stop stays stopped.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LiveTranscriber, isTranscriptionSupported } from '../speech/client/live-transcriber';
+
+/** Stand-in for the Web Speech API recognizer, driven manually from each test. */
+class FakeRecognition {
+  static instances: FakeRecognition[] = [];
+  continuous = false;
+  interimResults = false;
+  lang = '';
+  started = 0;
+  stopped = 0;
+  onstart: (() => void) | null = null;
+  onresult: ((event: any) => void) | null = null;
+  onerror: ((event: any) => void) | null = null;
+  onend: (() => void) | null = null;
+
+  constructor() {
+    FakeRecognition.instances.push(this);
+  }
+
+  start() {
+    this.started += 1;
+    this.onstart?.();
+  }
+
+  stop() {
+    this.stopped += 1;
+  }
+
+  /** Emit a recognition result. `resultIndex` mirrors the real event shape. */
+  emit(entries: { transcript: string; isFinal: boolean }[]) {
+    this.onresult?.({
+      resultIndex: 0,
+      results: entries.map((entry) => ({
+        0: { transcript: entry.transcript },
+        isFinal: entry.isFinal,
+      })),
+    });
+  }
+}
+
+beforeEach(() => {
+  FakeRecognition.instances = [];
+  vi.stubGlobal('window', { SpeechRecognition: FakeRecognition });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('LiveTranscriber', () => {
+  it('reports support when a recognizer is present', () => {
+    expect(isTranscriptionSupported()).toBe(true);
+  });
+
+  it('streams interim text and commits settled phrases', async () => {
+    const partials: string[] = [];
+    const commits: string[] = [];
+
+    const transcriber = new LiveTranscriber({
+      onPartial: (text) => partials.push(text),
+      onCommit: (text) => commits.push(text),
+    });
+
+    await transcriber.start();
+    expect(transcriber.isListening()).toBe(true);
+
+    const recognition = FakeRecognition.instances[0];
+    expect(recognition.continuous).toBe(true);
+    expect(recognition.interimResults).toBe(true);
+
+    recognition.emit([{ transcript: 'hello', isFinal: false }]);
+    recognition.emit([{ transcript: 'hello there', isFinal: false }]);
+    recognition.emit([{ transcript: 'hello there world', isFinal: true }]);
+
+    expect(partials).toContain('hello');
+    expect(partials).toContain('hello there');
+    // A commit supersedes the interim phrase rather than clearing it first, so
+    // consumers writing interim text into a document do not erase and re-insert.
+    expect(partials).not.toContain('');
+    expect(commits).toEqual(['hello there world']);
+  });
+
+  it('restarts itself when the browser ends the session on its own', async () => {
+    const transcriber = new LiveTranscriber();
+    await transcriber.start();
+
+    const recognition = FakeRecognition.instances[0];
+    recognition.onend?.();
+
+    expect(recognition.started).toBe(2);
+    expect(transcriber.isListening()).toBe(true);
+  });
+
+  it('stays stopped after an explicit stop', async () => {
+    const states: boolean[] = [];
+    const transcriber = new LiveTranscriber({ onStateChange: (v) => states.push(v) });
+
+    await transcriber.start();
+    const recognition = FakeRecognition.instances[0];
+    await transcriber.stop();
+    recognition.onend?.();
+
+    expect(recognition.stopped).toBe(1);
+    expect(recognition.started).toBe(1);
+    expect(transcriber.isListening()).toBe(false);
+    expect(states).toEqual([true, false]);
+  });
+
+  it('surfaces real errors but ignores routine silence', async () => {
+    const onError = vi.fn();
+    const transcriber = new LiveTranscriber({ onError });
+
+    await transcriber.start();
+    const recognition = FakeRecognition.instances[0];
+
+    recognition.onerror?.({ error: 'no-speech' });
+    expect(onError).not.toHaveBeenCalled();
+
+    recognition.onerror?.({ error: 'not-allowed' });
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('toggles listening on and off', async () => {
+    const transcriber = new LiveTranscriber();
+
+    await transcriber.toggle();
+    expect(transcriber.isListening()).toBe(true);
+
+    await transcriber.toggle();
+    expect(transcriber.isListening()).toBe(false);
+  });
+});

--- a/packages/use-voice-control/test/read-aloud.test.ts
+++ b/packages/use-voice-control/test/read-aloud.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @fileoverview Tests for `ReadAloudController`: chunk ordering, the one-chunk-ahead
+ * prefetch, stop/pause control, and the fallback to the browser's own synthesizer
+ * when no TTS endpoint answers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ReadAloudController } from '../speech/client/read-aloud';
+
+/** Minimal stand-in for HTMLAudioElement: `play()` starts, then fires `ended`. */
+class FakeAudio {
+  static instances: FakeAudio[] = [];
+  src: string;
+  paused = false;
+  private listeners = new Map<string, (() => void)[]>();
+
+  constructor(src: string) {
+    this.src = src;
+    FakeAudio.instances.push(this);
+  }
+
+  addEventListener(name: string, cb: () => void) {
+    const existing = this.listeners.get(name) ?? [];
+    this.listeners.set(name, [...existing, cb]);
+  }
+
+  play() {
+    setTimeout(() => this.listeners.get('ended')?.forEach((cb) => cb()), 0);
+    return Promise.resolve();
+  }
+
+  pause() {
+    this.paused = true;
+  }
+}
+
+const audioBlob = () => new Blob(['audio'], { type: 'audio/wav' });
+
+beforeEach(() => {
+  FakeAudio.instances = [];
+  vi.stubGlobal('Audio', FakeAudio);
+  vi.stubGlobal('URL', {
+    ...URL,
+    createObjectURL: vi.fn(() => 'blob:fake'),
+    revokeObjectURL: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('ReadAloudController', () => {
+  it('speaks every chunk in order and reports the end', async () => {
+    const spoken: string[] = [];
+    const onEnd = vi.fn();
+
+    const controller = new ReadAloudController({
+      maxChunkLength: 20,
+      synthesize: async (text) => {
+        spoken.push(text);
+        return audioBlob();
+      },
+      onChunk: ({ index }) => void index,
+      onEnd,
+    });
+
+    await controller.speak(
+      'The first sentence here. The second sentence here. The third one here.'
+    );
+
+    expect(spoken.length).toBeGreaterThan(1);
+    expect(spoken.join(' ')).toContain('The first sentence here.');
+    expect(spoken.join(' ')).toContain('The third one here.');
+    expect(onEnd).toHaveBeenCalledWith('finished');
+    expect(controller.getState()).toBe('idle');
+  });
+
+  it('reports each chunk with its position in the queue', async () => {
+    const chunks: { text: string; index: number; total: number }[] = [];
+
+    const controller = new ReadAloudController({
+      maxChunkLength: 20,
+      synthesize: async () => audioBlob(),
+      onChunk: (chunk) => chunks.push(chunk),
+    });
+
+    await controller.speak('Alpha beta gamma. Delta epsilon zeta. Eta theta iota.');
+
+    expect(chunks.map((c) => c.index)).toEqual(chunks.map((_, i) => i));
+    expect(new Set(chunks.map((c) => c.total)).size).toBe(1);
+    expect(chunks[0].total).toBe(chunks.length);
+  });
+
+  it('ignores empty text', async () => {
+    const synthesize = vi.fn();
+    const controller = new ReadAloudController({ synthesize });
+
+    await controller.speak('   \n  ');
+
+    expect(synthesize).not.toHaveBeenCalled();
+    expect(controller.getState()).toBe('idle');
+  });
+
+  it('stops mid-utterance without speaking the remaining chunks', async () => {
+    const spoken: string[] = [];
+    const onEnd = vi.fn();
+
+    const controller = new ReadAloudController({
+      maxChunkLength: 20,
+      synthesize: async (text) => {
+        spoken.push(text);
+        return audioBlob();
+      },
+      onChunk: ({ index }) => {
+        if (index === 0) controller.stop();
+      },
+      onEnd,
+    });
+
+    await controller.speak(
+      'One one one one one. Two two two two two. Three three three three. Four four four four.'
+    );
+
+    // The prefetch runs one chunk ahead, so at most the first two are ever
+    // synthesized — never the whole document.
+    expect(spoken.length).toBeLessThanOrEqual(2);
+    expect(onEnd).toHaveBeenCalledWith('stopped');
+    expect(controller.getState()).toBe('idle');
+    expect(controller.isActive()).toBe(false);
+  });
+
+  it('tracks paused and resumed state', async () => {
+    const states: string[] = [];
+    const controller = new ReadAloudController({
+      maxChunkLength: 20,
+      synthesize: async () => audioBlob(),
+      onStateChange: (state) => states.push(state),
+      onChunk: ({ index }) => {
+        if (index === 0) {
+          controller.pause();
+          expect(controller.getState()).toBe('paused');
+          controller.resume();
+        }
+      },
+    });
+
+    await controller.speak('First chunk of text. Second chunk of text.');
+
+    expect(states).toContain('paused');
+    expect(states[states.length - 1]).toBe('idle');
+  });
+
+  it('falls back to the browser synthesizer when the endpoint is unreachable', async () => {
+    const utterances: string[] = [];
+    class FakeUtterance {
+      onend: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      constructor(public text: string) {}
+    }
+
+    vi.stubGlobal('SpeechSynthesisUtterance', FakeUtterance);
+    vi.stubGlobal('speechSynthesis', {
+      speak: (utterance: FakeUtterance) => {
+        utterances.push(utterance.text);
+        setTimeout(() => utterance.onend?.(), 0);
+      },
+      cancel: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('no route mounted');
+      })
+    );
+
+    const onEnd = vi.fn();
+    const controller = new ReadAloudController({ maxChunkLength: 20, onEnd });
+
+    await controller.speak(
+      'Spoken without a server. Straight from the browser. No round trip at all. Not even once more.'
+    );
+
+    expect(utterances.length).toBeGreaterThan(2);
+    expect(onEnd).toHaveBeenCalledWith('finished');
+    // Once the endpoint has failed it is not probed again — only the first
+    // chunk and the one prefetched alongside it ever reach the network.
+    expect(
+      (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
+    ).toBeLessThanOrEqual(2);
+  });
+});

--- a/packages/use-voice-control/tsconfig.json
+++ b/packages/use-voice-control/tsconfig.json
@@ -14,6 +14,15 @@
     "noEmit": true,
     "types": []
   },
-  "include": ["speech/index.ts", "speech/core", "speech/types", "vite.config.ts"],
+  "include": [
+    "speech/index.ts",
+    "speech/core",
+    "speech/types",
+    "speech/client",
+    "speech/react",
+    "speech/utils/semantic-split.d.ts",
+    "speech/utils/sentence-detector.d.ts",
+    "vite.config.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/use-voice-control/vite.config.ts
+++ b/packages/use-voice-control/vite.config.ts
@@ -1,13 +1,24 @@
 import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
-// Library build for the published TTS entry point. The source lives under
-// `speech/`; `speech/index.ts` is the public API (`generateSpeech` + types).
+// Library build for the published entry points. The source lives under `speech/`:
+// `speech/index.ts` is the server-side TTS API (`generateSpeech` + types),
+// `speech/client` the framework-agnostic browser engines (read-aloud playback,
+// live dictation), and `speech/react` the hooks and overlay that wrap them.
 export default defineConfig({
   plugins: [
+    react(),
     dts({
-      include: ["speech/index.ts", "speech/core", "speech/types"],
+      include: [
+        "speech/index.ts",
+        "speech/core",
+        "speech/types",
+        "speech/client",
+        "speech/react",
+        "speech/utils/*.d.ts",
+      ],
     }),
   ],
   // Several modules under `speech/core` ship both a `.ts` source and a stray
@@ -18,9 +29,13 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(__dirname, "speech/index.ts"),
+      entry: {
+        index: resolve(__dirname, "speech/index.ts"),
+        client: resolve(__dirname, "speech/client/index.ts"),
+        react: resolve(__dirname, "speech/react/index.ts"),
+      },
       formats: ["es"],
-      fileName: () => "index.js",
+      fileName: (_format, entryName) => `${entryName}.js`,
     },
     rollupOptions: {
       // Keep runtime/optional peers out of the bundle so consumers provide them.


### PR DESCRIPTION
## Summary

This PR introduces comprehensive voice control capabilities to the editor and chat composer, including live dictation that types speech directly into documents and a read-aloud feature that synthesizes text. The implementation is built on a new `use-voice-control` package that provides framework-agnostic browser engines and React hooks.

## Key Changes

### New `use-voice-control` Package
- **`LiveTranscriber`**: Browser-side live dictation engine supporting both Web Speech API and on-device Moonshine model
  - Streams microphone audio and reports interim (partial) and committed phrases
  - Auto-restarts after Chromium's idle timeout while maintaining listening state
  - Comprehensive test coverage for interim vs. committed text and state management

- **`ReadAloudController`**: Text-to-speech playback engine with intelligent chunking
  - Chunks text along sentence/paragraph boundaries for faster playback start
  - One-chunk-ahead prefetching for seamless playback
  - Falls back to browser's `speechSynthesis` when TTS endpoint is unavailable
  - Supports pause/resume/stop controls with full test coverage

- **React hooks** (`useLiveTranscription`, `useReadAloud`): Expose state and controls to React components
- **`SpokenPhraseOverlay`**: Full-screen display of dictated phrases that auto-fades after 2 seconds

### Tiptap Extensions for `reason-editor`
- **`Transcribe` extension**: Types dictated speech into the document at cursor position
  - Rewrites in-progress phrases in place as they're spoken
  - Only settled phrases enter undo history; interim churn is discarded
  - Listening state lives in extension storage so toolbar, commands, and shortcuts drive one session
  - Includes `subscribeTranscribe` for UI to follow state and `lastPhrase`/`phraseId` pair

- **`ReadAloud` extension**: Speaks selection or whole document
  - Reads current selection when available, falls back to entire document
  - Playback state in extension storage for unified control across UI entry points
  - Includes `subscribeReadAloud` for UI to follow playback state and current chunk

### UI Integration
- Toolbar buttons for both Transcribe and ReadAloud with live state indicators
- Keyboard shortcuts and slash commands for voice control
- Plugin registry entries to enable/disable features
- Localization strings for tooltips
- `TranscribeOverlay` component for phrase display during dictation

### Chat Composer Updates
- Integrated `SpokenPhraseOverlay` into `ChatInputBox` for voice feedback
- Replaced legacy `useSpeechInput` hook with new `use-voice-control` package

## Notable Implementation Details

- **Interim text handling**: The Transcribe extension writes interim phrases with history disabled and removes them before committing settled text, so a single undo takes back one phrase rather than one word
- **Fallback strategy**: ReadAloud gracefully degrades to browser `speechSynthesis` when the TTS endpoint is unreachable
- **State management**: Both extensions use Tiptap's storage system with listener subscriptions, allowing multiple UI entry points (toolbar, commands, shortcuts) to drive a single session
- **Phrase tracking**: `phraseId` increments on every update including repeats, allowing UI to re-trigger timeouts even when identical words are spoken twice
- **Test infrastructure**: Added Vitest setup with proper cleanup for ProseMirror's async DOM observer

https://claude.ai/code/session_01RFcG97ViKC1QdjKhTTnTwZ