### PR TITLE
Disable source maps for Worker builds to fix deploy size limit

### DIFF
--- a/apps/qwksearch-web/vite.config.ts
+++ b/apps/qwksearch-web/vite.config.ts
@@ -72,6 +72,18 @@ export default defineConfig(({ command }) => ({
       external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse"],
     },
   },
+  environments: {
+    // Cloudflare rejects a Worker upload whose source maps total more than
+    // 15MB gzipped ("total sourcemap size is too large", API error 10021).
+    // The unminified rsc/ssr bundles blow past that on their own (~68MB raw /
+    // ~15.4MB gzipped), so `wrangler deploy` fails after the whole build has
+    // run. Since `minify` is off, the deployed Worker chunks are already
+    // readable source and the maps buy very little there, so don't emit them
+    // for the two Worker environments. The client build keeps its maps: those
+    // ship as static assets and don't count toward the Worker limit.
+    rsc: { build: { sourcemap: false } },
+    ssr: { build: { sourcemap: false } },
+  },
   ssr: {
     // Bundle workspace packages into the standalone output instead of treating
     // them as external dependencies (which vinext can't resolve at deploy time)

--- a/apps/qwksearch-web/wrangler.jsonc
+++ b/apps/qwksearch-web/wrangler.jsonc
@@ -8,7 +8,13 @@
   // entered in the CF dashboard (API keys, BETTER_AUTH_SECRET, …) because
   // this config defines no `vars`. Secrets survive either way.
   "keep_vars": true,
-  "upload_source_maps": true,
+  // Uploading Worker source maps (for prettier stack traces in the CF
+  // dashboard) is capped at 15MB gzipped; this app's unminified rsc/ssr
+  // bundles produced ~15.4MB and the deploy was rejected with API error
+  // 10021. The Worker chunks ship unminified, so the maps add little.
+  // Source-map *emission* is also off for the rsc/ssr environments — see
+  // `environments` in vite.config.ts. Inherited by the `production` env.
+  "upload_source_maps": false,
   "assets": {
     "directory": "dist/client",
     "not_found_handling": "none",


### PR DESCRIPTION
## Summary
Disables source map generation and uploading for Cloudflare Worker builds to resolve deployment failures caused by exceeding the 15MB gzipped source map size limit.

## Changes
- **vite.config.ts**: Added `environments` configuration to disable source map emission for `rsc` and `ssr` builds (Worker environments). Client builds retain source maps since they ship as static assets and don't count toward the Worker upload limit.
- **wrangler.jsonc**: Changed `upload_source_maps` from `true` to `false` to prevent uploading Worker source maps to Cloudflare. The unminified Worker chunks are already readable source code, making the maps redundant.

## Details
The app's unminified rsc/ssr bundles were generating ~15.4MB of gzipped source maps, which exceeded Cloudflare's 15MB limit and caused `wrangler deploy` to fail with API error 10021. Since:
1. Worker chunks are deployed unminified (readable source)
2. Source maps add minimal debugging value in this context
3. Client source maps (which are useful) don't count toward the Worker limit

Disabling source maps for Worker environments resolves the deployment issue while maintaining source maps for client-side debugging.

https://claude.ai/code/session_01V7zgevsXYZAgTAkTSyq7jU