### PR TITLE
Record PR #233 merged in the Share-button TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,118 @@
 ## In Progress
 
+## Article panel: Share button (native Web Share API with clipboard fallback)
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 22 ("Share button; email to friends;
+social actions.")
+**Branch:** `claude/adoring-mayer-jn1xra`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+Add a "Share" action to the article extract panel's toolbar
+(`ArticleActionButtons.tsx`) so a user can share the article they're
+reading — via the OS-native share sheet (which already surfaces Mail and
+installed social apps as targets on supporting browsers/devices) or, as a
+fallback on browsers without the Web Share API, by copying the article
+link to the clipboard.
+
+### Scope
+- New pure helper `packages/research-agent-ui/src/lib/shareArticle.ts`:
+  given `{ title, text, url }` and injected `share`/`writeText`
+  dependencies, calls `share()` when provided (returns `'shared'`), falls
+  back to `writeText(url)` when `share` is undefined or when `share()`
+  rejects with anything other than a user-cancellation `AbortError`
+  (returns `'copied'`), and returns `'cancelled'` without copying when the
+  user dismisses the native share sheet.
+- `ArticleActionButtons.tsx`: new `Share2`-icon toolbar button (tooltip
+  "Share article", no keyboard shortcut — see Non-goals) calling a new
+  `onShareClick` prop, placed next to the existing Copy button.
+- `ArticleExtractPanel.tsx`: wires `onShareClick` to a handler that calls
+  `shareArticle` with `navigator.share`/`navigator.clipboard.writeText`
+  (feature-detecting `navigator.share`), and shows a brief "Link copied!"
+  confirmation (mirroring the existing `showCopiedMessage` banner) when the
+  result is `'copied'`.
+
+### Non-goals
+- Bespoke share-intent URLs for individual platforms (Twitter/X, Facebook,
+  LinkedIn, WhatsApp, etc.) — the native Web Share API's share sheet
+  already lists installed apps (including Mail) as targets on supporting
+  browsers; dedicated per-platform intents are a follow-up if ever needed
+  for browsers without Web Share support.
+- A keyboard shortcut for the new action — every existing toolbar letter
+  shortcut is taken by an unrelated action (share's natural "s" is already
+  "Suggest"); left unbound rather than picking a non-mnemonic key.
+- Sharing from the chat conversation view (`ChatConversation`) — scoped to
+  the article extract panel only, matching where the existing Copy/
+  Favorite/Highlight toolbar actions already live.
+
+### Acceptance criteria
+- [x] Clicking Share on a browser with the Web Share API invokes
+      `navigator.share` with the article's title/cite/url.
+- [x] Clicking Share on a browser without the Web Share API copies the
+      article URL to the clipboard and shows a brief confirmation.
+- [x] If the user cancels the native share sheet (`AbortError`), nothing is
+      copied and no error is shown.
+- [x] If `navigator.share` rejects for any other reason, the clipboard
+      fallback still runs so the user isn't left without a way to share.
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for this package or at the repo
+      root (no ESLint config found); nothing to run
+- [x] Typecheck passes — `bun run type-check` in `research-agent-ui`
+      surfaces the same 5 **pre-existing** `TS2307` errors documented in
+      prior TODO.md tasks (`ChatHomepage.tsx`, `ChatWindow.tsx`,
+      `MessageSources.tsx`, `WebCitationBadge.tsx` — missing built `dist/`
+      output for workspace packages in a fresh checkout), none of which
+      this change touches. No new errors from this change's files
+      (`navigator.share` type-checks cleanly against the installed DOM lib).
+- [x] Tests pass — `bunx vitest run test/shareArticle.test.ts` in
+      `research-agent-ui`: 4/4 passed. `bun run test` in `research-agent-ui`:
+      71/71 passed (67 pre-existing + 4 new). Full workspace `bun run test`:
+      166/176 files, 2404/2458 tests pass (4 skipped); the 50 failures
+      across the same 10 files documented repeatedly in prior TODO.md tasks
+      (`search-web-api` engine tests hitting real external APIs, the
+      `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper`
+      missing its `jsdom` dependency, `chat-agent-toolkit`'s
+      `openrouter-default-model.test.js`) are pre-existing and unrelated —
+      none touch the changed files.
+- [x] Production/web build passes — `bun run build:web`: 14/14 turbo tasks
+      succeeded, including `qwksearch-web`'s full `vinext build`.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry and inline comments (no user-facing docs
+      describe individual article-toolbar actions); the component's
+      file-level doc comment and Storybook description were updated to
+      mention the new Share button.
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements
+      (`Article.url`/`.title`/`.cite` already populated in
+      `ArticleExtractPanel`; `Share2` icon confirmed present in the
+      installed `lucide-react` version)
+- [x] Implement `shareArticle.ts`
+- [x] Add the Share button to `ArticleActionButtons.tsx`
+- [x] Wire the handler into `ArticleExtractPanel.tsx`
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (unsupported browser,
+      user-cancelled share, share() rejecting for another reason)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint is
+      not actionable for this change)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality (also reverted an
+      unrelated `bun.lock` diff produced by `bun install` — pure
+      version-number sync to already-committed `package.json` bumps, out
+      of scope, matching prior tasks' precedent)
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Commit, push, and open the PR; then flip Status to Completed with the PR
+  link recorded.
+
 ## Completed
 
 ## Autocomplete: recognize a typed bare domain even when it's outside the ranked dataset

--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,13 @@
 
 ## Article panel: Share button (native Web Share API with clipboard fallback)
 
-**Status:** In Progress
+**Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 22 ("Share button; email to friends;
 social actions.")
 **Branch:** `claude/adoring-mayer-jn1xra`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/233
 **Started:** 2026-08-14
+**Completed:** 2026-08-14
 
 ### Goal
 Add a "Share" action to the article extract panel's toolbar
@@ -105,13 +106,15 @@ link to the clipboard.
       unrelated `bun.lock` diff produced by `bun install` — pure
       version-number sync to already-committed `package.json` bumps, out
       of scope, matching prior tasks' precedent)
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #233)
+- [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- Commit, push, and open the PR; then flip Status to Completed with the PR
-  link recorded.
+- None for this task. PR #233 open, CI/build/tests verified locally.
+- Natural follow-up (left for a future run, per Ideas Backlog item 22's
+  broader scope): bespoke per-platform share intents (Twitter/X, Facebook,
+  LinkedIn, WhatsApp) for browsers without Web Share API support.
 
 ## Completed
 
@@ -960,7 +963,10 @@ ext - dl to reason dl folswe
 19. Use open tabs as context.
 20. Preload page results for common questions with SSR.
 21. If autocomplete matches something like red.com, go there directly.
-22. Share button; email to friends; social actions.
+22. Share button; email to friends; social actions. — **first slice done, see
+    "Article panel: Share button (native Web Share API with clipboard
+    fallback)" above** (bespoke per-platform share intents remain a
+    follow-up)
 23. Suggest the next page from the sidebar on each page.
 24. For each topic, next-word prediction in model.
 25. Auto-search for topics in sidebar.

--- a/TODO.md
+++ b/TODO.md
@@ -111,7 +111,7 @@ link to the clipboard.
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task. PR #233 open, CI/build/tests verified locally.
+- None for this task. PR #233 merged.
 - Natural follow-up (left for a future run, per Ideas Backlog item 22's
   broader scope): bespoke per-platform share intents (Twitter/X, Facebook,
   LinkedIn, WhatsApp) for browsers without Web Share API support.

--- a/TODO.md
+++ b/TODO.md
@@ -1,97 +1,5 @@
 ## In Progress
 
-## Autocomplete: recognize a typed bare domain even when it's outside the ranked dataset
-
-**Status:** In Progress
-**Source:** TODO.md — Ideas Backlog item 21 ("If autocomplete matches
-something like red.com, go there directly.")
-**Branch:** `claude/adoring-mayer-va3awu`
-**PR:** Not created yet
-**Started:** 2026-08-14
-
-### Goal
-When the user types a string that looks like a real domain (e.g.
-`red.com`), offer a "go there directly" suggestion in the chat composer's
-autocomplete dropdown — even when that domain isn't one of the ~10k
-domains in the `domain-rank` ranked dataset the existing fuzzy domain
-search (`searchDomains` in
-`packages/research-agent-ui/src/api/handlers/autocomplete.ts`) matches
-against. Confirmed via a direct check that `red.com` itself is absent from
-`packages/domain-rank/data/domain-rank-merged.json` (10,020 entries), so
-today typing it produces zero domain suggestions — only the existing
-fuzzy match against known top domains works.
-
-### Scope
-- `packages/research-agent-ui/src/api/handlers/autocomplete.ts`:
-  `searchDomains` gains a literal-domain check on the last typed word using
-  `tldts` (already a dependency of `domain-rank`/`search-web-api`/
-  `qwksearch-web`, added here too) to validate the string has a real,
-  recognized public suffix (e.g. `.com`, `.io`, `.co.uk`) — this avoids
-  false positives on filename-like strings (`note.txt`, `script.js`) that a
-  naive `\w+\.\w+` regex would wrongly treat as domains, since `tldts`
-  checks against the actual public-suffix list rather than an arbitrary
-  extension pattern.
-- When the last word is a valid, ranked-dataset-independent domain and
-  isn't already present in the fuzzy results, prepend a synthetic
-  `DomainSuggestion` for it (unranked, so no rank badge renders — same
-  convention already used for dataset entries lacking a rank) ahead of the
-  fuzzy matches, still capped at `MAX_DOMAIN_SUGGESTIONS`.
-- No frontend (`ChatInputBox.tsx`) changes needed — it already renders
-  `domainSuggestions` generically and `goToDomain` already navigates
-  straight to `https://{domain}` on selection.
-
-### Non-goals
-- IP-address literals (e.g. `192.168.1.1`) or `localhost` — out of scope;
-  `tldts` won't recognize these as having a public suffix, and typing an
-  address is a different, less common flow than typing a memorable domain
-  name.
-- Auto-navigating without an explicit selection (e.g. on Enter with no
-  dropdown interaction) — this task only adds the *suggestion*; selecting
-  it (click, Tab, Enter-while-highlighted, or number key) already works via
-  the existing `goToDomain`/`chooseOption` wiring.
-- Changing the existing fuzzy ranked-domain matching behavior in any way
-  when the typed text does *not* look like a full domain.
-
-### Acceptance criteria
-- [ ] Typing a real-looking domain not present in the ranked dataset (e.g.
-      `red.com`) surfaces it as a domain suggestion.
-- [ ] Filename-like strings with non-TLD extensions (e.g. `note.txt`,
-      `script.js`) do NOT spuriously appear as domain suggestions.
-- [ ] A literal domain match that's already found via fuzzy search isn't
-      duplicated in the suggestion list.
-- [ ] The existing ranked-domain fuzzy-match behavior is unchanged for
-      queries that aren't themselves a full valid domain.
-- [ ] Selecting the synthetic suggestion navigates to `https://<domain>`,
-      matching existing dataset-backed domain suggestions.
-- [ ] Vitest coverage is added or updated
-- [ ] Lint passes
-- [ ] Typecheck passes
-- [ ] Tests pass
-- [ ] Production/web build passes
-- [ ] Documentation is updated if behavior or configuration changes
-
-### Implementation plan
-- [x] Inspect affected modules, local instructions, and existing tests
-- [x] Confirm API, schema, data-flow, or interface requirements (`tldts`
-      already used elsewhere in the repo for the same "is this a real
-      domain suffix" question; `research-agent-ui` doesn't yet depend on it)
-- [ ] Add `tldts` as a dependency of `research-agent-ui`
-- [ ] Implement the smallest useful vertical slice in `autocomplete.ts`
-- [ ] Add focused Vitest success-path coverage
-- [ ] Add focused failure/edge-case coverage (filename false positives,
-      dedupe against fuzzy results, short/invalid input)
-- [ ] Run focused tests and fix failures
-- [ ] Run linting and typechecking
-- [ ] Run the full relevant test suite
-- [ ] Run the production/web build
-- [ ] Review the final diff for scope and quality
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
-
-### Remaining work
-- Implementation not yet started — see Implementation plan above.
-
 ## Completed
 
 ## Autocomplete: recognize a typed bare domain even when it's outside the ranked dataset
@@ -213,9 +121,7 @@ fuzzy match against known top domains works.
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task. PR #231 open, CI/build/tests verified locally.
-
-## Completed
+- None for this task. PR #231 merged.
 
 ## Related panel: rank by shared tags as well as keyword overlap
 

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.stories.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.stories.tsx
@@ -8,9 +8,9 @@ import ArticleActionButtons from './ArticleActionButtons';
 
 /**
  * `ArticleActionButtons` is the toolbar at the top of the article extract
- * panel: Ask AI, Suggest, Copy, Highlight, Favorite, Open-in-new-tab, zoom
- * controls, and Close. Every button has a hover tooltip showing its keyboard
- * shortcut (e.g. `Alt+A`).
+ * panel: Ask AI, Suggest, Copy, Share, Highlight, Favorite, Open-in-new-tab,
+ * zoom controls, and Close. Every button has a hover tooltip showing its
+ * keyboard shortcut (e.g. `Alt+A`) where one is bound — Share has none.
  */
 const meta: Meta<typeof ArticleActionButtons> = {
   title: 'ArticleReader/ArticleActionButtons',
@@ -27,6 +27,7 @@ const meta: Meta<typeof ArticleActionButtons> = {
     onAskClick: fn(),
     onSuggestClick: fn(),
     onCopyClick: fn(),
+    onShareClick: fn(),
     onFavoriteClick: fn(),
     onHighlightToggle: fn(),
     onZoomIn: fn(),

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleActionButtons.tsx
@@ -1,12 +1,12 @@
 /**
- * @fileoverview Toolbar with Ask AI, Suggest, Copy, Highlight, Favorite, Open-in-new-tab, and Close buttons shown at the top of the article extract panel.
+ * @fileoverview Toolbar with Ask AI, Suggest, Copy, Share, Highlight, Favorite, Open-in-new-tab, and Close buttons shown at the top of the article extract panel.
  *
  * Each button has a shadcn/Radix tooltip that appears on hover (zero delay) showing the
  * action label and its keyboard shortcut. The shortcut key definitions are exported as
  * {@link ARTICLE_TOOLBAR_SHORTCUTS} so the panel can wire up the matching key handlers.
  */
 import React from 'react';
-import { Bot, MessageCircleQuestion, Clipboard, Star, Highlighter, ExternalLink, ZoomIn, ZoomOut, X } from 'lucide-react';
+import { Bot, MessageCircleQuestion, Clipboard, Star, Highlighter, ExternalLink, Share2, ZoomIn, ZoomOut, X } from 'lucide-react';
 import { Button } from '../../ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../ui/tooltip';
 import { cn } from '../../lib/utils';
@@ -63,6 +63,7 @@ interface ArticleActionButtonsProps {
   onAskClick: () => void;
   onSuggestClick: () => void;
   onCopyClick: () => void;
+  onShareClick: () => void;
   onFavoriteClick: () => void;
   onHighlightToggle: () => void;
   onZoomIn?: () => void;
@@ -110,6 +111,7 @@ const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
   onAskClick,
   onSuggestClick,
   onCopyClick,
+  onShareClick,
   onFavoriteClick,
   onHighlightToggle,
   onZoomIn,
@@ -161,6 +163,17 @@ const ArticleActionButtons: React.FC<ArticleActionButtonsProps> = ({
           className={iconButtonClass}
         >
           <Clipboard className="size-4" />
+        </Button>
+      </ToolbarTip>
+
+      <ToolbarTip label="Share article">
+        <Button
+          onClick={onShareClick}
+          variant="ghost"
+          size="icon"
+          className={iconButtonClass}
+        >
+          <Share2 className="size-4" />
         </Button>
       </ToolbarTip>
 

--- a/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
+++ b/packages/research-agent-ui/src/components/ArticleReader/ArticleExtractPanel.tsx
@@ -31,6 +31,7 @@ import { ARTICLE_TOOLBAR_SHORTCUTS } from './ArticleActionButtons';
 import { researchAgentUIConfig } from '../../config';
 import { useSession } from '../../hooks/useSession';
 import { useChat } from '../../hooks/useChat';
+import { shareArticle } from '../../lib/shareArticle';
 
 const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
   const {
@@ -53,6 +54,7 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
   const [extractedArticle, setExtractedArticle] = useState<Article | null>(null);
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
   const [showCopiedMessage, setShowCopiedMessage] = useState(false);
+  const [showLinkCopiedMessage, setShowLinkCopiedMessage] = useState(false);
   const [userPrompt, setUserPrompt] = useState(researchAgentUIConfig.defaultSummarizePrompt);
   const [isLoadingExtract, setIsLoadingExtract] = useState(false);
   const [isLoadingAI, setIsLoadingAI] = useState(false);
@@ -413,6 +415,30 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
     }
   };
 
+  const handleShareArticle = async () => {
+    const targetUrl = extractedArticle?.url || url;
+    if (!targetUrl) return;
+
+    try {
+      const result = await shareArticle(
+        { title: extractedArticle?.title, text: extractedArticle?.cite, url: targetUrl },
+        {
+          share:
+            typeof navigator !== 'undefined' && navigator.share
+              ? (data) => navigator.share(data)
+              : undefined,
+          writeText: (text) => navigator.clipboard.writeText(text),
+        },
+      );
+      if (result === 'copied') {
+        setShowLinkCopiedMessage(true);
+        setTimeout(() => setShowLinkCopiedMessage(false), 2000);
+      }
+    } catch (error) {
+      console.error('Failed to share article:', error);
+    }
+  };
+
   // Keep the shortcut handler map pointing at the freshest closures every render.
   shortcutActionsRef.current = {
     ask: () => callLanguageAPI('question'),
@@ -500,6 +526,7 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
           onAskClick={() => callLanguageAPI('question')}
           onSuggestClick={() => callLanguageAPI('suggest-followups')}
           onCopyClick={handleCopyHTMLToClipboard}
+          onShareClick={handleShareArticle}
           onFavoriteClick={toggleFavorite}
           onHighlightToggle={() => setIsHighlightMode(!isHighlightMode)}
           onZoomIn={handleZoomIn}
@@ -515,6 +542,12 @@ const ArticleExtractPanel: React.FC<ArticleExtractPanelProps> = (props) => {
               {showCopiedMessage && (
                 <div className="bg-blue-500 text-white text-sm font-medium px-3 py-2 rounded-md shadow-lg">
                   Copied!
+                </div>
+              )}
+
+              {showLinkCopiedMessage && (
+                <div className="bg-blue-500 text-white text-sm font-medium px-3 py-2 rounded-md shadow-lg">
+                  Link copied!
                 </div>
               )}
 

--- a/packages/research-agent-ui/src/lib/shareArticle.ts
+++ b/packages/research-agent-ui/src/lib/shareArticle.ts
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Share-an-article decision logic, decoupled from the browser
+ * Web Share/Clipboard APIs so it stays trivially testable.
+ *
+ * Prefers the OS-native share sheet (`navigator.share`) when the caller
+ * provides it — that sheet already lists Mail and installed social apps as
+ * targets on supporting browsers/devices. Falls back to copying the URL to
+ * the clipboard when native sharing isn't available, or when it fails for a
+ * reason other than the user dismissing the share sheet.
+ */
+
+export interface ShareableArticle {
+  title?: string;
+  text?: string;
+  url: string;
+}
+
+export interface ShareArticleDeps {
+  /** Bound `navigator.share`, or `undefined` when the API is unsupported. */
+  share?: (data: ShareableArticle) => Promise<void>;
+  /** Bound `navigator.clipboard.writeText`. */
+  writeText: (text: string) => Promise<void>;
+}
+
+export type ShareArticleResult = "shared" | "copied" | "cancelled";
+
+/** Whether an error represents the user dismissing the native share sheet. */
+function isShareCancellation(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+export async function shareArticle(
+  article: ShareableArticle,
+  deps: ShareArticleDeps,
+): Promise<ShareArticleResult> {
+  if (deps.share) {
+    try {
+      await deps.share(article);
+      return "shared";
+    } catch (error) {
+      if (isShareCancellation(error)) return "cancelled";
+      // Fall through to the clipboard fallback below.
+    }
+  }
+
+  await deps.writeText(article.url);
+  return "copied";
+}

--- a/packages/research-agent-ui/test/shareArticle.test.ts
+++ b/packages/research-agent-ui/test/shareArticle.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Unit tests for the share-an-article decision logic.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { shareArticle } from '../src/lib/shareArticle';
+
+const article = { title: 'Some Article', text: 'A citation', url: 'https://example.com/a' };
+
+describe('shareArticle', () => {
+    it('calls the native share API and returns "shared" when it succeeds', async () => {
+        const share = vi.fn().mockResolvedValue(undefined);
+        const writeText = vi.fn().mockResolvedValue(undefined);
+
+        const result = await shareArticle(article, { share, writeText });
+
+        expect(result).toBe('shared');
+        expect(share).toHaveBeenCalledWith(article);
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('falls back to copying the URL when native share is unsupported', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+
+        const result = await shareArticle(article, { writeText });
+
+        expect(result).toBe('copied');
+        expect(writeText).toHaveBeenCalledWith(article.url);
+    });
+
+    it('returns "cancelled" without copying when the user dismisses the share sheet', async () => {
+        const abortError = Object.assign(new Error('cancelled'), { name: 'AbortError' });
+        const share = vi.fn().mockRejectedValue(abortError);
+        const writeText = vi.fn().mockResolvedValue(undefined);
+
+        const result = await shareArticle(article, { share, writeText });
+
+        expect(result).toBe('cancelled');
+        expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it('falls back to copying the URL when native share rejects for another reason', async () => {
+        const share = vi.fn().mockRejectedValue(new Error('permission denied'));
+        const writeText = vi.fn().mockResolvedValue(undefined);
+
+        const result = await shareArticle(article, { share, writeText });
+
+        expect(result).toBe('copied');
+        expect(writeText).toHaveBeenCalledWith(article.url);
+    });
+});


### PR DESCRIPTION
## Summary
- PR #233 (the article-panel Share button) merged before this tracker-only follow-up commit could land on it, leaving `TODO.md` on `master` saying "PR: Not created yet" for a task whose PR was already merged.
- Documentation-only fix: updates the "Article panel: Share button" entry with the merged PR link, marks it Completed, and updates the Ideas Backlog annotation for item 22.

No code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKrZmmMLKJWpPkJys6RRJo)_