### PR TITLE
Fix outline filter dropping body-matched headings and mis-hiding items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ ext - dl to reason dl folswe
 2. Chat with open tabs as context.
 3. Show Vals scores for all models; example Kimi K2.5 page lists Vals Index 51.70%, latency 807.18s, and cost/test $0.29.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
 4. Outline tree should reuse Fumadocs page tree/sidebar patterns.
-5. Filter outline.
 6. Find/replace across all docs.
 7. Option to start talking automatically on first visit, or via a button from anywhere on the site.
 8. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
@@ -12,6 +11,10 @@ ext - dl to reason dl folswe
 10. common typoes
 11. https://github.com/cloudflare/moltworker
 
+
+## Completed
+
+5. Filter outline — fixed: filtering already existed in the sidebar outline panel, but it dropped headings that matched only via body text and mis-hid items when a filter was active (index mismatch between the filtered list and the full outline). See packages/react-reason-editor/src/search/OutlineView.tsx and SidebarContent.tsx.
 
 ## Longterm
 

--- a/packages/react-reason-editor/package.json
+++ b/packages/react-reason-editor/package.json
@@ -749,7 +749,8 @@
     "build:lib": "vite build",
     "build:demo": "vite build --config demo/vite.config.ts",
     "preview": "wrangler dev",
-    "deploy": "pnpm build:lib && pnpm build:demo && wrangler deploy"
+    "deploy": "pnpm build:lib && pnpm build:demo && wrangler deploy",
+    "test": "vitest run"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
@@ -892,6 +893,7 @@
     "typescript": "^6.0.3",
     "unplugin-dts": "1.0.2",
     "vite": "^8.0.16",
