### PR TITLE
Add "Related" sidebar panel suggesting documents by keyword overlap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,84 @@
 ## In Progress
 
+## Sidebar: suggest related documents by keyword overlap
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 1 ("in sidebar, have it sugegst
+related by keywords")
+**Branch:** `claude/adoring-mayer-vnisju`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+Add a new "Related" sidebar panel to the REASON editor that suggests other
+documents related to the currently active document, ranked by shared
+significant keywords — a small, independently useful first slice of Ideas
+Backlog item 1.
+
+### Scope
+- Pure `findRelatedDocuments` helper in
+  `packages/reason-editor/src/search/relatedDocuments.ts`: extracts
+  significant keywords (stopword- and length-filtered) from the active
+  document's title + plain-text content (reusing the existing
+  `stripHtmlToText` from `searchDocuments.ts`), scores every other
+  non-folder, non-deleted document by shared-keyword overlap, and returns
+  the top-N ranked matches.
+- New `'related'` `SidebarPanelType`, registered in `panelOptions.ts`
+  (`PANEL_OPTIONS`) so it's toggleable from the existing "Split View
+  Options" dropdown (`SidebarViewMenu`) exactly like the
+  `outline`/`files`/`ai`/`openTabs` panels.
+- A `renderRelated()` view added to `SidebarContent.tsx` (mirrors
+  `renderOutline`/`renderFiles`) showing the ranked related-document titles;
+  clicking one calls the existing `onSelect`.
+
+### Non-goals
+- Any server-side/embedding-based semantic similarity — this slice is pure
+  client-side keyword overlap, matching the existing `searchDocuments.ts`
+  approach (plain substring/keyword matching, no ML).
+- Related suggestions in the chat/search UI (`research-agent-ui`) or based
+  on open browser tabs — scoped to the REASON editor's document sidebar
+  only, matching where the Fumadocs-style outline/file-tree panels already
+  live.
+- Automatically opening/expanding a related document — this slice only
+  lists related documents and lets the user click through via the existing
+  `onSelect` callback.
+
+### Acceptance criteria
+- [ ] With an active document sharing keywords with other documents, the
+      "Related" panel lists them ranked by shared-keyword count, most
+      related first.
+- [ ] The active document itself is never included in its own related list.
+- [ ] Folders and soft-deleted documents are excluded from related
+      suggestions.
+- [ ] With no active document, or no keyword overlap with any other
+      document, the panel shows an empty state rather than throwing.
+- [ ] Vitest coverage is added or updated
+- [ ] Lint passes
+- [ ] Typecheck passes
+- [ ] Tests pass
+- [ ] Production/web build passes
+- [ ] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      sidebar panels)
+
+### Implementation plan
+- [ ] Inspect affected modules, local instructions, and existing tests
+- [ ] Confirm API, schema, data-flow, or interface requirements
+- [ ] Implement the smallest useful vertical slice
+- [ ] Add focused Vitest success-path coverage
+- [ ] Add focused failure, validation, or edge-case coverage
+- [ ] Run focused tests and fix failures
+- [ ] Run linting and typechecking
+- [ ] Run the full relevant test suite
+- [ ] Run the production/web build
+- [ ] Review the final diff for scope and quality
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Everything above; implementation not yet started.
+
 ## Fix common typos in AI prompt templates
 
 **Status:** In Progress

--- a/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -10,6 +10,7 @@ import { RefObject, useState, useCallback, useMemo, useRef } from 'react';
 import { FileTree } from '../../file-tree';
 import { OutlineView, type OutlineViewHandle } from '../../search/OutlineView';
 import type { ActiveHeadingEditorHandle } from '../../search/useActiveHeading';
+import { findRelatedDocuments } from '../../search/relatedDocuments';
 import { AIRewriteSuggestion } from '../../features/ai-rewrite/AIRewriteSuggestion';
 import { Input } from '../../app-ui/input';
 import { Document } from '../../documents/DocumentTree';
