### PR TITLE
fix(reason-editor): build sibling packages before tests run on a fresh clone

### DIFF
--- a/packages/reason-editor/package.json
+++ b/packages/reason-editor/package.json
@@ -777,6 +777,7 @@
     "build": "vite build && vite build --config demo/vite.config.ts",
     "build:lib": "vite build",
     "build:demo": "vite build --config demo/vite.config.ts",
+    "prepare": "vite build",
     "preview": "wrangler dev",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/packages/use-voice-control/package.json
+++ b/packages/use-voice-control/package.json
@@ -35,6 +35,7 @@
   ],
   "scripts": {
     "build": "tsc && vite build",
+    "prepare": "tsc && vite build",
     "dev": "vite build --watch",
     "type-check": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- `packages/reason-editor`'s tests import `use-voice-control/client` and several `react-reason-editor/*` self-referencing subpaths that only resolve once each package's own `dist/` exists.
- Neither `packages/use-voice-control` nor `packages/reason-editor` shipped a `prepare` script, so on a fresh clone `bun install` never built them, and `cd packages/reason-editor && bun run test` failed 4 of 41 suites (`test/read-aloud.test.ts`, `test/transcribe.test.ts`, `test/tiptap-editor-wrapper.test.tsx`, `test/docs-agent/adapter-parity.test.ts`) with `Failed to resolve import` errors. Turbo-driven runs were unaffected since `turbo.json`'s `test` task already declares `dependsOn: ["^build"]`.
- Added a `prepare` script to both packages (`"prepare": "vite build"` for reason-editor, matching its existing `build:lib`; `"prepare": "tsc && vite build"` for use-voice-control, matching its `build`), so `bun install` builds them automatically — the same convention already used by `packages/extract-pdf` and `packages/extract-youtube`.

## Validation
- [x] `bun install && cd packages/reason-editor && bun run test` — before the fix: 4 failed | 37 passed (41). After: `Test Files 41 passed (41)`, `Tests 445 passed (445)`.
- [x] `cd packages/reason-editor && bun run test:coverage` — passed, 97.52% statement coverage.
- [x] `cd packages/use-voice-control && bun run test` — `Test Files 5 passed (5)`, `Tests 57 passed (57)`.
- [x] `cd packages/use-voice-control && bun run type-check` (`tsc --noEmit`) — passed, no output.
- [x] Reproduced fresh-clone behavior by deleting both `dist/` dirs and re-running `bun install`: both `prepare` scripts ran automatically and rebuilt `dist/`.
- [ ] Root `bun run test` (all Vitest projects) — 10 unrelated test files fail both with and without this change (confirmed by stashing the diff and re-running): a pre-existing `jsdom` resolution issue in `packages/render-url-to-html/scraper-jsdom`, and `apps/qwksearch-web` config-route tests that fail only when run as part of the full multi-project run (they pass in isolation) — both unrelated to this change and out of scope for #210.
- [ ] `bun run build:web` (root, via turbo) — fails on a **separate, pre-existing** issue: `packages/reason-editor`'s `build` script also builds `demo/vite.config.ts`, but `packages/reason-editor/demo/` does not exist in the repo. This reproduces identically on `master` and is unaffected by this PR (which only adds a `prepare` script equivalent to `build:lib`, never touching the demo build). Filed as #213.

## Task tracking
- Closes #210
- Follow-ups: #213 (`packages/reason-editor`'s `build` script fails on a missing `demo/` directory, pre-existing and unrelated)

## Notes for reviewers
- Scope is intentionally minimal: two one-line `package.json` additions, no source changes. No new tests were added since this is a build/install-ordering fix, not new runtime behavior — correctness is verified by the previously-failing suites now passing.
- `prepare` scripts run on every `bun install` (not just fresh clones), adding ~a few seconds (`use-voice-control`) and ~2.5 minutes (`react-reason-editor`, due to its many extension entry points) to install time. This matches the existing tradeoff already accepted for `packages/extract-pdf` and `packages/extract-youtube`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Le66d4Nbi144V3cmA1ikAm)_