### PR TITLE
Add Find & Replace across all documents

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ ext - dl to reason dl folswe
 2. Chat with open tabs as context.
 3. Show Vals scores for all models; example Kimi K2.5 page lists Vals Index 51.70%, latency 807.18s, and cost/test $0.29.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
 4. Outline tree should reuse Fumadocs page tree/sidebar patterns.
-6. Find/replace across all docs.
 7. Option to start talking automatically on first visit, or via a button from anywhere on the site.
 8. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
 10. common typoes
@@ -16,6 +15,8 @@ ext - dl to reason dl folswe
 5. Filter outline — fixed: filtering already existed in the sidebar outline panel, but it dropped headings that matched only via body text and mis-hid items when a filter was active (index mismatch between the filtered list and the full outline). See packages/react-reason-editor/src/search/OutlineView.tsx and SidebarContent.tsx.
 
 9. Reasoning view zoom default at 125% — fixed: the zoom control defaulted to 100% and reset on every reload since it wasn't persisted. Default is now 125% and the chosen zoom level persists across sessions via localStorage (`REASON-zoom`), applied on mount. See packages/react-reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx. PR: https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/189
+
+6. Find/replace across all docs — added: a "Find & Replace in All Docs" dialog, reachable from the ⌘K/Ctrl+K command palette, searches every document's content and lets you replace all occurrences across every matching document in one action (with a per-document match preview and an explicit confirmation step). The document currently open in the editor is intentionally excluded from the bulk replace and flagged in the UI, since its in-memory editor state isn't reloaded from an external content change and would otherwise silently overwrite the replacement on its next autosave — use the existing in-editor Find & Replace for that one. See packages/react-reason-editor/src/search/findReplaceAllDocs.ts, FindReplaceAllDialog.tsx, and the wiring in useReasonDocsState.ts/ReasonDocs.tsx/ReasonDocsDialogs.tsx/SearchModal.tsx.
 
 ## Longterm
 
