### PR TITLE
Record PR #235 merged in the follow-up-suggestions test-coverage TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,146 @@
 ## In Progress
 
-## Article panel: Share button (native Web Share API with clipboard fallback)
+## Test coverage for the follow-up-suggestions pipeline
 
 **Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 17 ("Follow-up suggestions."). This
+feature is already fully implemented (inherited from an early bulk-import
+commit, `e21b8fc`) end-to-end for the chat conversation surface — LLM call,
+API route, client fetch, and UI render — but has zero test coverage anywhere
+in the pipeline. This task closes that gap; it does not add new
+user-visible behavior.
+**Branch:** `claude/adoring-mayer-zic4bl`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+Add Vitest coverage for the existing follow-up-suggestions backend pipeline
+(LLM generator → API handler → client fetch helper) so a future change to
+any of these files gets a regression signal, matching the existing test
+pattern used for the sibling autocomplete handler
+(`apps/qwksearch-web/app/api/agent/__tests__/autocomplete.test.ts`).
+
+### Scope
+- `packages/chat-agent-toolkit/test/suggestionGeneratorAgent.test.ts`:
+  unit tests for `generateSuggestions`
+  (`packages/chat-agent-toolkit/src/tools/search/suggestionGeneratorAgent.ts`),
+  mocking the `ai` package's `generateText` (same mocking pattern as
+  `packages/write-language/test/generate-response.attachments.test.ts`) to
+  assert the prompt is built from chat history, the parsed
+  `<suggestions>`-tagged output is returned, and malformed/missing-tag
+  output yields an empty array (via the existing `LineListOutputParser`).
+- `apps/qwksearch-web/app/api/agent/__tests__/suggestions.test.ts`: unit
+  tests for `createSuggestionsHandler`
+  (`packages/research-agent-ui/src/api/handlers/suggestions.ts`), mocking
+  `chat-agent-toolkit/tools/search/suggestionGeneratorAgent` and
+  `chat-agent-toolkit/models/registry`, asserting: non-user/assistant
+  messages (e.g. `source`) are filtered out of the chat history sent
+  upstream, a returned suggestion containing multiple `?`-terminated
+  questions is split into separate standalone suggestions, and the response
+  shape/status code.
+- `packages/research-agent-ui/test/suggestions.test.ts`: unit tests for
+  `getSuggestions` (`packages/research-agent-ui/src/lib/suggestions.ts`),
+  mocking the `grab-url` default export, asserting: localStorage-backed
+  model/provider/`maxFollowupQuestions` settings are read and sent, only
+  user/assistant messages are forwarded, a non-array `suggestions` response
+  yields `[]`, and a rejected fetch is swallowed and yields `[]`.
+
+### Non-goals
+- A UI/DOM test for `FollowUpSuggestions.tsx` — `research-agent-ui`'s test
+  suite has no existing `@testing-library/react`-style component test to
+  mirror (all current tests are logic/hook tests), and standing that up is
+  a separate, larger piece of work; left as a follow-up.
+- Any behavior change to the suggestions pipeline itself — this is a
+  test-only change.
+- The parallel article-reader follow-up-questions pipeline
+  (`ArticleFollowupQuestions.tsx`, `article-followups/route.ts`,
+  `api/handlers/article-followups.ts`) — same gap, but a separate surface;
+  left as a follow-up.
+
+### Acceptance criteria
+- [x] `generateSuggestions` returns the parsed list of suggestions from a
+      well-formed `<suggestions>`-tagged LLM response.
+- [x] `generateSuggestions` returns `[]` when the LLM response has no
+      `<suggestions>` tags.
+- [x] `createSuggestionsHandler`'s `POST` filters non-user/assistant
+      messages out of the chat history before calling `generateSuggestions`.
+- [x] `createSuggestionsHandler`'s `POST` splits a suggestion containing
+      multiple questions into separate standalone questions.
+- [x] `getSuggestions` sends the localStorage-backed model/provider/
+      max-questions settings and filtered chat history to the API.
+- [x] `getSuggestions` returns `[]` (not a throw) when the fetch rejects or
+      the response shape is unexpected.
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for `chat-agent-toolkit`,
+      `research-agent-ui`, or `qwksearch-web` (no ESLint config found);
+      nothing to run
+- [x] Typecheck passes — `bun run type-check` in `research-agent-ui`
+      surfaces the same 5 **pre-existing** `TS2307` errors documented in
+      prior TODO.md tasks (`ChatHomepage.tsx`, `ChatWindow.tsx`,
+      `MessageSources.tsx`, `WebCitationBadge.tsx` — missing built `dist/`
+      output for workspace packages in a fresh checkout), none of which this
+      change touches. No `typecheck`/`tsc` script exists for
+      `chat-agent-toolkit` or `qwksearch-web` directly (typechecked as part
+      of `research-agent-ui`'s and the build's checks).
+- [x] Tests pass — `bunx vitest run test/suggestionGeneratorAgent.test.ts`
+      in `chat-agent-toolkit`: 4/4 passed. `bunx vitest run
+      app/api/agent/__tests__/suggestions.test.ts` in `qwksearch-web`: 5/5
+      passed. `bunx vitest run test/suggestions.test.ts` in
+      `research-agent-ui`: 4/4 passed. Full `chat-agent-toolkit` suite:
+      51/54 passed (3 pre-existing failures in
+      `openrouter-default-model.test.js`, documented in prior TODO.md
+      tasks, unrelated to this change). Full `research-agent-ui` suite:
+      75/75 passed (71 pre-existing + 4 new). Full workspace `bun run
+      test`: 169/179 files, 2417/2471 tests pass (4 skipped); the 54
+      failures across the same 10 files documented repeatedly in prior
+      TODO.md tasks (`search-web-api` engine tests hitting real external
+      APIs, the `qwksearch-web` config route test, `shadcn-settings`,
+      `jsdom-scraper` missing its `jsdom` dependency, `chat-agent-toolkit`'s
+      `openrouter-default-model.test.js`) are pre-existing and unrelated —
+      none touch the 3 new test files.
+- [x] Production/web build passes — `bun run build:web`: 14/14 turbo tasks
+      succeeded, including `qwksearch-web`'s full `vinext build`.
+- [x] Documentation is updated if behavior or configuration changes — n/a,
+      test-only change
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm mocking patterns for `ai`'s `generateText`, `grab-url`, and
+      handler-level module mocks (mirrored from
+      `write-language/test/generate-response.attachments.test.ts` and
+      `apps/qwksearch-web/app/api/agent/__tests__/autocomplete.test.ts`)
+- [x] Run `bun install` (workspace had no installed `node_modules` yet)
+- [x] Add `suggestionGeneratorAgent.test.ts`
+- [x] Add `suggestions.test.ts` (API handler)
+- [x] Add `suggestions.test.ts` (client lib helper)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint is
+      not actionable for this change)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality (also reverted an
+      unrelated `bun.lock` diff produced by `bun install` — pure
+      version-number sync to already-committed `package.json` bumps, out of
+      scope, matching prior tasks' precedent)
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Commit, push, and open the PR; then flip Status to Completed with the PR
+  link recorded.
+
+## Completed
+
+## Article panel: Share button (native Web Share API with clipboard fallback)
+
+**Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 22 ("Share button; email to friends;
 social actions.")
 **Branch:** `claude/adoring-mayer-jn1xra`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/233 (merged)
 **Started:** 2026-08-14
+**Completed:** 2026-08-14
 
 ### Goal
 Add a "Share" action to the article extract panel's toolbar
@@ -105,15 +238,12 @@ link to the clipboard.
       unrelated `bun.lock` diff produced by `bun install` — pure
       version-number sync to already-committed `package.json` bumps, out
       of scope, matching prior tasks' precedent)
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #233, merged)
+- [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- Commit, push, and open the PR; then flip Status to Completed with the PR
-  link recorded.
-
-## Completed
+- None for this task. PR #233 merged.
 
 ## Autocomplete: recognize a typed bare domain even when it's outside the ranked dataset
 
@@ -959,8 +1089,8 @@ ext - dl to reason dl folswe
 18. Browser sidebar results.
 19. Use open tabs as context.
 20. Preload page results for common questions with SSR.
-21. If autocomplete matches something like red.com, go there directly.
-22. Share button; email to friends; social actions.
+21. If autocomplete matches something like red.com, go there directly. — **done, see "Autocomplete: recognize a typed bare domain even when it's outside the ranked dataset" above**
+22. Share button; email to friends; social actions. — **done, see "Article panel: Share button (native Web Share API with clipboard fallback)" above**
 23. Suggest the next page from the sidebar on each page.
 24. For each topic, next-word prediction in model.
 25. Auto-search for topics in sidebar.

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,10 @@
 ## In Progress
 
+## Completed
+
 ## Test coverage for the follow-up-suggestions pipeline
 
-**Status:** In Progress
+**Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 17 ("Follow-up suggestions."). This
 feature is already fully implemented (inherited from an early bulk-import
 commit, `e21b8fc`) end-to-end for the chat conversation surface — LLM call,
@@ -10,8 +12,9 @@ API route, client fetch, and UI render — but has zero test coverage anywhere
 in the pipeline. This task closes that gap; it does not add new
 user-visible behavior.
 **Branch:** `claude/adoring-mayer-zic4bl`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/235 (merged)
 **Started:** 2026-08-14
+**Completed:** 2026-08-14
 
 ### Goal
 Add Vitest coverage for the existing follow-up-suggestions backend pipeline
@@ -122,15 +125,16 @@ pattern used for the sibling autocomplete handler
       unrelated `bun.lock` diff produced by `bun install` — pure
       version-number sync to already-committed `package.json` bumps, out of
       scope, matching prior tasks' precedent)
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #235)
+- [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- Commit, push, and open the PR; then flip Status to Completed with the PR
-  link recorded.
-
-## Completed
+- None for this task. PR #235 merged.
+- Follow-ups (left for a future run, per this task's Non-goals): a
+  `FollowUpSuggestions.tsx` component/DOM test once `research-agent-ui`
+  has a `@testing-library/react` test to model it on; the same test-coverage
+  gap in the parallel article-reader follow-up-questions pipeline.
 
 ## Article panel: Share button (native Web Share API with clipboard fallback)
 

--- a/apps/qwksearch-web/app/api/agent/__tests__/suggestions.test.ts
+++ b/apps/qwksearch-web/app/api/agent/__tests__/suggestions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGenerateSuggestions = vi.fn()
+const mockLoadChatModel = vi.fn()
+
+vi.mock('chat-agent-toolkit/tools/search/suggestionGeneratorAgent', () => ({
+  default: (...args: unknown[]) => mockGenerateSuggestions(...args),
+}))
+
+vi.mock('chat-agent-toolkit/models/registry', () => ({
+  default: class {
+    loadChatModel(...args: unknown[]) {
+      return mockLoadChatModel(...args)
+    }
+  },
+}))
+
+import { createSuggestionsHandler } from 'research-agent-ui/api'
+
+const handler = createSuggestionsHandler()
+
+function postRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/agent/suggestions', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }) as any
+}
+
+const baseBody = {
+  chatHistory: [
+    { role: 'user', content: 'Tell me about SpaceX' },
+    { role: 'assistant', content: 'SpaceX is a rocket company.' },
+  ],
+  chatModel: { providerId: 'openai', key: 'gpt-4' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockLoadChatModel.mockResolvedValue({ id: 'fake-model' })
+})
+
+describe('createSuggestionsHandler POST', () => {
+  it('filters out non-user/assistant messages before calling generateSuggestions', async () => {
+    mockGenerateSuggestions.mockResolvedValue(['Tell me more about SpaceX'])
+
+    await handler.POST(
+      postRequest({
+        ...baseBody,
+        chatHistory: [
+          { role: 'source', content: 'some document text' },
+          ...baseBody.chatHistory,
+        ],
+      }),
+    )
+
+    expect(mockGenerateSuggestions).toHaveBeenCalledTimes(1)
+    const [input] = mockGenerateSuggestions.mock.calls[0]
+    expect(input.chat_history).toEqual([
+      { role: 'user', content: 'Tell me about SpaceX' },
+      { role: 'assistant', content: 'SpaceX is a rocket company.' },
+    ])
+  })
+
+  it('returns generated suggestions with a 200 status', async () => {
+    mockGenerateSuggestions.mockResolvedValue(['Who founded SpaceX?'])
+
+    const res = await handler.POST(postRequest(baseBody))
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.suggestions).toEqual(['Who founded SpaceX?'])
+  })
+
+  it('splits a suggestion containing multiple questions into separate questions', async () => {
+    mockGenerateSuggestions.mockResolvedValue([
+      'Who founded SpaceX? When was it founded?',
+      'What is Starship?',
+    ])
+
+    const res = await handler.POST(postRequest(baseBody))
+
+    const data = await res.json()
+    expect(data.suggestions).toEqual([
+      'Who founded SpaceX?',
+      'When was it founded?',
+      'What is Starship?',
+    ])
+  })
+
+  it('passes maxQuestions through to generateSuggestions', async () => {
+    mockGenerateSuggestions.mockResolvedValue([])
+
+    await handler.POST(postRequest({ ...baseBody, maxQuestions: 2 }))
+
+    const [input] = mockGenerateSuggestions.mock.calls[0]
+    expect(input.maxQuestions).toBe(2)
+  })
+
+  it('loads the chat model via the requested provider and key', async () => {
+    mockGenerateSuggestions.mockResolvedValue([])
+
+    await handler.POST(postRequest(baseBody))
+
+    expect(mockLoadChatModel).toHaveBeenCalledWith('openai', 'gpt-4')
+  })
+})

--- a/packages/chat-agent-toolkit/test/suggestionGeneratorAgent.test.ts
+++ b/packages/chat-agent-toolkit/test/suggestionGeneratorAgent.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Tests for the follow-up-suggestions LLM generator.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const generateTextMock = vi.fn();
+
+vi.mock('ai', () => ({
+  generateText: (args: unknown) => generateTextMock(args),
+}));
+
+import generateSuggestions from '../src/tools/search/suggestionGeneratorAgent';
+import type { ChatTurnMessage } from '../src/tools/search/meta-search-types';
+
+beforeEach(() => {
+  generateTextMock.mockReset();
+});
+
+const fakeLlm = { id: 'fake-model' } as any;
+
+describe('generateSuggestions', () => {
+  it('returns the parsed suggestions from a well-formed <suggestions> response', async () => {
+    generateTextMock.mockResolvedValue({
+      text: `<suggestions>\nTell me more about SpaceX\nWho is the CEO of SpaceX?\n</suggestions>`,
+    });
+
+    const chatHistory: ChatTurnMessage[] = [
+      { role: 'user', content: 'Tell me about SpaceX' },
+      { role: 'assistant', content: 'SpaceX is a rocket company.' },
+    ];
+
+    const result = await generateSuggestions({ chat_history: chatHistory }, fakeLlm);
+
+    expect(result).toEqual([
+      'Tell me more about SpaceX',
+      'Who is the CEO of SpaceX?',
+    ]);
+  });
+
+  it('returns an empty array when the response has no <suggestions> tags', async () => {
+    generateTextMock.mockResolvedValue({ text: 'sorry, I have nothing to suggest' });
+
+    const result = await generateSuggestions(
+      { chat_history: [{ role: 'user', content: 'hi' }] },
+      fakeLlm,
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('builds the prompt from the formatted chat history and passes the LLM through', async () => {
+    generateTextMock.mockResolvedValue({ text: '<suggestions>\nfoo\n</suggestions>' });
+
+    await generateSuggestions(
+      {
+        chat_history: [
+          { role: 'user', content: 'What is SpaceX?' },
+          { role: 'assistant', content: 'A rocket company.' },
+        ],
+      },
+      fakeLlm,
+    );
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    const arg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.model).toBe(fakeLlm);
+    expect(arg.temperature).toBe(0);
+    expect(arg.prompt).toContain('User: What is SpaceX?');
+    expect(arg.prompt).toContain('AI: A rocket company.');
+  });
+
+  it('respects a custom maxQuestions in the generated prompt', async () => {
+    generateTextMock.mockResolvedValue({ text: '<suggestions>\nfoo\n</suggestions>' });
+
+    await generateSuggestions(
+      { chat_history: [{ role: 'user', content: 'hi' }], maxQuestions: 2 },
+      fakeLlm,
+    );
+
+    const arg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.prompt).toContain('generate 2 suggestions');
+  });
+});

--- a/packages/research-agent-ui/test/suggestions.test.ts
+++ b/packages/research-agent-ui/test/suggestions.test.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Unit tests for the `getSuggestions` client fetch helper.
+ */
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import grab from 'grab-url';
+import { getSuggestions } from '../src/lib/suggestions';
+import type { Message } from '../src/components/ChatConversation/ChatWindow';
+
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
+
+const chatHistory: Message[] = [
+    { role: 'user', content: 'Tell me about SpaceX' } as Message,
+    { role: 'assistant', content: 'SpaceX is a rocket company.' } as Message,
+    { role: 'source', content: 'a big document dump' } as unknown as Message,
+];
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+});
+
+describe('getSuggestions', () => {
+    it('sends the localStorage-backed model settings and filtered chat history', async () => {
+        window.localStorage.setItem('chatModelKey', 'gpt-4');
+        window.localStorage.setItem('chatModelProviderId', 'openai');
+        window.localStorage.setItem('maxFollowupQuestions', '2');
+        mockGrab.mockResolvedValue({ suggestions: ['Who founded SpaceX?'] });
+
+        const result = await getSuggestions(chatHistory);
+
+        expect(mockGrab).toHaveBeenCalledTimes(1);
+        const [path, opts] = mockGrab.mock.calls[0];
+        expect(path).toBe('agent/suggestions');
+        const body = JSON.parse((opts as RequestInit).body as string);
+        expect(body.chatModel).toEqual({ providerId: 'openai', key: 'gpt-4' });
+        expect(body.maxQuestions).toBe(2);
+        expect(body.chatHistory).toEqual([
+            { role: 'user', content: 'Tell me about SpaceX' },
+            { role: 'assistant', content: 'SpaceX is a rocket company.' },
+        ]);
+        expect(result).toEqual(['Who founded SpaceX?']);
+    });
+
+    it('defaults maxQuestions to 4 when unset', async () => {
+        mockGrab.mockResolvedValue({ suggestions: [] });
+
+        await getSuggestions(chatHistory);
+
+        const [, opts] = mockGrab.mock.calls[0];
+        const body = JSON.parse((opts as RequestInit).body as string);
+        expect(body.maxQuestions).toBe(4);
+    });
+
+    it('returns an empty array when the response suggestions field is not an array', async () => {
+        mockGrab.mockResolvedValue({ suggestions: 'not an array' } as any);
+
+        const result = await getSuggestions(chatHistory);
+
+        expect(result).toEqual([]);
+    });
+
+    it('returns an empty array when the fetch rejects', async () => {
+        mockGrab.mockRejectedValue(new Error('network error'));
+
+        const result = await getSuggestions(chatHistory);
+
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Tracker-only follow-up: records that PR #235 (Vitest coverage for the follow-up-suggestions pipeline) merged, flips its `TODO.md` entry to Completed, and moves it into the `## Completed` section (removing the now-duplicate `## Completed` heading left behind).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es4fqSjz7xeAABM5AZndQ3)_