### PR TITLE
Rank the Related sidebar panel by shared tags as well as keyword overlap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,108 @@ Backlog on the next run)_
 
 ## Completed
 
+## Related panel: rank by shared tags as well as keyword overlap
+
+**Status:** Completed
+**Source:** TODO.md — Ideas Backlog item 1 ("in sidebar, have it sugegst
+related by keywords"), continuing the follow-up explicitly deferred in the
+"Sidebar: suggest related documents by keyword overlap" task's Remaining
+work ("incorporating document tags (`Document.tags`) into the relevance
+score alongside keyword overlap").
+**Branch:** `claude/adoring-mayer-0mn2j7`
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/229 (pending)
+**Started:** 2026-08-14
+**Completed:** 2026-08-14
+
+### Goal
+Make the sidebar's "Related" panel also rank documents by shared
+user-assigned tags (`Document.tags`), not just incidental keyword overlap —
+a deliberate relatedness signal the user themselves created via the existing
+tag-management UI, which the first slice's PR (#226) explicitly deferred.
+
+### Scope
+- `findRelatedDocuments` in `packages/reason-editor/src/search/relatedDocuments.ts`:
+  extract each document's tags (trimmed, lower-cased for case-insensitive
+  matching), count shared tags with the active document, and weight each
+  shared tag as `TAG_MATCH_WEIGHT` (5) shared keywords when ranking — tags
+  are a stronger, more deliberate signal than incidental keyword overlap.
+- A document with shared tags but zero shared keywords now qualifies for
+  the Related list (previously required at least one shared keyword).
+- `RelatedDocumentResult` gains a `sharedTagCount` field alongside the
+  existing `sharedKeywordCount`.
+- `SidebarContent.tsx`'s `renderRelated()`: show a small tag icon + count
+  next to the existing keyword-count badge when `sharedTagCount > 0`.
+
+### Non-goals
+- Any change to how tags are created/edited (`TagManagementDialog`,
+  `useReasonDocsState`) — this task only consumes the existing `tags`
+  field for scoring.
+- Weighting by tag *rarity* (e.g. TF-IDF-style boosts for uncommon tags) —
+  a flat per-tag weight is sufficient for this slice.
+- The other follow-ups noted in PR #226's Remaining work (surfacing
+  related-document suggestions in the chat/search UI, open-tab context) —
+  out of scope here, tag-aware scoring only.
+
+### Acceptance criteria
+- [x] A document sharing at least one tag with the active document appears
+      in the Related list even with zero shared keywords.
+- [x] A document with a shared tag ranks above a document with only a
+      larger keyword-only overlap.
+- [x] Tag matching is case-insensitive and ignores blank/whitespace-only
+      tags.
+- [x] Existing keyword-overlap-only ranking behavior is unchanged when
+      neither document has tags.
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for this package or at the
+      repo root (no ESLint config found); nothing to run
+- [x] Typecheck passes — `npx tsc --noEmit -p tsconfig.json` in
+      `reason-editor` surfaces the same 5 **pre-existing** errors as prior
+      tasks (`InviteModal.tsx`, `Pagination.ts`, `filetree.tsx`), none of
+      which this change touches. No new errors from this change's files.
+- [x] Tests pass — `bunx vitest run test/search/relatedDocuments.test.ts`
+      in `reason-editor`: 10/10 passed. Full `reason-editor` suite
+      (`bunx vitest run`): 471/471 passed (43/43 files). Full workspace
+      `bun run test`: 165/175 files, 2393/2451 tests pass (4 skipped); the
+      54 failures across the same 10 files documented in prior TODO.md
+      tasks (`search-web-api` engine tests hitting real external APIs, the
+      `qwksearch-web` config route test, `shadcn-settings`,
+      `jsdom-scraper` missing its `jsdom` dependency,
+      `settings-field.test.tsx`) are pre-existing and unrelated — none
+      touch `reason-editor`.
+- [x] Production/web build passes — `bun run build:web`: 14/14 turbo tasks
+      succeeded.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry and updated inline docs (no user-facing
+      docs describe individual sidebar panels)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements
+      (`Document.tags?: string[]`, already populated via
+      `TagManagementDialog`/`useReasonDocsState`)
+- [x] Implement the smallest useful vertical slice
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (tag-only match, tag beats
+      larger keyword overlap, case-insensitive/blank-tag handling)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint is
+      not actionable for this change)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality
+- [x] Commit and push the branch
+- [x] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task.
+- Natural follow-ups (left for a future run, per Ideas Backlog item 1's
+  broader scope): surfacing related-document suggestions in the
+  chat/search UI (`research-agent-ui`) rather than just the REASON editor
+  sidebar; open-tab context.
+
+## Completed
+
 ## Fix common typos in AI prompt templates
 
 **Status:** Completed
