### PR TITLE
Redesign compact weather widget with side-by-side layout

### DIFF
--- a/packages/react-weather-forecast/src/api/forecast.ts
+++ b/packages/react-weather-forecast/src/api/forecast.ts
@@ -34,6 +34,8 @@ function buildUrl(latitude: number, longitude: number, options: WeatherForecastO
       'temperature_2m_min',
       'weather_code',
       'precipitation_probability_max',
+      'precipitation_sum',
+      'wind_speed_10m_max',
     ].join(','),
   });
 
@@ -101,6 +103,8 @@ export async function getWeatherForecast(
       max: Math.round(data.daily.temperature_2m_max[index]),
       weatherCode: data.daily.weather_code[index],
       precipitationProbabilityMax: data.daily.precipitation_probability_max?.[index],
+      precipitationSum: data.daily.precipitation_sum?.[index],
+      windSpeedMax: data.daily.wind_speed_10m_max?.[index],
       icon: getWeatherIcon(data.daily.weather_code[index]),
     })),
   };

--- a/packages/react-weather-forecast/src/components/WeatherForecast.tsx
+++ b/packages/react-weather-forecast/src/components/WeatherForecast.tsx
@@ -35,6 +35,39 @@ function formatInZone(instant: Date, timezone: string | undefined, options: Intl
   }
 }
 
