### PR TITLE
Add grab-url dependency and update prebuild script

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",

--- a/bun.lock
+++ b/bun.lock
@@ -305,6 +305,9 @@
     "packages/extract-pdf": {
       "name": "extract-pdf",
       "version": "0.1.104",
+      "dependencies": {
+        "grab-url": "^1.6.22",
+      },
       "devDependencies": {
         "terser": "^5.46.0",
         "typescript": "^5.9.3",

--- a/packages/extract-pdf/package.json
+++ b/packages/extract-pdf/package.json
@@ -26,7 +26,9 @@
     "test:coverage": "bun test --coverage --coverage-reporter=lcov --coverage-reporter=text",
     "ship": "npm run build && npx standard-version --release-as patch; rm -f CHANGELOG.md; npm publish"
   },
-  "dependencies": {},
+  "dependencies": {
+    "grab-url": "^1.6.22"
+  },
   "optionalDependencies": {
     "@llamaindex/liteparse": "^2.10.0",
     "@llamaindex/liteparse-wasm": "^2.11.0"


### PR DESCRIPTION
## Summary
This PR adds the `grab-url` package as a dependency to the extract-pdf package and updates the prebuild script in the qwksearch-web app to include the use-voice-control package build step.

## Key Changes
- Added `grab-url` (^1.6.22) as a dependency in `packages/extract-pdf/package.json`
- Updated the prebuild script in `apps/qwksearch-web/package.json` to include building the `use-voice-control` package between `chat-agent-toolkit` and `research-agent-ui`

## Implementation Details
The `grab-url` dependency is now required by the extract-pdf package, likely to support URL fetching functionality. The prebuild script modification ensures that the use-voice-control package is built as part of the web app's build preparation process, maintaining the correct build order for all dependent packages.

https://claude.ai/code/session_013vcVBDbxYpRWfPMK2eqKix