### PR TITLE
Add a Favorites tab to the qwksearch-ext side panel

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,126 @@
 ## In Progress
 
+## Browser extension: Favorites (bookmarks) tab
+
+**Status:** Completed
+**Source:** TODO.md — Ideas Backlog item 14 ("Main nav: Tabs | AI chat | Web
+search | Favorites | History."), scoped to its next independently useful
+piece: a Favorites list view using `chrome.bookmarks`, explicitly called out
+as a remaining follow-up in the "Browser extension: History tab" task below,
+mirroring that task's and the Downloads tab's established pattern.
+**Branch:** `claude/adoring-mayer-fcxcmd`
+**PR:** Not created yet
+**Started:** 2026-08-15
+**Completed:** 2026-08-15
+
+### Goal
+Let a user see and act on their browser bookmarks from
+`apps/qwksearch-ext`'s side panel, via a new "Favorites" tab alongside the
+existing "Tabs", "Research", "Downloads", and "History" tabs, using Chrome's
+`chrome.bookmarks` API.
+
+### Scope
+- `apps/qwksearch-ext/wxt.config.ts`: add the `bookmarks` manifest
+  permission.
+- New pure helper module `apps/qwksearch-ext/lib/bookmarks.ts`:
+  - `hostnameFromUrl(url)`: extracts the hostname from a URL string,
+    falling back to the raw string if it fails to parse (mirrors
+    `lib/history.ts`, kept self-contained per this codebase's per-feature
+    pure-helper-module convention).
+  - `titleOrHostname(item)`: returns a bookmark node's title, trimmed,
+    falling back to its URL's hostname when the title is blank/missing.
+  - `isBookmarkNode(node)`: returns true when a `chrome.bookmarks.
+    BookmarkTreeNode`-shaped object has a non-empty `url` (as opposed to a
+    folder node, which has only `title`/`children`) — defensive filtering
+    even though `chrome.bookmarks.getRecent` is documented to exclude
+    folders.
+- New component `apps/qwksearch-ext/components/BookmarksList.tsx`: lists
+  the most recent 20 bookmarks (`chrome.bookmarks.getRecent(20)`, already
+  most-recent-first), each row showing favicon + title/hostname, with
+  click-to-open (`chrome.tabs.create({url})`) and a "remove bookmark" icon
+  button (`chrome.bookmarks.remove`). Kept in sync via
+  `chrome.bookmarks.onCreated`/`onRemoved`/`onChanged`.
+- `apps/qwksearch-ext/entrypoints/sidepanel/App.tsx`: add a "Favorites" tab
+  (`Star` icon) alongside "Tabs", "Research", "Downloads", and "History",
+  rendering `BookmarksList`.
+
+### Non-goals
+- Any main-nav restructuring (the backlog item's literal "Tabs | AI chat |
+  Web search | Favorites | History" layout) — out of scope; this task only
+  adds a Favorites tab to the existing side-panel tab strip, matching how
+  the History/Downloads tabs were added.
+- Creating new bookmarks from the panel (e.g. a "bookmark the current tab"
+  button) — this view is for browsing/acting on existing bookmarks, not a
+  bookmark-creation UI (matches the Downloads tab's precedent of not
+  initiating new downloads from the panel).
+- Browsing the full bookmark folder tree, or filtering/searching bookmarks
+  — out of scope for this first read/act-on-favorites slice (matches the
+  Downloads/History tabs' precedent of a flat recency-ordered list only).
+- Editing a bookmark's title/URL — only viewing, opening, and removing.
+
+### Acceptance criteria
+- [x] The Favorites tab lists the most recent bookmarks, most recent first,
+      with title (or hostname fallback).
+- [x] Clicking a bookmark opens it in a new tab.
+- [x] "Remove bookmark" erases it from Chrome's bookmarks and the panel's
+      list.
+- [x] The list stays in sync with new/changed/removed bookmarks without a
+      manual refresh (via `chrome.bookmarks.onCreated`/`onRemoved`/
+      `onChanged`).
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
+      root; nothing to run
+- [x] Typecheck passes — `bun run compile` (after clearing the stale
+      `tsconfig.tsbuildinfo` incremental cache) surfaces exactly 118 errors,
+      the same count as on `git stash`-ed (unmodified) code — confirmed via
+      a direct before/after comparison. All are the same **pre-existing**
+      `TS2304: Cannot find name 'chrome'` (missing global `chrome` types
+      throughout this app's `chrome.*`-using files), `TS2307` (missing
+      `research-agent-ui` `dist/` output), `TS2493`, and `TS2769` error
+      classes documented in prior TODO.md tasks; none reference
+      `BookmarksList.tsx` or `lib/bookmarks.ts`.
+- [x] Tests pass — `bunx vitest run test/bookmarks.test.ts`: 9/9 passed.
+      `bun run test` in `qwksearch-ext`: 81/81 passed (9/9 files, 72
+      pre-existing + 9 new).
+- [x] Production/web build passes — `bun run build:web` at the repo root:
+      14/14 turbo tasks succeeded. Also verified
+      `bunx turbo build --filter=qwksearch-extension-wxt` (Chrome target)
+      succeeds (11/11 tasks) and the built
+      `.output/chrome-mv3/manifest.json` includes the new `"bookmarks"`
+      permission.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      side-panel toolbar actions)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (mirrored `HistoryList.tsx`/`lib/history.ts`'s pattern)
+- [x] Confirm `chrome.bookmarks` API shape against the installed
+      `@types/chrome` (`BookmarkTreeNode`, `getRecent`, `remove`,
+      `onCreated`/`onRemoved`/`onChanged`)
+- [x] Implement the smallest useful vertical slice (`bookmarks` permission,
+      `lib/bookmarks.ts` pure helpers, `BookmarksList.tsx`,
+      `sidepanel/App.tsx` wiring)
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (blank title, missing title,
+      unparseable URL, folder node with no url, empty-string url)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint is
+      not actionable for this change; typecheck error count unchanged
+      before/after)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality (also reverted the
+      unrelated `bun.lock` package-version-sync diff produced by `bun
+      install` — pure version-number sync to already-committed
+      `package.json` bumps, out of scope, matching prior tasks' precedent)
+- [x] Commit and push the branch
+- [ ] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Create the pull request for this branch's commit(s).
+
 ## Completed
 
 ## Wire `research-agent-ui` into `qwksearch-ext`'s build (item 29c)
@@ -19,7 +140,11 @@ integration needs (`lib/next-navigation-shim.tsx`, `lib/grab-url-shim.ts`)
 and their Vite aliases in `wxt.config.ts` already existed from earlier
 work — only the dependency declaration/build-ordering was missing.
 **Branch:** `claude/adoring-mayer-wmhmlr`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/246 (merged
+— landed via a different session/branch than the one this entry originally
+tracked; the tracker entry below was written before that merge and never
+synced, matching the "History tab" task's precedent of squash-merge PRs not
+carrying tracker-bookkeeping commits back to master)
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 
@@ -132,17 +257,20 @@ turbo's `^build` dependency graph.
       `package.json` bumps, out of scope, matching prior tasks' precedent —
       keeping only the new `research-agent-ui: workspace:*` dependency line)
 - [x] Commit and push the branch
-- [ ] Create or update the pull request
+- [x] Create or update the pull request — merged as PR #246
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- Create the pull request for this branch's commit(s).
+- None for this task's own scope. PR #246 merged.
 - The Research tab's actual *runtime* behavior inside the shipped extension
   (whether every `research-agent-ui` API call correctly resolves against
   `https://qwksearch.com`, whether the bundled voice/ONNX assets work in
   the extension's sandboxed pages, etc.) has not been manually verified —
   out of scope per this task's Non-goals, but worth a manual QA pass before
   relying on the Research tab in production.
+- A post-merge Cloudflare Workers Build failure on this PR was flagged as
+  Ideas Backlog item 38 (external dashboard access needed to diagnose;
+  `bun run build:web` passed locally on the merged commit).
 
 ## Completed
 

--- a/apps/qwksearch-ext/components/BookmarksList.tsx
+++ b/apps/qwksearch-ext/components/BookmarksList.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from "react"
+import { X } from "lucide-react"
+import { Button } from "./ui/button"
+import { isBookmarkNode, titleOrHostname } from "@/lib/bookmarks"
+
+interface BookmarkResult {
+  id: string
+  url: string
+  title: string
+  favIconUrl: string
+}
+
+const MAX_BOOKMARKS = 20
+
+export default function BookmarksList() {
+  const [bookmarks, setBookmarks] = useState<BookmarkResult[]>([])
+
+  const fetchBookmarks = useCallback(() => {
+    chrome.bookmarks.getRecent(MAX_BOOKMARKS, (nodes) => {
+      setBookmarks(
+        nodes
+          .filter(isBookmarkNode)
+          .map((node) => ({
+            id: node.id,
+            url: node.url!,
+            title: titleOrHostname(node),
+            favIconUrl:
+              `chrome-extension://${chrome.runtime.id}` +
+              `/_favicon/?pageUrl=${encodeURIComponent(node.url!)}&size=16`
+          }))
+      )
+    })
+  }, [])
+
+  useEffect(() => {
+    fetchBookmarks()
+    chrome.bookmarks.onCreated.addListener(fetchBookmarks)
+    chrome.bookmarks.onRemoved.addListener(fetchBookmarks)
+    chrome.bookmarks.onChanged.addListener(fetchBookmarks)
+    return () => {
+      chrome.bookmarks.onCreated.removeListener(fetchBookmarks)
+      chrome.bookmarks.onRemoved.removeListener(fetchBookmarks)
+      chrome.bookmarks.onChanged.removeListener(fetchBookmarks)
+    }
+  }, [fetchBookmarks])
+
+  function openBookmark(url: string) {
+    chrome.tabs.create({ url })
+  }
+
+  function removeBookmark(id: string, e: React.MouseEvent) {
+    e.stopPropagation()
+    chrome.bookmarks.remove(id, () => fetchBookmarks())
+  }
+
+  return (
+    <>
+      <div className="list-group col">
+        {bookmarks.map((bookmark) => (
+          <div
+            key={bookmark.id}
+            className="list-group-item select-none cursor-pointer"
+            onClick={() => openBookmark(bookmark.url)}
+          >
+            <div className="py-2 px-3 flex items-center space-x-3 transition-colors duration-200 rounded-md border bg-slate-200 border-slate-300 hover:bg-gray-100">
+              <img src={bookmark.favIconUrl} alt="" className="w-4 h-4 shrink-0" />
+
+              <div className="grow flex flex-col justify-center overflow-hidden">
+                <p className="text-sm font-medium text-gray-900 truncate" title={bookmark.title}>
+                  {bookmark.title}
+                </p>
+                <p className="text-xs text-gray-500 truncate">{bookmark.url}</p>
+              </div>
+
+              <Button
+                variant="ghost"
+                size="icon"
+                className="shrink-0 h-6 w-6 hover:bg-slate-300"
+                onClick={(e) => removeBookmark(bookmark.id, e)}
+                title="Remove bookmark"
+              >
+                <X size={14} className="text-gray-500" />
+              </Button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {bookmarks.length === 0 && (
+        <div className="p-2 text-sm italic text-gray-600">No favorites yet</div>
+      )}
+    </>
+  )
+}

--- a/apps/qwksearch-ext/entrypoints/sidepanel/App.tsx
+++ b/apps/qwksearch-ext/entrypoints/sidepanel/App.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback } from "react"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
-import { Layers, BrainCircuit, Download, History } from "lucide-react"
+import { Layers, BrainCircuit, Download, History, Star } from "lucide-react"
 import TabSearch from "@/components/TabSearch"
 import TabList from "@/components/TabList"
 import ResearchTab from "@/components/ResearchTab"
 import DownloadsList from "@/components/DownloadsList"
 import HistoryList from "@/components/HistoryList"
+import BookmarksList from "@/components/BookmarksList"
 import { searchEngines } from "../../content/shortcut-search-web";
 
 interface TabResult {
@@ -63,6 +64,10 @@ export default function SidePanel() {
             <History size={16} />
             <span>History</span>
           </TabsTrigger>
+          <TabsTrigger value="favorites" className="flex items-center gap-2">
+            <Star size={16} />
+            <span>Favorites</span>
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="tabs">
@@ -89,6 +94,10 @@ export default function SidePanel() {
 
         <TabsContent value="history">
           <HistoryList />
+        </TabsContent>
+
+        <TabsContent value="favorites">
+          <BookmarksList />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/qwksearch-ext/lib/bookmarks.ts
+++ b/apps/qwksearch-ext/lib/bookmarks.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure helpers for rendering `chrome.bookmarks.BookmarkTreeNode`-shaped
+ * objects in the side panel's Favorites tab, kept free of the `chrome`
+ * global so they're directly unit-testable.
+ */
+export interface BookmarkNodeLike {
+  title?: string
+  url?: string
+}
+
+/** Extracts the hostname from a URL, falling back to the raw string if it doesn't parse. */
+export function hostnameFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname
+  } catch {
+    return url
+  }
+}
+
+/** Returns the bookmark's title, falling back to its URL's hostname when blank. */
+export function titleOrHostname(item: BookmarkNodeLike): string {
+  const title = item.title?.trim()
+  if (title) return title
+  return item.url ? hostnameFromUrl(item.url) : ""
+}
+
+/** True for an actual bookmark (has a URL), false for a folder node. */
+export function isBookmarkNode(node: BookmarkNodeLike): boolean {
+  return !!node.url
+}

--- a/apps/qwksearch-ext/test/bookmarks.test.ts
+++ b/apps/qwksearch-ext/test/bookmarks.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { hostnameFromUrl, isBookmarkNode, titleOrHostname } from "../lib/bookmarks"
+
+describe("hostnameFromUrl", () => {
+  it("returns the hostname for a well-formed URL", () => {
+    expect(hostnameFromUrl("https://example.com/path?q=1")).toBe("example.com")
+  })
+
+  it("returns the input unchanged when it doesn't parse as a URL", () => {
+    expect(hostnameFromUrl("not a url")).toBe("not a url")
+  })
+})
+
+describe("titleOrHostname", () => {
+  it("returns the trimmed title when present", () => {
+    expect(titleOrHostname({ title: "  Example Site  ", url: "https://example.com" })).toBe(
+      "Example Site"
+    )
+  })
+
+  it("falls back to the hostname when the title is blank", () => {
+    expect(titleOrHostname({ title: "   ", url: "https://example.com/path" })).toBe(
+      "example.com"
+    )
+  })
+
+  it("falls back to the hostname when the title is missing", () => {
+    expect(titleOrHostname({ url: "https://example.com" })).toBe("example.com")
+  })
+
+  it("returns an empty string when neither title nor url is present", () => {
+    expect(titleOrHostname({})).toBe("")
+  })
+})
+
+describe("isBookmarkNode", () => {
+  it("returns true for a node with a url", () => {
+    expect(isBookmarkNode({ title: "Example", url: "https://example.com" })).toBe(true)
+  })
+
+  it("returns false for a folder node with no url", () => {
+    expect(isBookmarkNode({ title: "My Folder" })).toBe(false)
+  })
+
+  it("returns false for a node with an empty-string url", () => {
+    expect(isBookmarkNode({ title: "Odd node", url: "" })).toBe(false)
+  })
+})

--- a/apps/qwksearch-ext/wxt.config.ts
+++ b/apps/qwksearch-ext/wxt.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
       'downloads',
       'downloads.open',
       'history',
+      'bookmarks',
     ],
     host_permissions: ['<all_urls>'],
     commands: {


### PR DESCRIPTION
## Summary
- Adds a "Favorites" tab to `apps/qwksearch-ext`'s side panel, backed by `chrome.bookmarks`, alongside the existing Tabs/Research/Downloads/History tabs — the follow-up explicitly called out when the History tab was added (TODO.md Ideas Backlog item 14).
- Lists the 20 most recent bookmarks (`chrome.bookmarks.getRecent`), each showing favicon + title (falling back to hostname), with click-to-open and a "remove bookmark" button, kept in sync via `onCreated`/`onRemoved`/`onChanged`.
- New pure helper module `lib/bookmarks.ts` (`hostnameFromUrl`, `titleOrHostname`, `isBookmarkNode`) with Vitest coverage, mirroring the existing `lib/history.ts`/`lib/downloads.ts` pattern.
- Adds the `bookmarks` manifest permission.
- Also fixes stale TODO.md bookkeeping: the item 29c task ("Wire research-agent-ui into qwksearch-ext's build") was already merged as PR #246, but its tracker entry still said "PR: Not created yet" / listed creating a PR as remaining work.

## Test plan
- [x] `bunx vitest run test/bookmarks.test.ts` — 9/9 passed
- [x] `bun run test` in `apps/qwksearch-ext` — 81/81 passed (72 pre-existing + 9 new)
- [x] `bun run compile` (typecheck) — same 118 pre-existing errors before and after this change (confirmed via `git stash` comparison); none reference the new files
- [x] `bun run build:web` at the repo root — 14/14 turbo tasks succeeded
- [x] `bunx turbo build --filter=qwksearch-extension-wxt` — 11/11 tasks succeeded; verified the built `.output/chrome-mv3/manifest.json` includes the new `"bookmarks"` permission

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqUat4iqaePsMkvXuF94Zg)_