### PR TITLE
fix(reason-editor): base design tokens on stock shadcn so tooltips re…

### DIFF
--- a/packages/react-reason-editor/demo/src/styles.css
+++ b/packages/react-reason-editor/demo/src/styles.css
@@ -18,38 +18,44 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* shadcn-style design tokens used by the organizer UI (bg-background,
-   border-border, text-muted-foreground, ...). Values mirror the lib's
-   THEME.light.default / THEME.dark.default in src/theme/theme.ts; inside
-   the editor the lib re-injects the same variables scoped to
-   .reactjs-tiptap-editor, so both layers stay in sync. */
+   border-border, text-muted-foreground, ...). These are the stock shadcn
+   defaults, in the standard whole-color (`oklch(...)`) form, so they line up
+   with the same token set the lib ships as a fallback in
+   src/styles/global.scss; inside the editor the lib re-injects equivalent
+   variables scoped to .reactjs-tiptap-editor, so both layers stay in sync. */
 @theme inline {
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
-  --color-popover: hsl(var(--popover));
-  --color-popover-foreground: hsl(var(--popover-foreground));
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
-  --color-secondary: hsl(var(--secondary));
-  --color-secondary-foreground: hsl(var(--secondary-foreground));
-  --color-muted: hsl(var(--muted));
-  --color-muted-foreground: hsl(var(--muted-foreground));
-  --color-accent: hsl(var(--accent));
-  --color-accent-foreground: hsl(var(--accent-foreground));
-  --color-destructive: hsl(var(--destructive));
-  --color-destructive-foreground: hsl(var(--destructive-foreground));
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
-  --color-sidebar: hsl(var(--background));
-  --color-sidebar-foreground: hsl(var(--foreground));
-  --color-sidebar-primary: hsl(var(--primary));
-  --color-sidebar-primary-foreground: hsl(var(--primary-foreground));
-  --color-sidebar-accent: hsl(var(--accent));
-  --color-sidebar-accent-foreground: hsl(var(--accent-foreground));
-  --color-sidebar-border: hsl(var(--border));
-  --color-sidebar-ring: hsl(var(--ring));
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
   --radius-xl: calc(var(--radius) + 4px);
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
@@ -57,48 +63,74 @@
 }
 
 :root {
-  --radius: 0.65rem;
-  --background: 0 0% 100%;
-  --foreground: 240 10% 3.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
-  --primary: 240 5.9% 10%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 240 4.8% 95.9%;
-  --secondary-foreground: 240 5.9% 10%;
-  --muted: 240 4.8% 95.9%;
-  --muted-foreground: 240 3.8% 46.1%;
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 240 5.9% 90%;
-  --input: 240 5.9% 90%;
-  --ring: 240 5.9% 10%;
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-  --background: 240 10% 3.9%;
-  --foreground: 0 0% 98%;
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
-  --primary: 0 0% 98%;
-  --primary-foreground: 240 5.9% 10%;
-  --secondary: 240 3.7% 15.9%;
-  --secondary-foreground: 0 0% 98%;
-  --muted: 240 3.7% 15.9%;
-  --muted-foreground: 240 5% 64.9%;
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 240 3.7% 15.9%;
-  --input: 240 3.7% 15.9%;
-  --ring: 240 4.9% 83.9%;
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 /* Tailwind v4 changed the default `border`/`divide` color to `currentColor`.
@@ -111,15 +143,15 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: hsl(var(--border));
+    border-color: var(--border);
   }
 }
 
 body {
   font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial;
   margin: 0;
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
+  background-color: var(--background);
+  color: var(--foreground);
 }
 
 .tiptap {

--- a/packages/react-reason-editor/src/app-styles/split-pane.css
+++ b/packages/react-reason-editor/src/app-styles/split-pane.css
@@ -25,21 +25,21 @@
   transform: translateX(-50%);
   width: 2px;
   height: 100%;
-  background-color: hsl(var(--border));
+  background-color: var(--border);
   border-radius: 2px;
   transition: width 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .split-pane-divider.horizontal:hover,
 .split-pane-divider.horizontal.dragging {
-  background-color: hsl(var(--primary) / 0.08);
+  background-color: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
 .split-pane-divider.horizontal:hover::before,
 .split-pane-divider.horizontal.dragging::before {
   width: 3px;
-  background-color: hsl(var(--primary));
-  box-shadow: 0 0 8px hsl(var(--primary) / 0.45);
+  background-color: var(--primary);
+  box-shadow: 0 0 8px color-mix(in oklab, var(--primary) 45%, transparent);
 }
 
 /* ── Vertical split (top/bottom panes) ── horizontal bar ── */
@@ -56,19 +56,19 @@
   transform: translateY(-50%);
   height: 2px;
   width: 100%;
-  background-color: hsl(var(--border));
+  background-color: var(--border);
   border-radius: 2px;
   transition: height 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .split-pane-divider.vertical:hover,
 .split-pane-divider.vertical.dragging {
-  background-color: hsl(var(--primary) / 0.08);
+  background-color: color-mix(in oklab, var(--primary) 8%, transparent);
 }
 
 .split-pane-divider.vertical:hover::before,
 .split-pane-divider.vertical.dragging::before {
   height: 3px;
-  background-color: hsl(var(--primary));
-  box-shadow: 0 0 8px hsl(var(--primary) / 0.45);
+  background-color: var(--primary);
+  box-shadow: 0 0 8px color-mix(in oklab, var(--primary) 45%, transparent);
 }

--- a/packages/react-reason-editor/src/app-ui/sidebar.tsx
+++ b/packages/react-reason-editor/src/app-ui/sidebar.tsx
@@ -503,7 +503,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1.5px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1.5px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1.5px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1.5px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",

--- a/packages/react-reason-editor/src/app-ui/tooltip.tsx
+++ b/packages/react-reason-editor/src/app-ui/tooltip.tsx
@@ -50,7 +50,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-2xl px-3 py-1.5 text-xs text-balance",
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}

