### PR TITLE
Record PR #224 merged in the outline auto-scroll TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,6 @@ model reads on every request — not just cosmetic.
 
 ## Outline sidebar: auto-scroll to reveal the active heading
 
-
 **Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 4 ("Outline tree should reuse
 Fumadocs page tree/sidebar patterns."), continuing the follow-up explicitly
@@ -80,7 +79,7 @@ scrolling" task below (PR #220's Non-goals / Remaining work: "auto-scroll
 the sidebar panel itself to reveal the active heading when it scrolls out of
 the panel's own viewport").
 **Branch:** `claude/adoring-mayer-ldfe0q`
-**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/224
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/224 (merged)
 **Started:** 2026-08-14
 **Completed:** 2026-08-14
 
@@ -166,7 +165,7 @@ completing the Fumadocs-style TOC behavior that PR #220 explicitly deferred.
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task. PR #224 is open and CI/review will be monitored.
+- None for this task. PR #224 merged.
 
 ## Outline sidebar: highlight the active heading while scrolling
 


### PR DESCRIPTION
## Summary
- PR #224 (the auto-scroll feature) was merged before this tracker-only follow-up could land on it, leaving `TODO.md` on `master` saying "PR: ...pull/224" without noting it was merged, and "PR #224 is open and CI/review will be monitored" in the Remaining work note.
- Documentation-only fix: marks the PR link `(merged)` and updates the remaining-work note. Also removes a stray double-blank-line left by an earlier merge-conflict resolution.

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EbXo6ecVWTzaJ3MKBzANoS)_