### PR TITLE
Stop uploading Worker source maps so deploys pass validation

### DIFF
--- a/apps/qwksearch-web/wrangler.jsonc
+++ b/apps/qwksearch-web/wrangler.jsonc
@@ -8,7 +8,18 @@
   // entered in the CF dashboard (API keys, BETTER_AUTH_SECRET, …) because
   // this config defines no `vars`. Secrets survive either way.
   "keep_vars": true,
-  "upload_source_maps": true,
+  // Cloudflare caps uploaded Worker source maps at 15 MB gzipped across the
+  // whole deploy; this app's server bundle produces ~68 MB gzipped of maps
+  // (the AI SDK providers, pdf/youtube extractors and the editor packages are
+  // all bundled into the rsc/ssr worker), so every deploy failed validation
+  // with error 10021 "total sourcemap size ... exceeds limit".
+  //
+  // The maps only affect how readable a stack trace is in Cloudflare's log
+  // viewer — they are not part of the Worker's runtime bundle and do not
+  // change behaviour or startup time. Re-enabling this requires getting the
+  // compressed maps under 15 MB first (e.g. dropping embedded sources), not
+  // just flipping the flag back.
+  "upload_source_maps": false,
   "assets": {
     "directory": "dist/client",
     "not_found_handling": "none",


### PR DESCRIPTION
Cloudflare rejects a deploy when the uploaded Worker source maps exceed 15 MB gzipped in total (validation error 10021). The qwksearch-web server bundle produces roughly 68 MB gzipped of maps, so every deploy failed before the Worker was ever published.

Source maps are only used to de-minify stack traces in Cloudflare's log viewer; they are not part of the Worker's runtime bundle, so turning the upload off costs nothing at runtime and unblocks deployment.


Claude-Session: https://claude.ai/code/session_01ErwKogKMaGstAeeWqrsuD9