+    "vitest": "^4.0.18",
     "wrangler": "^4.107.0"
   },
   "engines": {

--- a/packages/react-reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/react-reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -331,10 +331,12 @@ export const SidebarContent = ({
         </div>
       </div>
       <div className="flex-1 overflow-auto">
+        {/* filteredHeadings already matches outlineFilter against heading and body text;
+            don't also pass searchQuery, or OutlineView would re-filter by heading text only
+            and drop headings that matched via body text. */}
         <OutlineView
           ref={effectiveOutlineRef}
           headings={filteredHeadings}
-          searchQuery={outlineFilter}
           onNavigate={onNavigate}
         />
       </div>

--- a/packages/react-reason-editor/src/search/OutlineView.test.ts
+++ b/packages/react-reason-editor/src/search/OutlineView.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { filterOutline, isHiddenByCollapsedAncestor, type OutlineItem } from './OutlineView';
+
+const outline: OutlineItem[] = [
+  { id: 'a', level: 1, text: 'Alpha', line: 0 },
+  { id: 'b', level: 2, text: 'Alpha Child', line: 1 },
+  { id: 'c', level: 1, text: 'Beta', line: 2 },
+  { id: 'd', level: 2, text: 'Beta Child', line: 3 },
+];
+
+describe('filterOutline', () => {
+  it('returns the full outline when the query is blank', () => {
+    expect(filterOutline(outline, '')).toBe(outline);
+    expect(filterOutline(outline, '   ')).toBe(outline);
+  });
+
+  it('matches heading text case-insensitively', () => {
+    expect(filterOutline(outline, 'alpha')).toEqual([outline[0], outline[1]]);
+    expect(filterOutline(outline, 'BETA')).toEqual([outline[2], outline[3]]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterOutline(outline, 'nonexistent')).toEqual([]);
+  });
+});
+
+describe('isHiddenByCollapsedAncestor', () => {
+  it('never hides the first item', () => {
+    expect(isHiddenByCollapsedAncestor(outline, new Set(['a']), 0)).toBe(false);
+  });
+
+  it('hides a child whose parent heading is collapsed', () => {
+    expect(isHiddenByCollapsedAncestor(outline, new Set(['a']), 1)).toBe(true);
+  });
+
+  it('does not hide a child whose parent heading is expanded', () => {
+    expect(isHiddenByCollapsedAncestor(outline, new Set(), 1)).toBe(false);
+  });
+
+  it('does not leak collapse state across sibling top-level sections', () => {
+    // 'a' (index 0) is collapsed, but 'c' and 'd' sit under sibling 'c', not 'a'.
+    expect(isHiddenByCollapsedAncestor(outline, new Set(['a']), 2)).toBe(false);
+    expect(isHiddenByCollapsedAncestor(outline, new Set(['a']), 3)).toBe(false);
+  });
+
+  it('reflects the correct visibility when given the real outline index of a filtered item', () => {
+    // Regression test: OutlineView used to index into the full `outline` array
+    // using the filtered list's positional index, which diverges from the
+    // item's real index whenever filtering removes preceding items.
+    const collapsedIds = new Set(['a']);
+    const filtered = filterOutline(outline, 'beta'); // [c, d], real indices 2 and 3
+
+    const realIndices = filtered.map((item) => outline.findIndex((o) => o.id === item.id));
+    expect(realIndices).toEqual([2, 3]);
+
+    const visibility = realIndices.map((index) => isHiddenByCollapsedAncestor(outline, collapsedIds, index));
+    expect(visibility).toEqual([false, false]);
+
+    // Using the filtered list's positional index (the pre-fix bug) instead of
+    // the real index produces the wrong answer for 'd': it would incorrectly
+    // check 'b' (outline[1]) and report 'd' as hidden.
+    const buggyPositionalIndices = filtered.map((_item, index) => index);
+    const buggyVisibility = buggyPositionalIndices.map((index) =>
+      isHiddenByCollapsedAncestor(outline, collapsedIds, index)
+    );
+    expect(buggyVisibility).toEqual([false, true]);
+  });
+});

--- a/packages/react-reason-editor/src/search/OutlineView.tsx
+++ b/packages/react-reason-editor/src/search/OutlineView.tsx
@@ -21,7 +21,7 @@ import {
 } from '../app-ui/context-menu';
 
 /** Internal flattened representation of a single heading in the document. */
-interface OutlineItem {
+export interface OutlineItem {
   /** Stable identifier (from TocEntry) used for navigation and collapse state. */
   id: string;
   /** Heading level (1–6) corresponding to H1–H6. */
@@ -30,6 +30,44 @@ interface OutlineItem {
   text: string;
   /** Sequential index in the original heading list. */
   line: number;
+}
+
+/**
+ * Returns the subset of `outline` whose heading text contains `query`
+ * (case-insensitive). Returns `outline` unchanged when `query` is blank.
+ */
+export function filterOutline(outline: OutlineItem[], query: string): OutlineItem[] {
+  const trimmed = query.trim();
+  if (!trimmed) return outline;
+  const q = trimmed.toLowerCase();
+  return outline.filter((item) => item.text.toLowerCase().includes(q));
+}
+
+/**
+ * Returns whether the item at `itemIndex` within the full (unfiltered)
+ * `outline` is hidden because one of its ancestors is collapsed.
+ *
+ * @param outline - The full, unfiltered heading list.
+ * @param collapsedIds - IDs of currently collapsed headings.
+ * @param itemIndex - Index of the item within `outline` (not a filtered subset).
+ */
+export function isHiddenByCollapsedAncestor(
+  outline: OutlineItem[],
+  collapsedIds: Set<string>,
+  itemIndex: number
+): boolean {
+  const currentLevel = outline[itemIndex].level;
+
+  for (let i = itemIndex - 1; i >= 0; i--) {
+    if (outline[i].level < currentLevel) {
+      if (collapsedIds.has(outline[i].id)) {
+        return true;
+      }
+      if (outline[i].level === 1) break;
+    }
+  }
+
+  return false;
 }
 
 /**
@@ -126,11 +164,14 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
    * Returns the memoized, filtered subset of `outline`.
    * When `searchQuery` is empty the full list is returned.
    */
-  const filteredOutline = useMemo(() => {
-    if (!searchQuery.trim()) return outline;
-    const query = searchQuery.toLowerCase();
-    return outline.filter(item => item.text.toLowerCase().includes(query));
-  }, [outline, searchQuery]);
+  const filteredOutline = useMemo(() => filterOutline(outline, searchQuery), [outline, searchQuery]);
+
+  /** Maps each heading's ID to its index within the full (unfiltered) `outline`. */
+  const outlineIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    outline.forEach((item, index) => map.set(item.id, index));
+    return map;
+  }, [outline]);
 
   /**
    * Returns the IDs of all headings that are direct or indirect children
@@ -175,28 +216,6 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
   };
 
   /**
-   * Returns whether the heading at `itemIndex` is hidden because one of its
-   * ancestors is currently collapsed.
-   *
-   * @param itemIndex - Zero-based index in the flat `outline` array.
-   * @returns `true` if hidden, `false` if visible.
-   */
-  const isHiddenByParent = (itemIndex: number): boolean => {
-    const currentLevel = outline[itemIndex].level;
-
-    for (let i = itemIndex - 1; i >= 0; i--) {
-      if (outline[i].level < currentLevel) {
-        if (collapsedIds.has(outline[i].id)) {
-          return true;
-        }
-        if (outline[i].level === 1) break;
-      }
-    }
-
-    return false;
-  };
-
-  /**
    * Collapses all headings at the specified level and re-applies the
    * collapsed-IDs set.
    *
@@ -230,12 +249,13 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
 
   return (
     <div className="flex h-full flex-col overflow-auto">
-      {filteredOutline.map((item, index) => {
-        const nextItem = outline[index + 1];
+      {filteredOutline.map((item) => {
+        const actualIndex = outlineIndexById.get(item.id) ?? -1;
+        const nextItem = outline[actualIndex + 1];
         const hasChildren = nextItem && nextItem.level > item.level;
         const isCollapsed = collapsedIds.has(item.id);
 
-        if (isHiddenByParent(index)) {
+        if (actualIndex !== -1 && isHiddenByCollapsedAncestor(outline, collapsedIds, actualIndex)) {
           return null;
         }
 

--- a/packages/react-reason-editor/vitest.config.ts
+++ b/packages/react-reason-editor/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/**',
+        'dist/**',
+        'demo/**',
+        '**/*.test.ts',
+        '**/*.test.tsx',
+      ],
+    },
+  },
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,6 +5,7 @@ export default defineWorkspace([
   'packages/chat-agent-toolkit',
   'packages/extract-webpage',
   'packages/qwksearch-api-client',
+  'packages/react-reason-editor',
   'packages/render-url-to-html-cloudflare',
   'packages/research-agent-ui',
   'packages/search-web-api',


### PR DESCRIPTION
## Summary
- The sidebar "Filter outline" feature (`packages/react-reason-editor/src/layout/sidebar/SidebarContent.tsx`) already matched the search query against both heading text and section body text via `filteredHeadings`, but it also passed the raw query through to `OutlineView` as `searchQuery`. `OutlineView` then re-filtered that already-filtered list by heading text only, silently dropping any heading that had matched solely via its body text.
- `OutlineView`'s render loop also used the *filtered* list's positional `index` to look up ancestor/next-sibling info in the *full, unfiltered* `outline` array. Those indices diverge as soon as a filter removes preceding items, causing incorrect collapse-hide behavior and `hasChildren` detection while a filter was active.
- Fixed both: `SidebarContent` no longer double-passes the query (the headings it hands to `OutlineView` are already the final filtered set), and `OutlineView` now looks up each filtered item's real index in the full outline via an id→index map before using it.
- Extracted the filtering and ancestor-collapse logic into pure, exported functions (`filterOutline`, `isHiddenByCollapsedAncestor`) in `OutlineView.tsx` and added focused Vitest unit tests, including a regression test that reproduces the old index-mismatch bug.
- `react-reason-editor` had no test infrastructure at all; added `vitest.config.ts`, a `test` script, and registered the package in the root `vitest.workspace.ts`.

## Validation
- [x] `cd packages/react-reason-editor && bunx vitest run src/search/OutlineView.test.ts` — 8/8 passed
- [x] `cd packages/react-reason-editor && bunx vite build --config vite.config.ts` (`build:lib`) — succeeded (pre-existing, unrelated warnings only)
- [ ] `bunx tsc --noEmit -p packages/react-reason-editor/tsconfig.json` — pre-existing failure in `src/types/constants.types.ts` (invalid type-arithmetic syntax), reproduces on `master` before this change; the package's own `build` script already tolerates `tsc` failures (`tsc --project tsconfig.build.json || true`). Unrelated to this change.
- [ ] Root `bun run test` (full workspace) — not completed; the workspace includes several network-dependent integration suites (e.g. `search-web-api`, `extract-youtube`) that are slow/unreachable in this sandbox. Verified the affected package's suite directly instead.

## Task tracking
- Implements: TODO.md item "Filter outline" (moved to a new `## Completed` section in `TODO.md`)
- Follow-ups: none — the pre-existing `constants.types.ts` typecheck failure predates this change and is already tolerated by the package's build script; not filing a separate issue since it doesn't block anything.

## Notes for reviewers
- No public API changes for consumers of `react-reason-editor`; `OutlineView`'s `searchQuery` prop still works standalone (e.g. for future callers that don't pre-filter), and the added tests cover it directly.
- `OutlineItem` and the two helper functions are now exported from `OutlineView.tsx` solely so they're unit-testable; no other behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UNEVUWeSdCxo3dPMstVLH8)_