@@ -604,15 +706,16 @@ button / Ctrl+` shortcut in `ChatInputBox`.
     are unaffected — see item 0).
 ext - dl to reason dl folswe
 1. in sidebar, have it sugegst related by keywords — **first slice done, see
-   "Sidebar: suggest related documents by keyword overlap" above** (further
-   surfaces — chat/search UI, open-tab context, tag-aware scoring — remain
-   as follow-ups)
+   "Sidebar: suggest related documents by keyword overlap" above; tag-aware
+   scoring done, see "Related panel: rank by shared tags as well as
+   keyword overlap" above** (further surfaces — chat/search UI, open-tab
+   context — remain as follow-ups)
 2. Chat with open tabs as context.
 3. Show Vals scores for all models; example Kimi K2.5 page lists Vals Index 51.70%, latency 807.18s, and cost/test $0.29.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
 4. Outline tree should reuse Fumadocs page tree/sidebar patterns. — **done, see "Outline sidebar: highlight the active heading while scrolling" above**
 5. Option to start talking automatically on first visit, or via a button from anywhere on the site. — **done, see "Voice auto-start on first visit" above**
 6. OpenRouter apps inspiration/reference: [openrouter.ai/apps](https://openrouter.ai/apps), and OpenRouter also documents app attribution plus public app rankings.
-7. common typoes — **in progress, see "Fix common typos in AI prompt templates" above**
+7. common typoes — **done, see "Fix common typos in AI prompt templates" above**
 8. https://github.com/cloudflare/moltworker
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,91 +1,18 @@
 ## In Progress
 
-## Sidebar: suggest related documents by keyword overlap
+_(none — see Completed below; a new task will be selected from the Ideas
+Backlog on the next run)_
 
-**Status:** In Progress
-**Source:** TODO.md — Ideas Backlog item 1 ("in sidebar, have it sugegst
-related by keywords")
-**Branch:** `claude/adoring-mayer-vnisju`
-**PR:** Not created yet
-**Started:** 2026-08-14
-
-### Goal
-Add a new "Related" sidebar panel to the REASON editor that suggests other
-documents related to the currently active document, ranked by shared
-significant keywords — a small, independently useful first slice of Ideas
-Backlog item 1.
-
-### Scope
-- Pure `findRelatedDocuments` helper in
-  `packages/reason-editor/src/search/relatedDocuments.ts`: extracts
-  significant keywords (stopword- and length-filtered) from the active
-  document's title + plain-text content (reusing the existing
-  `stripHtmlToText` from `searchDocuments.ts`), scores every other
-  non-folder, non-deleted document by shared-keyword overlap, and returns
-  the top-N ranked matches.
-- New `'related'` `SidebarPanelType`, registered in `panelOptions.ts`
-  (`PANEL_OPTIONS`) so it's toggleable from the existing "Split View
-  Options" dropdown (`SidebarViewMenu`) exactly like the
-  `outline`/`files`/`ai`/`openTabs` panels.
-- A `renderRelated()` view added to `SidebarContent.tsx` (mirrors
-  `renderOutline`/`renderFiles`) showing the ranked related-document titles;
-  clicking one calls the existing `onSelect`.
-
-### Non-goals
-- Any server-side/embedding-based semantic similarity — this slice is pure
-  client-side keyword overlap, matching the existing `searchDocuments.ts`
-  approach (plain substring/keyword matching, no ML).
-- Related suggestions in the chat/search UI (`research-agent-ui`) or based
-  on open browser tabs — scoped to the REASON editor's document sidebar
-  only, matching where the Fumadocs-style outline/file-tree panels already
-  live.
-- Automatically opening/expanding a related document — this slice only
-  lists related documents and lets the user click through via the existing
-  `onSelect` callback.
-
-### Acceptance criteria
-- [ ] With an active document sharing keywords with other documents, the
-      "Related" panel lists them ranked by shared-keyword count, most
-      related first.
-- [ ] The active document itself is never included in its own related list.
-- [ ] Folders and soft-deleted documents are excluded from related
-      suggestions.
-- [ ] With no active document, or no keyword overlap with any other
-      document, the panel shows an empty state rather than throwing.
-- [ ] Vitest coverage is added or updated
-- [ ] Lint passes
-- [ ] Typecheck passes
-- [ ] Tests pass
-- [ ] Production/web build passes
-- [ ] Documentation is updated if behavior or configuration changes — n/a
-      beyond this tracker entry (no user-facing docs describe individual
-      sidebar panels)
-
-### Implementation plan
-- [ ] Inspect affected modules, local instructions, and existing tests
-- [ ] Confirm API, schema, data-flow, or interface requirements
-- [ ] Implement the smallest useful vertical slice
-- [ ] Add focused Vitest success-path coverage
-- [ ] Add focused failure, validation, or edge-case coverage
-- [ ] Run focused tests and fix failures
-- [ ] Run linting and typechecking
-- [ ] Run the full relevant test suite
-- [ ] Run the production/web build
-- [ ] Review the final diff for scope and quality
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
-
-### Remaining work
-- Everything above; implementation not yet started.
+## Completed
 
 ## Fix common typos in AI prompt templates
 
-**Status:** In Progress
+**Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 7 ("common typoes")
 **Branch:** `claude/adoring-mayer-du2vzr`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/222 (merged)
 **Started:** 2026-08-14
+**Completed:** 2026-08-14
 
 ### Goal
 Fix real, user-visible typos found by a repo-wide sweep, focusing on the
@@ -118,12 +45,25 @@ model reads on every request — not just cosmetic.
 - [x] No test asserts on the exact pre-fix typo'd text (confirmed via
       grep of `packages/write-language/test/` and
       `packages/chat-agent-toolkit/test/`)
-- [ ] Vitest coverage is added or updated — n/a, pure prompt-copy text
+- [x] Vitest coverage is added or updated — n/a, pure prompt-copy text
       change with no test asserting exact wording either before or after
-- [ ] Lint passes
-- [ ] Typecheck passes
-- [ ] Tests pass
-- [ ] Production/web build passes
+- [ ] Lint passes — no `lint` script exists for this package or at the
+      repo root (no ESLint config found); nothing to run
+- [ ] Typecheck passes — no `typecheck`/`tsc` script exists for
+      `chat-agent-toolkit` or `write-language`; nothing to run
+- [x] Tests pass — `bunx vitest run packages/chat-agent-toolkit/test/`:
+      47/50 pass (the 3 failures in `openrouter-default-model.test.js` are
+      pre-existing and unrelated — they assert on OpenRouter's default
+      free-model id/metadata, a file untouched by this change).
+      `bunx vitest run packages/write-language/test/`: 78/78 pass. Full
+      workspace `bun run test`: 165/175 files, 2387/2448 tests pass (4
+      skipped); the 57 failures across the same 10 files documented in
+      prior TODO.md tasks (`search-web-api` engine tests hitting real
+      external APIs, the `qwksearch-web` config route test,
+      `shadcn-settings`, `jsdom-scraper` missing its `jsdom` dependency)
+      are pre-existing and unrelated — none touch the two changed files.
+- [x] Production/web build passes — `bun run build:web`: 14/14 turbo tasks
+      succeeded.
 - [x] Documentation is updated if behavior or configuration changes (n/a —
       no behavior change; this tracker entry documents the change)
 
@@ -133,20 +73,23 @@ model reads on every request — not just cosmetic.
 - [x] Implement the smallest useful vertical slice (fix the 4 typo
       instances across the 2 files)
 - [x] Add focused Vitest coverage — n/a, see acceptance criteria note
-- [ ] Run focused tests and fix failures
-- [ ] Run linting and typechecking
-- [ ] Run the full relevant test suite
-- [ ] Run the production/web build
-- [ ] Review the final diff for scope and quality
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — neither
+      is actionable for this change)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #222, already merged before
+      this tracker-only follow-up)
+- [x] Update tracker status, completed checkboxes, and remaining work
+      (also removed a stale duplicate "In Progress" entry for the
+      already-merged "Sidebar: suggest related documents" task left behind
+      by a prior run, and fixed this entry's section nesting — it had been
+      left outside the `## Completed` heading)
 
 ### Remaining work