--- a/packages/react-reason-editor/src/components/Bubble/RichTextBubbleKatex.tsx
+++ b/packages/react-reason-editor/src/components/Bubble/RichTextBubbleKatex.tsx
@@ -95,7 +95,7 @@ function ModalEditKatex({ children, visible, toggleVisible }: any) {
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>{t('editor.formula.dialog.text')}</DialogTitle>
 
-        <div style={{ height: '100%', border: '1px solid hsl(var(--border))' }}>
+        <div style={{ height: '100%', border: '1px solid var(--border)' }}>
           <div className='richtext-flex richtext-gap-[10px] richtext-rounded-[10px] richtext-p-[10px]'>
             <div className='richtext-flex-1'>
               <Label className='mb-[6px]'>Expression</Label>
@@ -109,7 +109,7 @@ function ModalEditKatex({ children, visible, toggleVisible }: any) {
                 rows={10}
                 value={currentValue}
                 style={{
-                  color: 'hsl(var(--foreground))',
+                  color: 'var(--foreground)',
                 }}
               />
 
@@ -121,7 +121,7 @@ function ModalEditKatex({ children, visible, toggleVisible }: any) {
                 rows={10}
                 value={currentMacros}
                 style={{
-                  color: 'hsl(var(--foreground))',
+                  color: 'var(--foreground)',
                 }}
               />
             </div>

--- a/packages/react-reason-editor/src/components/ui/sidebar.tsx
+++ b/packages/react-reason-editor/src/components/ui/sidebar.tsx
@@ -503,7 +503,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background shadow-[0_0_0_1.5px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1.5px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1.5px_var(--sidebar-border)] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1.5px_var(--sidebar-accent)]",
       },
       size: {
         default: "h-8 text-sm",

--- a/packages/react-reason-editor/src/editor-views/config/baseKit.ts
+++ b/packages/react-reason-editor/src/editor-views/config/baseKit.ts
@@ -24,7 +24,7 @@ export function buildBaseKit(): any[] {
     Text,
     Dropcursor.configure({
       class: 'react-reason-editor-theme',
-      color: 'hsl(var(--primary))',
+      color: 'var(--primary)',
       width: 2,
     }),
     Gapcursor,

--- a/packages/react-reason-editor/src/extensions/Attachment/components/NodeViewAttachment/index.module.scss
+++ b/packages/react-reason-editor/src/extensions/Attachment/components/NodeViewAttachment/index.module.scss
@@ -3,7 +3,7 @@
   /* for NodeView */
   border-width: 1px !important;
   border-radius: var(--radius) !important;
-  border-color: hsl(var(--border)) !important;
+  border-color: var(--border) !important;
   padding: 8px;
   display: flex;
   align-items: center;

--- a/packages/react-reason-editor/src/extensions/Drawio/components/NodeViewDrawio/index.module.scss
+++ b/packages/react-reason-editor/src/extensions/Drawio/components/NodeViewDrawio/index.module.scss
@@ -5,7 +5,7 @@
   line-height: 0;
 
   .renderWrap {
-    border: 1px dashed hsl(var(--border)) !important;
+    border: 1px dashed var(--border) !important;
     border-radius: 6px;
 
     &::after {
@@ -37,7 +37,7 @@
     bottom: 10px;
     z-index: 2;
     padding: 2px 4px;
-    border: 1px solid hsl(var(--border));
+    border: 1px solid var(--border);
     border-radius: 6px;
   }
 }
@@ -48,7 +48,7 @@
 
 .active {
   .renderWrap {
-    border-color: hsl(var(--primary)) !important;
-    box-shadow: 0 0 0 2px hsl(var(--primary) / 0.1);
+    border-color: var(--primary) !important;
+    box-shadow: 0 0 0 2px color-mix(in oklab, var(--primary) 10%, transparent);
   }
 }

--- a/packages/react-reason-editor/src/extensions/Iframe/components/index.module.scss
+++ b/packages/react-reason-editor/src/extensions/Iframe/components/index.module.scss
@@ -5,7 +5,7 @@
   overflow: hidden;
   line-height: 0;
   flex-direction: column;
-  border: 1px dashed hsl(var(--border)) !important;
+  border: 1px dashed var(--border) !important;
   border-radius: 6px;
 
   .handlerWrap {

--- a/packages/react-reason-editor/src/extensions/Katex/components/RichTextKatex.tsx
+++ b/packages/react-reason-editor/src/extensions/Katex/components/RichTextKatex.tsx
@@ -107,7 +107,7 @@ export function RichTextKatex() {
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>{t('editor.formula.dialog.text')}</DialogTitle>
 
-        <div style={{ height: '100%', border: '1px solid hsl(var(--border))' }}>
+        <div style={{ height: '100%', border: '1px solid var(--border)' }}>
           <div className='richtext-flex richtext-gap-[10px] richtext-rounded-[10px] richtext-p-[10px]'>
             <div className='richtext-flex-1'>
               <Label className='mb-[6px]'>Expression</Label>
@@ -121,7 +121,7 @@ export function RichTextKatex() {
                 rows={10}
                 value={currentValue}
                 style={{
-                  color: 'hsl(var(--foreground))',
+                  color: 'var(--foreground)',
                 }}
               />
 
@@ -136,7 +136,7 @@ export function RichTextKatex() {
                   setCurrentMacros(e.target.value);
                 }}
                 style={{
-                  color: 'hsl(var(--foreground))',
+                  color: 'var(--foreground)',
                 }}
               />
             </div>

--- a/packages/react-reason-editor/src/extensions/Mermaid/components/EditMermaidBlock.tsx
+++ b/packages/react-reason-editor/src/extensions/Mermaid/components/EditMermaidBlock.tsx
@@ -126,7 +126,7 @@ export const EditMermaidBlock: React.FC<IProps> = ({ editor, attrs, extension })
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>Edit Mermaid</DialogTitle>
 
-        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid hsl(var(--border))' }}>
+        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid var(--border)' }}>
           <div className='richtext-flex richtext-gap-[10px] richtext-rounded-[10px] richtext-p-[10px]'>
             <Textarea
               autoFocus
@@ -138,7 +138,7 @@ export const EditMermaidBlock: React.FC<IProps> = ({ editor, attrs, extension })
               rows={10}
               value={mermaidCode}
               style={{
-                color: 'hsl(var(--foreground))',
+                color: 'var(--foreground)',
               }}
             />
 
@@ -148,7 +148,7 @@ export const EditMermaidBlock: React.FC<IProps> = ({ editor, attrs, extension })
               ref={mermaidRef as any}
               style={{
                 height: '100%',
-                border: '1px solid hsl(var(--border))',
+                border: '1px solid var(--border)',
                 minHeight: 500,
               }}
             />

--- a/packages/react-reason-editor/src/extensions/Mermaid/components/RichTextMermaid.tsx
+++ b/packages/react-reason-editor/src/extensions/Mermaid/components/RichTextMermaid.tsx
@@ -141,7 +141,7 @@ export function RichTextMermaid() {
       <DialogContent className='richtext-z-[99999] !richtext-max-w-[1300px]'>
         <DialogTitle>Mermaid</DialogTitle>
 
-        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid hsl(var(--border))' }}>
+        <div ref={loadMermaid} style={{ height: '100%', border: '1px solid var(--border)' }}>
           {loading ? (
             <p>Loading...</p>
           ) : (
@@ -156,7 +156,7 @@ export function RichTextMermaid() {
                   rows={10}
                   value={mermaidCode}
                   style={{
-                    color: 'hsl(var(--foreground))',
+                    color: 'var(--foreground)',
                   }}
                 />
 

--- a/packages/react-reason-editor/src/store/ThemeColorReactive.tsx
+++ b/packages/react-reason-editor/src/store/ThemeColorReactive.tsx
@@ -29,11 +29,16 @@ export function ThemeColorReactive() {
       div[data-richtext-portal], div[data-richtext-portal] * {
         ${Object.entries(themeObject)
           .map(([key, value]) => {
-            if (typeof borderRadius === 'string' && key === 'radius') {
-              return `--${key}: ${borderRadius};`;
+            if (key === 'radius') {
+              return `--${key}: ${typeof borderRadius === 'string' ? borderRadius : value};`;
             }
 
-            return `--${key}: ${value};`;
+            // THEME stores palettes as bare HSL channel triplets. Emit them as
+            // whole `hsl()` colors so the variables match the shadcn token
+            // format every consumer's Tailwind expects — a bare triplet in a
+            // `background-color: var(--popover)` is invalid and drops the
+            // declaration, leaving portalled surfaces unstyled.
+            return `--${key}: hsl(${value});`;
           })
           .join('\n')}
       }

--- a/packages/react-reason-editor/src/styles/columns.scss
+++ b/packages/react-reason-editor/src/styles/columns.scss
@@ -9,7 +9,7 @@
     padding: 12px;
     border-width: 1px;
     border-style: solid;
-    border-color: hsl(var(--border));
+    border-color: var(--border);
     border-radius: 2px;
     flex: 1 1 0%;
     box-sizing: border-box;

--- a/packages/react-reason-editor/src/styles/editor.scss
+++ b/packages/react-reason-editor/src/styles/editor.scss
@@ -1,7 +1,7 @@
 
 .reactjs-tiptap-editor {
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
+  background-color: var(--background);
+  color: var(--foreground);
   // Fill the host container so height constraints propagate to the editor.
   // Resolves to `auto` (content height) when the parent is auto-height, so the
   // common page-grows embedding is unaffected; when the parent is bounded (e.g.
@@ -72,7 +72,7 @@
         @apply richtext-bg-black/5 dark:richtext-bg-white/10;
 
         hr {
-          border-top-color: hsl(var(--foreground)) !important;
+          border-top-color: var(--foreground) !important;
         }
       }
 
@@ -88,7 +88,7 @@
 
     :not(.image-view)::selection,
     :not(.search-result)::selection {
-      background-color: hsl(var(--accent)) !important;
+      background-color: var(--accent) !important;
     }
 
     .is-empty::before {
@@ -167,7 +167,7 @@
 
         &--focused:hover,
         &--resizing:hover {
-          outline-color: hsl(var(--primary));
+          outline-color: var(--primary);
         }
 
         &__placeholder {
@@ -186,7 +186,7 @@
       }
 
       .image-view__body--focused {
-        outline-color: hsl(var(--primary)) !important;
+        outline-color: var(--primary) !important;
       }
 
       &.focus {
@@ -220,7 +220,7 @@
         height: 12px;
         border: 1px solid #fff;
         border-radius: 2px;
-        background-color: hsl(var(--primary));
+        background-color: var(--primary);
 
         &--tl {
           top: -6px;
@@ -266,12 +266,12 @@
   }
 
   .ProseMirror {
-    caret-color: hsl(var(--richtext-text-foreground)) !important;
+    caret-color: var(--foreground) !important;
   }
 }
 
 .bg-item-active.bg-item-active {
-  background-color: hsl(var(--accent)) !important;
+  background-color: var(--accent) !important;
 }
 
 .heading-1 {

--- a/packages/react-reason-editor/src/styles/global.scss
+++ b/packages/react-reason-editor/src/styles/global.scss
@@ -2,51 +2,94 @@
 @tailwind components;
 @tailwind utilities;
 
-// shadcn UI design tokens - light theme
-:root {
-  --radius: 0.65rem;
-  --background: 0 0% 100%;
-  --foreground: 240 10% 3.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
-  --primary: 240 5.9% 10%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 240 4.8% 95.9%;
-  --secondary-foreground: 240 5.9% 10%;
-  --muted: 240 4.8% 95.9%;
-  --muted-foreground: 240 3.8% 46.1%;
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 240 5.9% 90%;
-  --input: 240 5.9% 90%;
-  --ring: 240 5.9% 10%;
+// Stock shadcn/ui design tokens (the `new-york`/neutral defaults), verbatim.
+//
+// Two things about this block matter, and both exist because this stylesheet
+// is shipped as `react-reason-editor/style.css` into host apps that have their
+// own shadcn theme:
+//
+// 1. The values are whole colors (`oklch(...)`), not the legacy bare HSL
+//    channel triplets this file used to carry. Current shadcn — and therefore
+//    every host on Tailwind v4 — maps `--color-popover: var(--popover)` and
+//    expects a complete color. A triplet like `0 0% 100%` dropped into that
+//    slot is invalid at computed-value time, so `bg-popover`,
+//    `text-popover-foreground` and `border-border` silently resolve to
+//    nothing: portalled tooltips render as unformatted text on a transparent
+//    box. Matching the standard format keeps host utilities working.
+// 2. The selectors are wrapped in `:where()`, which zeroes their specificity.
+//    A host's own `:root { ... }` / `.dark { ... }` therefore always wins, no
+//    matter which stylesheet the bundler emits last, so these act purely as
+//    fallbacks for consumers that render the editor without a shadcn theme of
+//    their own.
+:where(:root) {
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
-// shadcn UI design tokens - dark theme
-.dark {
-  --background: 240 10% 3.9%;
-  --foreground: 0 0% 98%;
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
-  --primary: 0 0% 98%;
-  --primary-foreground: 240 5.9% 10%;
-  --secondary: 240 3.7% 15.9%;
-  --secondary-foreground: 0 0% 98%;
-  --muted: 240 3.7% 15.9%;
-  --muted-foreground: 240 5% 64.9%;
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
-  --destructive: 0 62.8% 30.6%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 240 3.7% 15.9%;
-  --input: 240 3.7% 15.9%;
-  --ring: 240 4.9% 83.9%;
+:where(.dark) {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 // https://github.com/radix-ui/primitives/issues/1496

--- a/packages/react-reason-editor/src/styles/mention.scss
+++ b/packages/react-reason-editor/src/styles/mention.scss
@@ -1,6 +1,6 @@
 [data-type='mention'] {
-  color: hsl(var(--primary));
-  background: hsl(var(--muted));
+  color: var(--primary);
+  background: var(--muted);
   padding: 2px 4px;
   border-radius: 6px;
 }

--- a/packages/react-reason-editor/src/styles/shadcnTokens.test.ts
+++ b/packages/react-reason-editor/src/styles/shadcnTokens.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Guards the shape of the shadcn design tokens this package ships.
+ *
+ * `react-reason-editor/style.css` is loaded into host apps that have their own
+ * shadcn theme, so two properties of the token block are load-bearing and easy
+ * to regress by hand:
+ *
+ *  - values must be whole colors, not the legacy bare HSL channel triplets.
+ *    Current shadcn maps `--color-popover: var(--popover)`, so a triplet is
+ *    invalid at computed-value time and silently drops `bg-popover`,
+ *    `text-popover-foreground` and friends — which is what left portalled
+ *    tooltips rendering unformatted.
+ *  - selectors must stay wrapped in `:where()` so a host's own `:root` /
+ *    `.dark` always wins on specificity regardless of stylesheet order.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { THEME } from '../theme/theme';
+
+const globalScss = fs.readFileSync(path.resolve(__dirname, 'global.scss'), 'utf-8');
+
+/** Parses the `--name: value;` pairs declared under `selector { ... }`. */
+function tokensOf(selector: string): Record<string, string> {
+  const start = globalScss.indexOf(`${selector} {`);
+
+  if (start === -1) return {};
+
+  const block = globalScss.slice(start, globalScss.indexOf('\n}', start));
+  const tokens: Record<string, string> = {};
+
+  for (const [, name, value] of block.matchAll(/(--[\w-]+):\s*([^;]+);/g)) {
+    tokens[name] = value.trim();
+  }
+
+  return tokens;
+}
+
+const LIGHT = tokensOf(':where(:root)');
+const DARK = tokensOf(':where(.dark)');
+
+// A bare `0 0% 100%` — the legacy shadcn-v3 convention that broke host themes.
+const BARE_HSL_TRIPLET = /^-?[\d.]+(deg)? -?[\d.]+% -?[\d.]+%/;
+
+describe('shipped shadcn design tokens', () => {
+  it('defines the light and dark palettes', () => {
+    expect(Object.keys(LIGHT).length).toBeGreaterThan(20);
+    expect(Object.keys(DARK).length).toBeGreaterThan(20);
+  });
+
+  it('covers the token set the components reference', () => {
+    for (const token of [
+      '--background',
+      '--foreground',
+      '--popover',
+      '--popover-foreground',
+      '--primary',
+      '--primary-foreground',
+      '--border',
+      '--sidebar',
+      '--sidebar-border',
+    ]) {
+      expect(LIGHT).toHaveProperty(token);
+    }
+  });
+
+  it.each([
+    ['light', LIGHT],
+    ['dark', DARK],
+  ])('states %s colors as whole colors, not bare HSL triplets', (_name, tokens) => {
+    for (const [token, value] of Object.entries(tokens)) {
+      if (token === '--radius') continue;
+
+      expect(value, `${token} must be a whole color`).not.toMatch(BARE_HSL_TRIPLET);
+      expect(value, `${token} must be a whole color`).toMatch(
+        /^(oklch|hsl|rgb|color|var|#)/
+      );
+    }
+  });
+
+  it('keeps both blocks at zero specificity so host themes win', () => {
+    // A `:root` / `.dark` selector that is not wrapped in `:where()` would
+    // outrank the host app's own token block whenever this stylesheet happens
+    // to be emitted last.
+    const unscoped = globalScss.match(/^\s*(:root|\.dark)\s*\{/gm);
+
+    expect(unscoped).toBeNull();
+  });
+
+  it('wraps the runtime theme palettes in hsl() rather than emitting triplets', () => {
+    // ThemeColorReactive injects THEME entries as custom properties. The
+    // palettes are stored as triplets, so the injector must add the hsl()
+    // wrapper — see ThemeColorReactive for the emit site.
+    const injector = fs.readFileSync(
+      path.resolve(__dirname, '../store/ThemeColorReactive.tsx'),
+      'utf-8'
+    );
+
+    expect(injector).toContain('hsl(${value})');
+    expect(THEME.light.default.popover).toMatch(BARE_HSL_TRIPLET);
+  });
+});

--- a/packages/react-reason-editor/tailwind.config.js
+++ b/packages/react-reason-editor/tailwind.config.js
@@ -32,39 +32,59 @@ export default {
       },
     },
     extend: {
+      // Tokens hold whole colors (`oklch(...)`), matching current shadcn, so
+      // they are consumed directly rather than wrapped in `hsl()`. See
+      // src/styles/global.scss for why the standard format is load-bearing.
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        border: 'var(--border)',
+        input: 'var(--input)',
+        ring: 'var(--ring)',
+        background: 'var(--background)',
+        foreground: 'var(--foreground)',
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
+          DEFAULT: 'var(--primary)',
+          foreground: 'var(--primary-foreground)',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+          DEFAULT: 'var(--secondary)',
+          foreground: 'var(--secondary-foreground)',
         },
         destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
+          DEFAULT: 'var(--destructive)',
+          foreground: 'var(--destructive-foreground)',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: 'var(--muted)',
+          foreground: 'var(--muted-foreground)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: 'var(--accent)',
+          foreground: 'var(--accent-foreground)',
         },
         popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+          DEFAULT: 'var(--popover)',
+          foreground: 'var(--popover-foreground)',
         },
         card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
+          DEFAULT: 'var(--card)',
+          foreground: 'var(--card-foreground)',
+        },
+        sidebar: {
+          DEFAULT: 'var(--sidebar)',
+          foreground: 'var(--sidebar-foreground)',
+          primary: 'var(--sidebar-primary)',
+          'primary-foreground': 'var(--sidebar-primary-foreground)',
+          accent: 'var(--sidebar-accent)',
+          'accent-foreground': 'var(--sidebar-accent-foreground)',
+          border: 'var(--sidebar-border)',
+          ring: 'var(--sidebar-ring)',
+        },
+        chart: {
+          1: 'var(--chart-1)',
+          2: 'var(--chart-2)',
+          3: 'var(--chart-3)',
+          4: 'var(--chart-4)',
+          5: 'var(--chart-5)',
         },
       },
       borderRadius: {


### PR DESCRIPTION
…nder

The editor shipped its shadcn tokens in the legacy v3 convention — bare HSL channel triplets (`--popover: 0 0% 100%`) consumed as `hsl(var(--popover))`. `react-reason-editor/style.css` declared them on an unlayered `:root`, so in a host app it was emitted after the app's own theme and overwrote it.

Current shadcn maps `--color-popover: var(--popover)` and expects a whole color, so those triplets are invalid at computed-value time: `bg-popover`, `text-popover-foreground` and `border-border` were dropped wholesale. Portalled surfaces built from them — the sidebar tooltips most visibly — came out as unformatted text on a transparent box.

Adopt the stock shadcn token set as the base instead:

- Restate the light/dark palettes as the standard `oklch(...)` defaults, and add the sidebar/chart tokens the sidebar components already referenced.
- Wrap the selectors in `:where()` so they carry zero specificity. A host's own `:root` / `.dark` now always wins, whatever order the bundler emits, leaving these purely as fallbacks for consumers with no shadcn theme of their own.
- Read tokens directly as `var(--token)` across the Tailwind config, SCSS and inline styles; alpha-modified uses move to `color-mix()`.
- Wrap the runtime palettes ThemeColorReactive injects in `hsl()`, since THEME still stores triplets.
- Restore the stock `rounded-md` on the tooltip content.

Also fixes a caret-color rule that referenced `--richtext-text-foreground`, which no stylesheet defines.


Claude-Session: https://claude.ai/code/session_01Hv9p6eKmdmcKMneWgCbda6