### PR TITLE
docs: link merged zoom-default PR in TODO.md

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ ext - dl to reason dl folswe
 
 5. Filter outline — fixed: filtering already existed in the sidebar outline panel, but it dropped headings that matched only via body text and mis-hid items when a filter was active (index mismatch between the filtered list and the full outline). See packages/react-reason-editor/src/search/OutlineView.tsx and SidebarContent.tsx.
 
-9. Reasoning view zoom default at 125% — fixed: the zoom control defaulted to 100% and reset on every reload since it wasn't persisted. Default is now 125% and the chosen zoom level persists across sessions via localStorage (`REASON-zoom`), applied on mount. See packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx.
+9. Reasoning view zoom default at 125% — fixed: the zoom control defaulted to 100% and reset on every reload since it wasn't persisted. Default is now 125% and the chosen zoom level persists across sessions via localStorage (`REASON-zoom`), applied on mount. See packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx. PR: https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/189
 
 ## Longterm
 


### PR DESCRIPTION
## Summary
- One-line doc fix: PR #189 (default Reasoning-view zoom to 125%, TODO.md item 9) was squash-merged a few seconds after being opened — before a follow-up commit adding the PR link to the tracker's Completed entry could land on that branch.
- This re-applies just that link so TODO.md's Completed section for item 9 references the PR that shipped it, matching the format already used for item 5.

## Validation
- N/A — documentation-only change, no code touched.

## Task tracking
- Implements: tracker hygiene follow-up for TODO.md item 9 / PR #189.
- Follow-ups: none.

## Notes for reviewers
- No functional change. Branch was restarted from `master` per the merged-PR protocol since the previous `claude/beautiful-fermat-t2hipu` history was already merged.


---
_Generated by [Claude Code](https://claude.ai/code/session_019y15Fh3ENTByFtafYMKyf7)_