### PR TITLE
Sync TODO.md for PR #251 and flag a fifth Workers Build failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@ the follow-up explicitly deferred as a Non-goal in the "Browser extension:
 Favorites (bookmarks) tab" task below ("Editing a bookmark's title/URL —
 only viewing, opening, and removing" for the first slice).
 **Branch:** `claude/adoring-mayer-c9coc7`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/251
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 
@@ -2301,6 +2301,15 @@ ext - dl to reason dl folswe
     `TODO.md`, and `bun run build:web` passed 14/14 turbo tasks locally on
     this exact commit before the check ran. Four consecutive failures
     across four different PRs/commits, including a markdown-only one,
-    rules out this repo's source as the cause. Still needs a human with
+    rules out this repo's source as the cause.
+
+    **Update: it recurred a fifth time, on PR #251 (commit `070415d`, the
+    "Edit a bookmark's title" task), build ID
+    `9c7e0d5d-3dc3-4092-8c61-89b86deab316`. Same pattern again: the diff
+    only touched `apps/qwksearch-ext/` plus `TODO.md`, and `bun run
+    build:web` passed 14/14 turbo tasks locally on this exact commit before
+    the check ran (and before merging). Five consecutive failures across
+    five different PRs/commits confirms this is not transient and not
+    caused by this repo's source. Still needs a human with
     Cloudflare dashboard access to diagnose — this environment has no
     credentials for it.

--- a/TODO.md
+++ b/TODO.md
@@ -2310,6 +2310,15 @@ ext - dl to reason dl folswe
     build:web` passed 14/14 turbo tasks locally on this exact commit before
     the check ran (and before merging). Five consecutive failures across
     five different PRs/commits confirms this is not transient and not
-    caused by this repo's source. Still needs a human with
+    caused by this repo's source.
+
+    **Update: it recurred a sixth time, on PR #252 (commit `91c1fb0`, the
+    TODO.md tracker-sync-only follow-up to PR #251), build ID
+    `01c74939-2faa-46b9-8f5d-41b4c9f7130b`. This PR's diff touches only
+    `TODO.md` — zero code — the second time a pure-documentation PR has
+    triggered the identical failure (the first being PR #249, see the third
+    occurrence above), reconfirming this is entirely a Cloudflare-side/
+    Workers-Build infrastructure issue with no code-level trigger in this
+    repo whatsoever. Still needs a human with
     Cloudflare dashboard access to diagnose — this environment has no
     credentials for it.


### PR DESCRIPTION
## Summary
- Records PR #251's merged link in the tracker's "Edit a bookmark's title" entry.
- Flags a fifth recurrence of the pre-existing "Workers Builds: qwksearch-research-agent" Cloudflare deploy check failure (Ideas Backlog item 39), on PR #251 (commit `070415d`, build ID `9c7e0d5d-3dc3-4092-8c61-89b86deab316`). Same pattern as the prior four occurrences: the diff only touched `apps/qwksearch-ext/` and `TODO.md`, and `bun run build:web` passed 14/14 turbo tasks locally on that commit before merging — this is a Cloudflare-side/infra issue unrelated to this repo's source.

This is a documentation-only change (TODO.md), no code changes.

## Test plan
- N/A — pure tracker documentation update.

---
_Generated by [Claude Code](https://claude.ai/code/session_0161xcfHo5ffmRNUAaq5YXQ4)_