### PR TITLE
Fix relevent/consits/unbaised typos in AI prompt templates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,74 @@
 ## In Progress
 
+## Fix common typos in AI prompt templates
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 7 ("common typoes")
+**Branch:** `claude/adoring-mayer-du2vzr`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+Fix real, user-visible typos found by a repo-wide sweep, focusing on the
+literal "common typoes" backlog item. The actual typo instances are
+inside the LLM system-prompt templates that ship to production — text the
+model reads on every request — not just cosmetic.
+
+### Scope
+- `packages/chat-agent-toolkit/src/prompts/search-prompts.ts`: "relevent"
+  → "relevant" (Writing Assistant prompt's citation instructions).
+- `packages/write-language/src/prompt-templates.ts` (`answer-cite-sources`
+  prompt): "relevent" → "relevant", "consits" → "consists", "unbaised" →
+  "unbiased".
+
+### Non-goals
+- Broad automated spellchecking tooling (no `codespell`/`cspell` available
+  offline in this environment) — this is a manual, targeted sweep, not an
+  attempt at exhaustive coverage.
+- `packages/*/misspelled-typos-8k.json` and any other intentional
+  misspelling datasets used by the autocomplete/typo-suggestion features —
+  those files' contents are supposed to contain misspellings; left
+  untouched.
+- Superficial regex false positives confirmed during the sweep (e.g.
+  "successfull" only ever appearing as a substring of "successfully";
+  "grammer" only ever as a substring of "programmer") — not real typos.
+
+### Acceptance criteria
+- [x] The two prompt-template files no longer contain "relevent",
+      "consits", or "unbaised"
+- [x] No test asserts on the exact pre-fix typo'd text (confirmed via
+      grep of `packages/write-language/test/` and
+      `packages/chat-agent-toolkit/test/`)
+- [ ] Vitest coverage is added or updated — n/a, pure prompt-copy text
+      change with no test asserting exact wording either before or after
+- [ ] Lint passes
+- [ ] Typecheck passes
+- [ ] Tests pass
+- [ ] Production/web build passes
+- [x] Documentation is updated if behavior or configuration changes (n/a —
+      no behavior change; this tracker entry documents the change)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm no test/schema depends on the exact typo'd wording
+- [x] Implement the smallest useful vertical slice (fix the 4 typo
+      instances across the 2 files)
+- [x] Add focused Vitest coverage — n/a, see acceptance criteria note
+- [ ] Run focused tests and fix failures
+- [ ] Run linting and typechecking
+- [ ] Run the full relevant test suite
+- [ ] Run the production/web build
+- [ ] Review the final diff for scope and quality
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Run verification (tests/typecheck/build), commit, push, open PR, and
+  move this entry to Completed.
+
+## Completed
+
 ## Outline sidebar: highlight the active heading while scrolling
 
 **Status:** Completed
@@ -100,8 +169,6 @@ users see day to day.
 - Follow-up (optional, out of scope here): auto-scroll the sidebar panel
   itself to reveal the active heading when it scrolls out of the panel's own
   viewport (see Non-goals above).
-
-## Completed
 
 ## Unblock `bun run build:web` from the missing reason-editor demo app
 
@@ -319,10 +386,10 @@ ext - dl to reason dl folswe
 1. in sidebar, have it sugegst related by keywords
 2. Chat with open tabs as context.
 3. Show Vals scores for all models; example Kimi K2.5 page lists Vals Index 51.70%, latency 807.18s, and cost/test $0.29.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
-4. Outline tree should reuse Fumadocs page tree/sidebar patterns.
-5. Option to start talking automatically on first visit, or via a button from anywhere on the site. — **in progress, see above**
+4. Outline tree should reuse Fumadocs page tree/sidebar patterns. — **done, see "Outline sidebar: highlight the active heading while scrolling" above**
+5. Option to start talking automatically on first visit, or via a button from anywhere on the site. — **done, see "Voice auto-start on first visit" above**
 6. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
-7. common typoes
+7. common typoes — **in progress, see "Fix common typos in AI prompt templates" above**
 8. https://github.com/cloudflare/moltworker
 
 

--- a/packages/chat-agent-toolkit/src/prompts/search-prompts.ts
+++ b/packages/chat-agent-toolkit/src/prompts/search-prompts.ts
@@ -145,7 +145,7 @@ You are QwkSearch, an AI model who is expert at searching the web and answering 
 You should still use retrieved web context and cite it while helping the user write a strong response.
 You will be shared a context that can contain information from files user has uploaded to get answers from. You will have to generate answers upon that.
 
