### PR TITLE
Add voice input auto-start on first visit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,98 @@
+## In Progress
+
+## Voice auto-start on first visit
+
+**Status:** In Progress
+**Source:** TODO.md — "Option to start talking automatically on first visit, or via a button from anywhere on the site."
+**Branch:** `claude/adoring-mayer-drmy2g`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+Let a user opt in to having voice dictation start automatically the first
+time they load the chat composer, instead of only via the existing mic
+button / Ctrl+` shortcut in `ChatInputBox`.
+
+### Scope
+- A `voiceAutoStart` localStorage-backed setting, toggled from
+  `VoiceSettingsPanel` (mirrors the existing `useTTSKokoro` pattern there).
+- A small pure-function module (`src/lib/voiceAutoStart.ts`) that decides
+  whether to auto-start, given the setting, speech-support, current
+  listening state, and a "already triggered this browser" flag — so it only
+  fires once per browser, not on every mount/navigation.
+- A thin hook (`useVoiceAutoStart`) wiring that decision into
+  `ChatInputBox`'s existing `toggleSpeech`/`isListening`/`isSpeechSupported`
+  from `useSpeechInput`.
+
+### Non-goals
+- A floating mic button rendered outside the chat composer / on non-chat
+  routes (settings, docs, admin) — the existing Ctrl+` shortcut and the
+  composer's mic button already work "from anywhere" the composer is
+  mounted; a separate global FAB is a larger, separate change.
+- Server-side or cross-device persistence of the setting (localStorage only,
+  matching the rest of `VoiceSettingsPanel`).
+
+### Acceptance criteria
+- [x] Enabling the setting and visiting the chat composer for the first time
+      in a browser starts dictation automatically (when speech is
+      supported).
+- [x] It does not re-trigger on subsequent mounts/navigations in the same
+      browser (tracked via a "triggered" localStorage flag).
+- [x] It never fires when speech input isn't supported, or the mic is
+      already listening.
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for this package or at the repo
+      root (no ESLint config found); nothing to run
+- [ ] Typecheck passes — `bun run type-check` in `research-agent-ui` fails
+      on **pre-existing** `TS2307` errors (`chat-agent-toolkit`,
+      `use-voice-control/*`, `use-weather-forecast`, `trending-news-api`)
+      because those workspace packages have no built `dist/` output in a
+      fresh checkout; confirmed identical on `git stash` (pre-change code).
+      Out of scope for this task.
+- [x] Tests pass — `bun run test` in `research-agent-ui`: 67/67 passed
+      (including the 14 new voice-auto-start tests)
+- [ ] Production/web build passes — `bun run build:web` in progress at time
+      of commit; `research-agent-ui`'s own `bun run build` (vite bundle)
+      already passes
+- [x] Documentation is updated if behavior or configuration changes (n/a — no user-facing docs describe voice settings beyond in-app copy)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements
+- [x] Implement the smallest useful vertical slice
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure, validation, or edge-case coverage
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see notes above — neither is actionable for this change)
+- [x] Run the full relevant test suite
+- [ ] Run the production/web build (in progress — see Remaining work)
+- [x] Review the final diff for scope and quality
+- [x] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Confirm the `bun run build:web` production build (kicked off in the
+  background) completes cleanly; if it fails for reasons unrelated to this
+  change (env vars/secrets not present in this sandbox — no `.env.local`
+  with real Better Auth/DB/provider secrets), record the exact command and
+  error here and treat it as an out-of-scope pre-existing gap.
+- Open the PR and link it here.
+- Move this entry to `## Completed` once the PR is up.
+
+---
+
+## Ideas Backlog
 
 ext - dl to reason dl folswe
 1. in sidebar, have it sugegst related by keywords
 2. Chat with open tabs as context.
 3. Show Vals scores for all models; example Kimi K2.5 page lists Vals Index 51.70%, latency 807.18s, and cost/test $0.29.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
 4. Outline tree should reuse Fumadocs page tree/sidebar patterns.
-7. Option to start talking automatically on first visit, or via a button from anywhere on the site.
-8. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
-10. common typoes
-11. https://github.com/cloudflare/moltworker
+5. Option to start talking automatically on first visit, or via a button from anywhere on the site. — **in progress, see above**
+6. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
+7. common typoes
+8. https://github.com/cloudflare/moltworker
 
 
 ## Longterm

--- a/packages/research-agent-ui/src/components/MessageComposer/ChatInputBox.tsx
+++ b/packages/research-agent-ui/src/components/MessageComposer/ChatInputBox.tsx
@@ -14,6 +14,7 @@ import { FilePreviewCard } from "../FileUpload/FilePreviewCard";
 import { PastedContentCard } from "./PastedContentCard";
 import { useChat } from '../../hooks/useChat';
 import { useSpeechInput } from '../../hooks/voice/useSpeechToTranscript';
