### PR TITLE
Default the Reasoning view zoom to 125% and persist it

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@ ext - dl to reason dl folswe
 6. Find/replace across all docs.
 7. Option to start talking automatically on first visit, or via a button from anywhere on the site.
 8. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
-9. Reasoning view zoom default at 125%.
 10. common typoes
 11. https://github.com/cloudflare/moltworker
 
@@ -15,6 +14,8 @@ ext - dl to reason dl folswe
 ## Completed
 
 5. Filter outline — fixed: filtering already existed in the sidebar outline panel, but it dropped headings that matched only via body text and mis-hid items when a filter was active (index mismatch between the filtered list and the full outline). See packages/react-reason-editor/src/search/OutlineView.tsx and SidebarContent.tsx.
+
+9. Reasoning view zoom default at 125% — fixed: the zoom control defaulted to 100% and reset on every reload since it wasn't persisted. Default is now 125% and the chosen zoom level persists across sessions via localStorage (`REASON-zoom`), applied on mount. See packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx.
 
 ## Longterm
 

--- a/packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.test.ts
+++ b/packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_ZOOM, clampZoom, zoomIn, zoomOut } from './RichTextZoom';
+
+describe('DEFAULT_ZOOM', () => {
+  it('defaults the reasoning view to 125% zoom', () => {
+    expect(DEFAULT_ZOOM).toBe(1.25);
+  });
+});
+
+describe('clampZoom', () => {
+  it('leaves in-range values unchanged', () => {
+    expect(clampZoom(1)).toBe(1);
+    expect(clampZoom(1.25)).toBe(1.25);
+  });
+
+  it('clamps values below the minimum', () => {
+    expect(clampZoom(0.1)).toBe(0.5);
+  });
+
+  it('clamps values above the maximum', () => {
+    expect(clampZoom(5)).toBe(2);
+  });
+});
+
+describe('zoomIn', () => {
+  it('increases the scale by one step', () => {
+    expect(zoomIn(1)).toBe(1.25);
+  });
+
+  it('stops at the maximum zoom', () => {
+    expect(zoomIn(2)).toBe(2);
+    expect(zoomIn(1.9)).toBe(2);
+  });
+});
+
+describe('zoomOut', () => {
+  it('decreases the scale by one step', () => {
+    expect(zoomOut(1)).toBe(0.75);
+  });
+
+  it('stops at the minimum zoom', () => {
+    expect(zoomOut(0.5)).toBe(0.5);
+    expect(zoomOut(0.6)).toBe(0.5);
+  });
+});

--- a/packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx
+++ b/packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx
@@ -2,9 +2,32 @@
  * Toolbar control (React) for the Zoom extension, which adds zooming the editor content. Renders the button and dispatches the matching editor command when activated.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ZoomIn, ZoomOut } from 'lucide-react';
 import { createPortal } from 'react-dom';