@@ -44,3 +45,5 @@ ext - dl to reason dl folswe
 35. Release on HN, YouTube, and Product Hunt.
 36. https://21st.dev/community/agents
 37. from the drodpown menu have tit  insret to as about tabstion ...` to show where the warning was created)
+38. Follow-up to #6 (Find/replace across all docs): also apply a confirmed replace to the document currently open in the editor. Today it's skipped because `TiptapEditorWrapper`/`useSyncStore` only reload editor content when the document ID (`contentKey`) changes, so an external content change to the open doc would be silently overwritten by the editor's own debounced autosave. Needs a safe way to force the editor to reload content after an external update (e.g. bump a reload token independent of doc ID) before this doc can be included.
+39. `packages/react-reason-editor`'s `build:lib` script (`vite build`) fails on master independent of any TODO work: `src/extensions/Zoom/Zoom.ts` is referenced as a build entry but doesn't exist, and there are several pre-existing TypeScript errors (`src/dialogs/InviteModal.tsx`, `src/editor-views/components/Toolbar.tsx` and `config/pluginRegistry.tsx` importing a nonexistent `react-reason-editor/wordcount` subpath, `src/extensions/Pagination/Pagination.ts`, `src/file-tree/filetree.tsx`, `src/types/constants.types.ts` — the last one also breaks plain `tsc --noEmit`). `bun run test` (Vitest) is unaffected and passes. Repro: `cd packages/react-reason-editor && bun run build:lib`.

--- a/packages/react-reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/react-reason-editor/src/editor/ReasonDocs.tsx
@@ -193,6 +193,8 @@ const Index = () => {
       <ReasonDocsDialogs
         isSearchModalOpen={state.isSearchModalOpen}
         setIsSearchModalOpen={state.setIsSearchModalOpen}
+        isFindReplaceAllOpen={state.isFindReplaceAllOpen}
+        setIsFindReplaceAllOpen={state.setIsFindReplaceAllOpen}
         isSettingsOpen={state.isSettingsOpen}
         setIsSettingsOpen={state.setIsSettingsOpen}
         settingsInitialSection={settingsInitialSection}
@@ -204,6 +206,7 @@ const Index = () => {
         setIsTagDialogOpen={state.setIsTagDialogOpen}
         documents={state.documents}
         activeDocument={state.activeDocument}
+        activeDocId={state.activeDocId}
         tagManagementDocId={state.tagManagementDocId}
         defaultSidebarView={state.defaultSidebarView}
         setDefaultSidebarView={state.setDefaultSidebarView}
@@ -211,6 +214,7 @@ const Index = () => {
         setEnableDatabaseSync={state.setEnableDatabaseSync}
         setDocuments={state.setDocuments}
         onSelectDocument={state.handleSelectDocument}
+        onReplaceInAllDocuments={state.handleReplaceInAllDocuments}
         onToggleTheme={handleToggleTheme}
         currentTheme={theme}
         onUpdateTags={state.handleUpdateTags}

--- a/packages/react-reason-editor/src/editor/ReasonDocsDialogs.tsx
+++ b/packages/react-reason-editor/src/editor/ReasonDocsDialogs.tsx
@@ -5,6 +5,8 @@
  */
 import type { Document } from '../documents/DocumentTree';
 import { SearchModal } from '../search/SearchModal';
+import { FindReplaceAllDialog } from '../search/FindReplaceAllDialog';
+import type { ReplaceAllResult } from '../search/findReplaceAllDocs';
 import { Settings } from '../features/settings/Settings';
 import { TeamManagement } from '../features/team/TeamManagement';
 import { InviteModal } from '../dialogs/InviteModal';
@@ -16,6 +18,10 @@ interface ReasonDocsDialogsProps {
   isSearchModalOpen: boolean;
   /** Setter for `isSearchModalOpen`. */
   setIsSearchModalOpen: (open: boolean) => void;
+  /** Controls visibility of the cross-document find & replace dialog. */
+  isFindReplaceAllOpen: boolean;
+  /** Setter for `isFindReplaceAllOpen`. */
+  setIsFindReplaceAllOpen: (open: boolean) => void;
   /** Controls visibility of the settings dialog. */
   isSettingsOpen: boolean;
   /** Setter for `isSettingsOpen`. */
@@ -38,6 +44,8 @@ interface ReasonDocsDialogsProps {
   documents: Document[];
   /** Currently active document, used by the invite modal for context. */
   activeDocument: Document | undefined;
+  /** ID of the currently active/open document, excluded from cross-document replace. */
+  activeDocId: string | null;
   /** ID of the document whose tags are currently being managed; null if none. */
   tagManagementDocId: string | null;
   defaultSidebarView: 'split' | 'tree' | 'outline' | 'last-used';
@@ -46,6 +54,12 @@ interface ReasonDocsDialogsProps {
   setEnableDatabaseSync: (enabled: boolean) => void;
   setDocuments: (docs: Document[] | ((prev: Document[]) => Document[])) => void;
   onSelectDocument: (id: string) => void;
+  /** Replaces `query` with `replacement` across all documents except the active one. */
+  onReplaceInAllDocuments: (
+    query: string,
+    replacement: string,
+    options: { caseSensitive?: boolean }
+  ) => ReplaceAllResult;
   onToggleTheme: () => void;
   currentTheme: string | undefined;
   onUpdateTags: (tags: string[]) => void;
@@ -58,6 +72,8 @@ interface ReasonDocsDialogsProps {
 export function ReasonDocsDialogs({
   isSearchModalOpen,
   setIsSearchModalOpen,
+  isFindReplaceAllOpen,
+  setIsFindReplaceAllOpen,
   isSettingsOpen,
   setIsSettingsOpen,
   settingsInitialSection,
@@ -69,6 +85,7 @@ export function ReasonDocsDialogs({
   setIsTagDialogOpen,
   documents,
   activeDocument,
+  activeDocId,
   tagManagementDocId,
   defaultSidebarView,
   setDefaultSidebarView,
@@ -76,6 +93,7 @@ export function ReasonDocsDialogs({
   setEnableDatabaseSync,
   setDocuments,
   onSelectDocument,
+  onReplaceInAllDocuments,
   onToggleTheme,
   currentTheme,
   onUpdateTags,
@@ -89,8 +107,17 @@ export function ReasonDocsDialogs({
         onSelectDocument={onSelectDocument}
         onOpenSettings={() => setIsSettingsOpen(true)}
         onOpenTeams={() => setIsTeamsOpen(true)}
+        onOpenFindReplaceAll={() => setIsFindReplaceAllOpen(true)}
         onToggleTheme={onToggleTheme}
         currentTheme={currentTheme}
+      />
+
+      <FindReplaceAllDialog
+        open={isFindReplaceAllOpen}
+        onOpenChange={setIsFindReplaceAllOpen}
+        documents={documents}
+        activeDocId={activeDocId}
+        onReplaceAll={onReplaceInAllDocuments}
       />
 
       <Settings

--- a/packages/react-reason-editor/src/editor/useReasonDocsState.ts
+++ b/packages/react-reason-editor/src/editor/useReasonDocsState.ts
@@ -18,6 +18,7 @@ import { useLocalStorage } from "../app-hooks/useLocalStorage";
 import { useIsMobile } from "../app-hooks/use-mobile";
 import { useDocumentSync } from "../app-hooks/useDocumentSync";
 import { defaultDocuments } from "../documents/defaultDocuments";
+import { replaceInAllDocuments, type ReplaceAllResult } from "../search/findReplaceAllDocs";
 import { toast } from "sonner";
 
 /**
@@ -30,6 +31,7 @@ export function useReasonDocsState() {
   const isMobile = useIsMobile();
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isSearchModalOpen, setIsSearchModalOpen] = useState(false);
+  const [isFindReplaceAllOpen, setIsFindReplaceAllOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isTeamsOpen, setIsTeamsOpen] = useState(false);
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
@@ -323,6 +325,46 @@ export function useReasonDocsState() {
         return doc;
       });
     });
+  };
+
+  /**
+   * Replaces every occurrence of `query` with `replacement` across all
+   * documents except the one currently open in the editor (whose in-memory
+   * Tiptap state would otherwise overwrite the replacement on its next
+   * autosave). Queues each changed document for database sync when enabled.
+   *
+   * @param query - Text to search for.
+   * @param replacement - Text to replace matches with.
+   * @param options - Case-sensitivity option.
+   * @returns A summary of how many occurrences/documents were changed.
+   */
+  const handleReplaceInAllDocuments = (
+    query: string,
+    replacement: string,
+    options: { caseSensitive?: boolean } = {},
+  ): ReplaceAllResult => {
+    const excludeIds = activeDocId ? [activeDocId] : [];
+    const result = replaceInAllDocuments(documents, query, replacement, {
+      ...options,
+      excludeIds,
+    });
+
+    if (result.changedIds.length === 0) return result;
+
+    setDocuments(result.documents);
+
+    if (enableDatabaseSync) {
+      const changedIds = new Set(result.changedIds);
+      result.documents.forEach((doc) => {
+        if (changedIds.has(doc.id)) queueDocumentForSync(doc);
+      });
+    }
+
+    toast.success(
+      `Replaced ${result.replacedCount} occurrence${result.replacedCount === 1 ? "" : "s"} in ${result.changedIds.length} document${result.changedIds.length === 1 ? "" : "s"}`,
+    );
+
+    return result;
   };
 
   /**
@@ -770,6 +812,8 @@ export function useReasonDocsState() {
     editorRef,
     headings,
     setHeadings,
+    isFindReplaceAllOpen,
+    setIsFindReplaceAllOpen,
     documents,
     setDocuments,
     activeDocId,
@@ -797,6 +841,7 @@ export function useReasonDocsState() {
     handleDeleteDocument,
     handleDuplicateDocument,
     handleUpdateDocument,
+    handleReplaceInAllDocuments,
     handleToggleExpand,
     handleMoveDocument,
     handleAddTag,

--- a/packages/react-reason-editor/src/search/FindReplaceAllDialog.tsx
+++ b/packages/react-reason-editor/src/search/FindReplaceAllDialog.tsx
@@ -1,0 +1,194 @@
+/**
+ * @module FindReplaceAllDialog
+ * @description Dialog that searches and replaces text across every document
+ * in the workspace at once, as opposed to the in-editor Find & Replace toolbar
+ * popover which only operates on the document currently open in the editor.
+ */
+import { useMemo, useState } from 'react';
+import { Replace, FileText } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '../app-ui/dialog';
+import { Input } from '../app-ui/input';
+import { Button } from '../app-ui/button';
+import { Switch } from '../app-ui/switch';
+import { ScrollArea } from '../app-ui/scroll-area';
+import { Document } from '../documents/DocumentTree';
+import { searchAllDocuments, type ReplaceAllResult } from './findReplaceAllDocs';
+
+/** Props for the {@link FindReplaceAllDialog} component. */
+interface FindReplaceAllDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Callback to open or close the dialog. */
+  onOpenChange: (open: boolean) => void;
+  /** Full document list to search across. */
+  documents: Document[];
+  /** ID of the document currently open in the editor, if any. Excluded from replace-all. */
+  activeDocId: string | null;
+  /**
+   * Replaces every occurrence of `query` with `replacement` across all
+   * documents (except the active one) and returns a summary of the change.
+   */
+  onReplaceAll: (
+    query: string,
+    replacement: string,
+    options: { caseSensitive?: boolean }
+  ) => ReplaceAllResult;
+}
+
+/**
+ * Dialog for finding and replacing text across the entire document workspace.
+ * Shows a live per-document match preview as the user types, and requires an
+ * explicit confirmation click before applying the replacement.
+ */
+export const FindReplaceAllDialog = ({
+  open,
+  onOpenChange,
+  documents,
+  activeDocId,
+  onReplaceAll,
+}: FindReplaceAllDialogProps) => {
+  const [query, setQuery] = useState('');
+  const [replacement, setReplacement] = useState('');
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const [lastResult, setLastResult] = useState<ReplaceAllResult | null>(null);
+
+  const matches = useMemo(
+    () => searchAllDocuments(documents, query, { caseSensitive }),
+    [documents, query, caseSensitive]
+  );
+
+  const replaceableMatches = matches.filter((m) => m.documentId !== activeDocId);
+  const totalMatches = replaceableMatches.reduce((sum, m) => sum + m.matchCount, 0);
+  const activeDocSkipped = matches.some((m) => m.documentId === activeDocId);
+
+  const reset = () => {
+    setQuery('');
+    setReplacement('');
+    setConfirming(false);
+    setLastResult(null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleReplaceAll = () => {
+    const result = onReplaceAll(query, replacement, { caseSensitive });
+    setLastResult(result);
+    setConfirming(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl w-[95vw] sm:w-full">
+        <DialogHeader>
+          <DialogTitle>Find & Replace in All Docs</DialogTitle>
+          <DialogDescription>
+            Search and replace text across every document in the workspace.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            autoFocus
+            placeholder="Find..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setConfirming(false);
+              setLastResult(null);
+            }}
+          />
+          <Input
+            placeholder="Replace with..."
+            value={replacement}
+            onChange={(e) => {
+              setReplacement(e.target.value);
+              setConfirming(false);
+              setLastResult(null);
+            }}
+          />
+
+          <div className="flex items-center gap-2">
+            <Switch checked={caseSensitive} onCheckedChange={setCaseSensitive} />
+            <span className="text-sm text-muted-foreground">Case sensitive</span>
+          </div>
+        </div>
+
+        {query.trim() !== '' && (
+          <ScrollArea className="max-h-64 border rounded-md">
+            {matches.length === 0 ? (
+              <p className="text-sm text-muted-foreground text-center py-6">
+                No matches found for "{query}"
+              </p>
+            ) : (
+              <ul>
+                {matches.map((m) => (
+                  <li
+                    key={m.documentId}
+                    className="px-3 py-2 border-b border-border last:border-0 flex items-start gap-2"
+                  >
+                    <FileText className="h-4 w-4 mt-0.5 flex-shrink-0 text-muted-foreground" />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium truncate">{m.title}</span>
+                        <span className="text-xs text-muted-foreground flex-shrink-0">
+                          {m.matchCount} match{m.matchCount === 1 ? '' : 'es'}
+                          {m.documentId === activeDocId ? ' (open — skipped)' : ''}
+                        </span>
+                      </div>
+                      <p className="text-xs text-muted-foreground line-clamp-1">{m.snippet}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </ScrollArea>
+        )}
+
+        {activeDocSkipped && (
+          <p className="text-xs text-muted-foreground">
+            The document currently open in the editor is skipped here — use its in-editor
+            Find & Replace instead.
+          </p>
+        )}
+
+        {lastResult && (
+          <p className="text-sm text-foreground">
+            Replaced {lastResult.replacedCount} occurrence{lastResult.replacedCount === 1 ? '' : 's'} in{' '}
+            {lastResult.changedIds.length} document{lastResult.changedIds.length === 1 ? '' : 's'}.
+          </p>
+        )}
+
+        <div className="flex items-center justify-end gap-2">
+          {confirming ? (
+            <>
+              <Button variant="outline" onClick={() => setConfirming(false)}>
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={handleReplaceAll}>
+                Confirm replace in {replaceableMatches.length} doc{replaceableMatches.length === 1 ? '' : 's'}
+              </Button>
+            </>
+          ) : (
+            <Button
+              onClick={() => setConfirming(true)}
+              disabled={totalMatches === 0}
+            >
+              <Replace className="h-4 w-4" />
+              Replace All ({totalMatches})
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/react-reason-editor/src/search/SearchModal.tsx
+++ b/packages/react-reason-editor/src/search/SearchModal.tsx
@@ -5,7 +5,7 @@
  * for settings, teams, and theme toggling.
  */
 import { useState, useMemo, useEffect, useRef } from 'react';
-import { Search, FileText, X, Settings, Users, Moon, Sun, Command } from 'lucide-react';
+import { Search, FileText, X, Settings, Users, Moon, Sun, Command, Replace } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -31,6 +31,8 @@ interface SearchModalProps {
   onOpenSettings?: () => void;
   /** Opens the teams/organization management dialog. */
   onOpenTeams?: () => void;
+  /** Opens the cross-document find & replace dialog. */
+  onOpenFindReplaceAll?: () => void;
   /** Toggles the active UI theme. */
   onToggleTheme?: () => void;
   /** Currently active theme name; used to label the toggle action. */
@@ -72,6 +74,7 @@ export const SearchModal = ({
   onSelectDocument,
   onOpenSettings,
   onOpenTeams,
+  onOpenFindReplaceAll,
   onToggleTheme,
   currentTheme = 'light',
 }: SearchModalProps) => {
@@ -108,6 +111,19 @@ export const SearchModal = ({
       });
     }
 
+    if (onOpenFindReplaceAll) {
+      actions.push({
+        id: 'find-replace-all',
+        label: 'Find & Replace in All Docs',
+        icon: <Replace className="h-4 w-4" />,
+        action: () => {
+          onOpenFindReplaceAll();
+          onOpenChange(false);
+        },
+        keywords: ['find', 'replace', 'search', 'all', 'documents', 'bulk'],
+      });
+    }
+
     if (onToggleTheme) {
       actions.push({
         id: 'theme',
@@ -121,7 +137,7 @@ export const SearchModal = ({
     }
 
     return actions;
-  }, [onOpenSettings, onOpenTeams, onToggleTheme, currentTheme, onOpenChange]);
+  }, [onOpenSettings, onOpenTeams, onOpenFindReplaceAll, onToggleTheme, currentTheme, onOpenChange]);
 
   const searchResults = useMemo(() => {
     if (!query.trim()) return [];

--- a/packages/react-reason-editor/src/search/findReplaceAllDocs.test.ts
+++ b/packages/react-reason-editor/src/search/findReplaceAllDocs.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { searchAllDocuments, replaceInAllDocuments } from './findReplaceAllDocs';
+import type { Document } from '../documents/DocumentTree';
+
+function makeDoc(overrides: Partial<Document> & { id: string }): Document {
+  return {
+    title: 'Untitled',
+    content: '',
+    parentId: null,
+    children: [],
+    isExpanded: false,
+    ...overrides,
+  } as Document;
+}
+
+const documents: Document[] = [
+  makeDoc({ id: 'a', title: 'Alpha Notes', content: 'The quick brown fox jumps over the lazy fox.' }),
+  makeDoc({ id: 'b', title: 'Beta Notes', content: 'No matches here.' }),
+  makeDoc({ id: 'c', title: 'FOX file', content: 'A single Fox appears once.' }),
+  makeDoc({ id: 'folder', title: 'A Folder', content: 'fox', isFolder: true }),
+  makeDoc({ id: 'deleted', title: 'Trashed', content: 'fox', isDeleted: true }),
+];
+
+describe('searchAllDocuments', () => {
+  it('returns [] for a blank query', () => {
+    expect(searchAllDocuments(documents, '')).toEqual([]);
+    expect(searchAllDocuments(documents, '   ')).toEqual([]);
+  });
+
+  it('matches case-insensitively by default and counts every occurrence', () => {
+    const results = searchAllDocuments(documents, 'fox');
+
+    expect(results.map((r) => r.documentId)).toEqual(['a', 'c']);
+    expect(results[0].matchCount).toBe(2);
+    expect(results[1].matchCount).toBe(1);
+  });
+
+  it('skips folders and deleted documents', () => {
+    const results = searchAllDocuments(documents, 'fox');
+    expect(results.some((r) => r.documentId === 'folder')).toBe(false);
+    expect(results.some((r) => r.documentId === 'deleted')).toBe(false);
+  });
+
+  it('respects the caseSensitive option', () => {
+    const results = searchAllDocuments(documents, 'Fox', { caseSensitive: true });
+    expect(results.map((r) => r.documentId)).toEqual(['c']);
+  });
+
+  it('builds a truncated snippet around the first match', () => {
+    const long = makeDoc({
+      id: 'long',
+      title: 'Long doc',
+      content: 'x'.repeat(100) + 'NEEDLE' + 'y'.repeat(100),
+    });
+    const [result] = searchAllDocuments([long], 'NEEDLE');
+
+    expect(result.snippet.startsWith('...')).toBe(true);
+    expect(result.snippet.endsWith('...')).toBe(true);
+    expect(result.snippet).toContain('NEEDLE');
+  });
+});
+
+describe('replaceInAllDocuments', () => {
+  it('is a no-op for a blank query', () => {
+    const result = replaceInAllDocuments(documents, '', 'bar');
+    expect(result).toEqual({ documents, changedIds: [], replacedCount: 0 });
+  });
+
+  it('replaces every occurrence across all matching documents', () => {
+    const result = replaceInAllDocuments(documents, 'fox', 'dog');
+
+    expect(result.changedIds).toEqual(['a', 'c']);
+    expect(result.replacedCount).toBe(3);
+
+    const docA = result.documents.find((d) => d.id === 'a')!;
+    const docC = result.documents.find((d) => d.id === 'c')!;
+    expect(docA.content).toBe('The quick brown dog jumps over the lazy dog.');
+    expect(docC.content).toBe('A single dog appears once.');
+  });
+
+  it('leaves non-matching documents untouched, by reference', () => {
+    const result = replaceInAllDocuments(documents, 'fox', 'dog');
+    const docB = result.documents.find((d) => d.id === 'b')!;
+    expect(docB).toBe(documents[1]);
+  });
+
+  it('does not modify folders or deleted documents even when their content matches', () => {
+    const result = replaceInAllDocuments(documents, 'fox', 'dog');
+    const folder = result.documents.find((d) => d.id === 'folder')!;
+    const deleted = result.documents.find((d) => d.id === 'deleted')!;
+    expect(folder.content).toBe('fox');
+    expect(deleted.content).toBe('fox');
+  });
+
+  it('skips documents listed in excludeIds', () => {
+    const result = replaceInAllDocuments(documents, 'fox', 'dog', { excludeIds: ['a'] });
+
+    expect(result.changedIds).toEqual(['c']);
+    const docA = result.documents.find((d) => d.id === 'a')!;
+    expect(docA).toBe(documents[0]);
+  });
+
+  it('respects the caseSensitive option', () => {
+    const result = replaceInAllDocuments(documents, 'Fox', 'dog', { caseSensitive: true });
+    expect(result.changedIds).toEqual(['c']);
+  });
+
+  it('inserts the replacement text literally, even when it looks like a $-substitution pattern', () => {
+    const doc = makeDoc({ id: 'price', title: 'Price doc', content: 'Cost: PLACEHOLDER' });
+    const result = replaceInAllDocuments([doc], 'PLACEHOLDER', '$100 ($&)');
+
+    expect(result.documents[0].content).toBe('Cost: $100 ($&)');
+  });
+});

--- a/packages/react-reason-editor/src/search/findReplaceAllDocs.ts
+++ b/packages/react-reason-editor/src/search/findReplaceAllDocs.ts
@@ -1,0 +1,129 @@
+/**
+ * @module findReplaceAllDocs
+ * @description Pure helpers for finding and replacing text across every
+ * document in the workspace, as opposed to the single-document Find & Replace
+ * extension (`extensions/SearchAndReplace`) which only operates on the
+ * document currently loaded into the Tiptap editor.
+ */
+import type { Document } from '../documents/DocumentTree';
+
+/** Options shared by {@link searchAllDocuments} and {@link replaceInAllDocuments}. */
+export interface FindReplaceOptions {
+  /** When `true`, matching is case-sensitive. Defaults to `false`. */
+  caseSensitive?: boolean;
+}
+
+/** A single document's match summary for a cross-document search. */
+export interface DocumentMatch {
+  documentId: string;
+  title: string;
+  matchCount: number;
+  /** Context around the first match, truncated with `...` when clipped. */
+  snippet: string;
+}
+
+/** Result of a cross-document replace-all operation. */
+export interface ReplaceAllResult {
+  /** The full document list with matching documents replaced in place. */
+  documents: Document[];
+  /** IDs of documents whose content actually changed. */
+  changedIds: string[];
+  /** Total number of individual occurrences replaced across all documents. */
+  replacedCount: number;
+}
+
+const SNIPPET_RADIUS = 40;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Folders and deleted documents have no searchable body content. */
+function isSearchable(doc: Document): boolean {
+  return !doc.isFolder && !doc.isDeleted;
+}
+
+function buildMatcher(query: string, options: FindReplaceOptions): RegExp {
+  return new RegExp(escapeRegExp(query), options.caseSensitive ? 'g' : 'gi');
+}
+
+/**
+ * Searches every searchable document's content for `query`, reporting a match
+ * count and a context snippet per matching document. Returns `[]` for a blank
+ * query.
+ */
+export function searchAllDocuments(
+  documents: Document[],
+  query: string,
+  options: FindReplaceOptions = {}
+): DocumentMatch[] {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const matcher = buildMatcher(trimmed, options);
+  const results: DocumentMatch[] = [];
+
+  for (const doc of documents) {
+    if (!isSearchable(doc)) continue;
+
+    const content = doc.content || '';
+    const matches = content.match(matcher);
+    if (!matches || matches.length === 0) continue;
+
+    const matchIndex = content.search(matcher);
+    const start = Math.max(0, matchIndex - SNIPPET_RADIUS);
+    const end = Math.min(content.length, matchIndex + trimmed.length + SNIPPET_RADIUS);
+    const snippet =
+      (start > 0 ? '...' : '') + content.slice(start, end) + (end < content.length ? '...' : '');
+
+    results.push({
+      documentId: doc.id,
+      title: doc.title || 'Untitled',
+      matchCount: matches.length,
+      snippet,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Replaces every occurrence of `query` with `replacement` across all
+ * searchable documents, skipping any document whose ID is in
+ * `options.excludeIds` (used to skip the document currently open in the
+ * editor, whose in-memory Tiptap state would otherwise silently overwrite the
+ * replacement on its next autosave). Documents with no match are returned
+ * by reference, unchanged. A blank query is a no-op.
+ */
+export function replaceInAllDocuments(
+  documents: Document[],
+  query: string,
+  replacement: string,
+  options: FindReplaceOptions & { excludeIds?: string[] } = {}
+): ReplaceAllResult {
+  const trimmed = query.trim();
+  if (!trimmed) {
+    return { documents, changedIds: [], replacedCount: 0 };
+  }
+
+  const excludeIds = new Set(options.excludeIds ?? []);
+  const matcher = buildMatcher(trimmed, options);
+  const changedIds: string[] = [];
+  let replacedCount = 0;
+
+  const nextDocuments = documents.map((doc) => {
+    if (!isSearchable(doc) || excludeIds.has(doc.id)) return doc;
+
+    const content = doc.content || '';
+    const matches = content.match(matcher);
+    if (!matches || matches.length === 0) return doc;
+
+    replacedCount += matches.length;
+    changedIds.push(doc.id);
+    // Replace via a function so `replacement` is inserted literally, never
+    // interpreted as a `$&`/`$1`-style substitution pattern.
+    return { ...doc, content: content.replace(matcher, () => replacement) };
+  });
+
+  return { documents: nextDocuments, changedIds, replacedCount };
+}


### PR DESCRIPTION
## Summary
- Adds a "Find & Replace in All Docs" dialog, reachable from the existing Ctrl/Cmd+K command palette (`SearchModal`), that searches every document's content and replaces all matches across every matching document in one confirmed action, with a live per-document match-count preview.
- The document currently open in the editor is intentionally excluded from the bulk replace (and flagged in the UI): `TiptapEditorWrapper` only reloads editor content when the document ID changes, so an external content change to the open doc would otherwise be silently overwritten by the editor's own debounced autosave. The in-editor Find & Replace (`extensions/SearchAndReplace`) still covers that case.
- New pure helpers in `packages/react-reason-editor/src/search/findReplaceAllDocs.ts` (`searchAllDocuments`, `replaceInAllDocuments`) do the actual matching/replacing over the in-memory `Document[]` list (skipping folders/deleted docs, literal-not-regex replacement so `$`-looking replacement text is never treated as a substitution pattern).
- `useReasonDocsState.handleReplaceInAllDocuments` wires the replace into the existing `setDocuments` / `queueDocumentForSync` persistence path (same pattern already used by `handleUpdateDocument`).

## Validation
- [x] `cd packages/react-reason-editor && bun run test` (Vitest) — 3 files, 28 tests passed (12 new for `findReplaceAllDocs`, 16 pre-existing).
- [x] `cd packages/react-reason-editor && bunx tsc --noEmit -p tsconfig.json` — no errors in any file touched by this change. The command does report 3 pre-existing syntax errors in `src/types/constants.types.ts`, confirmed via `git stash` to exist identically on `master` before this PR.
- [ ] `cd packages/react-reason-editor && bun run build:lib` — blocked by pre-existing issues unrelated to this change, also confirmed via `git stash` to exist identically on `master`: a missing build entry file (`src/extensions/Zoom/Zoom.ts` doesn't exist) and several pre-existing type errors (`InviteModal.tsx`, `Toolbar.tsx`/`pluginRegistry.tsx` importing a nonexistent `react-reason-editor/wordcount` subpath, `Pagination.ts`, `filetree.tsx`, `constants.types.ts`). Filed as TODO #39.

## Task tracking
- Implements: TODO.md item 6, "Find/replace across all docs" (moved to Completed)
- Follow-ups:
  - TODO.md #38 — include the currently-open document in the bulk replace once there's a safe way to force `TiptapEditorWrapper` to reload content after an external update.
  - TODO.md #39 — pre-existing `packages/react-reason-editor` `build:lib` breakage (missing `Zoom.ts` entry, several unrelated type errors), independent of this change.

## Notes for reviewers
- No backend/schema changes — this operates entirely on the in-memory `documents` array already synced via `useDocumentSync`/`grab-url`.
- The repo's only CI workflow that runs on push (`test-web-api.yml`) is scoped to `apps/qwksearch-web` + a couple of other packages and doesn't cover `react-reason-editor`, so I ran its Vitest/tsc checks locally as shown above.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbH94RgfDMZawaFaTDVAUX)_