### PR TITLE
Offer default search provider/homepage via chrome_settings_overrides

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,139 @@
 
 ## Completed
 
+## Default search provider support in the browser extension (chrome_settings_overrides)
+
+**Status:** Completed
+**Source:** TODO.md — Ideas Backlog item 29 ("Default search support; Chrome
+extensions can override homepage, startup pages, and search provider via
+`chrome_settings_overrides`.")
+**Branch:** `claude/adoring-mayer-0psw2h`
+**PR:** Not created yet
+**Started:** 2026-08-14
+**Completed:** 2026-08-14
+
+### Goal
+Let `apps/qwksearch-ext` (the Chrome extension) offer to become the
+browser's homepage, startup page, and default search provider via Chrome's
+native `chrome_settings_overrides` manifest key — the standard,
+user-confirmed mechanism Chrome extensions use for this (Chrome shows its
+own permission prompt on install; nothing here bypasses that).
+
+### Scope
+- `apps/qwksearch-ext/wxt.config.ts`: convert the static `manifest` object
+  into a `(env) => ({...})` function (WXT's documented per-browser manifest
+  pattern) and add a `chrome_settings_overrides` block — `homepage`,
+  `startup_pages`, and `search_provider` (`name`, `keyword`, `search_url`
+  with a `{searchTerms}` placeholder, `favicon_url`, `encoding`,
+  `is_default: true`) — gated on `env.browser === 'chrome'`.
+- Reuse the same production host (`https://qwksearch.com`) and query-param
+  convention (`?q=`) already established for QwkSearch searches in
+  `apps/qwksearch-ext/content/shortcut-search-web.ts`.
+
+### Non-goals
+- Firefox/other-browser equivalents — `chrome_settings_overrides.homepage`/
+  `startup_pages` aren't part of Firefox's supported subset, and the idea
+  itself says "Chrome extensions"; gating to `env.browser === 'chrome'`
+  keeps `build:firefox`/`zip:firefox` unaffected.
+- Any change to the existing in-app/side-panel search-engine list
+  (`content/shortcut-search-web.ts`) — this task only adds the browser-level
+  override, reusing that file's existing URL convention.
+- A dedicated 16×16 favicon asset — reuses the existing hosted
+  `https://qwksearch.com/favicon.ico`.
+
+### Acceptance criteria
+- [x] The Chrome build's resolved manifest includes
+      `chrome_settings_overrides.homepage`, `.startup_pages`, and
+      `.search_provider` with a valid `search_url` containing
+      `{searchTerms}` — verified by invoking `wxt.config.ts`'s exported
+      `manifest(env)` function directly with `{ browser: 'chrome' }` (see
+      Implementation plan note below on why the actual built
+      `.output/chrome-mv3/manifest.json` couldn't be inspected instead).
+- [x] The Firefox build's resolved manifest does NOT include
+      `chrome_settings_overrides` — verified the same way with
+      `{ browser: 'firefox' }`, which returns `chrome_settings_overrides:
+      undefined`.
+- [x] Vitest coverage is added or updated — n/a; per repo precedent
+      (`vitest.config.ts` coverage is scoped to `lib/**` and `content/**`
+      only, and no existing test touches `wxt.config.ts` or any other
+      manifest field such as `permissions`/`content_security_policy`), a
+      static manifest-config addition is conventionally left untested here.
+- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or at the
+      repo root (no ESLint config found); nothing to run
+- [x] Typecheck passes — `bun run compile` in `qwksearch-ext` surfaces the
+      same **pre-existing** `TS2304`/`TS2493`/`TS2769` errors (missing
+      global `chrome` types in several unrelated files, a tuple-index error
+      in `test/message-api.test.ts`, and an `OxcOptions` overload mismatch
+      in `vitest.config.ts`) on `git stash`-ed (unmodified) code too; none
+      touch `wxt.config.ts` or are introduced by this change.
+- [x] Tests pass — `bun run test` in `qwksearch-ext`: 42/42 passed (5/5
+      files). Full workspace `bun run test`: 169/179 files, 2415/2471 tests
+      pass (4 skipped); the 52 failures across the same 10 files documented
+      repeatedly in prior TODO.md tasks (`search-web-api` engine tests
+      hitting real external APIs, the `qwksearch-web` config route test,
+      `shadcn-settings`, `jsdom-scraper` missing its `jsdom` dependency,
+      `chat-agent-toolkit`'s `openrouter-default-model.test.js`) are
+      pre-existing and unrelated — none touch `qwksearch-ext`.
+- [x] Production/web build passes — `bun run build:web` (the repo's
+      standard production/web build target): 14/14 turbo tasks succeeded.
+      `qwksearch-ext`'s own `bun run build` (Chrome target) fails, but this
+      is a **pre-existing, unrelated** failure: `vite:css` /
+      `styles/globals.css` errors with "It looks like you're trying to use
+      tailwindcss directly as a PostCSS plugin. The PostCSS plugin has
+      moved to a separate package... install @tailwindcss/postcss" —
+      reproduces identically with this change `git stash`-ed. Root cause is
+      the installed `tailwindcss@4.3.3` vs. `postcss.config.js` still
+      referencing the old `tailwindcss` PostCSS-plugin API; fixing it means
+      adding a new dependency (`@tailwindcss/postcss`) and touching
+      `postcss.config.js`, out of scope for a manifest-only change. Filed as
+      a new Ideas Backlog follow-up below (item 29b) since it currently
+      blocks building/zipping the Chrome extension at all, not just
+      verifying this task.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry and inline comments (no user-facing docs
+      describe the extension's manifest internals)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm the production host/query-param convention and WXT's
+      per-browser `manifest` function support
+- [x] Implement the smallest useful vertical slice
+- [x] Attempt to build the Chrome target and inspect
+      `.output/chrome-mv3/manifest.json` for the new key — blocked by the
+      pre-existing, unrelated Tailwind/PostCSS build failure documented
+      above (confirmed via `git stash` that it predates this change); fell
+      back to directly invoking the exported `manifest(env)` function for
+      both `browser: 'chrome'` and `browser: 'firefox'` and asserting on
+      the returned object, which exercises the exact same code path the
+      real build would call
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint is
+      not actionable for this change; typecheck failures are pre-existing)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality (also reverted an
+      unrelated `bun.lock` diff produced by `bun install` — pure
+      version-number sync to already-committed `package.json` bumps, out of
+      scope, matching prior tasks' precedent)
+- [x] Commit and push the branch
+- [x] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task's own scope.
+- Follow-up filed as Ideas Backlog item 29b: `qwksearch-ext`'s own
+  `bun run build`/`zip` (Chrome target) fails on a fresh checkout due to a
+  pre-existing Tailwind v4 PostCSS-plugin mismatch (`postcss.config.js`
+  still uses the old `tailwindcss: {}` plugin form; needs
+  `@tailwindcss/postcss` installed and referenced instead). This blocks
+  building or zipping the Chrome extension at all — not just this task —
+  and should be fixed as its own dedicated task. Once fixed, a follow-up
+  verification step is to inspect the real
+  `.output/chrome-mv3/manifest.json` and `.output/firefox-mv2/manifest.json`
+  (or `-mv3`, depending on WXT's Firefox target) to confirm this task's
+  `chrome_settings_overrides` block matches what the direct function-call
+  verification already showed.
+
 ## Test coverage for the follow-up-suggestions pipeline
 
 **Status:** Completed
@@ -1105,7 +1238,14 @@ ext - dl to reason dl folswe
 26. Prioritize sidebar with AI tips about the current page.
 27. Cache questions and use them to build connections.
 28. Add downloads tab; also back, refresh, undo close, new tab.
-29. Default search support; Chrome extensions can override homepage, startup pages, and search provider via `chrome_settings_overrides`.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
+29. Default search support; Chrome extensions can override homepage, startup pages, and search provider via `chrome_settings_overrides`.[developer.chrome](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override) — **done, see "Default search provider support in the browser extension (chrome_settings_overrides)" above**
+29b. `qwksearch-ext`'s own `bun run build`/`zip` (Chrome target) fails on a
+     fresh checkout: `postcss.config.js` still uses the old
+     `tailwindcss: {}` PostCSS-plugin form against the installed
+     `tailwindcss@4.3.3`, which requires the separate `@tailwindcss/postcss`
+     package instead. Discovered while verifying item 29 above (pre-existing,
+     confirmed via `git stash`); blocks building or zipping the Chrome
+     extension at all, independent of any other change.
 31. Agents that scrape the web and work with datasets like LinkedIn.
 32. Auto-generate keyphrase completions for on-page Ctrl+F search.
 33. Markdown/file tree view inspiration: [ld246.com/guide/markdown](https://ld246.com/guide/markdown).

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,10 @@
 ## In Progress
 
+## Completed
+
 ## Test coverage for the follow-up-suggestions pipeline
 
-**Status:** In Progress
+**Status:** Completed
 **Source:** TODO.md — Ideas Backlog item 17 ("Follow-up suggestions."). This
 feature is already fully implemented (inherited from an early bulk-import
 commit, `e21b8fc`) end-to-end for the chat conversation surface — LLM call,
@@ -10,8 +12,9 @@ API route, client fetch, and UI render — but has zero test coverage anywhere
 in the pipeline. This task closes that gap; it does not add new
 user-visible behavior.
 **Branch:** `claude/adoring-mayer-zic4bl`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/235 (merged)
 **Started:** 2026-08-14
+**Completed:** 2026-08-14
 
 ### Goal
 Add Vitest coverage for the existing follow-up-suggestions backend pipeline
@@ -122,15 +125,19 @@ pattern used for the sibling autocomplete handler
       unrelated `bun.lock` diff produced by `bun install` — pure
       version-number sync to already-committed `package.json` bumps, out of
       scope, matching prior tasks' precedent)
-- [ ] Commit and push the branch
-- [ ] Create or update the pull request
-- [ ] Update tracker status, completed checkboxes, and remaining work
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #235, merged)
+- [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- Commit, push, and open the PR; then flip Status to Completed with the PR
-  link recorded.
-
-## Completed
+- None for this task. PR #235 merged. (This run found the implementation,
+  tests, commit, and PR already complete from a prior session — the tracker
+  had simply not been flipped to Completed yet; this run only updates the
+  tracker.)
+- Deferred follow-ups noted above remain open: a UI/DOM test for
+  `FollowUpSuggestions.tsx`, and test coverage for the parallel
+  article-reader follow-up-questions pipeline
+  (`ArticleFollowupQuestions.tsx` / `article-followups` route/handler).
 
 ## Article panel: Share button (native Web Share API with clipboard fallback)
 
@@ -1085,7 +1092,8 @@ ext - dl to reason dl folswe
 14. Main nav: Tabs | AI chat | Web search | Favorites | History.
 15. Queries should run on cached pages that belong to topic outlines.
 16. Research agents should queue the next video.
-17. Follow-up suggestions.
+17. Follow-up suggestions. — **feature already implemented; test coverage
+    added, see "Test coverage for the follow-up-suggestions pipeline" above**
 18. Browser sidebar results.
 19. Use open tabs as context.
 20. Preload page results for common questions with SSR.

--- a/apps/qwksearch-ext/wxt.config.ts
+++ b/apps/qwksearch-ext/wxt.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
       },
     },
   }),
-  manifest: {
+  manifest: (env) => ({
     name: 'QwkSearch Tab Manager AI',
     version: '6.0.0',
     permissions: [
@@ -71,5 +71,23 @@ export default defineConfig({
         matches: ['<all_urls>'],
       },
     ],
-  },
+    // homepage/startup_pages/search_provider aren't part of Firefox's
+    // supported chrome_settings_overrides subset, so only offer this on Chrome.
+    ...(env.browser === 'chrome'
+      ? {
+          chrome_settings_overrides: {
+            homepage: 'https://qwksearch.com',
+            startup_pages: ['https://qwksearch.com'],
+            search_provider: {
+              name: 'QwkSearch',
+              keyword: 'qwk',
+              search_url: 'https://qwksearch.com?q={searchTerms}',
+              favicon_url: 'https://qwksearch.com/favicon.ico',
+              encoding: 'UTF-8',
+              is_default: true,
+            },
+          },
+        }
+      : {}),
+  }),
 });


### PR DESCRIPTION
## Summary
- Addresses Ideas Backlog item 29 in `TODO.md` ("Default search support; Chrome extensions can override homepage, startup pages, and search provider via `chrome_settings_overrides`.")
- `apps/qwksearch-ext/wxt.config.ts`: converts the static `manifest` object into a `(env) => ({...})` function (WXT's documented per-browser manifest pattern) and adds a `chrome_settings_overrides` block — `homepage`, `startup_pages`, and `search_provider` (with a `{searchTerms}` placeholder `search_url`, `is_default: true`) — gated on `env.browser === 'chrome'`, since Firefox doesn't support the `homepage`/`startup_pages` sub-keys.
- Reuses the production host (`https://qwksearch.com`) and `?q=` query convention already established for QwkSearch searches in `content/shortcut-search-web.ts`.
- Chrome shows its own native permission prompt when an extension requests this, so nothing here bypasses user consent.

## Test plan
- [x] Verified the resolved manifest directly (via `bun -e` invoking the exported `manifest(env)` function) for both `browser: 'chrome'` (includes `chrome_settings_overrides` with the expected `search_url`/`homepage`/`startup_pages`) and `browser: 'firefox'` (`chrome_settings_overrides` is `undefined`)
- [x] `bun run test` in `apps/qwksearch-ext`: 42/42 passed
- [x] Full workspace `bun run test`: 169/179 files, 2415/2471 tests pass; the 52 failures across 10 files are pre-existing and unrelated (documented repeatedly in `TODO.md`)
- [x] `bun run build:web`: 14/14 turbo tasks succeeded
- [x] `bun run compile` in `apps/qwksearch-ext` surfaces only pre-existing, unrelated TS errors (confirmed identical via `git stash`)
- [ ] `qwksearch-ext`'s own `bun run build` (Chrome target) — **pre-existing, unrelated failure** (confirmed via `git stash`): `postcss.config.js` still uses the old `tailwindcss: {}` PostCSS-plugin form against the installed `tailwindcss@4.3.3`, which now requires the separate `@tailwindcss/postcss` package. This blocks building/zipping the extension at all, independent of this change, so I couldn't inspect the real built `manifest.json` directly — verified via the direct function-call approach above instead. Filed as a new tracked follow-up (`TODO.md` Ideas Backlog item 29b).


---
_Generated by [Claude Code](https://claude.ai/code/session_016iSXUXqv6g444gKQT6LhRz)_