### PR TITLE
Default the REASON editor zoom control to 125%

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,6 @@ ext - dl to reason dl folswe
 6. Find/replace across all docs.
 7. Option to start talking automatically on first visit, or via a button from anywhere on the site.
 8. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
-9. Reasoning view zoom default at 125%.
 10. common typoes
 11. https://github.com/cloudflare/moltworker
 

--- a/packages/reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx
+++ b/packages/reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx
@@ -26,8 +26,11 @@ function Toast({ message }: { message: string }) {
   );
 }
 
+/** Default zoom applied to the editor content on mount. */
+export const DEFAULT_ZOOM_SCALE = 1.25;
+
 export function RichTextZoom() {
-  const [scale, setScale] = useState(1);
+  const [scale, setScale] = useState(DEFAULT_ZOOM_SCALE);
   const [toast, setToast] = useState<string | null>(null);
 
   const showToast = (message: string) => {
@@ -55,6 +58,10 @@ export function RichTextZoom() {
       (editor as HTMLElement).style.transformOrigin = 'top left';
     }
   };
+
+  useEffect(() => {
+    applyZoom(DEFAULT_ZOOM_SCALE);
+  }, []);
 
   return (
     <>

--- a/packages/reason-editor/test/richtext-zoom.test.tsx
+++ b/packages/reason-editor/test/richtext-zoom.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Confirms the REASON editor's zoom toolbar control defaults to 125% on
+ * mount and that in/out clicks still step and clamp correctly from there.
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_ZOOM_SCALE, RichTextZoom } from '@/extensions/Zoom/components/RichTextZoom';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let proseMirror: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+
+  proseMirror = document.createElement('div');
+  proseMirror.className = 'ProseMirror';
+  document.body.append(proseMirror);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  proseMirror.remove();
+});
+
+function mount() {
+  act(() => {
+    root.render(<RichTextZoom />);
+  });
+}
+
+function zoomOutButton() {
+  return container.querySelector('button[title^="Zoom Out"]') as HTMLButtonElement;
+}
+
+function zoomInButton() {
+  return container.querySelector('button[title^="Zoom In"]') as HTMLButtonElement;
+}
+
+describe('RichTextZoom', () => {
+  it('defaults to 125% and applies it to the editor content on mount', () => {
+    mount();
+
+    expect(DEFAULT_ZOOM_SCALE).toBe(1.25);
+    expect(proseMirror.style.transform).toBe('scale(1.25)');
+    expect(zoomInButton().title).toBe('Zoom In (125%)');
+    expect(zoomOutButton().title).toBe('Zoom Out (125%)');
+  });
+
+  it('steps up from the 125% default and updates the applied transform', () => {
+    mount();
+
+    act(() => zoomInButton().click());
+
+    expect(zoomInButton().title).toBe('Zoom In (150%)');
+    expect(proseMirror.style.transform).toBe('scale(1.5)');
+  });
+
+  it('steps down from the 125% default and clamps at the 50% floor', () => {
+    mount();
+
+    act(() => zoomOutButton().click());
+    expect(proseMirror.style.transform).toBe('scale(1)');
+
+    act(() => zoomOutButton().click());
+    expect(proseMirror.style.transform).toBe('scale(0.75)');
+
+    act(() => zoomOutButton().click());
+    expect(proseMirror.style.transform).toBe('scale(0.5)');
+
+    act(() => zoomOutButton().click());
+    expect(proseMirror.style.transform).toBe('scale(0.5)');
+    expect(zoomOutButton().title).toBe('Zoom Out (50%)');
+  });
+});


### PR DESCRIPTION
## Summary
- `RichTextZoom` (the zoom in/out control on the REASON editor toolbar) previously started at 100% zoom.
- It now defaults to **125%** on mount, exported as `DEFAULT_ZOOM_SCALE`, and applies that transform to `.ProseMirror` as soon as the toolbar mounts.
- Removed the now-completed item from `TODO.md`: "Reasoning view zoom default at 125%."

## Validation
- [x] `bun x vitest run test/richtext-zoom.test.tsx` (in `packages/reason-editor`) — 3/3 passed. Covers: 125% applied on mount, zoom-in stepping from the new default, zoom-out clamping at the 50% floor.
- [x] `bun run test` (in `packages/reason-editor`) — 349/353 passed. The 4 pre-existing failures (`read-aloud.test.ts`, `tiptap-editor-wrapper.test.tsx`, `transcribe.test.ts`, `docs-agent/adapter-parity.test.ts`) reproduce identically on the unmodified base branch — they fail to resolve `react-reason-editor/*` and `use-voice-control/*` workspace subpath imports until those sibling packages are built, unrelated to this change.
- [x] `bun x tsc --noEmit -p tsconfig.json` (in `packages/reason-editor`) — same 17 pre-existing errors before and after this change (missing workspace-package type declarations, an unrelated `InviteModal.tsx` type mismatch, etc.); none touch the `Zoom` extension.
- [x] `bun run build:editor` — `build:lib` (the actual `react-reason-editor` package consumed by the web app) succeeds. `build:demo` fails, but `packages/reason-editor/demo/` is listed in `.gitignore` and doesn't exist in the repo at all, so that step can't succeed in any checkout — unrelated to this change.

## Task tracking
- Implements: `TODO.md` item "Reasoning view zoom default at 125%."
- Follow-ups: none

## Notes for reviewers
- No API, schema, or config changes. Purely a default-value + effect change in one component, plus its test.
- Pre-existing test/build gaps noted above are environment/workspace-build issues (missing built sibling packages, gitignored demo dir) — not introduced by this PR. Worth a follow-up if the team wants `bun install` alone to produce a fully green `bun run test` / `build:editor` in a fresh checkout, but that's out of scope for this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMgs2yhdikje9ezmBLMNkt)_