+import { useLocalStorage } from '../../../app-hooks/useLocalStorage';
+
+/** Zoom applied to the editor content the first time a session opens it. */
+export const DEFAULT_ZOOM = 1.25;
+const ZOOM_STEP = 0.25;
+const MIN_ZOOM = 0.5;
+const MAX_ZOOM = 2;
+const ZOOM_STORAGE_KEY = 'REASON-zoom';
+
+/** Clamps `scale` to the [MIN_ZOOM, MAX_ZOOM] range supported by the zoom controls. */
+export function clampZoom(scale: number): number {
+  return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale));
+}
+
+/** Returns the zoom level after zooming in one step from `scale`. */
+export function zoomIn(scale: number): number {
+  return clampZoom(scale + ZOOM_STEP);
+}
+
+/** Returns the zoom level after zooming out one step from `scale`. */
+export function zoomOut(scale: number): number {
+  return clampZoom(scale - ZOOM_STEP);
+}
 
 function Toast({ message }: { message: string }) {
   const [isVisible, setIsVisible] = useState(true);
@@ -27,25 +50,11 @@ function Toast({ message }: { message: string }) {
 }
 
 export function RichTextZoom() {
-  const [scale, setScale] = useState(1);
+  const [scale, setScale] = useLocalStorage(ZOOM_STORAGE_KEY, DEFAULT_ZOOM);
   const [toast, setToast] = useState<string | null>(null);
 
   const showToast = (message: string) => {
     setToast(message);
-  };
-
-  const handleZoomIn = () => {
-    const newScale = Math.min(scale + 0.25, 2);
-    setScale(newScale);
-    applyZoom(newScale);
-    showToast(`Zoom: ${Math.round(newScale * 100)}%`);
-  };
-
-  const handleZoomOut = () => {
-    const newScale = Math.max(scale - 0.25, 0.5);
-    setScale(newScale);
-    applyZoom(newScale);
-    showToast(`Zoom: ${Math.round(newScale * 100)}%`);
   };
 
   const applyZoom = (zoomLevel: number) => {
@@ -54,6 +63,27 @@ export function RichTextZoom() {
       (editor as HTMLElement).style.transform = `scale(${zoomLevel})`;
       (editor as HTMLElement).style.transformOrigin = 'top left';
     }
+  };
+
+  // Re-apply the persisted (or default) zoom to the editor on mount, since
+  // it's a DOM style rather than something React renders declaratively.
+  useEffect(() => {
+    applyZoom(scale);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleZoomIn = () => {
+    const newScale = zoomIn(scale);
+    setScale(newScale);
+    applyZoom(newScale);
+    showToast(`Zoom: ${Math.round(newScale * 100)}%`);
+  };
+
+  const handleZoomOut = () => {
+    const newScale = zoomOut(scale);
+    setScale(newScale);
+    applyZoom(newScale);
+    showToast(`Zoom: ${Math.round(newScale * 100)}%`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- Implements TODO.md item 9: "Reasoning view zoom default at 125%."
- The Reasoning view's zoom toolbar control (`RichTextZoom`) always started at 100% (`useState(1)`) and reset on every reload/remount because the scale lived only in transient React state.
- Switched it to `useLocalStorage('REASON-zoom', 1.25)`, matching the sibling `REASON-*` persisted settings already used throughout `useReasonDocsState.ts` (e.g. `REASON-sidebar-width`, `REASON-left-panels`).
- The persisted (or default) zoom is now applied to the `.ProseMirror` element on mount via a `useEffect`, since it wasn't previously applied until the user manually clicked zoom in/out.
- Extracted the clamp/step math (`clampZoom`, `zoomIn`, `zoomOut`) into small pure functions so they're unit-testable without a DOM.

## Validation
- [x] `bun run vitest run src/extensions/Zoom/components/RichTextZoom.test.ts` (in `packages/react-reason-editor`) — 8/8 passed
- [x] `bun run vitest run` (in `packages/react-reason-editor`) — 16/16 passed (full package suite)
- [ ] `bun run test` (repo root, full monorepo Vitest suite) — has many pre-existing failures in unrelated packages (live-network search-engine scraping tests, missing env/credentials for auth/KV tests, etc.), confirmed unrelated by re-running on the base branch before this change. None touch `react-reason-editor`.
- [ ] `bunx tsc --noEmit` (in `packages/react-reason-editor`) — pre-existing syntax errors in `src/types/constants.types.ts` (unrelated file, not touched here), also present on the base branch.
- [ ] `bun run build:lib` (in `packages/react-reason-editor`) — pre-existing failure, also reproduces unmodified on the base branch: `[UNRESOLVED_ENTRY] Cannot resolve entry module src/extensions/Zoom/Zoom.ts` (the `Zoom` extension directory has never had a top-level entry file the way sibling extensions like `WordCount` do) plus the same `constants.types.ts` errors. This also breaks `apps/qwksearch-web`'s `prebuild` script, which chains into `react-reason-editor`'s `build:lib`. Filed as a follow-up (see below) — fixing it is unrelated to the zoom-default change and would meaningfully expand this PR's scope.

## Task tracking
- Implements: TODO.md item 9 ("Reasoning view zoom default at 125%"), moved to the Completed section in this PR.
- Follow-ups: pre-existing `react-reason-editor` build breakage (missing `Zoom.ts` entry file + `constants.types.ts` syntax errors) that also blocks `qwksearch-web`'s build — will file as a tracked GitHub issue.

## Notes for reviewers
- No product/UX decision was needed beyond the TODO wording itself; 125% was taken as the literal target default.
- The zoom control still targets `document.querySelector('.ProseMirror')` (pre-existing pattern, unchanged) rather than a scoped ref — out of scope for this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_019y15Fh3ENTByFtafYMKyf7)_