### PR TITLE
Record PR #235 merged in the follow-up-suggestions test coverage TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,10 @@
 ## In Progress
 
+## Completed
+
 ## Test coverage for the follow-up-suggestions pipeline
 
-**Status:** In Progress
+**Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 17 ("Follow-up suggestions."). This
 feature is already fully implemented (inherited from an early bulk-import
 commit, `e21b8fc`) end-to-end for the chat conversation surface — LLM call,
@@ -10,8 +12,9 @@ API route, client fetch, and UI render — but has zero test coverage anywhere
 in the pipeline. This task closes that gap; it does not add new
 user-visible behavior.
 **Branch:** `claude/adoring-mayer-zic4bl`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/235 (merged)
 **Started:** 2026-08-14
+**Completed:** 2026-08-14
 
 ### Goal
 Add Vitest coverage for the existing follow-up-suggestions backend pipeline
@@ -122,15 +125,19 @@ pattern used for the sibling autocomplete handler
       unrelated `bun.lock` diff produced by `bun install` — pure
       version-number sync to already-committed `package.json` bumps, out of
       scope, matching prior tasks' precedent)
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #235, merged)
+- [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- Commit, push, and open the PR; then flip Status to Completed with the PR
-  link recorded.
-
-## Completed
+- None for this task. PR #235 merged. (This run found the implementation,
+  tests, commit, and PR already complete from a prior session — the tracker
+  had simply not been flipped to Completed yet; this run only updates the
+  tracker.)
+- Deferred follow-ups noted above remain open: a UI/DOM test for
+  `FollowUpSuggestions.tsx`, and test coverage for the parallel
+  article-reader follow-up-questions pipeline
+  (`ArticleFollowupQuestions.tsx` / `article-followups` route/handler).
 
 ## Article panel: Share button (native Web Share API with clipboard fallback)
 
@@ -1085,7 +1092,8 @@ ext - dl to reason dl folswe
 14. Main nav: Tabs | AI chat | Web search | Favorites | History.
 15. Queries should run on cached pages that belong to topic outlines.
 16. Research agents should queue the next video.
-17. Follow-up suggestions.
+17. Follow-up suggestions. — **feature already implemented; test coverage
+    added, see "Test coverage for the follow-up-suggestions pipeline" above**
 18. Browser sidebar results.
 19. Use open tabs as context.
 20. Preload page results for common questions with SSR.


### PR DESCRIPTION
## Summary
- `TODO.md` still listed "Test coverage for the follow-up-suggestions pipeline" as `In Progress` with the PR marked "Not created yet," but the implementation (3 new test files across `chat-agent-toolkit`, `qwksearch-web`, and `research-agent-ui`), commit, and PR #235 were already merged into `master` from a prior session.
- Flips the entry to `Completed`, records the PR #235 link, checks off the remaining implementation-plan boxes, and annotates Ideas Backlog item 17 ("Follow-up suggestions.") accordingly.
- Tracker-only change — no production code touched.

## Test plan
- N/A — documentation/tracker change only, no code paths affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_016iSXUXqv6g444gKQT6LhRz)_