### PR TITLE
Fix glowing effect arc lagging behind cursor pointer

### DIFF
--- a/packages/research-agent-ui/src/ui/glowing-effect.tsx
+++ b/packages/research-agent-ui/src/ui/glowing-effect.tsx
@@ -13,6 +13,11 @@ interface GlowingEffectProps {
   glow?: boolean;
   className?: string;
   disabled?: boolean;
+  /**
+   * Seconds the highlight takes to ease to the pointer's angle. Keep this
+   * short: the arc is drawn at the *animated* angle, so a long duration leaves
+   * the glow trailing far behind the cursor while the pointer is moving.
+   */
   movementDuration?: number;
   borderWidth?: number;
 }
@@ -25,13 +30,14 @@ const GlowingEffect = memo(
     variant = "default",
     glow = false,
     className,
-    movementDuration = 2,
+    movementDuration = 0.2,
     borderWidth = 1,
     disabled = true,
   }: GlowingEffectProps) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const lastPosition = useRef({ x: 0, y: 0 });
     const animationFrameRef = useRef<number>(0);
+    const angleAnimationRef = useRef<{ stop: () => void } | null>(null);
 
     const handleMove = useCallback(
       (e?: MouseEvent | { x: number; y: number }) => {
@@ -85,7 +91,11 @@ const GlowingEffect = memo(
           const angleDiff = ((targetAngle - currentAngle + 180) % 360) - 180;
           const newAngle = currentAngle + angleDiff;
 
-          animate(currentAngle, newAngle, {
+          // Stop the previous tween first. Without this, every pointer move
+          // stacks another animation onto the same `--start` property and the
+          // older ones keep writing stale angles over the newer ones.
+          angleAnimationRef.current?.stop();
+          angleAnimationRef.current = animate(currentAngle, newAngle, {
             duration: movementDuration,
             ease: [0.16, 1, 0.3, 1],
             onUpdate: (value) => {
@@ -103,17 +113,27 @@ const GlowingEffect = memo(
       const handleScroll = () => handleMove();
       const handlePointerMove = (e: PointerEvent) => handleMove(e);
 
-      window.addEventListener("scroll", handleScroll, { passive: true });
-      document.body.addEventListener("pointermove", handlePointerMove, {
+      // Capture phase: `scroll` does not bubble, so a window-phase listener
+      // misses scrolling inside nested containers (the source grid has its
+      // own). Missing those leaves the cached rect — and the glow — stale.
+      window.addEventListener("scroll", handleScroll, {
         passive: true,
+        capture: true,
+      });
+      window.addEventListener("pointermove", handlePointerMove, {
+        passive: true,
+        capture: true,
       });
 
       return () => {
         if (animationFrameRef.current) {
           cancelAnimationFrame(animationFrameRef.current);
         }
-        window.removeEventListener("scroll", handleScroll);
-        document.body.removeEventListener("pointermove", handlePointerMove);
+        angleAnimationRef.current?.stop();
+        window.removeEventListener("scroll", handleScroll, { capture: true });
+        window.removeEventListener("pointermove", handlePointerMove, {
+          capture: true,
+        });
       };
     }, [handleMove, disabled]);
 

--- a/packages/research-agent-ui/test/glowing-effect.test.tsx
+++ b/packages/research-agent-ui/test/glowing-effect.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+
+/**
+ * The pointer-tracked glow is driven by a `--start` angle that is tweened on
+ * every pointer move. Two things used to make the visible arc sit far away
+ * from the cursor:
+ *
+ *  1. each move started a new tween without stopping the previous one, so
+ *     several tweens wrote conflicting angles to the same custom property, and
+ *  2. the tween ran for two seconds, so the arc trailed the pointer by a large
+ *     angle for as long as the pointer kept moving.
+ *
+ * These tests pin both down.
+ */
+
+type AnimateCall = { from: number; to: number; duration: number };
+
+const animateCalls: AnimateCall[] = [];
+const stopSpies: Array<ReturnType<typeof vi.fn>> = [];
+
+vi.mock('motion/react', () => ({
+  animate: (from: number, to: number, options: { duration: number }) => {
+    animateCalls.push({ from, to, duration: options.duration });
+    const stop = vi.fn();
+    stopSpies.push(stop);
+    return { stop };
+  },
+}));
+
+// Imported after the mock so the component picks up the stubbed `animate`.
+const { GlowingEffect } = await import('../src/ui/glowing-effect');
+
+const CARD = { left: 100, top: 100, width: 200, height: 100 };
+
+/** jsdom lays nothing out, so the component's rect has to be stubbed. */
+const stubRect = () =>
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+    ...CARD,
+    right: CARD.left + CARD.width,
+    bottom: CARD.top + CARD.height,
+    x: CARD.left,
+    y: CARD.top,
+    toJSON: () => ({}),
+  } as DOMRect);
+
+/** Dispatch a pointer move and run the rAF callback the handler queues. */
+const movePointer = (x: number, y: number) => {
+  const event = new MouseEvent('pointermove', { clientX: x, clientY: y });
+  window.dispatchEvent(event);
+  vi.advanceTimersByTime(32);
+};
+
+describe('GlowingEffect pointer tracking', () => {
+  beforeEach(() => {
+    animateCalls.length = 0;
+    stopSpies.length = 0;
+    vi.useFakeTimers();
+    stubRect();
+    render(<GlowingEffect disabled={false} glow proximity={64} inactiveZone={0.01} />);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('stops the in-flight tween before starting the next one', () => {
+    movePointer(340, 150);
+    movePointer(345, 150);
+    movePointer(350, 150);
+
+    expect(animateCalls.length).toBe(3);
+    // Every tween but the last one must have been stopped, so only a single
+    // animation is ever writing `--start`.
+    expect(stopSpies.slice(0, -1).every((stop) => stop.mock.calls.length > 0)).toBe(true);
+    expect(stopSpies[stopSpies.length - 1]).not.toHaveBeenCalled();
+  });
+
+  it('tweens toward the pointer fast enough to stay under the cursor', () => {
+    movePointer(340, 150);
+
+    expect(animateCalls[0].duration).toBeLessThanOrEqual(0.3);
+  });
+
+  it('aims the arc at the pointer angle measured from the element centre', () => {
+    // Pointer directly to the right of the card centre (200, 150): the conic
+    // gradient starts at 12 o'clock, so "right" is 90deg.
+    movePointer(340, 150);
+
+    expect(animateCalls[0].to).toBeCloseTo(90, 5);
+
+    // Directly below the centre is 180deg. The tween takes the shortest route,
+    // so the raw target can be the negative equivalent of that angle.
+    movePointer(200, 250);
+
+    const normalized = ((animateCalls[1].to % 360) + 360) % 360;
+    expect(normalized).toBeCloseTo(180, 5);
+  });
+});


### PR DESCRIPTION
## Summary
Fixed the glowing effect component where the arc would trail significantly behind the cursor during pointer movement. The issue was caused by two problems: multiple concurrent animations writing conflicting angles to the same CSS custom property, and an excessively long animation duration (2 seconds).

## Key Changes
- **Reduced animation duration** from 2 seconds to 0.2 seconds to keep the arc close to the cursor during movement
- **Stop previous animations before starting new ones** by storing and calling the `stop()` method on the animation controller, preventing stale animations from overwriting newer angle values
- **Fixed event listener registration** by switching from `document.body` to `window` for `pointermove` events and adding `capture: true` to both `scroll` and `pointermove` listeners to properly handle nested scrollable containers
- **Added comprehensive test suite** to verify the animation behavior and prevent regression of these issues

## Implementation Details
- The `angleAnimationRef` now tracks the current animation controller so it can be stopped before starting a new tween
- Event listeners now use capture phase to ensure scroll events from nested containers are caught (the source grid has its own scrollable container)
- Added JSDoc documentation explaining the `movementDuration` parameter and why it must be kept short
- Tests verify that: previous tweens are stopped, animation duration is short enough, and the arc aims correctly at the pointer angle relative to the element center

https://claude.ai/code/session_01XiMaSBhVn7Exzdh7TkCKWk