### PR TITLE
Add a Downloads tab to the qwksearch-ext side panel

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,121 @@
 ## In Progress
 
+## Browser extension: Downloads tab
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 28 ("Add downloads tab; also back,
+refresh, undo close, new tab."), scoped to its next independently useful
+piece: a Downloads list view. (Back/refresh/new-tab browser-chrome-style
+buttons remain a separate follow-up — see Non-goals.)
+**Branch:** `claude/adoring-mayer-ddv3jg`
+**PR:** Not created yet
+**Started:** 2026-08-14
+
+### Goal
+Let a user see and act on their recent downloads from
+`apps/qwksearch-ext`'s side panel, via a new "Downloads" tab alongside the
+existing "Tabs" and "Research" tabs, using Chrome's `chrome.downloads` API.
+
+### Scope
+- `apps/qwksearch-ext/wxt.config.ts`: add the `downloads` and
+  `downloads.open` manifest permissions (`downloads.open` is required by
+  `chrome.downloads.open()` in addition to `downloads`).
+- New pure helper module `apps/qwksearch-ext/lib/downloads.ts`:
+  - `basenameFromPath(path)`: extracts the filename from an absolute local
+    path, handling both `/`- and `\`-separated paths.
+  - `formatDownloadStatus(item)`: renders a short human-readable status
+    label (`"Downloading NN%"`, `"Downloading"` when size is unknown,
+    `"Paused"`, `"Complete"`, `"Failed"`/`"Failed: <reason>"`) from a
+    `DownloadItem`-shaped object.
+- New component `apps/qwksearch-ext/components/DownloadsList.tsx`: lists
+  the most recent 20 downloads
+  (`chrome.downloads.search({orderBy: ['-startTime'], limit: 20})`), each
+  row showing filename + status, with "show in folder"
+  (`chrome.downloads.show`) and "remove from list" (`chrome.downloads.erase`)
+  icon buttons, and click-to-open (`chrome.downloads.open`) once complete.
+  Kept in sync via `chrome.downloads.onCreated`/`onChanged`/`onErased`.
+- `apps/qwksearch-ext/entrypoints/sidepanel/App.tsx`: add a "Downloads" tab
+  (`Download` icon) alongside "Tabs" and "Research", rendering
+  `DownloadsList`.
+
+### Non-goals
+- Back/refresh/new-tab browser-chrome-style buttons — remains a separate
+  follow-up, per the "Undo close tab" task's precedent below.
+- Removing the downloaded file from disk (`chrome.downloads.removeFile`)
+  or accepting dangerous downloads (`chrome.downloads.acceptDanger`) — out
+  of scope for this first read/act-on-history slice.
+- Initiating new downloads from the panel — this view is for the browser's
+  existing download history, not a download manager UI.
+
+### Acceptance criteria
+- [x] The Downloads tab lists the most recent downloads, most recent
+      first, with filename and status.
+- [x] Clicking a completed download opens it; clicking an
+      in-progress/interrupted one does nothing.
+- [x] "Show in folder" reveals the file; "remove from list" erases it from
+      Chrome's download history and the panel's list.
+- [x] The list stays in sync with new/changed/erased downloads without a
+      manual refresh (via `chrome.downloads.onCreated`/`onChanged`/`onErased`).
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
+      root; nothing to run
+- [x] Typecheck passes — `bun run compile` (after clearing the stale
+      `tsconfig.tsbuildinfo` incremental cache) surfaces only the same
+      **pre-existing** `TS2304: Cannot find name 'chrome'` class of error
+      already present throughout this app's `chrome.*`-using files (this
+      task's `DownloadsList.tsx` and `sidepanel/App.tsx` additions are
+      further instances of that same class, not a new category); also the
+      same pre-existing `TS2493`/`TS2769` errors documented in prior
+      TODO.md tasks.
+- [x] Tests pass — `bunx vitest run test/downloads.test.ts`: 13/13 passed.
+      `bun run test` in `qwksearch-ext`: 60/60 passed (7/7 files, 47
+      pre-existing + 13 new). Full workspace `bun run test`: 171/181 files,
+      2434/2489 tests pass (4 skipped); the 51 failures across the same 10
+      files documented repeatedly in prior TODO.md tasks (`search-web-api`
+      engine tests hitting real external APIs, the `qwksearch-web` config
+      route test, `shadcn-settings`, `jsdom-scraper` missing its `jsdom`
+      dependency, `chat-agent-toolkit`'s `openrouter-default-model.test.js`)
+      are pre-existing and unrelated — none touch `qwksearch-ext`.
+- [x] Production/web build passes — `bun run build:web`: 14/14 turbo tasks
+      succeeded.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      side-panel toolbar actions)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (mirrored `TabList.tsx`'s `chrome.sessions` wiring pattern from the
+      "Undo close tab" task below)
+- [x] Confirm `chrome.downloads` API shape against the installed
+      `@types/chrome`
+- [x] Implement the smallest useful vertical slice (`downloads`/
+      `downloads.open` permissions, `lib/downloads.ts` pure helpers,
+      `DownloadsList.tsx`, `sidepanel/App.tsx` wiring)
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (unknown size, paused,
+      interrupted with/without error reason, over-100% clamping, path
+      separators, no-slash filenames)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint
+      is not actionable for this change; typecheck failures are
+      pre-existing)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality
+- [x] Commit and push the branch
+- [ ] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Create the pull request for this branch's commit(s).
+- Follow-ups noted above remain open: browser-chrome-style
+  back/refresh/new-tab buttons, removing files from disk
+  (`chrome.downloads.removeFile`), and accepting dangerous downloads
+  (`chrome.downloads.acceptDanger`) — all separate, independently useful
+  slices of Ideas Backlog item 28.
+
+## Completed
+
 ## Browser extension: "Undo close tab" button
 
 **Status:** Completed
@@ -8,7 +124,7 @@ refresh, undo close, new tab."), scoped down to its smallest independently
 useful piece: undo-close-tab. (Downloads tab, back/refresh/new-tab remain
 separate follow-ups — see Non-goals.)
 **Branch:** `claude/adoring-mayer-803j75`
-**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/241
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/241 (merged)
 **Started:** 2026-08-14
 **Completed:** 2026-08-14
 
@@ -107,14 +223,12 @@ browser's own Ctrl+Shift+T, but reachable from the extension's own UI.
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task's own scope. PR #241 open, CI/build/tests verified
+- None for this task's own scope. PR #241 merged, CI/build/tests verified
   locally.
-- Follow-ups noted above remain open: a "Downloads" tab/panel using
-  `chrome.downloads`, and browser-chrome-style back/refresh/new-tab
-  buttons — both separate, independently useful slices of Ideas Backlog
-  item 28.
-
-## Completed
+- Follow-ups noted above remain open: browser-chrome-style
+  back/refresh/new-tab buttons — a separate, independently useful slice of
+  Ideas Backlog item 28. (The "Downloads" tab/panel follow-up is now
+  underway — see "Browser extension: Downloads tab" above.)
 
 ## Fix `qwksearch-ext`'s Tailwind v4 PostCSS plugin mismatch
 
@@ -243,8 +357,6 @@ cleared, filed as new Ideas Backlog item 29c.
   `qwksearch-ext`'s build requires wiring up this dependency chain — a
   materially larger, separate task from a PostCSS config fix, so it's left
   as its own dedicated follow-up rather than folded into this one.
-
-## Completed
 
 ## Default search provider support in the browser extension (chrome_settings_overrides)
 

--- a/apps/qwksearch-ext/components/DownloadsList.tsx
+++ b/apps/qwksearch-ext/components/DownloadsList.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useState } from "react"
+import { FolderOpen, X } from "lucide-react"
+import { Button } from "./ui/button"
+import { basenameFromPath, formatDownloadStatus } from "@/lib/downloads"
+
+interface DownloadResult {
+  id: number
+  filename: string
+  status: string
+  complete: boolean
+}
+
+const MAX_DOWNLOADS = 20
+
+export default function DownloadsList() {
+  const [downloads, setDownloads] = useState<DownloadResult[]>([])
+
+  const fetchDownloads = useCallback(() => {
+    chrome.downloads.search({ orderBy: ["-startTime"], limit: MAX_DOWNLOADS }, (items) => {
+      setDownloads(
+        items.map((item) => ({
+          id: item.id,
+          filename: basenameFromPath(item.filename) || item.url,
+          status: formatDownloadStatus(item),
+          complete: item.state === "complete"
+        }))
+      )
+    })
+  }, [])
+
+  useEffect(() => {
+    fetchDownloads()
+    chrome.downloads.onCreated.addListener(fetchDownloads)
+    chrome.downloads.onChanged.addListener(fetchDownloads)
+    chrome.downloads.onErased.addListener(fetchDownloads)
+    return () => {
+      chrome.downloads.onCreated.removeListener(fetchDownloads)
+      chrome.downloads.onChanged.removeListener(fetchDownloads)
+      chrome.downloads.onErased.removeListener(fetchDownloads)
+    }
+  }, [fetchDownloads])
+
+  function openDownload(download: DownloadResult) {
+    if (!download.complete) return
+    chrome.downloads.open(download.id)
+  }
+
+  function showDownload(id: number, e: React.MouseEvent) {
+    e.stopPropagation()
+    chrome.downloads.show(id)
+  }
+
+  function removeDownload(id: number, e: React.MouseEvent) {
+    e.stopPropagation()
+    chrome.downloads.erase({ id }, () => fetchDownloads())
+  }
+
+  return (
+    <>
+      <div className="list-group col">
+        {downloads.map((download) => (
+          <div
+            key={download.id}
+            className="list-group-item select-none cursor-pointer"
+            onClick={() => openDownload(download)}
+          >
+            <div className="py-2 px-3 flex items-center space-x-3 transition-colors duration-200 rounded-md border bg-slate-200 border-slate-300 hover:bg-gray-100">
+              <div className="grow flex flex-col justify-center overflow-hidden">
+                <p
+                  className="text-sm font-medium text-gray-900 truncate"
+                  title={download.filename}
+                >
+                  {download.filename}
+                </p>
+                <p className="text-xs text-gray-500 truncate">{download.status}</p>
+              </div>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="shrink-0 h-6 w-6 hover:bg-slate-300"
+                onClick={(e) => showDownload(download.id, e)}
+                title="Show in folder"
+              >
+                <FolderOpen size={14} className="text-gray-500" />
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="shrink-0 h-6 w-6 hover:bg-slate-300"
+                onClick={(e) => removeDownload(download.id, e)}
+                title="Remove from list"
+              >
+                <X size={14} className="text-gray-500" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {downloads.length === 0 && (
+        <div className="p-2 text-sm italic text-gray-600">No downloads yet</div>
+      )}
+    </>
+  )
+}

--- a/apps/qwksearch-ext/entrypoints/sidepanel/App.tsx
+++ b/apps/qwksearch-ext/entrypoints/sidepanel/App.tsx
@@ -1,9 +1,10 @@
 import { useState, useCallback } from "react"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
-import { Layers, BrainCircuit } from "lucide-react"
+import { Layers, BrainCircuit, Download } from "lucide-react"
 import TabSearch from "@/components/TabSearch"
 import TabList from "@/components/TabList"
 import ResearchTab from "@/components/ResearchTab"
+import DownloadsList from "@/components/DownloadsList"
 import { searchEngines } from "../../content/shortcut-search-web";
 
 interface TabResult {
@@ -53,6 +54,10 @@ export default function SidePanel() {
             <BrainCircuit size={16} />
             <span>Research</span>
           </TabsTrigger>
+          <TabsTrigger value="downloads" className="flex items-center gap-2">
+            <Download size={16} />
+            <span>Downloads</span>
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="tabs">
@@ -71,6 +76,10 @@ export default function SidePanel() {
 
         <TabsContent value="research">
           <ResearchTab />
+        </TabsContent>
+
+        <TabsContent value="downloads">
+          <DownloadsList />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/qwksearch-ext/lib/downloads.ts
+++ b/apps/qwksearch-ext/lib/downloads.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure helpers for rendering `chrome.downloads.DownloadItem`-shaped objects
+ * in the side panel's Downloads tab, kept free of the `chrome` global so
+ * they're directly unit-testable.
+ */
+export interface DownloadItemLike {
+  filename: string
+  state: "in_progress" | "interrupted" | "complete"
+  paused?: boolean
+  bytesReceived?: number
+  totalBytes?: number
+  error?: string
+}
+
+/**
+ * Extracts the last path segment from an absolute local path, handling both
+ * `/`- and `\`-separated paths (Chrome reports Windows-style paths on
+ * Windows regardless of the host OS running these tests).
+ */
+export function basenameFromPath(path: string): string {
+  if (!path) return ""
+  const segments = path.replace(/\\/g, "/").split("/")
+  return segments[segments.length - 1] || path
+}
+
+/** Renders a short human-readable status label for a download item. */
+export function formatDownloadStatus(item: DownloadItemLike): string {
+  if (item.state === "interrupted") {
+    return item.error ? `Failed: ${item.error}` : "Failed"
+  }
+
+  if (item.state === "complete") {
+    return "Complete"
+  }
+
+  if (item.paused) return "Paused"
+
+  const total = item.totalBytes ?? -1
+  const received = item.bytesReceived ?? 0
+  if (total > 0) {
+    const pct = Math.min(100, Math.round((received / total) * 100))
+    return `Downloading ${pct}%`
+  }
+
+  return "Downloading"
+}

--- a/apps/qwksearch-ext/test/downloads.test.ts
+++ b/apps/qwksearch-ext/test/downloads.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import { basenameFromPath, formatDownloadStatus } from "../lib/downloads"
+
+describe("basenameFromPath", () => {
+  it("returns the filename from a unix-style path", () => {
+    expect(basenameFromPath("/home/user/Downloads/report.pdf")).toBe("report.pdf")
+  })
+
+  it("returns the filename from a windows-style path", () => {
+    expect(basenameFromPath("C:\\Users\\me\\Downloads\\report.pdf")).toBe("report.pdf")
+  })
+
+  it("returns the input unchanged when there are no path separators", () => {
+    expect(basenameFromPath("report.pdf")).toBe("report.pdf")
+  })
+
+  it("returns an empty string for an empty path", () => {
+    expect(basenameFromPath("")).toBe("")
+  })
+
+  it("returns the path when it ends in a separator", () => {
+    expect(basenameFromPath("/home/user/Downloads/")).toBe("/home/user/Downloads/")
+  })
+})
+
+describe("formatDownloadStatus", () => {
+  it("reports Complete for a finished download", () => {
+    expect(formatDownloadStatus({ filename: "a", state: "complete" })).toBe("Complete")
+  })
+
+  it("reports Failed with the error reason for an interrupted download", () => {
+    expect(
+      formatDownloadStatus({ filename: "a", state: "interrupted", error: "NETWORK_FAILED" })
+    ).toBe("Failed: NETWORK_FAILED")
+  })
+
+  it("reports plain Failed when an interrupted download has no error reason", () => {
+    expect(formatDownloadStatus({ filename: "a", state: "interrupted" })).toBe("Failed")
+  })
+
+  it("reports Paused for a paused in-progress download", () => {
+    expect(
+      formatDownloadStatus({ filename: "a", state: "in_progress", paused: true, bytesReceived: 10, totalBytes: 100 })
+    ).toBe("Paused")
+  })
+
+  it("reports a percentage for an in-progress download with a known size", () => {
+    expect(
+      formatDownloadStatus({ filename: "a", state: "in_progress", bytesReceived: 25, totalBytes: 100 })
+    ).toBe("Downloading 25%")
+  })
+
+  it("caps the percentage at 100 even if bytesReceived exceeds totalBytes", () => {
+    expect(
+      formatDownloadStatus({ filename: "a", state: "in_progress", bytesReceived: 150, totalBytes: 100 })
+    ).toBe("Downloading 100%")
+  })
+
+  it("reports plain Downloading when the total size is unknown (-1)", () => {
+    expect(
+      formatDownloadStatus({ filename: "a", state: "in_progress", bytesReceived: 10, totalBytes: -1 })
+    ).toBe("Downloading")
+  })
+
+  it("reports plain Downloading when totalBytes is missing", () => {
+    expect(formatDownloadStatus({ filename: "a", state: "in_progress" })).toBe("Downloading")
+  })
+})

--- a/apps/qwksearch-ext/wxt.config.ts
+++ b/apps/qwksearch-ext/wxt.config.ts
@@ -52,6 +52,8 @@ export default defineConfig({
       'declarativeNetRequest',
       'offscreen',
       'sessions',
+      'downloads',
+      'downloads.open',
     ],
     host_permissions: ['<all_urls>'],
     commands: {


### PR DESCRIPTION
## Summary
- Adds a "Downloads" tab (`chrome.downloads`) to `apps/qwksearch-ext`'s side panel, alongside the existing "Tabs" and "Research" tabs.
- Lists the 20 most recent downloads (most recent first) with filename + status (`Downloading NN%`, `Paused`, `Complete`, `Failed`/`Failed: <reason>`); click a completed entry to open it, plus "show in folder" and "remove from list" actions. Stays live via `chrome.downloads.onCreated`/`onChanged`/`onErased`.
- New pure helper module `lib/downloads.ts` (`basenameFromPath`, `formatDownloadStatus`) with Vitest coverage.
- Adds the `downloads` and `downloads.open` manifest permissions.
- Next independently useful slice of TODO.md Ideas Backlog item 28 ("Add downloads tab; also back, refresh, undo close, new tab."), following the "Undo close tab" slice merged in #241. Back/refresh/new-tab remain a separate follow-up.
- Tracker cleanup: moves the already-merged "Undo close tab" entry from `In Progress` into `Completed` in `TODO.md`, and removes a leftover duplicate `## Completed` heading.

## Test plan
- [x] `bunx vitest run test/downloads.test.ts` in `qwksearch-ext`: 13/13 passed
- [x] `bun run test` in `qwksearch-ext`: 60/60 passed (47 pre-existing + 13 new)
- [x] Full workspace `bun run test`: 171/181 files pass; the 10 failing files are pre-existing and unrelated (documented in TODO.md)
- [x] `bun run build:web`: 14/14 turbo tasks succeeded
- [x] `bun run compile` in `qwksearch-ext`: only pre-existing `TS2304`/`TS2493`/`TS2769` errors (this app has no global `chrome` types wired into its tsconfig; pre-existing across every `chrome.*` call site)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01P81mnZfFdMNETdhUrCaWCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01P81mnZfFdMNETdhUrCaWCv)_