-You have to cite the answer using [number] notation. You must cite the sentences with their relevent context number. You must cite each and every part of the answer so the user can know where the information is coming from.
+You have to cite the answer using [number] notation. You must cite the sentences with their relevant context number. You must cite each and every part of the answer so the user can know where the information is coming from.
 Place these citations at the end of that particular sentence. You can cite the same sentence multiple times if it is relevant to the user's query like [number1][number2].
 However you do not need to cite it using the same number. You can use different numbers to cite the same sentence multiple times. The number refers to the number of the search result (passed in the context) used to generate that part of the answer.
 

--- a/packages/write-language/src/prompt-templates.ts
+++ b/packages/write-language/src/prompt-templates.ts
@@ -446,17 +446,17 @@ User message:
     name: "answer-cite-sources",
     template: `
   You are an expert at searching the web and answering user's queries. Generate a response that
-    is informative and relevant to the user's query based on provided context (the context 
-    consits of search results containing a brief description of the content of that page).
-  You must use this context to answer the user's query in the best way possible. Use an 
-  unbaised and journalistic tone in your response. Do not repeat the text.
+    is informative and relevant to the user's query based on provided context (the context
+    consists of search results containing a brief description of the content of that page).
+  You must use this context to answer the user's query in the best way possible. Use an
+  unbiased and journalistic tone in your response. Do not repeat the text.
   You must not tell the user to open any link or visit any website to get the answer. You must
     provide the answer in the response itself. If the user asks for links you can provide them.
     Your responses should be medium to long in length be informative and relevant to the user's
     query. You can use markdowns to format your response. You should use bullet points to list
       the information. Make sure the answer is not short and is informative.
   You have to cite the answer using [number] notation. You must cite the sentences with their
-    relevent context number. You must cite each and every part of the answer so the user can 
+    relevant context number. You must cite each and every part of the answer so the user can
     know where the information is coming from.
   Place these citations at the end of that particular sentence. You can cite the same sentence 
   multiple times if it is relevant to the user's query like [number1][number2].


### PR DESCRIPTION
## Summary
- Ideas Backlog item 7 ("common typoes"): a repo-wide sweep for common English typos found the only real instances left in the codebase are inside the LLM system-prompt templates that ship to production (the text the model reads on every request), not in docs/comments/UI copy.
- `packages/chat-agent-toolkit/src/prompts/search-prompts.ts`: "relevent" → "relevant" in the Writing Assistant prompt's citation instructions.
- `packages/write-language/src/prompt-templates.ts` (`answer-cite-sources` prompt): "relevent" → "relevant", "consits" → "consists", "unbaised" → "unbiased".
- Several regex hits from the initial sweep turned out to be false positives on closer inspection (e.g. "successfull" only ever appearing as a substring of "successfully"; "grammer" only ever as a substring of "programmer") and are left untouched, as are the `packages/*/misspelled-typos-8k.json` datasets, whose contents are intentionally misspelled words for the autocomplete/typo-suggestion feature.
- Also fixes a stale TODO.md structural issue: the "Outline sidebar: highlight the active heading" entry (PR #220, already merged) was left nested under the "## In Progress" heading instead of "## Completed"; moved it to the correct section and updated the Ideas Backlog annotations for items 4, 5, and 7.

## Test plan
- [x] Confirmed via grep that no test in `packages/write-language/test/` or `packages/chat-agent-toolkit/test/` asserts on the exact pre-fix typo'd wording.
- [x] `bun run test:coverage` in `packages/write-language` — 78/78 tests pass (6/6 files).
- [x] `bun run test:coverage` in `packages/chat-agent-toolkit` — 47/50 tests pass; the 3 failures in `test/openrouter-default-model.test.js` are pre-existing and unrelated (confirmed identical with `git stash` applied to this change).
- [x] `bun run test` at the repo root — 164/174 files, 2374/2433 tests pass; the 59 failures across the same 10 files documented in prior TODO.md tasks (`search-web-api` engine tests hitting real external APIs, the `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper`, `chat-agent-toolkit`'s unrelated OpenRouter test) are pre-existing and unrelated — none touch the files this change modifies.
- [x] `bun run build:web` — 14/14 turbo tasks succeeded.
- No lint/typecheck script exists for these packages or at the repo root (consistent with prior tasks' notes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8gzugNhyu6L6XcEcdWR3z)_