### PR TITLE
Recognize typed bare domains outside the ranked dataset in autocomplete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,96 @@
 ## In Progress
 
-_(none — see Completed below; a new task will be selected from the Ideas
-Backlog on the next run)_
+## Autocomplete: recognize a typed bare domain even when it's outside the ranked dataset
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 21 ("If autocomplete matches
+something like red.com, go there directly.")
+**Branch:** `claude/adoring-mayer-va3awu`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+When the user types a string that looks like a real domain (e.g.
+`red.com`), offer a "go there directly" suggestion in the chat composer's
+autocomplete dropdown — even when that domain isn't one of the ~10k
+domains in the `domain-rank` ranked dataset the existing fuzzy domain
+search (`searchDomains` in
+`packages/research-agent-ui/src/api/handlers/autocomplete.ts`) matches
+against. Confirmed via a direct check that `red.com` itself is absent from
+`packages/domain-rank/data/domain-rank-merged.json` (10,020 entries), so
+today typing it produces zero domain suggestions — only the existing
+fuzzy match against known top domains works.
+
+### Scope
+- `packages/research-agent-ui/src/api/handlers/autocomplete.ts`:
+  `searchDomains` gains a literal-domain check on the last typed word using
+  `tldts` (already a dependency of `domain-rank`/`search-web-api`/
+  `qwksearch-web`, added here too) to validate the string has a real,
+  recognized public suffix (e.g. `.com`, `.io`, `.co.uk`) — this avoids
+  false positives on filename-like strings (`note.txt`, `script.js`) that a
+  naive `\w+\.\w+` regex would wrongly treat as domains, since `tldts`
+  checks against the actual public-suffix list rather than an arbitrary
+  extension pattern.
+- When the last word is a valid, ranked-dataset-independent domain and
+  isn't already present in the fuzzy results, prepend a synthetic
+  `DomainSuggestion` for it (unranked, so no rank badge renders — same
+  convention already used for dataset entries lacking a rank) ahead of the
+  fuzzy matches, still capped at `MAX_DOMAIN_SUGGESTIONS`.
+- No frontend (`ChatInputBox.tsx`) changes needed — it already renders
+  `domainSuggestions` generically and `goToDomain` already navigates
+  straight to `https://{domain}` on selection.
+
+### Non-goals
+- IP-address literals (e.g. `192.168.1.1`) or `localhost` — out of scope;
+  `tldts` won't recognize these as having a public suffix, and typing an
+  address is a different, less common flow than typing a memorable domain
+  name.
+- Auto-navigating without an explicit selection (e.g. on Enter with no
+  dropdown interaction) — this task only adds the *suggestion*; selecting
+  it (click, Tab, Enter-while-highlighted, or number key) already works via
+  the existing `goToDomain`/`chooseOption` wiring.
+- Changing the existing fuzzy ranked-domain matching behavior in any way
+  when the typed text does *not* look like a full domain.
+
+### Acceptance criteria
+- [ ] Typing a real-looking domain not present in the ranked dataset (e.g.
+      `red.com`) surfaces it as a domain suggestion.
+- [ ] Filename-like strings with non-TLD extensions (e.g. `note.txt`,
+      `script.js`) do NOT spuriously appear as domain suggestions.
+- [ ] A literal domain match that's already found via fuzzy search isn't
+      duplicated in the suggestion list.
+- [ ] The existing ranked-domain fuzzy-match behavior is unchanged for
+      queries that aren't themselves a full valid domain.
+- [ ] Selecting the synthetic suggestion navigates to `https://<domain>`,
+      matching existing dataset-backed domain suggestions.
+- [ ] Vitest coverage is added or updated
+- [ ] Lint passes
+- [ ] Typecheck passes
+- [ ] Tests pass
+- [ ] Production/web build passes
+- [ ] Documentation is updated if behavior or configuration changes
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements (`tldts`
+      already used elsewhere in the repo for the same "is this a real
+      domain suffix" question; `research-agent-ui` doesn't yet depend on it)
+- [ ] Add `tldts` as a dependency of `research-agent-ui`
+- [ ] Implement the smallest useful vertical slice in `autocomplete.ts`
+- [ ] Add focused Vitest success-path coverage
+- [ ] Add focused failure/edge-case coverage (filename false positives,
+      dedupe against fuzzy results, short/invalid input)
+- [ ] Run focused tests and fix failures
+- [ ] Run linting and typechecking
+- [ ] Run the full relevant test suite
+- [ ] Run the production/web build
+- [ ] Review the final diff for scope and quality
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Implementation not yet started — see Implementation plan above.
 
 ## Completed
 

--- a/apps/qwksearch-web/app/api/agent/__tests__/autocomplete.test.ts
+++ b/apps/qwksearch-web/app/api/agent/__tests__/autocomplete.test.ts
@@ -92,6 +92,33 @@ describe('createAutocompleteHandler GET', () => {
     expect(data.suggestions.length).toBeGreaterThan(0)
   })
 
+  it('recognizes a real domain not present in the ranked dataset', async () => {
+    mockAutoComplete.mockResolvedValue([])
+    const res = await handler.GET(getRequest({ q: 'red.com' }))
+    const data = await res.json()
+    const domains: Array<{ domain: string; rank: number }> = data.domains
+    const match = domains.find((d) => d.domain === 'red.com')
+    expect(match).toBeDefined()
+    expect(match!.rank).toBe(Number.MAX_SAFE_INTEGER)
+  })
+
+  it('does not treat a filename-like string as a domain', async () => {
+    mockAutoComplete.mockResolvedValue([])
+    const res = await handler.GET(getRequest({ q: 'note.txt' }))
+    const data = await res.json()
+    const domains: Array<{ domain: string }> = data.domains
+    expect(domains.some((d) => d.domain === 'note.txt')).toBe(false)
+  })
+
+  it('does not duplicate a domain already found via the ranked-dataset fuzzy match', async () => {
+    mockAutoComplete.mockResolvedValue([])
+    const res = await handler.GET(getRequest({ q: 'example.com' }))
+    const data = await res.json()
+    const domains: Array<{ domain: string }> = data.domains
+    const matches = domains.filter((d) => d.domain === 'example.com')
+    expect(matches).toHaveLength(1)
+  })
+
   it('returns 500 on unexpected autocomplete error', async () => {
     mockAutoComplete.mockRejectedValue(new Error('network failure'))
     const res = await handler.GET(getRequest({ q: 'error case' }))

--- a/bun.lock
+++ b/bun.lock
@@ -723,6 +723,7 @@
         "sonner": "^2.0.7",
         "streamdown": "^2.5.0",
         "tailwind-merge": "^3.6.0",
+        "tldts": "^7.4.2",
         "trending-news-api": "workspace:*",
         "turndown": "^7.2.4",
         "use-voice-control": "^0.1.37",

--- a/packages/research-agent-ui/package.json
+++ b/packages/research-agent-ui/package.json
@@ -106,6 +106,7 @@
     "sonner": "^2.0.7",
     "streamdown": "^2.5.0",
     "tailwind-merge": "^3.6.0",
+    "tldts": "^7.4.2",
     "turndown": "^7.2.4",
     "use-voice-control": "^0.1.37"
   },

--- a/packages/research-agent-ui/src/api/handlers/autocomplete.ts
+++ b/packages/research-agent-ui/src/api/handlers/autocomplete.ts
@@ -7,6 +7,7 @@
  */
 import { searchAutocompleteMulti } from "extract-webpage/suggest-next-words/autocomplete-search-engines";
 import Fuse from "fuse.js";
+import { parse as parseHostname } from "tldts";
 import domainData from "domain-rank/data/domain-rank-merged.json";
 
 const DEFAULT_BACKENDS = ["google", "duckduckgo", "wikipedia"];
@@ -55,25 +56,49 @@ function getDomainIndex(): Fuse<DomainEntry> {
   return fuseIndex;
 }
 
+function toDomainSuggestion(domain: string, name: string, rank: number): DomainSuggestion {
+  return {
+    domain,
+    name,
+    favicon: `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=64`,
+    rank,
+  };
+}
+
+// Recognizes a typed word as a real, navigable domain (real registered TLD)
+// even when it's outside the ranked `domain-rank` dataset, e.g. "red.com".
+// Uses tldts's public-suffix check rather than a naive `\w+\.\w+` regex so
+// filename-like strings ("note.txt", "script.js") aren't mistaken for domains.
+function matchLiteralDomain(word: string): string | null {
+  const parsed = parseHostname(word);
+  return parsed.domain && parsed.isIcann ? parsed.hostname : null;
+}
+
 function searchDomains(query: string): DomainSuggestion[] {
   const words = query.split(/\s+/).filter(Boolean);
   const lastWord = words[words.length - 1] || "";
   if (lastWord.length < 3) return [];
 
-  return getDomainIndex()
+  const fuzzyMatches = getDomainIndex()
     .search(lastWord, { limit: 12 })
     .sort(
       (a, b) =>
         Math.round((a.score ?? 1) * 10) - Math.round((b.score ?? 1) * 10) ||
         a.item.rank - b.item.rank,
     )
-    .slice(0, MAX_DOMAIN_SUGGESTIONS)
-    .map(({ item }) => ({
-      domain: item.domain,
-      name: item.name,
-      favicon: `https://www.google.com/s2/favicons?domain=${encodeURIComponent(item.domain)}&sz=64`,
-      rank: item.rank,
-    }));
+    .map(({ item }) => toDomainSuggestion(item.domain, item.name, item.rank));
+
+  const literalDomain = matchLiteralDomain(lastWord);
+  if (
+    literalDomain &&
+    !fuzzyMatches.some((d) => d.domain === literalDomain)
+  ) {
+    fuzzyMatches.unshift(
+      toDomainSuggestion(literalDomain, "", Number.MAX_SAFE_INTEGER),
+    );
+  }
+
+  return fuzzyMatches.slice(0, MAX_DOMAIN_SUGGESTIONS);
 }
 
 async function autocompleteWithFallback(


### PR DESCRIPTION
## Summary
- The chat composer's "Related"... er, domain-suggestion dropdown (`searchDomains` in `packages/research-agent-ui/src/api/handlers/autocomplete.ts`) only matched typed text against the ~10k domains in the `domain-rank` ranked dataset via fuzzy search, so typing a real but unranked domain (e.g. `red.com`, confirmed absent from the 10,020-entry dataset) produced zero "go there directly" suggestions.
- Added a literal-domain check on the last typed word using `tldts` (already used elsewhere in this repo for the same purpose) to validate it has a real, recognized public suffix, and surface it as a suggestion ahead of fuzzy matches, deduped against them and still capped at `MAX_DOMAIN_SUGGESTIONS`.
- Using `tldts`'s public-suffix list rather than a naive `\w+\.\w+` regex avoids false positives on filename-like strings (`note.txt`, `script.js`) that aren't real TLDs.
- No frontend changes needed — `ChatInputBox.tsx` already renders `domainSuggestions` generically and `goToDomain` already navigates to `https://{domain}` on selection.
- Addresses Ideas Backlog item 21 in `TODO.md` ("If autocomplete matches something like red.com, go there directly.").

## Test plan
- [x] `bunx vitest run app/api/agent/__tests__/autocomplete.test.ts` in `apps/qwksearch-web` (new/updated tests): 11/11 passed
- [x] `bun run test` in `packages/research-agent-ui`: 67/67 passed
- [x] `bun run type-check` in `packages/research-agent-ui`: no new errors (5 pre-existing `TS2307` errors in unrelated files, documented in `TODO.md`)
- [x] Full workspace `bun run test`: 165/175 files, 2402/2454 tests pass; the 52 failures across 10 files are pre-existing and unrelated (documented repeatedly in `TODO.md` — external-API-dependent `search-web-api` tests, a `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper` missing its `jsdom` dependency)
- [x] `bun run build:web`: 14/14 turbo tasks succeeded, including `qwksearch-web`'s full `vinext build`

---
_Generated by [Claude Code](https://claude.ai/code/session_017W3ACAPiH3kXRA6opQEGai)_