-- Run verification (tests/typecheck/build), commit, push, open PR, and
-  move this entry to Completed.
-
-## Completed
+- None for this task. PR #222 merged; this run only finalized the tracker.
 
 ## Sidebar: suggest related documents by keyword overlap
 

--- a/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -19,7 +19,7 @@ import type { TocEntry } from '../../app-types/toc';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../../utils/storage';
-import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2 } from 'lucide-react';
+import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag } from 'lucide-react';
 import { FileTypeIcon } from '../../app-ui/FileTypeIcon';
 import { cn } from '../../app-utils/utils';
 import {
@@ -398,7 +398,7 @@ export const SidebarContent = ({
         {relatedResults.length === 0 ? (
           <div className="px-2 py-3 text-xs text-muted-foreground">No related documents found</div>
         ) : (
-          relatedResults.map(({ document: doc, sharedKeywordCount }) => (
+          relatedResults.map(({ document: doc, sharedKeywordCount, sharedTagCount }) => (
             <div
               key={doc.id}
               className="group flex items-center gap-2 px-2 py-1.5 rounded-md cursor-pointer transition-colors hover:bg-sidebar-accent"
@@ -406,7 +406,13 @@ export const SidebarContent = ({
             >
               <Link2 className="shrink-0 h-4 w-4 text-muted-foreground" />
               <span className="flex-1 truncate text-sm">{doc.title}</span>
-              <span className="shrink-0 text-xs text-muted-foreground">{sharedKeywordCount}</span>
+              {sharedTagCount > 0 && (
+                <span className="shrink-0 flex items-center gap-0.5 text-xs text-muted-foreground" title={`${sharedTagCount} shared tag${sharedTagCount === 1 ? '' : 's'}`}>
+                  <Tag className="h-3 w-3" />
+                  {sharedTagCount}
+                </span>
+              )}
+              <span className="shrink-0 text-xs text-muted-foreground" title={`${sharedKeywordCount} shared keyword${sharedKeywordCount === 1 ? '' : 's'}`}>{sharedKeywordCount}</span>
             </div>
           ))
         )}

--- a/packages/reason-editor/src/search/relatedDocuments.ts
+++ b/packages/reason-editor/src/search/relatedDocuments.ts
@@ -4,7 +4,8 @@
  * Related panel. Scores every other document by how many significant
  * keywords it shares with the active document's title and plain-text
  * content — the same plain-text approach {@link searchDocuments} uses, no
- * server calls or embeddings involved.
+ * server calls or embeddings involved — boosted by any shared user-assigned
+ * tags, a more deliberate relatedness signal than incidental keyword overlap.
  */
 import type { Document } from '../documents/DocumentTree';
 import { stripHtmlToText } from './searchDocuments';
@@ -15,10 +16,14 @@ export interface RelatedDocumentResult {
   document: Document;
   /** Number of significant keywords shared with the active document. */
   sharedKeywordCount: number;
+  /** Number of tags shared with the active document (case-insensitive). */
+  sharedTagCount: number;
 }
 
 const MIN_KEYWORD_LENGTH = 4;
 const DEFAULT_LIMIT = 10;
+/** Weight applied to each shared tag when ranking, relative to a single shared keyword. */
+const TAG_MATCH_WEIGHT = 5;
 
 /** Common English words excluded from keyword extraction as too generic to signal relevance. */
 const STOPWORDS = new Set([
@@ -46,10 +51,24 @@ function extractKeywords(doc: Document): Set<string> {
   return keywords;
 }
 
+/** Extracts the set of trimmed, lower-cased tags assigned to a document. */
+function extractTags(doc: Document): Set<string> {
+  const tags = new Set<string>();
+  for (const tag of doc.tags ?? []) {
+    const normalized = tag.trim().toLowerCase();
+    if (normalized) tags.add(normalized);
+  }
+  return tags;
+}
+
 /**
- * Ranks candidate documents by how many significant keywords they share with
- * `activeDocument`'s title and content. Folders, soft-deleted documents, and
- * the active document itself are never suggested.
+ * Ranks candidate documents by how many significant keywords and tags they
+ * share with `activeDocument`. Each shared tag counts as {@link
+ * TAG_MATCH_WEIGHT} shared keywords when ranking, since a user-assigned tag
+ * is a more deliberate relatedness signal than incidental keyword overlap. A
+ * document with no shared keywords but at least one shared tag still
+ * qualifies. Folders, soft-deleted documents, and the active document itself
+ * are never suggested.
  *
  * @param documents - Candidate documents to search (typically all documents).
  * @param activeDocument - The currently open document, or `undefined`/`null` when none is active.
@@ -63,7 +82,8 @@ export function findRelatedDocuments(
   if (!activeDocument) return [];
 
   const activeKeywords = extractKeywords(activeDocument);
-  if (activeKeywords.size === 0) return [];
+  const activeTags = extractTags(activeDocument);
+  if (activeKeywords.size === 0 && activeTags.size === 0) return [];
 
   const results: RelatedDocumentResult[] = [];
 
@@ -76,15 +96,21 @@ export function findRelatedDocuments(
       if (docKeywords.has(keyword)) sharedKeywordCount++;
     }
 
-    if (sharedKeywordCount > 0) {
-      results.push({ document: doc, sharedKeywordCount });
+    const docTags = extractTags(doc);
+    let sharedTagCount = 0;
+    for (const tag of activeTags) {
+      if (docTags.has(tag)) sharedTagCount++;
+    }
+
+    if (sharedKeywordCount > 0 || sharedTagCount > 0) {
+      results.push({ document: doc, sharedKeywordCount, sharedTagCount });
     }
   }
 
   results.sort((a, b) => {
-    if (b.sharedKeywordCount !== a.sharedKeywordCount) {
-      return b.sharedKeywordCount - a.sharedKeywordCount;
-    }
+    const scoreA = a.sharedKeywordCount + a.sharedTagCount * TAG_MATCH_WEIGHT;
+    const scoreB = b.sharedKeywordCount + b.sharedTagCount * TAG_MATCH_WEIGHT;
+    if (scoreB !== scoreA) return scoreB - scoreA;
     return a.document.title.localeCompare(b.document.title);
   });
 

--- a/packages/reason-editor/test/search/relatedDocuments.test.ts
+++ b/packages/reason-editor/test/search/relatedDocuments.test.ts
@@ -85,4 +85,56 @@ describe('findRelatedDocuments', () => {
 
     expect(findRelatedDocuments(docs, active)).toEqual([]);
   });
+
+  it('includes documents that share a tag but no keywords', () => {
+    const active = makeDoc({ id: 'active', title: 'Budget Plan', content: '<p>budget finances</p>', tags: ['finance'] });
+    const docs = [
+      active,
+      makeDoc({ id: 'tagged', title: 'Unrelated Title', content: '<p>completely different words</p>', tags: ['Finance'] }),
+      makeDoc({ id: 'untagged', title: 'Other Title', content: '<p>completely different words</p>' }),
+    ];
+
+    const results = findRelatedDocuments(docs, active);
+
+    expect(results.map((r) => r.document.id)).toEqual(['tagged']);
+    expect(results[0].sharedTagCount).toBe(1);
+    expect(results[0].sharedKeywordCount).toBe(0);
+  });
+
+  it('ranks a shared tag above a larger keyword-only overlap', () => {
+    const active = makeDoc({
+      id: 'active',
+      title: 'Sprint Planning',
+      content: '<p>backlog grooming velocity</p>',
+      tags: ['sprint'],
+    });
+    const docs = [
+      active,
+      makeDoc({
+        id: 'many-keywords',
+        title: 'Sprint Retro',
+        content: '<p>backlog grooming velocity notes extra words</p>',
+      }),
+      makeDoc({
+        id: 'tag-match',
+        title: 'Unrelated',
+        content: '<p>nothing shared here</p>',
+        tags: ['sprint'],
+      }),
+    ];
+
+    const results = findRelatedDocuments(docs, active);
+
+    expect(results[0].document.id).toBe('tag-match');
+  });
+
+  it('matches tags case-insensitively and ignores blank tags', () => {
+    const active = makeDoc({ id: 'active', title: 'Notes', content: '<p>notes</p>', tags: [' Work ', ''] });
+    const docs = [active, makeDoc({ id: 'other', title: 'Other', content: '<p>different</p>', tags: ['work'] })];
+
+    const results = findRelatedDocuments(docs, active);
+
+    expect(results.map((r) => r.document.id)).toEqual(['other']);
+    expect(results[0].sharedTagCount).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- Ideas Backlog item 1, continuing the follow-up explicitly deferred in PR #226's Remaining work: "incorporating document tags (`Document.tags`) into the relevance score alongside keyword overlap."
- `findRelatedDocuments` (`packages/reason-editor/src/search/relatedDocuments.ts`) now also extracts each document's tags (trimmed, lower-cased) and counts shared tags with the active document. Each shared tag is weighted as 5 shared keywords when ranking — a user-assigned tag is a more deliberate relatedness signal than incidental keyword overlap.
- A document with shared tags but zero shared keywords now qualifies for the Related list (previously required at least one shared keyword).
- `RelatedDocumentResult` gains a `sharedTagCount` field. `SidebarContent.tsx`'s `renderRelated()` shows a small tag icon + count next to the existing keyword-count badge when tags are shared.

## Test plan
- [x] New Vitest coverage in `packages/reason-editor/test/search/relatedDocuments.test.ts`: tag-only match with zero keyword overlap, a shared tag outranking a larger keyword-only overlap, case-insensitive/blank-tag handling.
- [x] `bunx vitest run test/search/relatedDocuments.test.ts` in `packages/reason-editor`: 10/10 pass.
- [x] Full `reason-editor` suite (`bunx vitest run`): 471/471 pass (43/43 files).
- [x] `npx tsc --noEmit -p tsconfig.json` in `packages/reason-editor`: same 5 **pre-existing** errors documented in prior TODO.md tasks (`InviteModal.tsx`, `Pagination.ts`, `filetree.tsx`), none touching this change's files.
- [x] `bun run test` at the repo root: 165/175 files, 2393/2451 tests pass (4 skipped); the 54 failures across 10 files are the same pre-existing, unrelated failures documented in prior TODO.md tasks (`search-web-api` engine tests hitting real external APIs, the `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper` missing a dependency) — none touch `reason-editor`.
- [x] `bun run build:web`: 14/14 turbo tasks succeeded.
- No lint script exists at the repo root or for this package (consistent with prior tasks' notes).

---
_Generated by [Claude Code](https://claude.ai/code/session_013JSvt8gWwkKNou54CNjGzH)_