### PR TITLE
Redesign compact weather widget as fixed-width card layout

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",

--- a/packages/react-weather-forecast/src/components/WeatherForecast.tsx
+++ b/packages/react-weather-forecast/src/components/WeatherForecast.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
-import type { HourlyWeather, TemperatureUnit, WeatherForecastOptions, WindSpeedUnit } from '../types';
+import type { DailyWeather, HourlyWeather, TemperatureUnit, WeatherForecastOptions, WindSpeedUnit } from '../types';
 import { WeatherIcon } from '../icons/WeatherIcon';
 import { WindIcon } from '../icons/weather-icons';
 
@@ -35,6 +35,29 @@ function formatInZone(instant: Date, timezone: string | undefined, options: Intl
   }
 }
 
+// The clock is shown with the hour and minute large and the seconds (plus any
+// AM/PM marker) trailing in a smaller, dimmer size, so split it into those two
+// halves. Falls back to one undivided string if the locale's parts are not
+// where we expect them.
+function clockParts(instant: Date, timezone: string | undefined): { main: string; tail: string } {
+  const options: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit', second: '2-digit' };
+  const format = (() => {
+    try {
+      return new Intl.DateTimeFormat([], { ...options, timeZone: timezone || undefined });
+    } catch {
+      return new Intl.DateTimeFormat([], options);
+    }
+  })();
+  const parts = format.formatToParts(instant);
+  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((p) => p.type === type)?.value;
+  const hour = part('hour');
+  const minute = part('minute');
+  const second = part('second');
+  if (!hour || !minute || !second) return { main: format.format(instant), tail: '' };
+  const dayPeriod = part('dayPeriod');
+  return { main: `${hour}:${minute}`, tail: `:${second}${dayPeriod ? ` ${dayPeriod}` : ''}` };
+}
+
 // Just the zone abbreviation (e.g. "GMT+2"), so it can be shown apart from the
 // clock itself.
 function zoneLabel(instant: Date, timezone: string | undefined): string {
@@ -62,10 +85,20 @@ function parseCalendarDate(date: string): Date {
   return new Date(year, month - 1, day);
 }
 
-// The day right after today reads better as "Tomorrow" than as its weekday.
-function upcomingDayLabel(date: string, offsetFromToday: number): string {
-  if (offsetFromToday === 1) return 'Tomorrow';
-  return parseCalendarDate(date).toLocaleDateString([], { weekday: 'long' });
+// The upcoming days sit in narrow columns along the bottom of the card, so
+// they are labelled with the abbreviated weekday ("Fri") rather than a full
+// name or "Tomorrow".
+function upcomingDayLabel(date: string): string {
+  return parseCalendarDate(date).toLocaleDateString([], { weekday: 'short' });
+}
+
+// Daily totals that no longer have a column of their own in the card layout are
+// kept as hover text so the detail is still reachable.
+function upcomingDayDetail(day: DailyWeather, windSpeedUnitLabel: string): string | undefined {
+  const details: string[] = [];
+  if (day.precipitationSum !== undefined) details.push(`${day.precipitationSum.toFixed(1)} mm`);
+  if (day.windSpeedMax !== undefined) details.push(`${day.windSpeedMax.toFixed(1)} ${windSpeedUnitLabel} wind`);
+  return details.length > 0 ? details.join(' · ') : undefined;
 }
 
 const styles = {
@@ -82,34 +115,45 @@ const styles = {
   hours: { display: 'flex', gap: 12, overflowX: 'auto', paddingBottom: 4 } as React.CSSProperties,
   hourCard: { minWidth: 72, textAlign: 'center' as const, padding: 8, borderRadius: 8, background: '#f9fafb' },
   dayRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '8px 0', borderBottom: '1px solid #f3f4f6' } as React.CSSProperties,
-  compactRoot: { fontFamily: 'system-ui, sans-serif', display: 'flex', flexDirection: 'column', gap: 8, padding: '10px 14px', borderRadius: 8 } as React.CSSProperties,
-  // Current conditions on the left, upcoming days on the right; both columns
-  // wrap to full width when the widget is too narrow to hold them side by side.
-  compactBody: { display: 'flex', flexWrap: 'wrap', alignItems: 'flex-start', gap: 12 } as React.CSSProperties,
-  compactCurrent: { flex: '1 1 45%', minWidth: 140, display: 'flex', flexDirection: 'column', gap: 8 } as React.CSSProperties,
-  compactHeader: { display: 'flex', alignItems: 'center', gap: 10 } as React.CSSProperties,
-  compactHeaderText: { display: 'flex', alignItems: 'baseline', gap: 8, flexWrap: 'wrap' } as React.CSSProperties,
-  compactTime: { fontSize: 18, fontWeight: 600, lineHeight: 1.15 } as React.CSSProperties,
-  compactDate: { fontSize: 11, opacity: 0.7 } as React.CSSProperties,
-  compactStats: { display: 'flex', flexWrap: 'wrap', gap: 12, fontSize: 12, opacity: 0.9 } as React.CSSProperties,
-  // A shared grid keeps the day / icon / temps / rain / wind columns aligned
-  // across every upcoming row.
-  // Columns are content-sized (so no column can be squeezed away) and the spare
-  // width is spread between them; that also makes the grid's min-content width
-  // large enough to wrap below the current conditions on narrow screens.
+  // Card-sized: a fixed maximum width with generous, even padding, so the
+  // widget reads as a self-contained tile wherever it is dropped in.
+  compactRoot: {
+    fontFamily: 'system-ui, sans-serif',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 14,
+    padding: 18,
+    borderRadius: 16,
+    width: '100%',
+    maxWidth: 340,
+    boxSizing: 'border-box',
+  } as React.CSSProperties,
+  // Current conditions stack down the card; the upcoming days sit in a row
+  // along the bottom.
+  compactBody: { display: 'flex', flexDirection: 'column', gap: 10 } as React.CSSProperties,
+  compactCity: { fontSize: 15, fontWeight: 700, lineHeight: 1.2 } as React.CSSProperties,
+  compactHeader: { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8 } as React.CSSProperties,
+  compactTemp: { fontSize: 32, fontWeight: 600, lineHeight: 1 } as React.CSSProperties,
+  // The short-term outlook ("59 deg in 6h") trails the current temperature.
+  compactOutlook: { display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, opacity: 0.75, whiteSpace: 'nowrap' } as React.CSSProperties,
+  compactTime: { fontSize: 26, fontWeight: 600, lineHeight: 1.1 } as React.CSSProperties,
+  compactSeconds: { fontSize: 13, fontWeight: 500, opacity: 0.6 } as React.CSSProperties,
+  compactDate: { fontSize: 11, opacity: 0.7, marginTop: 2 } as React.CSSProperties,
+  compactStats: { display: 'flex', flexWrap: 'wrap', gap: 14, fontSize: 12, opacity: 0.9 } as React.CSSProperties,
+  // Three equal columns along the bottom edge, each stacking weekday / icon /
+  // high-low so the row stays readable at card width.
   upcoming: {
-    flex: '1 1 260px',
     display: 'grid',
-    gridTemplateColumns: 'auto auto auto auto auto',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    columnGap: 10,
-    rowGap: 6,
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: 8,
+    paddingTop: 12,
+    borderTop: '1px solid currentColor',
+    borderTopColor: 'rgba(128,128,128,0.25)',
     fontSize: 12,
   } as React.CSSProperties,
-  upcomingDay: { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', opacity: 0.85 } as React.CSSProperties,
-  upcomingTemps: { whiteSpace: 'nowrap', textAlign: 'right' } as React.CSSProperties,
-  upcomingMetric: { whiteSpace: 'nowrap', textAlign: 'right', opacity: 0.7 } as React.CSSProperties,
+  upcomingDay: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4, textAlign: 'center' } as React.CSSProperties,
+  upcomingDayName: { opacity: 0.7, whiteSpace: 'nowrap' } as React.CSSProperties,
+  upcomingTemps: { whiteSpace: 'nowrap' } as React.CSSProperties,
   compactStat: { display: 'flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' } as React.CSSProperties,
   unitSwitch: { display: 'inline-flex', alignItems: 'center', cursor: 'pointer', userSelect: 'none' } as React.CSSProperties,
   rain: { color: '#2563eb', whiteSpace: 'nowrap' } as React.CSSProperties,
@@ -182,7 +226,7 @@ function SingleWeatherForecast(props: Props) {
   const currentTime = formatInZone(now, timezone, { hour: 'numeric', minute: '2-digit', second: '2-digit', timeZoneName: 'short' });
   // The compact layout shows the clock at a larger size, so the zone label is
   // split off onto the smaller date line to keep the time on one line.
-  const currentClock = formatInZone(now, timezone, { hour: 'numeric', minute: '2-digit', second: '2-digit' });
+  const currentClock = clockParts(now, timezone);
   const currentZone = zoneLabel(now, timezone);
 
   if (props.compact) {
@@ -190,75 +234,74 @@ function SingleWeatherForecast(props: Props) {
     const today = data.daily[0];
     const in6Hours = closestHour(data.hourly, new Date(forecastBase.getTime() + 6 * 60 * 60 * 1000));
     const windSpeedUnitLabel = WIND_SPEED_UNIT_LABELS[props.windSpeedUnit ?? 'mph'];
-    // Today already has its own column on the left, so the upcoming list starts
-    // at tomorrow and stays short enough to sit beside it.
-    const upcomingDays = data.daily.slice(1, 5);
+    // Today is already summarised in the card's own stats line, so the bottom
+    // row starts at tomorrow and shows the next three days.
+    const upcomingDays = data.daily.slice(1, 4);
 
     return (
       <div className={props.className} style={{ ...styles.compactRoot, ...props.style }}>
         <div style={styles.compactBody}>
-          <div style={styles.compactCurrent}>
-            <div style={styles.compactHeader}>
-              <WeatherIcon condition={data.current.icon} width={24} height={24} title="Current weather" />
-              <div>
-                <div style={styles.compactHeaderText}>
-                  <strong style={{ fontSize: 16 }}>{data.current.temperature}</strong>
-                  {renderUnitSwitch(12)}
-                  <span style={{ fontSize: 14, opacity: 0.8 }}>
-                    {data.location?.city || 'Current location'}
-                  </span>
-                </div>
-                <div style={styles.compactTime}>{currentClock}</div>
-                <div style={styles.compactDate}>
-                  {currentDate}
-                  {currentZone ? ` · ${currentZone}` : ''}
-                </div>
-              </div>
-            </div>
+          <div style={styles.compactCity}>
+            {data.location?.city || 'Current location'}
+            {data.location?.region ? `, ${data.location.region}` : ''}
+          </div>
 
-            <div style={styles.compactStats}>
-              {today && (
-                <span style={styles.compactStat}>
-                  <WeatherIcon condition={today.icon} width={16} height={16} title="Today's high and low" />
-                  {today.max}&deg; / {today.min}&deg;
-                  <RainBadge probability={today.precipitationProbabilityMax} compact />
-                </span>
-              )}
-              <span style={styles.compactStat}>
-                <WindIcon width={16} height={16} title="Wind speed" />
-                {data.current.windSpeed !== undefined ? `${Math.round(data.current.windSpeed)} ${windSpeedUnitLabel}` : '—'}
+          <div style={styles.compactHeader}>
+            <WeatherIcon condition={data.current.icon} width={30} height={30} title="Current weather" />
+            <strong style={styles.compactTemp}>{data.current.temperature}</strong>
+            {renderUnitSwitch(13)}
+            {in6Hours && (
+              <span style={styles.compactOutlook}>
+                <WeatherIcon condition={in6Hours.icon} width={14} height={14} title="In 6 hours" />
+                {in6Hours.temperature}&deg; 6h
+                <RainBadge probability={in6Hours.precipitationProbability} compact />
               </span>
-              {in6Hours && (
-                <span style={styles.compactStat}>
-                  <WeatherIcon condition={in6Hours.icon} width={16} height={16} title="In 6 hours" />
-                  {in6Hours.temperature}&deg; in 6h
-                  <RainBadge probability={in6Hours.precipitationProbability} compact />
-                </span>
-              )}
+            )}
+          </div>
+
+          <div>
+            <div style={styles.compactTime}>
+              {currentClock.main}
+              {currentClock.tail && <span style={styles.compactSeconds}>{currentClock.tail}</span>}
+            </div>
+            <div style={styles.compactDate}>
+              {currentDate}
+              {currentZone ? ` · ${currentZone}` : ''}
             </div>
           </div>
 
-          {upcomingDays.length > 0 && (
-            <div style={styles.upcoming}>
-              {upcomingDays.map((day, index) => (
-                <React.Fragment key={day.date}>
-                  <span style={styles.upcomingDay}>{upcomingDayLabel(day.date, index + 1)}</span>
-                  <WeatherIcon condition={day.icon} width={16} height={16} />
-                  <span style={styles.upcomingTemps}>
-                    <strong>{day.max}&deg;</strong>
-                    <span style={{ opacity: 0.7 }}> / {day.min}&deg;</span>
-                  </span>
-                  <span style={styles.upcomingMetric}>
-                    {day.precipitationSum !== undefined ? `${day.precipitationSum.toFixed(1)} mm` : '—'}
-                  </span>
-                  <span style={styles.upcomingMetric}>
-                    {day.windSpeedMax !== undefined ? `${day.windSpeedMax.toFixed(1)} ${windSpeedUnitLabel}` : '—'}
-                  </span>
-                </React.Fragment>
-              ))}
-            </div>
-          )}
+          <div style={styles.compactStats}>
+            {today && (
+              <span style={styles.compactStat}>
+                <WeatherIcon condition={today.icon} width={16} height={16} title="Today's high and low" />
+                {today.max}&deg; / {today.min}&deg;
+                <RainBadge probability={today.precipitationProbabilityMax} compact />
+              </span>
+            )}
+            <span style={styles.compactStat}>
+              <WindIcon width={16} height={16} title="Wind speed" />
+              {data.current.windSpeed !== undefined ? `${Math.round(data.current.windSpeed)} ${windSpeedUnitLabel}` : '—'}
+            </span>
+          </div>
         </div>
+
+        {upcomingDays.length > 0 && (
+          <div style={styles.upcoming}>
+            {upcomingDays.map((day) => (
+              <div key={day.date} style={styles.upcomingDay} title={upcomingDayDetail(day, windSpeedUnitLabel)}>
+                <span style={styles.upcomingDayName}>{upcomingDayLabel(day.date)}</span>
+                <WeatherIcon condition={day.icon} width={18} height={18} />
+                <span style={styles.upcomingTemps}>
+                  <strong>{day.max}&deg;</strong>
+                  <span style={{ opacity: 0.6 }}> / {day.min}&deg;</span>
+                </span>
+                {day.precipitationProbabilityMax !== undefined && day.precipitationProbabilityMax > 0 && (
+                  <span style={{ ...styles.rain, fontSize: 11 }}>{day.precipitationProbabilityMax}%</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/react-weather-forecast/test/WeatherForecast.test.tsx
+++ b/packages/react-weather-forecast/test/WeatherForecast.test.tsx
@@ -32,6 +32,8 @@ function forecast(overrides: Partial<WeatherForecastData> = {}): WeatherForecast
         windSpeedMax: 4.5,
       },
       { date: '2024-01-03', min: 57, max: 77, weatherCode: 3, icon: 'clouds', precipitationSum: 0, windSpeedMax: 3.5 },
+      { date: '2024-01-04', min: 51, max: 75, weatherCode: 3, icon: 'clouds' },
+      { date: '2024-01-05', min: 50, max: 74, weatherCode: 3, icon: 'clouds' },
     ],
     ...overrides,
   } as WeatherForecastData;
@@ -126,46 +128,51 @@ describe('<WeatherForecast />', () => {
     expect(spy.mock.calls.length).toBe(callsBefore);
   });
 
-  it('renders the compact layout with today, tomorrow and wind', async () => {
+  it('renders the compact card with the location, today and wind', async () => {
     vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(forecast());
 
     render(<WeatherForecast latitude={1} longitude={2} compact />);
 
-    expect(await screen.findByText('Austin')).toBeTruthy();
-    expect(screen.getAllByText(/Tomorrow/).length).toBeGreaterThan(0);
+    expect(await screen.findByText('Austin, Texas')).toBeTruthy();
     // windSpeed 8.4 mph, rounded, with the default unit label.
     expect(screen.getByText('8 mph')).toBeTruthy();
     // The compact layout omits the full hour/day breakdown.
     expect(screen.queryByText('Next hours')).toBeNull();
   });
 
-  it('lists the upcoming days with precipitation and peak wind', async () => {
+  it('shows the next three days, by abbreviated weekday, along the bottom', async () => {
     vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(forecast());
 
     render(<WeatherForecast latitude={1} longitude={2} compact />);
 
-    // The day after today is labelled "Tomorrow"; later days use their weekday.
-    expect(await screen.findByText('Tomorrow')).toBeTruthy();
-    expect(screen.getByText('Wednesday')).toBeTruthy();
-    expect(screen.getByText('0.5 mm')).toBeTruthy();
-    expect(screen.getByText('0.0 mm')).toBeTruthy();
-    expect(screen.getByText('4.5 mph')).toBeTruthy();
+    // Today (Monday) is summarised above; the row starts at the day after.
+    expect(await screen.findByText('Tue')).toBeTruthy();
+    expect(screen.getByText('Wed')).toBeTruthy();
+    expect(screen.getByText('Thu')).toBeTruthy();
+    // Only three days fit the bottom row, so the fifth day is dropped.
+    expect(screen.queryByText('Fri')).toBeNull();
+    expect(screen.queryByText('Mon')).toBeNull();
   });
 
-  it('shows placeholders for upcoming days without precipitation or wind data', async () => {
-    vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(
-      forecast({
-        daily: [
-          { date: '2024-01-01', min: 55, max: 79, weatherCode: 0, icon: 'sun' },
-          { date: '2024-01-02', min: 58, max: 80, weatherCode: 0, icon: 'sun' },
-        ],
-      })
-    );
+  it('keeps daily precipitation and peak wind as hover text on each day', async () => {
+    vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(forecast());
 
     render(<WeatherForecast latitude={1} longitude={2} compact />);
 
-    await screen.findByText('Tomorrow');
-    expect(screen.getAllByText('—').length).toBe(2);
+    const tuesday = (await screen.findByText('Tue')).parentElement;
+    expect(tuesday?.getAttribute('title')).toBe('0.5 mm · 4.5 mph wind');
+    // Days without those totals carry no hover text at all.
+    expect(screen.getByText('Thu').parentElement?.getAttribute('title')).toBeNull();
+  });
+
+  it('shows the precipitation chance for upcoming days only when non-zero', async () => {
+    vi.spyOn(forecastApi, 'getWeatherForecast').mockResolvedValue(forecast());
+
+    render(<WeatherForecast latitude={1} longitude={2} compact />);
+
+    // Tomorrow's 70% chance is shown; Wednesday has no chance recorded.
+    expect(await screen.findByText('70%')).toBeTruthy();
+    expect(screen.queryByText('0%')).toBeNull();
   });
 
   it('shows a wind placeholder when wind speed is missing', async () => {

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -151,24 +151,23 @@ export default function ChatHomepage() {
 
           <div className="w-full max-w-2xl mt-8 space-y-2">
             <RecentHistoryChips />
-            {/* The weather widget takes the full row: its current conditions sit
-                in the left half with the upcoming days tabled in the right half,
-                which needs more width than a shared column allows. */}
-            <WeatherForecast
-              compact
-              forecastDays={5}
-              forecastHours={12}
-              locations={weatherLocations.length > 0 ? weatherLocations : undefined}
-              className="rounded-2xl w-full"
-              style={{
-                background: 'rgba(255,255,255,0.08)',
-                border: '1px solid rgba(255,255,255,0.15)',
-                color: 'inherit',
-                backdropFilter: 'blur(8px)',
-                maxWidth: '100%',
-              }}
-            />
             <div className="flex flex-col md:flex-row gap-2 w-full">
+              {/* The compact weather widget is a fixed-width card, so it sits
+                  beside the trending news column rather than taking its own row
+                  (and stretches to full width once they stack on mobile). */}
+              <WeatherForecast
+                compact
+                forecastDays={5}
+                forecastHours={12}
+                locations={weatherLocations.length > 0 ? weatherLocations : undefined}
+                className="rounded-2xl"
+                style={{
+                  background: 'rgba(255,255,255,0.08)',
+                  border: '1px solid rgba(255,255,255,0.15)',
+                  color: 'inherit',
+                  backdropFilter: 'blur(8px)',
+                }}
+              />
               <TrendingNews
                 compact
                 maxTopics={6}


### PR DESCRIPTION
## Summary
Redesigned the compact weather forecast widget from a flexible two-column layout to a fixed-width card design with improved visual hierarchy and information organization.

## Key Changes

- **Layout restructuring**: Changed from a side-by-side layout (current conditions + upcoming days) to a vertical card layout with upcoming days in a row at the bottom
  - Added fixed `maxWidth: 340px` and consistent padding to create a self-contained card appearance
  - Reorganized current conditions to stack vertically within the card

- **Visual improvements**:
  - Increased current temperature display size (32px) with larger weather icon (30px)
  - Split clock display into main time and secondary seconds/AM-PM using new `clockParts()` helper function
  - Added city/region name as prominent header
  - Improved spacing and typography hierarchy throughout

- **Upcoming days redesign**:
  - Changed from 5-column grid layout to 3-column equal-width grid
  - Switched day labels from "Tomorrow"/"weekday name" to abbreviated weekdays ("Tue", "Wed", etc.)
  - Moved precipitation sum and wind speed data to hover tooltips via `upcomingDayDetail()` helper
  - Added inline precipitation probability display (only when > 0%)
  - Improved visual centering and spacing of day cards

- **Data handling**:
  - Updated upcoming days slice from `slice(1, 5)` to `slice(1, 4)` to show exactly 3 days
  - Added `DailyWeather` type import for better type safety
  - Removed `offsetFromToday` parameter from day labeling logic

- **Integration updates**:
  - Updated ChatHomepage to position weather widget beside trending news in a flex row instead of taking full width
  - Adjusted styling to work with fixed-width card rather than flexible layout

## Implementation Details

- New `clockParts()` function uses `Intl.DateTimeFormat.formatToParts()` to intelligently split time display into main (hour:minute) and tail (seconds + AM/PM) portions
- New `upcomingDayDetail()` function generates hover text from daily totals, joining multiple metrics with " · " separator
- Maintained responsive behavior with `md:flex-row` breakpoint in parent layout for mobile stacking

https://claude.ai/code/session_0191gFqFrnhd6c6ar2wy4hVE