### PR TITLE
Fix REASON outline filter hiding/showing the wrong headings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@ ext - dl to reason dl folswe
 2. Chat with open tabs as context.
 3. Show Vals scores for all models; example Kimi K2.5 page lists Vals Index 51.70%, latency 807.18s, and cost/test $0.29.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
 4. Outline tree should reuse Fumadocs page tree/sidebar patterns.
-5. Filter outline.
 6. Find/replace across all docs.
 7. Option to start talking automatically on first visit, or via a button from anywhere on the site.
 8. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.

--- a/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -371,7 +371,6 @@ export const SidebarContent = ({
         <OutlineView
           ref={effectiveOutlineRef}
           headings={filteredHeadings}
-          searchQuery={outlineFilter}
           onNavigate={onNavigate}
         />
       </div>

--- a/packages/reason-editor/src/search/OutlineView.tsx
+++ b/packages/reason-editor/src/search/OutlineView.tsx
@@ -77,6 +77,15 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
     }));
   }, [headings]);
 
+  // Maps a heading id back to its position in the unfiltered `outline`
+  // array, needed because `filteredOutline` (below) is a subset whose
+  // render-loop positions no longer match `outline`'s document order.
+  const outlineIndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    outline.forEach((item, index) => map.set(item.id, index));
+    return map;
+  }, [outline]);
+
   useImperativeHandle(ref, () => ({
     expandAll: () => {
       setCollapsedIds(new Set());
@@ -175,8 +184,9 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
   };
 
   /**
-   * Returns whether the heading at `itemIndex` is hidden because one of its
-   * ancestors is currently collapsed.
+   * Returns whether the heading at `itemIndex` (an index into the unfiltered
+   * `outline` array) is hidden because one of its ancestors is currently
+   * collapsed.
    *
    * @param itemIndex - Zero-based index in the flat `outline` array.
    * @returns `true` if hidden, `false` if visible.
@@ -230,12 +240,18 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
 
   return (
     <div className="flex h-full flex-col overflow-auto">
-      {filteredOutline.map((item, index) => {
-        const nextItem = outline[index + 1];
+      {filteredOutline.map((item) => {
+        // `filteredOutline` is a subset of `outline`, so its position in the
+        // rendered list does not match `item`'s position in the unfiltered
+        // outline. Look up the real index for the sibling/ancestor checks
+        // below, which rely on `outline`'s original document order. `item`
+        // always originates from `outline`, so the lookup always succeeds.
+        const realIndex = outlineIndexById.get(item.id) as number;
+        const nextItem = outline[realIndex + 1];
         const hasChildren = nextItem && nextItem.level > item.level;
         const isCollapsed = collapsedIds.has(item.id);
 
-        if (isHiddenByParent(index)) {
+        if (isHiddenByParent(realIndex)) {
           return null;
         }
 

--- a/packages/reason-editor/test/search/OutlineView.test.tsx
+++ b/packages/reason-editor/test/search/OutlineView.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Regression coverage for the outline filter's ancestor-collapse and
+ * has-children checks, which must resolve a filtered item back to its real
+ * position in the unfiltered outline rather than its position in the
+ * filtered list.
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { OutlineView } from '@/search/OutlineView';
+import type { TocEntry } from '@/app-types/toc';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+// Introduction (h1)
+//   Setup (h2)
+//   Details (h2)
+// Conclusion (h1)
+const HEADINGS: TocEntry[] = [
+  ['h1', 'Introduction', 'h1'],
+  ['h2', 'Setup', 'h2'],
+  ['h2b', 'Details', 'h2'],
+  ['h3', 'Conclusion', 'h1'],
+];
+
+function mount(props: { headings?: TocEntry[]; searchQuery?: string } = {}) {
+  act(() => {
+    root.render(<OutlineView headings={props.headings ?? HEADINGS} searchQuery={props.searchQuery} />);
+  });
+}
+
+function headingRow(text: string) {
+  return Array.from(container.querySelectorAll('span')).find((el) => el.textContent === text)?.closest('div');
+}
+
+function toggleButton(text: string) {
+  return headingRow(text)?.querySelector('button') as HTMLButtonElement | undefined;
+}
+
+function collapseFirstHeading() {
+  // The first rendered row is "Introduction"; its toggle button is its own
+  // expand/collapse chevron, distinct from the row's onClick navigation.
+  act(() => {
+    toggleButton('Introduction')!.click();
+  });
+}
+
+describe('OutlineView', () => {
+  it('renders every heading when there is no search query', () => {
+    mount();
+
+    expect(headingRow('Introduction')).toBeTruthy();
+    expect(headingRow('Setup')).toBeTruthy();
+    expect(headingRow('Details')).toBeTruthy();
+    expect(headingRow('Conclusion')).toBeTruthy();
+  });
+
+  it('hides a filtered item whose ancestor is collapsed, even though it is first in the filtered list', () => {
+    mount();
+    collapseFirstHeading();
+
+    // Re-render with a query that narrows the list to just "Details" (real
+    // index 2), which becomes index 0 within the filtered list. A naive
+    // implementation that checks ancestor-collapse using the filtered-list
+    // index instead of the real index would look up "Introduction" (real
+    // index 0) instead of "Details", find no earlier collapsed ancestor,
+    // and incorrectly show the row.
+    mount({ searchQuery: 'Details' });
+
+    expect(headingRow('Details')).toBeFalsy();
+  });
+
+  it('still shows a filtered item when its ancestor is not collapsed', () => {
+    mount({ searchQuery: 'Details' });
+
+    expect(headingRow('Details')).toBeTruthy();
+  });
+
+  it('does not show an expand chevron for a filtered last-heading with no children', () => {
+    // "Conclusion" (real index 3, the last heading) has no children. Filtered
+    // down to just this item, it sits at filtered-list index 0 — the same
+    // position "Introduction" (which does have children) occupies in the
+    // unfiltered list. A naive implementation that derives `hasChildren` from
+    // the filtered-list index would incorrectly show a chevron.
+    mount({ searchQuery: 'Conclusion' });
+
+    const chevronButton = toggleButton('Conclusion');
+    expect(chevronButton?.className).toContain('invisible');
+  });
+
+  it('shows an expand chevron for a filtered heading that does have children', () => {
+    mount({ searchQuery: 'Introduction' });
+
+    const chevronButton = toggleButton('Introduction');
+    expect(chevronButton?.className).not.toContain('invisible');
+  });
+
+  it('shows a "no headings" placeholder when the outline is empty', () => {
+    mount({ headings: [] });
+
+    expect(container.textContent).toContain('No headings found in this document');
+  });
+});


### PR DESCRIPTION
## Summary

`TODO.md` listed "Filter outline" as a backlog idea. Investigating, the sidebar's outline filter is already built (search box + section-body matching), but it had two bugs that made it unreliable:

- **`packages/reason-editor/src/search/OutlineView.tsx`** — once a search query narrowed the rendered list, the ancestor-collapse check (`isHiddenByParent`) and the expand-chevron/`hasChildren` calculation both indexed into the *filtered* list's position instead of the item's real position in the full outline. That mismatch meant a matched heading could reference a completely unrelated heading when deciding whether to hide it or show a chevron — e.g. filtering to a heading whose parent is collapsed could incorrectly show it, and filtering to a childless heading could incorrectly show an expand chevron.
- **`packages/reason-editor/src/layout/sidebar/SidebarContent.tsx`** — the sidebar already filters headings by heading text *or* section body text (`filteredHeadings`), then passed that pre-filtered list to `OutlineView` **and** the raw query as `searchQuery`, which re-filtered by heading text only. That silently dropped headings that only matched via body text — the search box's stated purpose ("Filter headings & text…") was partly broken.

Fix: `OutlineView` now resolves each filtered item back to its real index via a memoized id→index map before doing ancestor/children lookups, and `SidebarContent` stops passing the redundant `searchQuery` since it already filters `headings` itself.

## Validation
- [x] `cd packages/reason-editor && bunx vitest run test/search/OutlineView.test.tsx` — 6/6 passed (verified 2 of them fail against the pre-fix code, confirming they catch the bugs)
- [x] `cd packages/reason-editor && bunx vitest run` — 355/355 tests pass; 4 test files fail to even load due to a pre-existing, unrelated cross-package import-resolution issue (`use-voice-control/client`, `react-reason-editor/style.css`, etc. — these packages need a full monorepo build first). Confirmed identical on the base branch before this change.
- [x] `cd packages/reason-editor && bunx tsc --noEmit -p tsconfig.json` — same 17 pre-existing errors as the base branch (none in the files touched here), no new errors introduced
- [ ] `bun run build:web` — blocked upstream: `react-reason-editor`'s own `build` script also builds its local demo app, which fails with `UNRESOLVED_ENTRY` on `demo/vite.config.ts` in this sandbox. Confirmed identical on the base branch (pre-existing, unrelated to this change). The actual consumed library build (`vite build`, i.e. `packages/reason-editor` → `dist/`) succeeds on its own.

No lint script or eslint config exists in this package/repo.

## Task tracking
- Implements: `TODO.md` item "Filter outline" (removed from the list)
- Follow-ups: none tracked — the `build:web`/demo-build issue above is pre-existing and outside this change's scope

## Notes for reviewers
- Repo has no open issues/PRs to link against; `TODO.md` is the informal backlog.
- Scope intentionally stays to the filtering correctness bug — did not add ancestor-context-when-only-a-descendant-matches (i.e. keeping a non-matching parent visible for breadcrumb context), which would be a UX enhancement beyond fixing the existing broken behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_013cGw84Mnrx1GU5jW2Riqhm)_