### PR TITLE
Auto-scroll the outline sidebar to reveal the active heading

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,8 +13,7 @@ scrolling" task below (PR #220's Non-goals / Remaining work: "auto-scroll
 the sidebar panel itself to reveal the active heading when it scrolls out of
 the panel's own viewport").
 **Branch:** `claude/adoring-mayer-ldfe0q`
-**PR:** Not created yet — will be created and linked immediately after this
-commit is pushed.
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/224
 **Started:** 2026-08-14
 **Completed:** 2026-08-14
 
@@ -100,8 +99,7 @@ completing the Fumadocs-style TOC behavior that PR #220 explicitly deferred.
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task. PR will be linked above once created; CI/review will
-  be monitored.
+- None for this task. PR #224 is open and CI/review will be monitored.
 
 ## Outline sidebar: highlight the active heading while scrolling
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,115 @@
 ## In Progress
 
+## Completed
+
+## Outline sidebar: auto-scroll to reveal the active heading
+
+
+**Status:** Completed
+**Source:** TODO.md — Ideas Backlog item 4 ("Outline tree should reuse
+Fumadocs page tree/sidebar patterns."), continuing the follow-up explicitly
+deferred in the "Outline sidebar: highlight the active heading while
+scrolling" task below (PR #220's Non-goals / Remaining work: "auto-scroll
+the sidebar panel itself to reveal the active heading when it scrolls out of
+the panel's own viewport").
+**Branch:** `claude/adoring-mayer-ldfe0q`
+**PR:** Not created yet — will be created and linked immediately after this
+commit is pushed.
+**Started:** 2026-08-14
+**Completed:** 2026-08-14
+
+### Goal
+When scroll-spy (`useActiveHeading`) marks a new heading "active" in the
+`OutlineView` sidebar panel, and that row is scrolled out of the panel's own
+viewport, automatically scroll the panel so the active row becomes visible —
+completing the Fumadocs-style TOC behavior that PR #220 explicitly deferred.
+
+### Scope
+- A small, pure `computeScrollIntoViewOffset` helper in
+  `packages/reason-editor/src/search/OutlineView.tsx` (or a co-located
+  module) that, given the outline panel's own scroll container
+  (`scrollTop`/`clientHeight`) and the active row's offset
+  (`offsetTop`/`offsetHeight`), returns the `scrollTop` needed to bring the
+  row fully into view, or `null` if it's already fully visible.
+- Wire a container ref onto `OutlineView`'s own scrollable root div and a
+  per-row ref map (heading id → row `<div>`), then an effect keyed on the
+  active heading id that applies the computed offset.
+- No-op (no scrolling) when there is no active heading, no `editorRef`, or
+  the active row isn't currently rendered (e.g. hidden by a collapsed
+  ancestor).
+
+### Non-goals
+- Automatically expanding a collapsed ancestor so a hidden active row
+  becomes visible — out of scope; this slice only scrolls rows that are
+  already rendered.
+- Smooth/animated scrolling — an instant `scrollTop` jump is sufficient for
+  this slice and keeps the behavior simple to test in jsdom.
+- Touching `DynamicIslandTOC.tsx` or `RichTextTableOfContents.tsx` — only
+  the sidebar `OutlineView` panel is in scope, matching PR #220's scoping.
+
+### Acceptance criteria
+- [x] When the active heading changes to a row that is scrolled above the
+      panel's visible area, the panel scrolls up just enough to reveal it.
+- [x] When the active heading changes to a row that is scrolled below the
+      panel's visible area, the panel scrolls down just enough to reveal it.
+- [x] When the active row is already fully visible, the panel's scroll
+      position is left untouched.
+- [x] With no `editorRef`/no active heading, no scrolling occurs and nothing
+      throws.
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for this package or at the repo
+      root (no ESLint config found); nothing to run
+- [x] Typecheck passes — `npx tsc --noEmit -p tsconfig.json` in
+      `reason-editor` surfaces the same 5 **pre-existing** errors as the
+      prior task (`InviteModal.tsx`, `Pagination.ts`, `filetree.tsx`), none
+      of which this change touches. No new errors from this change's files.
+- [x] Tests pass — `bun run test` in `reason-editor`: 461/461 passed
+      (42/42 files, including 8 new/updated tests in `OutlineView.test.tsx`
+      covering `computeScrollIntoViewOffset` directly plus the
+      mount-triggered auto-scroll behavior). Full workspace `bun run test`:
+      164/174 files, 2385/2441 tests pass (4 skipped); the 52 failures
+      across the same 10 files documented in the prior "Unblock
+      `bun run build:web`"/"highlight the active heading" task entries
+      (`search-web-api` engine tests hitting real external APIs, the
+      `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper`)
+      are pre-existing and unrelated — none touch `reason-editor`.
+- [x] Production/web build passes — `bun run build:web`: 14/14 turbo tasks
+      succeeded, including `react-reason-editor#build` and
+      `qwksearch-web#build`'s full `vinext` pipeline.
+- [x] Documentation is updated if behavior or configuration changes (this
+      tracker entry + inline comments where non-obvious)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements
+- [x] Implement the smallest useful vertical slice
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (no editorRef; row already
+      visible; boundary case where the row exactly fills the viewport)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — neither
+      is actionable for this change)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality (also reverted an
+      unrelated `bun.lock` diff produced by `bun install` — pure
+      version-number sync, out of scope, matching the prior task's
+      precedent)
+- [x] Commit and push the branch
+- [x] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task. PR will be linked above once created; CI/review will
+  be monitored.
+
 ## Outline sidebar: highlight the active heading while scrolling
 
 **Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 4 ("Outline tree should reuse
 Fumadocs page tree/sidebar patterns.")
 **Branch:** `claude/adoring-mayer-ntjy99`
-**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/220
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/220 (merged)
 **Started:** 2026-08-14
 **Completed:** 2026-08-14
 
@@ -96,12 +199,9 @@ users see day to day.
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task. PR #220 is open and CI/review will be monitored.
-- Follow-up (optional, out of scope here): auto-scroll the sidebar panel
-  itself to reveal the active heading when it scrolls out of the panel's own
-  viewport (see Non-goals above).
-
-## Completed
+- None for this task. PR #220 merged.
+- Follow-up now in progress above: "Outline sidebar: auto-scroll to reveal
+  the active heading" (see Non-goals above).
 
 ## Unblock `bun run build:web` from the missing reason-editor demo app
 

--- a/packages/reason-editor/src/search/OutlineView.tsx
+++ b/packages/reason-editor/src/search/OutlineView.tsx
@@ -6,7 +6,7 @@
  */
 import { HashIcon, ChevronRightIcon } from 'lucide-react';
 import { cn } from '../app-utils/utils';
-import { useMemo, useState, useEffect, useImperativeHandle, forwardRef, type RefObject } from 'react';
+import { useMemo, useState, useEffect, useRef, useImperativeHandle, forwardRef, type RefObject } from 'react';
 import type { TocEntry } from '../app-types/toc';
 import { useActiveHeading, type ActiveHeadingEditorHandle } from './useActiveHeading';
 import {
@@ -66,6 +66,28 @@ interface OutlineViewProps {
 const STORAGE_KEY = 'outline-collapse-preferences';
 
 /**
+ * Given the outline panel's own scroll container (`scrollTop`/`clientHeight`)
+ * and the active row's offset within it (`offsetTop`/`offsetHeight`), returns
+ * the `scrollTop` needed to bring the row fully into view — scrolling up if
+ * it's above the visible area, down if it's below — or `null` if the row is
+ * already fully visible and no scrolling is needed.
+ */
+export function computeScrollIntoViewOffset(
+  container: { scrollTop: number; clientHeight: number },
+  row: { offsetTop: number; offsetHeight: number },
+): number | null {
+  if (row.offsetTop < container.scrollTop) {
+    return row.offsetTop;
+  }
+  const rowBottom = row.offsetTop + row.offsetHeight;
+  const viewportBottom = container.scrollTop + container.clientHeight;
+  if (rowBottom > viewportBottom) {
+    return rowBottom - container.clientHeight;
+  }
+  return null;
+}
+
+/**
  * Collapsible document outline panel. Renders a heading tree built from
  * `headings` with click-to-navigate, expand/collapse, drag-to-reorder,
  * search filtering, and a context menu for bulk collapse-level controls.
@@ -74,6 +96,23 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
   const [defaultCollapseLevel, setDefaultCollapseLevel] = useState<number | null>(null);
   const activeHeadingId = useActiveHeading(headings, editorRef);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // Auto-scroll the outline panel itself so the active row stays visible as
+  // scroll-spy advances, mirroring Fumadocs' TOC sidebar behavior. No-ops
+  // when the active row isn't currently rendered (e.g. hidden by a
+  // collapsed ancestor) or already fully visible.
+  useEffect(() => {
+    if (!activeHeadingId) return;
+    const container = containerRef.current;
+    const row = rowRefs.current.get(activeHeadingId);
+    if (!container || !row) return;
+    const offset = computeScrollIntoViewOffset(container, row);
+    if (offset !== null) {
+      container.scrollTop = offset;
+    }
+  }, [activeHeadingId]);
 
   // Derive flat outline from TocEntry list: [key, text, tag]
   const outline = useMemo<OutlineItem[]>(() => {
@@ -247,7 +286,7 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
   }
 
   return (
-    <div className="flex h-full flex-col overflow-auto">
+    <div ref={containerRef} className="flex h-full flex-col overflow-auto">
       {filteredOutline.map((item) => {
         // `filteredOutline` is a subset of `outline`, so its position in the
         // rendered list does not match `item`'s position in the unfiltered
@@ -268,6 +307,10 @@ export const OutlineView = forwardRef<OutlineViewHandle, OutlineViewProps>(({ he
           <ContextMenu key={item.id}>
             <ContextMenuTrigger>
               <div
+                ref={(el) => {
+                  if (el) rowRefs.current.set(item.id, el);
+                  else rowRefs.current.delete(item.id);
+                }}
                 data-active={isActive || undefined}
                 className={cn(
                   'flex items-center gap-1 rounded-md cursor-pointer transition-colors hover:bg-sidebar-accent',

--- a/packages/reason-editor/test/search/OutlineView.test.tsx
+++ b/packages/reason-editor/test/search/OutlineView.test.tsx
@@ -9,7 +9,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { OutlineView } from '@/search/OutlineView';
+import { OutlineView, computeScrollIntoViewOffset } from '@/search/OutlineView';
 import type { ActiveHeadingEditorHandle } from '@/search/useActiveHeading';
 import type { TocEntry } from '@/app-types/toc';
 
@@ -88,6 +88,22 @@ function headingRow(text: string) {
 
 function toggleButton(text: string) {
   return headingRow(text)?.querySelector('button') as HTMLButtonElement | undefined;
+}
+
+/**
+ * jsdom's `offsetTop`/`offsetHeight`/`clientHeight`/`scrollTop` are always 0
+ * (no real layout engine), so tests that exercise the outline panel's
+ * auto-scroll-into-view effect stub them per-element with `defineProperty`
+ * (plain assignment throws on the getter-only layout properties).
+ */
+function stubLayout(el: HTMLElement, props: Record<string, number>) {
+  for (const [key, value] of Object.entries(props)) {
+    Object.defineProperty(el, key, { value, writable: true, configurable: true });
+  }
+}
+
+function outlineContainer(): HTMLDivElement {
+  return container.querySelector('.overflow-auto') as HTMLDivElement;
 }
 
 function collapseFirstHeading() {
@@ -177,5 +193,77 @@ describe('OutlineView', () => {
     mount({ editorRef });
 
     expect(headingRow('Introduction')?.getAttribute('data-active')).toBe('true');
+  });
+
+  it('scrolls the panel down when the newly active row is below the visible area', () => {
+    mount();
+    stubLayout(outlineContainer(), { clientHeight: 100, scrollTop: 0 });
+    stubLayout(headingRow('Details')!, { offsetTop: 150, offsetHeight: 20 });
+
+    // threshold = 768 * 0.3 = 230.4; h1/h2/h2b are all <= threshold, h3 is
+    // not, so "Details" (h2b) is the active heading.
+    const editorRef = mockEditorRef({ h1: -300, h2: -100, h2b: 50, h3: 600 });
+    mount({ editorRef });
+
+    expect(outlineContainer().scrollTop).toBe(70);
+  });
+
+  it('scrolls the panel up when the newly active row is above the visible area', () => {
+    mount();
+    stubLayout(outlineContainer(), { clientHeight: 100, scrollTop: 70 });
+    stubLayout(headingRow('Introduction')!, { offsetTop: 0, offsetHeight: 20 });
+
+    const editorRef = mockEditorRef({ h1: 400, h2: 500, h2b: 600, h3: 700 });
+    mount({ editorRef });
+
+    expect(outlineContainer().scrollTop).toBe(0);
+  });
+
+  it('does not scroll the panel when the newly active row is already fully visible', () => {
+    mount();
+    stubLayout(outlineContainer(), { clientHeight: 100, scrollTop: 20 });
+    stubLayout(headingRow('Setup')!, { offsetTop: 30, offsetHeight: 20 });
+
+    const editorRef = mockEditorRef({ h1: -50, h2: 100, h2b: 300, h3: 600 });
+    mount({ editorRef });
+
+    expect(outlineContainer().scrollTop).toBe(20);
+  });
+
+  it('does not scroll when no editorRef is supplied (no active heading)', () => {
+    mount();
+    const el = outlineContainer();
+    stubLayout(el, { clientHeight: 100, scrollTop: 42 });
+
+    // Re-render without changing anything active-heading related.
+    mount();
+
+    expect(el.scrollTop).toBe(42);
+  });
+});
+
+describe('computeScrollIntoViewOffset', () => {
+  const container = { scrollTop: 50, clientHeight: 100 };
+
+  it('scrolls up to the row’s top when the row starts above the visible area', () => {
+    const offset = computeScrollIntoViewOffset(container, { offsetTop: 20, offsetHeight: 20 });
+    expect(offset).toBe(20);
+  });
+
+  it('scrolls down just enough to reveal the row’s bottom when it ends below the visible area', () => {
+    // viewport bottom = 150; row bottom = 160 + 20 = 180; needed scrollTop = 180 - 100 = 80.
+    const offset = computeScrollIntoViewOffset(container, { offsetTop: 160, offsetHeight: 20 });
+    expect(offset).toBe(80);
+  });
+
+  it('returns null when the row is already fully visible', () => {
+    const offset = computeScrollIntoViewOffset(container, { offsetTop: 60, offsetHeight: 20 });
+    expect(offset).toBeNull();
+  });
+
+  it('returns null when the row exactly fills the visible area’s edges', () => {
+    // row spans [50, 150), exactly the container's visible [scrollTop, scrollTop + clientHeight) range.
+    const offset = computeScrollIntoViewOffset(container, { offsetTop: 50, offsetHeight: 100 });
+    expect(offset).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Completes the Fumadocs-style TOC follow-up that PR #220 explicitly deferred: when scroll-spy (`useActiveHeading`) marks a new heading "active" in the `OutlineView` sidebar panel, and its row is scrolled out of the panel's own viewport, the panel now auto-scrolls just enough to reveal it.
- New pure `computeScrollIntoViewOffset` helper in `packages/reason-editor/src/search/OutlineView.tsx`: given the panel's own scroll container (`scrollTop`/`clientHeight`) and the active row's offset (`offsetTop`/`offsetHeight`), returns the `scrollTop` needed to reveal it, or `null` if already fully visible.
- Wires a container ref and a per-row ref map into an effect keyed on the active heading id that applies the computed offset.
- No-ops with no active heading, no `editorRef`, or when the active row isn't currently rendered (e.g. hidden by a collapsed ancestor).

## Test plan
- [x] `bun run test` in `packages/reason-editor`: 461/461 passed (8 new/updated tests covering `computeScrollIntoViewOffset` directly and the mount-triggered auto-scroll behavior — scroll up, scroll down, already-visible no-op, no-editorRef no-op, boundary case)
- [x] `bun run test` at the repo root: 164/174 files, 2385/2441 tests pass; the 52 failures across 10 files are pre-existing/unrelated (external API calls, `jsdom-scraper`, `qwksearch-web` config route, `shadcn-settings`) and don't touch `reason-editor` — same set documented in prior merged PRs (#218, #220)
- [x] `npx tsc --noEmit -p tsconfig.json` in `reason-editor`: same 5 pre-existing errors as before (`InviteModal.tsx`, `Pagination.ts`, `filetree.tsx`), none touched by this change
- [x] `bun run build:web`: 14/14 turbo tasks succeeded

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbXo6ecVWTzaJ3MKBzANoS)_