+import { useVoiceAutoStart } from '../../hooks/voice/useVoiceAutoStart';
 import { SpokenPhraseOverlay } from 'use-voice-control/react';
 import { useFileHandling } from '../FileUpload/useFileHandling';
 import FileUploadDropdown from '../FileUpload/FileUploadDropdown';
@@ -139,6 +140,8 @@ const ChatInputBox = ({ onNewChat }: ChatInputBoxProps) => {
         // Only when listening starts — `message` changes constantly while dictating.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isListening]);
+
+    useVoiceAutoStart({ isSpeechSupported, isListening, toggleSpeech });
 
     const [placeholderIndex, setPlaceholderIndex] = useState(0);
     const [showPlaceholder, setShowPlaceholder] = useState(true);

--- a/packages/research-agent-ui/src/components/VoiceSettings/VoiceSettingsPanel.tsx
+++ b/packages/research-agent-ui/src/components/VoiceSettings/VoiceSettingsPanel.tsx
@@ -6,6 +6,7 @@ import KokoroVoiceSelector from './KokoroVoiceSelector';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../ui/tooltip';
 import { Volume2, Settings2 } from 'lucide-react';
 import { cn } from '../../lib/utils';
+import { isVoiceAutoStartEnabled, setVoiceAutoStartEnabled } from '../../lib/voiceAutoStart';
 
 export default function VoiceSettingsPanel() {
   const [showSettings, setShowSettings] = useState(false);
@@ -15,6 +16,7 @@ export default function VoiceSettingsPanel() {
   const [ttsSpeaker, setTtsSpeaker] = useState(() =>
     localStorage.getItem('ttsSpeaker') || 'angus'
   );
+  const [autoStartVoice, setAutoStartVoice] = useState(() => isVoiceAutoStartEnabled());
 
   const { start: previewStart, speechStatus } = useTextToSpeech(
     'This is a preview of the selected voice.',
@@ -29,6 +31,11 @@ export default function VoiceSettingsPanel() {
   const handleSpeakerChange = (speaker: string) => {
     setTtsSpeaker(speaker);
     localStorage.setItem('ttsSpeaker', speaker);
+  };
+
+  const handleToggleAutoStart = (enabled: boolean) => {
+    setAutoStartVoice(enabled);
+    setVoiceAutoStartEnabled(enabled);
   };
 
   return (
@@ -117,6 +124,28 @@ export default function VoiceSettingsPanel() {
                 </button>
               </div>
             )}
+          </div>
+
+          {/* Voice input auto-start */}
+          <div className="space-y-2 pt-2 border-t border-white/10 dark:border-black/10">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={autoStartVoice}
+                onChange={(e) => handleToggleAutoStart(e.target.checked)}
+                className="rounded"
+              />
+              <span className="font-medium text-sm">Start talking automatically on first visit</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="text-xs text-muted-foreground cursor-help">ⓘ</span>
+                </TooltipTrigger>
+                <TooltipContent side="right" className="max-w-xs">
+                  Opens the mic the first time you load the chat composer in this browser, so you can start
+                  talking right away instead of clicking the mic button.
+                </TooltipContent>
+              </Tooltip>
+            </label>
           </div>
 
           <div className="text-xs text-muted-foreground pt-2 border-t border-white/10 dark:border-black/10">

--- a/packages/research-agent-ui/src/hooks/voice/useVoiceAutoStart.ts
+++ b/packages/research-agent-ui/src/hooks/voice/useVoiceAutoStart.ts
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Auto-starts dictation once per browser when the user has
+ * opted in via `VoiceSettingsPanel`'s "start talking automatically" setting.
+ *
+ * Fires at most once per browser (tracked in localStorage), so the composer
+ * remounting on navigation doesn't reopen the mic repeatedly.
+ */
+"use client";
+
+import { useEffect } from "react";
+import {
+  hasVoiceAutoStartTriggered,
+  isVoiceAutoStartEnabled,
+  markVoiceAutoStartTriggered,
+  shouldAutoStartVoice,
+} from "../../lib/voiceAutoStart";
+
+export interface UseVoiceAutoStartOptions {
+  isSpeechSupported: boolean;
+  isListening: boolean;
+  toggleSpeech: () => Promise<void>;
+}
+
+export function useVoiceAutoStart({
+  isSpeechSupported,
+  isListening,
+  toggleSpeech,
+}: UseVoiceAutoStartOptions): void {
+  useEffect(() => {
+    if (
+      shouldAutoStartVoice(
+        { enabled: isVoiceAutoStartEnabled(), isSpeechSupported, isListening },
+        hasVoiceAutoStartTriggered(),
+      )
+    ) {
+      markVoiceAutoStartTriggered();
+      void toggleSpeech();
+    }
+    // Only ever meant to run once, when speech support is first known.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSpeechSupported]);
+}

--- a/packages/research-agent-ui/src/lib/voiceAutoStart.ts
+++ b/packages/research-agent-ui/src/lib/voiceAutoStart.ts
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview localStorage-backed "start talking automatically" voice setting.
+ *
+ * Two flags: whether the user opted in (persists across visits, toggled from
+ * `VoiceSettingsPanel`), and whether auto-start has already fired once in
+ * this browser (so it starts dictation on first visit only, not on every
+ * mount/navigation while the composer remounts).
+ */
+const ENABLED_KEY = "voiceAutoStart";
+const TRIGGERED_KEY = "voiceAutoStartTriggered";
+
+const isBrowser = typeof window !== "undefined";
+
+/** Whether the user has opted in to auto-starting dictation. */
+export function isVoiceAutoStartEnabled(): boolean {
+  if (!isBrowser) return false;
+  return localStorage.getItem(ENABLED_KEY) === "true";
+}
+
+/** Persists the user's auto-start preference. */
+export function setVoiceAutoStartEnabled(enabled: boolean): void {
+  if (!isBrowser) return;
+  localStorage.setItem(ENABLED_KEY, String(enabled));
+}
+
+/** Marks auto-start as already fired in this browser. */
+export function markVoiceAutoStartTriggered(): void {
+  if (!isBrowser) return;
+  localStorage.setItem(TRIGGERED_KEY, "true");
+}
+
+export interface ShouldAutoStartVoiceOptions {
+  /** Whether the user opted in via `isVoiceAutoStartEnabled()`. */
+  enabled: boolean;
+  /** Whether the browser/environment can actually run speech input. */
+  isSpeechSupported: boolean;
+  /** Whether dictation is already listening. */
+  isListening: boolean;
+}
+
+/**
+ * Pure decision of whether to auto-start dictation right now. Does not read
+ * or write localStorage itself so it stays trivially testable; callers read
+ * the "already triggered" flag and call `markVoiceAutoStartTriggered()`.
+ */
+export function shouldAutoStartVoice(
+  { enabled, isSpeechSupported, isListening }: ShouldAutoStartVoiceOptions,
+  alreadyTriggered: boolean,
+): boolean {
+  return enabled && isSpeechSupported && !isListening && !alreadyTriggered;
+}
+
+/** Whether auto-start has already fired in this browser. */
+export function hasVoiceAutoStartTriggered(): boolean {
+  if (!isBrowser) return false;
+  return localStorage.getItem(TRIGGERED_KEY) === "true";
+}

--- a/packages/research-agent-ui/test/useVoiceAutoStart.test.ts
+++ b/packages/research-agent-ui/test/useVoiceAutoStart.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Unit tests for the `useVoiceAutoStart` hook.
+ */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useVoiceAutoStart } from '../src/hooks/voice/useVoiceAutoStart';
+import { hasVoiceAutoStartTriggered, setVoiceAutoStartEnabled } from '../src/lib/voiceAutoStart';
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+describe('useVoiceAutoStart', () => {
+    it('starts dictation and marks it triggered when the user opted in and speech is supported', () => {
+        setVoiceAutoStartEnabled(true);
+        const toggleSpeech = vi.fn().mockResolvedValue(undefined);
+
+        renderHook(() =>
+            useVoiceAutoStart({ isSpeechSupported: true, isListening: false, toggleSpeech })
+        );
+
+        expect(toggleSpeech).toHaveBeenCalledTimes(1);
+        expect(hasVoiceAutoStartTriggered()).toBe(true);
+    });
+
+    it('does nothing when the user has not opted in', () => {
+        const toggleSpeech = vi.fn().mockResolvedValue(undefined);
+
+        renderHook(() =>
+            useVoiceAutoStart({ isSpeechSupported: true, isListening: false, toggleSpeech })
+        );
+
+        expect(toggleSpeech).not.toHaveBeenCalled();
+        expect(hasVoiceAutoStartTriggered()).toBe(false);
+    });
+
+    it('does not start when speech is unsupported', () => {
+        setVoiceAutoStartEnabled(true);
+        const toggleSpeech = vi.fn().mockResolvedValue(undefined);
+
+        renderHook(() =>
+            useVoiceAutoStart({ isSpeechSupported: false, isListening: false, toggleSpeech })
+        );
+
+        expect(toggleSpeech).not.toHaveBeenCalled();
+    });
+
+    it('does not start again on a second mount once already triggered', () => {
+        setVoiceAutoStartEnabled(true);
+        const toggleSpeech = vi.fn().mockResolvedValue(undefined);
+
+        renderHook(() =>
+            useVoiceAutoStart({ isSpeechSupported: true, isListening: false, toggleSpeech })
+        );
+        renderHook(() =>
+            useVoiceAutoStart({ isSpeechSupported: true, isListening: false, toggleSpeech })
+        );
+
+        expect(toggleSpeech).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/research-agent-ui/test/voiceAutoStart.test.ts
+++ b/packages/research-agent-ui/test/voiceAutoStart.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Unit tests for the "start talking automatically" voice setting.
+ */
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+    hasVoiceAutoStartTriggered,
+    isVoiceAutoStartEnabled,
+    markVoiceAutoStartTriggered,
+    setVoiceAutoStartEnabled,
+    shouldAutoStartVoice,
+} from '../src/lib/voiceAutoStart';
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+describe('isVoiceAutoStartEnabled / setVoiceAutoStartEnabled', () => {
+    it('defaults to disabled when nothing is stored', () => {
+        expect(isVoiceAutoStartEnabled()).toBe(false);
+    });
+
+    it('persists an enabled preference', () => {
+        setVoiceAutoStartEnabled(true);
+
+        expect(isVoiceAutoStartEnabled()).toBe(true);
+    });
+
+    it('persists a disabled preference after being enabled', () => {
+        setVoiceAutoStartEnabled(true);
+        setVoiceAutoStartEnabled(false);
+
+        expect(isVoiceAutoStartEnabled()).toBe(false);
+    });
+});
+
+describe('markVoiceAutoStartTriggered / hasVoiceAutoStartTriggered', () => {
+    it('defaults to not triggered', () => {
+        expect(hasVoiceAutoStartTriggered()).toBe(false);
+    });
+
+    it('records that auto-start already fired', () => {
+        markVoiceAutoStartTriggered();
+
+        expect(hasVoiceAutoStartTriggered()).toBe(true);
+    });
+});
+
+describe('shouldAutoStartVoice', () => {
+    const base = { enabled: true, isSpeechSupported: true, isListening: false };
+
+    it('starts when enabled, supported, idle, and not yet triggered', () => {
+        expect(shouldAutoStartVoice(base, false)).toBe(true);
+    });
+
+    it('does not start when the user has not opted in', () => {
+        expect(shouldAutoStartVoice({ ...base, enabled: false }, false)).toBe(false);
+    });
+
+    it('does not start when speech input is unsupported', () => {
+        expect(shouldAutoStartVoice({ ...base, isSpeechSupported: false }, false)).toBe(false);
+    });
+
+    it('does not start when already listening', () => {
+        expect(shouldAutoStartVoice({ ...base, isListening: true }, false)).toBe(false);
+    });
+
+    it('does not start when it already triggered once in this browser', () => {
+        expect(shouldAutoStartVoice(base, true)).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds an opt-in "Start talking automatically on first visit" checkbox to `VoiceSettingsPanel`, addressing the TODO.md item: "Option to start talking automatically on first visit, or via a button from anywhere on the site."
- New `src/lib/voiceAutoStart.ts`: pure localStorage-backed helpers (`isVoiceAutoStartEnabled`, `setVoiceAutoStartEnabled`, `hasVoiceAutoStartTriggered`, `markVoiceAutoStartTriggered`, `shouldAutoStartVoice`).
- New `src/hooks/voice/useVoiceAutoStart.ts`: wires the decision into `ChatInputBox`'s existing `toggleSpeech`/`isListening`/`isSpeechSupported` from `useSpeechInput`. Fires at most once per browser so remounts/navigation don't reopen the mic repeatedly.

**Non-goals** (documented in TODO.md): a global floating mic button rendered outside the chat composer on non-chat routes — the existing Ctrl+\` shortcut and composer mic button already work "from anywhere" the composer is mounted; a separate global FAB would be a larger, separate change.

## Test plan
- [x] `bun run test` in `packages/research-agent-ui` — 67/67 passed (14 new tests covering `voiceAutoStart.ts` and `useVoiceAutoStart`)
- [x] `bun run build` in `packages/research-agent-ui` (vite bundle) — passes
- [ ] Lint — no `lint` script/ESLint config exists in this package or repo root
- [ ] Typecheck (`bun run type-check`) — fails on pre-existing `TS2307` errors for workspace packages with no built `dist/` (`chat-agent-toolkit`, `use-voice-control/*`, `use-weather-forecast`, `trending-news-api`); confirmed identical on the base commit via `git stash`, unrelated to this change
- [ ] `bun run build:web` (full production build) — in progress at time of PR; will report back if it surfaces anything caused by this change

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTXAAN6sZD9674tYPQjdMH)_