+// Just the zone abbreviation (e.g. "GMT+2"), so it can be shown apart from the
+// clock itself.
+function zoneLabel(instant: Date, timezone: string | undefined): string {
+  const options: Intl.DateTimeFormatOptions = { hour: 'numeric', timeZoneName: 'short' };
+  try {
+    const format = (() => {
+      try {
+        return new Intl.DateTimeFormat([], { ...options, timeZone: timezone || undefined });
+      } catch {
+        return new Intl.DateTimeFormat([], options);
+      }
+    })();
+    return format.formatToParts(instant).find((part) => part.type === 'timeZoneName')?.value ?? '';
+  } catch {
+    return '';
+  }
+}
+
+// Daily dates arrive as plain "YYYY-MM-DD" calendar days; `new Date(...)` would
+// read those as UTC midnight and roll back a day in western timezones, so build
+// the date from its parts and let it stay a local calendar day.
+function parseCalendarDate(date: string): Date {
+  const [year, month, day] = date.split('-').map(Number);
+  if (!year || !month || !day) return new Date(date);
+  return new Date(year, month - 1, day);
+}
+
+// The day right after today reads better as "Tomorrow" than as its weekday.
+function upcomingDayLabel(date: string, offsetFromToday: number): string {
+  if (offsetFromToday === 1) return 'Tomorrow';
+  return parseCalendarDate(date).toLocaleDateString([], { weekday: 'long' });
+}
+
 const styles = {
   root: {
     fontFamily: 'system-ui, sans-serif',
@@ -50,10 +83,33 @@ const styles = {
   hourCard: { minWidth: 72, textAlign: 'center' as const, padding: 8, borderRadius: 8, background: '#f9fafb' },
   dayRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '8px 0', borderBottom: '1px solid #f3f4f6' } as React.CSSProperties,
   compactRoot: { fontFamily: 'system-ui, sans-serif', display: 'flex', flexDirection: 'column', gap: 8, padding: '10px 14px', borderRadius: 8 } as React.CSSProperties,
+  // Current conditions on the left, upcoming days on the right; both columns
+  // wrap to full width when the widget is too narrow to hold them side by side.
+  compactBody: { display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 12 } as React.CSSProperties,
+  compactCurrent: { flex: '1 1 45%', minWidth: 140, display: 'flex', flexDirection: 'column', gap: 8 } as React.CSSProperties,
   compactHeader: { display: 'flex', alignItems: 'center', gap: 10 } as React.CSSProperties,
   compactHeaderText: { display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' } as React.CSSProperties,
-  compactDateTime: { fontSize: 11, opacity: 0.7 } as React.CSSProperties,
+  compactTime: { fontSize: 18, fontWeight: 600, lineHeight: 1.15 } as React.CSSProperties,
+  compactDate: { fontSize: 11, opacity: 0.7 } as React.CSSProperties,
   compactStats: { display: 'flex', flexWrap: 'wrap', gap: 12, fontSize: 12, opacity: 0.9 } as React.CSSProperties,
+  // A shared grid keeps the day / icon / temps / rain / wind columns aligned
+  // across every upcoming row.
+  // Columns are content-sized (so no column can be squeezed away) and the spare
+  // width is spread between them; that also makes the grid's min-content width
+  // large enough to wrap below the current conditions on narrow screens.
+  upcoming: {
+    flex: '1 1 260px',
+    display: 'grid',
+    gridTemplateColumns: 'auto auto auto auto auto',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    columnGap: 10,
+    rowGap: 6,
+    fontSize: 12,
+  } as React.CSSProperties,
+  upcomingDay: { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', opacity: 0.85 } as React.CSSProperties,
+  upcomingTemps: { whiteSpace: 'nowrap', textAlign: 'right' } as React.CSSProperties,
+  upcomingMetric: { whiteSpace: 'nowrap', textAlign: 'right', opacity: 0.7 } as React.CSSProperties,
   compactStat: { display: 'flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' } as React.CSSProperties,
   unitSwitch: { display: 'inline-flex', alignItems: 'center', cursor: 'pointer', userSelect: 'none' } as React.CSSProperties,
   rain: { color: '#2563eb', whiteSpace: 'nowrap' } as React.CSSProperties,
@@ -124,59 +180,83 @@ function SingleWeatherForecast(props: Props) {
   const timezone = data.location?.timezone;
   const currentDate = formatInZone(now, timezone, { weekday: 'short', month: 'short', day: 'numeric' });
   const currentTime = formatInZone(now, timezone, { hour: 'numeric', minute: '2-digit', second: '2-digit', timeZoneName: 'short' });
+  // The compact layout shows the clock at a larger size, so the zone label is
+  // split off onto the smaller date line to keep the time on one line.
+  const currentClock = formatInZone(now, timezone, { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+  const currentZone = zoneLabel(now, timezone);
 
   if (props.compact) {
     const forecastBase = new Date(data.current.time);
     const today = data.daily[0];
-    const tomorrow = data.daily[1];
     const in6Hours = closestHour(data.hourly, new Date(forecastBase.getTime() + 6 * 60 * 60 * 1000));
     const windSpeedUnitLabel = WIND_SPEED_UNIT_LABELS[props.windSpeedUnit ?? 'mph'];
+    // Today already has its own column on the left, so the upcoming list starts
+    // at tomorrow and stays short enough to sit beside it.
+    const upcomingDays = data.daily.slice(1, 5);
 
     return (
       <div className={props.className} style={{ ...styles.compactRoot, ...props.style }}>
-        <div style={styles.compactHeader}>
-          <WeatherIcon condition={data.current.icon} width={24} height={24} title="Current weather" />
-          <div>
-            <div style={styles.compactHeaderText}>
-              <strong style={{ fontSize: 16 }}>{data.current.temperature}</strong>
-              {renderUnitSwitch(12)}
-              <span style={{ fontSize: 14, opacity: 0.8 }}>
-                {data.location?.city || 'Current location'}
-              </span>
+        <div style={styles.compactBody}>
+          <div style={styles.compactCurrent}>
+            <div style={styles.compactHeader}>
+              <WeatherIcon condition={data.current.icon} width={24} height={24} title="Current weather" />
+              <div>
+                <div style={styles.compactHeaderText}>
+                  <strong style={{ fontSize: 16 }}>{data.current.temperature}</strong>
+                  {renderUnitSwitch(12)}
+                  <span style={{ fontSize: 14, opacity: 0.8 }}>
+                    {data.location?.city || 'Current location'}
+                  </span>
+                </div>
+                <div style={styles.compactTime}>{currentClock}</div>
+                <div style={styles.compactDate}>
+                  {currentDate}
+                  {currentZone ? ` · ${currentZone}` : ''}
+                </div>
+              </div>
             </div>
-            <div style={styles.compactDateTime}>
-              {currentDate}
-              {' · '}
-              {currentTime}
+
+            <div style={styles.compactStats}>
+              {today && (
+                <span style={styles.compactStat}>
+                  <WeatherIcon condition={today.icon} width={16} height={16} title="Today's high and low" />
+                  {today.max}&deg; / {today.min}&deg;
+                  <RainBadge probability={today.precipitationProbabilityMax} compact />
+                </span>
+              )}
+              <span style={styles.compactStat}>
+                <WindIcon width={16} height={16} title="Wind speed" />
+                {data.current.windSpeed !== undefined ? `${Math.round(data.current.windSpeed)} ${windSpeedUnitLabel}` : '—'}
+              </span>
+              {in6Hours && (
+                <span style={styles.compactStat}>
+                  <WeatherIcon condition={in6Hours.icon} width={16} height={16} title="In 6 hours" />
+                  {in6Hours.temperature}&deg; in 6h
+                  <RainBadge probability={in6Hours.precipitationProbability} compact />
+                </span>
+              )}
             </div>
           </div>
-        </div>
 
-        <div style={styles.compactStats}>
-          {today && (
-            <span style={styles.compactStat}>
-              <WeatherIcon condition={today.icon} width={16} height={16} title="Today's high and low" />
-              {today.max}&deg; / {today.min}&deg;
-              <RainBadge probability={today.precipitationProbabilityMax} compact />
-            </span>
-          )}
-          {tomorrow && (
-            <span style={styles.compactStat}>
-              <WeatherIcon condition={tomorrow.icon} width={16} height={16} title="Tomorrow's high and low" />
-              Tomorrow {tomorrow.max}&deg; / {tomorrow.min}&deg;
-              <RainBadge probability={tomorrow.precipitationProbabilityMax} compact />
-            </span>
-          )}
-          <span style={styles.compactStat}>
-            <WindIcon width={16} height={16} title="Wind speed" />
-            {data.current.windSpeed !== undefined ? `${Math.round(data.current.windSpeed)} ${windSpeedUnitLabel}` : '—'}
-          </span>
-          {in6Hours && (
-            <span style={styles.compactStat}>
-              <WeatherIcon condition={in6Hours.icon} width={16} height={16} title="In 6 hours" />
-              {in6Hours.temperature}&deg; in 6h
-              <RainBadge probability={in6Hours.precipitationProbability} compact />
-            </span>
+          {upcomingDays.length > 0 && (
+            <div style={styles.upcoming}>
+              {upcomingDays.map((day, index) => (
+                <React.Fragment key={day.date}>
+                  <span style={styles.upcomingDay}>{upcomingDayLabel(day.date, index + 1)}</span>
+                  <WeatherIcon condition={day.icon} width={16} height={16} />
+                  <span style={styles.upcomingTemps}>
+                    <strong>{day.max}&deg;</strong>
+                    <span style={{ opacity: 0.7 }}> / {day.min}&deg;</span>
+                  </span>
+                  <span style={styles.upcomingMetric}>
+                    {day.precipitationSum !== undefined ? `${day.precipitationSum.toFixed(1)} mm` : '—'}
+                  </span>
+                  <span style={styles.upcomingMetric}>
+                    {day.windSpeedMax !== undefined ? `${day.windSpeedMax.toFixed(1)} ${windSpeedUnitLabel}` : '—'}
+                  </span>
+                </React.Fragment>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/packages/react-weather-forecast/src/types.ts
+++ b/packages/react-weather-forecast/src/types.ts
@@ -62,6 +62,10 @@ export type DailyWeather = {
   max: number;
   weatherCode: number;
   precipitationProbabilityMax?: number;
+  /** Total precipitation for the day, in millimetres. */
+  precipitationSum?: number;
+  /** Peak wind speed for the day, in the requested wind speed unit. */
+  windSpeedMax?: number;
   icon: WeatherCondition;
 };
 

--- a/packages/react-weather-forecast/test/WeatherForecast.test.tsx
+++ b/packages/react-weather-forecast/test/WeatherForecast.test.tsx
@@ -21,7 +21,17 @@ function forecast(overrides: Partial<WeatherForecastData> = {}): WeatherForecast
     ],
     daily: [
       { date: '2024-01-01', min: 55, max: 79, weatherCode: 0, icon: 'sun', precipitationProbabilityMax: 10 },
-      { date: '2024-01-02', min: 58, max: 80, weatherCode: 95, icon: 'cloud-bolt', precipitationProbabilityMax: 70 },
+      {
+        date: '2024-01-02',
+        min: 58,
+        max: 80,
+        weatherCode: 95,
+        icon: 'cloud-bolt',
+        precipitationProbabilityMax: 70,
+        precipitationSum: 0.5,
+        windSpeedMax: 4.5,
+      },
+      { date: '2024-01-03', min: 57, max: 77, weatherCode: 3, icon: 'clouds', precipitationSum: 0, windSpeedMax: 3.5 },
     ],
     ...overrides,
   } as WeatherForecastData;
@@ -127,6 +137,35 @@ describe('<WeatherForecast />', () => {
     expect(screen.getByText('8 mph')).toBeTruthy();
     // The compact layout omits the full hour/day breakdown.
     expect(screen.queryByText('Next hours')).toBeNull();
+  });
+
+  it('lists the upcoming days with precipitation and peak wind', async () => {
+    vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(forecast());
+
+    render(<WeatherForecast latitude={1} longitude={2} compact />);
+
+    // The day after today is labelled "Tomorrow"; later days use their weekday.
+    expect(await screen.findByText('Tomorrow')).toBeTruthy();
+    expect(screen.getByText('Wednesday')).toBeTruthy();
+    expect(screen.getByText('0.5 mm')).toBeTruthy();
+    expect(screen.getByText('0.0 mm')).toBeTruthy();
+    expect(screen.getByText('4.5 mph')).toBeTruthy();
+  });
+
+  it('shows placeholders for upcoming days without precipitation or wind data', async () => {
+    vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(
+      forecast({
+        daily: [
+          { date: '2024-01-01', min: 55, max: 79, weatherCode: 0, icon: 'sun' },
+          { date: '2024-01-02', min: 58, max: 80, weatherCode: 0, icon: 'sun' },
+        ],
+      })
+    );
+
+    render(<WeatherForecast latitude={1} longitude={2} compact />);
+
+    await screen.findByText('Tomorrow');
+    expect(screen.getAllByText('—').length).toBe(2);
   });
 
   it('shows a wind placeholder when wind speed is missing', async () => {

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -151,21 +151,24 @@ export default function ChatHomepage() {
 
           <div className="w-full max-w-2xl mt-8 space-y-2">
             <RecentHistoryChips />
+            {/* The weather widget takes the full row: its current conditions sit
+                in the left half with the upcoming days tabled in the right half,
+                which needs more width than a shared column allows. */}
+            <WeatherForecast
+              compact
+              forecastDays={5}
+              forecastHours={12}
+              locations={weatherLocations.length > 0 ? weatherLocations : undefined}
+              className="rounded-2xl w-full"
+              style={{
+                background: 'rgba(255,255,255,0.08)',
+                border: '1px solid rgba(255,255,255,0.15)',
+                color: 'inherit',
+                backdropFilter: 'blur(8px)',
+                maxWidth: '100%',
+              }}
+            />
             <div className="flex flex-col md:flex-row gap-2 w-full">
-              <WeatherForecast
-                compact
-                forecastDays={5}
-                forecastHours={12}
-                locations={weatherLocations.length > 0 ? weatherLocations : undefined}
-                className="rounded-2xl md:flex-1"
-                style={{
-                  background: 'rgba(255,255,255,0.08)',
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  color: 'inherit',
-                  backdropFilter: 'blur(8px)',
-                  maxWidth: '100%',
-                }}
-              />
               <TrendingNews
                 compact
                 maxTopics={6}


### PR DESCRIPTION
## Summary
Redesigned the compact weather forecast widget to display current conditions and upcoming days in a side-by-side layout instead of a horizontal list. The new layout provides better visual hierarchy and more detailed daily forecasts including precipitation and wind data.

## Key Changes

- **Layout restructuring**: Changed from a single-row layout to a two-column flex layout (`compactBody`) where current conditions occupy the left column and upcoming days are displayed in a grid on the right
- **Enhanced daily forecast data**: Added `precipitationSum` and `windSpeedMax` fields to the `DailyWeather` type and updated the API to fetch these metrics from the weather service
- **Improved time display**: Split the time display into a larger clock (`compactTime`) and a separate date/zone line (`compactDate`) for better readability in the compact layout
- **New utility functions**:
  - `zoneLabel()`: Extracts timezone abbreviation separately from the full timestamp
  - `parseCalendarDate()`: Properly parses calendar dates as local dates instead of UTC
  - `upcomingDayLabel()`: Formats upcoming day labels with "Tomorrow" for the next day and weekday names for later days
- **Upcoming days grid**: Implemented a CSS grid layout for the 4-day forecast (days 2-5) showing day name, weather icon, high/low temps, precipitation, and peak wind speed
- **Responsive design**: Grid columns use `flex: 1 1 260px` to wrap below current conditions on narrow screens
- **Updated test data**: Added precipitation and wind speed data to test fixtures and added new test cases for the upcoming days display

## Notable Implementation Details

- The upcoming days list starts at index 1 (tomorrow) and includes up to 4 days to keep the layout compact
- Missing precipitation or wind data displays as "—" placeholder
- The layout uses CSS Grid with `justifyContent: space-between` to distribute columns evenly across available width
- Updated the ChatHomepage to move the weather widget to full width since the new layout requires more horizontal space

https://claude.ai/code/session_016HZb2N8nn2vcG7nLUN8Gny