@@ -18,7 +19,7 @@ import type { TocEntry } from '../../app-types/toc';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../../utils/storage';
-import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus } from 'lucide-react';
+import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2 } from 'lucide-react';
 import { FileTypeIcon } from '../../app-ui/FileTypeIcon';
 import { cn } from '../../app-utils/utils';
 import {
@@ -38,6 +39,7 @@ const PANEL_TITLES: Record<SidebarPanelType, string> = {
   files: 'Files',
   outline: 'Outline',
   openTabs: 'Open Tabs',
+  related: 'Related',
 };
 
 /** Props for the {@link SidebarContent} component. */
@@ -382,6 +384,36 @@ export const SidebarContent = ({
     </div>
   );
 
+  const relatedResults = useMemo(
+    () => findRelatedDocuments(activeDocuments, activeDocument),
+    [activeDocuments, activeDocument],
+  );
+
+  const renderRelated = () => (
+    <div className="h-full overflow-hidden flex flex-col">
+      <div className="px-3 py-2 border-b border-sidebar-border shrink-0">
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Related</p>
+      </div>
+      <div className="flex-1 overflow-auto px-1 py-1">
+        {relatedResults.length === 0 ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">No related documents found</div>
+        ) : (
+          relatedResults.map(({ document: doc, sharedKeywordCount }) => (
+            <div
+              key={doc.id}
+              className="group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer transition-colors hover:bg-sidebar-accent"
+              onClick={() => handleSelect(doc.id)}
+            >
+              <Link2 className="shrink-0 h-4 w-4 text-muted-foreground" />
+              <span className="flex-1 truncate text-sm">{doc.title}</span>
+              <span className="shrink-0 text-xs text-muted-foreground">{sharedKeywordCount}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+
   const renderAi = () => (
     <div className="h-full overflow-hidden flex flex-col">
       <div className="px-3 py-2 border-b border-sidebar-border shrink-0">
@@ -419,6 +451,7 @@ export const SidebarContent = ({
       case 'files': return renderFiles();
       case 'openTabs': return renderOpenTabs();
       case 'outline': return renderOutline();
+      case 'related': return renderRelated();
       case 'ai': return renderAi();
     }
   };

--- a/packages/reason-editor/src/layout/sidebar/panelOptions.ts
+++ b/packages/reason-editor/src/layout/sidebar/panelOptions.ts
@@ -5,7 +5,7 @@
  * sidebar and the right panel, and by the {@link SidebarViewMenu} dropdown
  * that controls them.
  */
-import { Sparkles, FileText, AlignLeft, Layers, type LucideIcon } from 'lucide-react';
+import { Sparkles, FileText, AlignLeft, Layers, Link2, type LucideIcon } from 'lucide-react';
 import type { SidebarPanelType } from './types';
 
 /** Ordered list of togglable panel kinds shown in the view menu, with display metadata. */
@@ -14,6 +14,7 @@ export const PANEL_OPTIONS: { type: SidebarPanelType; label: string; icon: Lucid
   { type: 'files', label: 'Files', icon: FileText },
   { type: 'outline', label: 'Outline', icon: AlignLeft },
   { type: 'openTabs', label: 'Open Tabs', icon: Layers },
+  { type: 'related', label: 'Related', icon: Link2 },
 ];
 
 /**

--- a/packages/reason-editor/src/layout/sidebar/types.ts
+++ b/packages/reason-editor/src/layout/sidebar/types.ts
@@ -10,7 +10,7 @@ import type { TocEntry } from "../../app-types/toc";
 import type { ActiveHeadingEditorHandle } from "../../search/useActiveHeading";
 
 /** A single togglable panel kind that can appear in the left or right sidebar. */
-export type SidebarPanelType = "ai" | "files" | "outline" | "openTabs";
+export type SidebarPanelType = "ai" | "files" | "outline" | "openTabs" | "related";
 
 /** The kind of resource a tab in the "Open Tabs" panel represents. */
 export type OpenTabKind = "file" | "chat";

--- a/packages/reason-editor/src/search/relatedDocuments.ts
+++ b/packages/reason-editor/src/search/relatedDocuments.ts
@@ -1,0 +1,92 @@
+/**
+ * @module relatedDocuments
+ * @description Client-side "related documents" suggestions for the sidebar's
+ * Related panel. Scores every other document by how many significant
+ * keywords it shares with the active document's title and plain-text
+ * content — the same plain-text approach {@link searchDocuments} uses, no
+ * server calls or embeddings involved.
+ */
+import type { Document } from '../documents/DocumentTree';
+import { stripHtmlToText } from './searchDocuments';
+
+/** A related-document suggestion returned by {@link findRelatedDocuments}. */
+export interface RelatedDocumentResult {
+  /** The related document. */
+  document: Document;
+  /** Number of significant keywords shared with the active document. */
+  sharedKeywordCount: number;
+}
+
+const MIN_KEYWORD_LENGTH = 4;
+const DEFAULT_LIMIT = 10;
+
+/** Common English words excluded from keyword extraction as too generic to signal relevance. */
+const STOPWORDS = new Set([
+  'about', 'above', 'after', 'again', 'against', 'along', 'also', 'always',
+  'among', 'around', 'because', 'before', 'below', 'between', 'both',
+  'cannot', 'could', 'does', 'doing', 'down', 'during', 'each', 'either',
+  'every', 'first', 'from', 'further', 'have', 'having', 'here', 'into',
+  'just', 'more', 'most', 'once', 'only', 'other', 'over', 'same', 'shall',
+  'should', 'since', 'some', 'such', 'than', 'that', 'their', 'them',
+  'then', 'there', 'these', 'they', 'this', 'those', 'through', 'under',
+  'until', 'very', 'were', 'what', 'when', 'where', 'which', 'while',
+  'will', 'with', 'would', 'your',
+]);
+
+/** Extracts the set of lower-cased, stopword-filtered significant keywords from a document. */
+function extractKeywords(doc: Document): Set<string> {
+  const text = `${doc.title} ${stripHtmlToText(doc.content)}`.toLowerCase();
+  const words = text.match(/[a-z0-9]+/g) ?? [];
+  const keywords = new Set<string>();
+  for (const word of words) {
+    if (word.length >= MIN_KEYWORD_LENGTH && !STOPWORDS.has(word)) {
+      keywords.add(word);
+    }
+  }
+  return keywords;
+}
+
+/**
+ * Ranks candidate documents by how many significant keywords they share with
+ * `activeDocument`'s title and content. Folders, soft-deleted documents, and
+ * the active document itself are never suggested.
+ *
+ * @param documents - Candidate documents to search (typically all documents).
+ * @param activeDocument - The currently open document, or `undefined`/`null` when none is active.
+ * @param limit - Maximum number of suggestions to return (default 10).
+ */
+export function findRelatedDocuments(
+  documents: Document[],
+  activeDocument: Document | undefined | null,
+  limit: number = DEFAULT_LIMIT,
+): RelatedDocumentResult[] {
+  if (!activeDocument) return [];
+
+  const activeKeywords = extractKeywords(activeDocument);
+  if (activeKeywords.size === 0) return [];
+
+  const results: RelatedDocumentResult[] = [];
+
+  for (const doc of documents) {
+    if (doc.id === activeDocument.id || doc.isFolder || doc.isDeleted) continue;
+
+    const docKeywords = extractKeywords(doc);
+    let sharedKeywordCount = 0;
+    for (const keyword of activeKeywords) {
+      if (docKeywords.has(keyword)) sharedKeywordCount++;
+    }
+
+    if (sharedKeywordCount > 0) {
+      results.push({ document: doc, sharedKeywordCount });
+    }
+  }
+
+  results.sort((a, b) => {
+    if (b.sharedKeywordCount !== a.sharedKeywordCount) {
+      return b.sharedKeywordCount - a.sharedKeywordCount;
+    }
+    return a.document.title.localeCompare(b.document.title);
+  });
+
+  return results.slice(0, limit);
+}

--- a/packages/reason-editor/test/search/relatedDocuments.test.ts
+++ b/packages/reason-editor/test/search/relatedDocuments.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Coverage for the sidebar's "Related" panel keyword-overlap ranking.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { Document } from '@/documents/DocumentTree';
+import { findRelatedDocuments } from '@/search/relatedDocuments';
+
+function makeDoc(overrides: Partial<Document> & { id: string }): Document {
+  return {
+    title: 'Untitled',
+    content: '',
+    parentId: null,
+    ...overrides,
+  };
+}
+
+describe('findRelatedDocuments', () => {
+  it('returns an empty list when there is no active document', () => {
+    const docs = [makeDoc({ id: '1', title: 'Recipes', content: '<p>Pasta</p>' })];
+
+    expect(findRelatedDocuments(docs, undefined)).toEqual([]);
+    expect(findRelatedDocuments(docs, null)).toEqual([]);
+  });
+
+  it('ranks documents by the number of shared significant keywords, most shared first', () => {
+    const active = makeDoc({
+      id: 'active',
+      title: 'Sprint Planning',
+      content: '<p>backlog grooming velocity</p>',
+    });
+    const docs = [
+      active,
+      makeDoc({ id: 'strong', title: 'Sprint Retro', content: '<p>backlog grooming velocity notes</p>' }),
+      makeDoc({ id: 'weak', title: 'Sprint Notes', content: '<p>random unrelated words</p>' }),
+      makeDoc({ id: 'none', title: 'Groceries', content: '<p>milk eggs bread</p>' }),
+    ];
+
+    const results = findRelatedDocuments(docs, active);
+
+    expect(results.map((r) => r.document.id)).toEqual(['strong', 'weak']);
+    expect(results[0].sharedKeywordCount).toBeGreaterThan(results[1].sharedKeywordCount);
+  });
+
+  it('never includes the active document itself', () => {
+    const active = makeDoc({ id: 'active', title: 'Budget Plan', content: '<p>budget plan finances</p>' });
+    const docs = [active];
+
+    expect(findRelatedDocuments(docs, active)).toEqual([]);
+  });
+
+  it('excludes folders and soft-deleted documents from suggestions', () => {
+    const active = makeDoc({ id: 'active', title: 'Budget Plan', content: '<p>budget finances quarterly</p>' });
+    const docs = [
+      active,
+      makeDoc({ id: 'folder', title: 'Budget Folder', content: '<p>budget finances quarterly</p>', isFolder: true }),
+      makeDoc({ id: 'deleted', title: 'Old Budget', content: '<p>budget finances quarterly</p>', isDeleted: true }),
+    ];
+
+    expect(findRelatedDocuments(docs, active)).toEqual([]);
+  });
+
+  it('returns an empty list when there is no keyword overlap with any other document', () => {
+    const active = makeDoc({ id: 'active', title: 'Budget Plan', content: '<p>budget finances quarterly</p>' });
+    const docs = [active, makeDoc({ id: 'other', title: 'Groceries', content: '<p>milk eggs bread</p>' })];
+
+    expect(findRelatedDocuments(docs, active)).toEqual([]);
+  });
+
+  it('respects the limit parameter', () => {
+    const active = makeDoc({ id: 'active', title: 'Sprint Planning', content: '<p>backlog grooming velocity</p>' });
+    const docs = [
+      active,
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeDoc({ id: `related-${i}`, title: `Sprint Doc ${i}`, content: '<p>backlog grooming velocity</p>' }),
+      ),
+    ];
+
+    expect(findRelatedDocuments(docs, active, 2)).toHaveLength(2);
+  });
+
+  it('ignores short and generic stopwords when extracting keywords', () => {
+    const active = makeDoc({ id: 'active', title: 'The Plan', content: '<p>with that this were about</p>' });
+    const docs = [active, makeDoc({ id: 'other', title: 'The Idea', content: '<p>with that this were about</p>' })];
+
+    expect(findRelatedDocuments(docs, active)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Ideas Backlog item 1 ("in sidebar, have it sugegst related by keywords"): adds a small, independently useful first slice — a "Related" panel in the REASON editor's sidebar that suggests other documents related to the currently active one, ranked by shared significant keywords.
- New pure `findRelatedDocuments` helper (`packages/reason-editor/src/search/relatedDocuments.ts`): extracts stopword-/length-filtered keywords from the active document's title + plain-text content (reusing `stripHtmlToText` from the existing `searchDocuments.ts`), scores every other non-folder, non-deleted document by shared-keyword overlap, and returns the top-N ranked matches.
- New `'related'` `SidebarPanelType`, registered in `panelOptions.ts` so it's toggleable from the existing "Split View Options" dropdown exactly like the `outline`/`files`/`ai`/`openTabs` panels, with a `renderRelated()` view in `SidebarContent.tsx` that lists ranked related-document titles and navigates via the existing `onSelect` callback on click.
- Client-side keyword overlap only (no embeddings/server calls), scoped to the REASON editor's document sidebar (not the chat/search UI or open browser tabs) — see TODO.md's Non-goals for the full list of what's explicitly deferred.

## Test plan
- [x] New Vitest coverage in `packages/reason-editor/test/search/relatedDocuments.test.ts`: ranking by shared-keyword count, excludes the active document itself, excludes folders/soft-deleted documents, empty state with no active document or no overlap, respects the result limit, ignores stopwords/short words.
- [x] `bun run test` in `packages/reason-editor`: 468/468 tests pass (43/43 files).
- [x] `npx tsc --noEmit -p tsconfig.json` in `packages/reason-editor`: same 5 **pre-existing** errors as documented in prior TODO.md tasks (`InviteModal.tsx`, `Pagination.ts`, `filetree.tsx`), none touching this change's files.
- [x] `bun run test` at the repo root: 165/175 files, 2391/2448 tests pass (4 skipped); the 53 failures across 10 files are the same pre-existing, unrelated failures documented in prior TODO.md tasks (`search-web-api` engine tests hitting real external APIs, the `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper`) — none touch `reason-editor`.
- [x] `bun run build:web`: 14/14 turbo tasks succeeded.
- No lint script exists at the repo root or for this package (consistent with prior tasks' notes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUsJJgnQHgpEKGWSULi78q)_