### PR TITLE
Fix react-reason-editor's broken library build

### DIFF
--- a/packages/react-reason-editor/package.json
+++ b/packages/react-reason-editor/package.json
@@ -190,6 +190,9 @@
       ],
       "./officepaste": [
         "./dist/extensions/OfficePaste/index.d.ts"
+      ],
+      "./zoom": [
+        "./dist/extensions/Zoom/index.d.ts"
       ]
     }
   },
@@ -739,6 +742,16 @@
       "import": {
         "types": "./dist/extensions/OfficePaste/index.d.ts",
         "default": "./dist/OfficePaste.js"
+      }
+    },
+    "./zoom": {
+      "require": {
+        "types": "./dist/extensions/Zoom/index.d.ts",
+        "default": "./dist/Zoom.cjs"
+      },
+      "import": {
+        "types": "./dist/extensions/Zoom/index.d.ts",
+        "default": "./dist/Zoom.js"
       }
     }
   },

--- a/packages/react-reason-editor/src/extensions/Zoom/Zoom.ts
+++ b/packages/react-reason-editor/src/extensions/Zoom/Zoom.ts
@@ -1,0 +1,9 @@
+/**
+ * Public surface of the Zoom extension, which scales the editor content. Unlike
+ * most extensions this one has no Tiptap extension of its own — zooming is a DOM
+ * transform driven from the toolbar — so this module only re-exports the React
+ * control and the zoom helpers. It exists as a top-level module because the
+ * library build derives one entry per `src/extensions/<Name>/<Name>.ts`.
+ */
+
+export * from './components/RichTextZoom';

--- a/packages/react-reason-editor/src/extensions/Zoom/index.ts
+++ b/packages/react-reason-editor/src/extensions/Zoom/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Entry point for the Zoom extension that re-exports the zoom control and its helpers. Lets the app import editor zooming from a single, stable module path.
+ */
+
+export * from './Zoom';

--- a/packages/react-reason-editor/src/types/constants.types.ts
+++ b/packages/react-reason-editor/src/types/constants.types.ts
@@ -3,15 +3,13 @@
 /** Default language value type */
 export type DEFAULT_LANG_VALUE = 'en';
 
-/** Throttle time constant types (milliseconds) */
-type EDITOR_UPDATE_THROTTLE_WAIT_TIME_TYPE = 200;
-type EDITOR_UPDATE_WATCH_THROTTLE_WAIT_TIME_TYPE = typeof EDITOR_UPDATE_THROTTLE_WAIT_TIME - 80;
-
-export { DEFAULT_LANG_VALUE };
-
 /** Throttle time for editor input (milliseconds) */
-const EDITOR_UPDATE_THROTTLE_WAIT_TIME: number = 200;
+export type EDITOR_UPDATE_THROTTLE_WAIT_TIME_TYPE = 200;
 
-/** Watch throttling time must be less than update time otherwise cursor position reaches end (ms) */
-const EDITOR_UPDATE_WATCH_THROTTLE_WAIT_TIME: typeof EDITOR_UPDATE_THROTTLE_WAIT_TIME - 80 = 
-  (typeof 'string' === undefined ? 1 : null); // eslint-disable-line @typescript-eslint/ban-types
+/**
+ * Watch throttling time must be less than the update time, otherwise the
+ * cursor position reaches the end (milliseconds). Spelled as the resolved
+ * literal because arithmetic on a `typeof` is not valid in type position —
+ * it has to stay in sync with the value in `@/constants` by hand.
+ */
+export type EDITOR_UPDATE_WATCH_THROTTLE_WAIT_TIME_TYPE = 120;

--- a/packages/react-reason-editor/vite.config.ts
+++ b/packages/react-reason-editor/vite.config.ts
@@ -69,8 +69,14 @@ export default defineConfig(async ({ mode }) => {
     path.resolve(__dirname, 'src/reason-docs.ts'),
   ];
 
+  // Only the extension directory name is read off each match, so any stray
+  // .ts anywhere under an extension is enough to declare an entry at
+  // src/extensions/<Name>/<Name>.ts. Colocated tests must therefore be
+  // ignored alongside index.ts: a test file in a component-only extension
+  // (Subscript, Superscript) would otherwise demand an entry module that
+  // does not exist and fail the build with UNRESOLVED_ENTRY.
   const files = await globbySync('src/extensions/**/*.ts', {
-    ignore: ['src/**/*/index.ts', 'src/**/*.spec.ts'], // Exclude .spec.ts files
+    ignore: ['src/**/*/index.ts', 'src/**/*.spec.ts', 'src/**/*.test.ts'],
   });
 
   const exports = {};


### PR DESCRIPTION
`bun run build:lib` failed on master, which also broke qwksearch-web's
prebuild since that chains into this package's build:lib.

Two independent causes:

Unresolvable Zoom entry. vite.config.ts globs src/extensions/**/*.ts and
reads only the extension directory name off each match, deriving an entry
at src/extensions/<Name>/<Name>.ts. Zoom is a component-only extension
with no such module, but its colocated RichTextZoom.test.ts matched the
glob, so the build demanded src/extensions/Zoom/Zoom.ts and died with
UNRESOLVED_ENTRY. Give Zoom the entry module and index.ts re-export that
its siblings have, so it participates in the multi-entry build properly,
and add the matching ./zoom subpath to package.json — without it the
built dist/Zoom.js is unreachable, since the ./* catchall maps to the
lowercase ./dist/zoom. Also ignore *.test.ts alongside *.spec.ts when
globbing entries: the remaining component-only extensions (Subscript,
Superscript) would hit the same failure the moment a test lands next to
them.

Syntax errors in src/types/constants.types.ts. The file used
`typeof X - 80` in type position, which is not valid TypeScript, and
re-exported a type without `export type` under isolatedModules. It also
declared runtime consts duplicating the real ones in src/constants. Cut
those and leave valid, exported literal types.

Verified: build:lib exits 0, the Zoom entry emits dist/Zoom.js,
dist/Zoom.cjs and dist/extensions/Zoom/index.d.ts with the expected
exports, and the package's 38 tests pass. Seven unrelated type errors
remain elsewhere in src (InviteModal, Toolbar, pluginRegistry,
Pagination, filetree); they are pre-existing, reported by unplugin-dts
without failing the build, and left alone here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012D7qyP3HHsCGgia48jBwcQ