### PR TITLE
Add a "Chat about my open tabs" button to the qwksearch-ext Research tab

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,141 @@
 ## In Progress
 
+## Browser extension: "Chat about my open tabs" button
+
+**Status:** Completed
+**Source:** TODO.md — Ideas Backlog items 2 ("Chat with open tabs as
+context.") and 19 ("Use open tabs as context."), scoped to the smallest
+independently useful first slice: a button that seeds the Research tab's
+chat with the list of the user's currently open tabs, using the
+`research-agent-ui` `useChat().sendMessage` API that's already exposed to
+consumers — no changes to the shared `research-agent-ui` package needed.
+(A prior investigation ruled out reusing the existing `systemInstructions`
+`localStorage` key: `apps/qwksearch-ext/components/SearchSettings.tsx`
+already binds that same key two-way to a user-facing "custom instructions"
+settings field, so writing tab context into it would silently clobber a
+user's saved custom instructions. `sendMessage` avoids that entirely.)
+**Branch:** `claude/adoring-mayer-1sn4od`
+**PR:** Not created yet
+**Started:** 2026-08-15
+**Completed:** 2026-08-15
+
+### Goal
+Let a user click a button in `apps/qwksearch-ext`'s side panel Research tab
+that lists their currently open browser tabs (title + URL) as the first
+message in the chat, so they can immediately ask follow-up questions about
+them (e.g. "summarize these" or "which of these is most relevant to X"),
+without leaving the panel or manually typing/copy-pasting each tab.
+
+### Scope
+- New pure helper module `apps/qwksearch-ext/lib/open-tabs-context.ts`:
+  - `isContextableTab(tab)`: true when a tab-like object has an `http(s)://`
+    URL (excludes internal `chrome://`/`chrome-extension://`/`about:`/
+    `file://` pages, which aren't meaningful chat context and may be
+    extension/browser-internal).
+  - `formatOpenTabsMessage(tabs)`: filters to contextable tabs, returns
+    `undefined` when there are none, otherwise a numbered
+    title/hostname-fallback + URL list message (reusing
+    `hostnameFromUrl` from `lib/history.ts`) ending with a short prompt line,
+    ready to hand straight to `sendMessage`.
+- `apps/qwksearch-ext/components/ResearchTab.tsx`: add a small button
+  (rendered inside the existing `ChatProvider` tree, above `ChatWindow`)
+  that on click calls `chrome.tabs.query({currentWindow: true})`, formats
+  the result via `formatOpenTabsMessage`, and calls the chat's
+  `sendMessage(message)` — disabled while a message is already sending
+  (`useChat().loading`).
+
+### Non-goals
+- Any change to `packages/research-agent-ui` — this slice deliberately uses
+  only its already-public `useChat().sendMessage` API.
+- Extracting each tab's full page text/content (mirroring `TabSearch.tsx`'s
+  `chrome.scripting.executeScript` pattern) — this first slice only sends
+  title + URL per tab; full-page-content context is a separate, larger
+  follow-up (would need per-tab content-script injection and is a much
+  bigger payload).
+- Letting the user edit the generated message before it's sent (e.g.
+  prefilling the chat input box instead of sending immediately) — no setter
+  for the chat input's text is exposed by `research-agent-ui`'s public API
+  today; out of scope for this slice.
+- Any settings/toggle to auto-include tabs on every message, or to persist
+  which tabs were included — this is a one-shot "seed the conversation"
+  action only.
+- Tabs from other windows (`chrome.tabs.query({currentWindow: true})` only)
+  — matches the likely user intent of "the tabs I'm looking at right now"
+  and avoids potentially large/irrelevant context from unrelated windows.
+
+### Acceptance criteria
+- [x] Clicking the button when there's at least one contextable open tab
+      sends a chat message listing those tabs (title/hostname + URL) via
+      `useChat().sendMessage`.
+- [x] Clicking the button when there are zero contextable open tabs (e.g.
+      only `chrome://` pages) does not call `sendMessage`.
+- [x] The button is disabled while a chat message is already sending
+      (`loading` from `useChat()`).
+- [x] Vitest coverage is added or updated
+- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
+      root; nothing to run
+- [x] Typecheck passes — `bun run compile` (after clearing the stale
+      `tsconfig.tsbuildinfo` incremental cache) surfaces exactly 121 errors,
+      one more than the 120 on `git stash -u`-ed (unmodified) code —
+      confirmed via a direct before/after diff of the full error list. The
+      one new error (`components/ResearchTab.tsx(25,5): error TS2304:
+      Cannot find name 'chrome'` at the new `chrome.tabs.query` call) is a
+      further instance of the same **pre-existing** `TS2304` class already
+      present throughout this app's `chrome.*`-using files, not a new
+      category; the two `research-agent-ui`-module-resolution `TS2307`
+      errors are the same pre-existing pair (just shifted one line by the
+      new `useChat` import).
+- [x] Tests pass — `bunx vitest run test/open-tabs-context.test.ts`: 14/14
+      passed. `bun run test` in `qwksearch-ext`: 100/100 passed (11/11
+      files, 86 pre-existing + 14 new). Full workspace `bun run test`:
+      175/185 files, 2474/2529 tests pass (4 skipped); the 51 failures
+      across the same 10 files documented repeatedly in prior TODO.md tasks
+      (`search-web-api` engine tests hitting real external APIs, the
+      `qwksearch-web` config route test, `shadcn-settings`, `jsdom-scraper`
+      missing its `jsdom` dependency, `chat-agent-toolkit`'s
+      `openrouter-default-model.test.js`) are pre-existing and unrelated —
+      none touch `qwksearch-ext`.
+- [x] Production/web build passes — `bun run build:web` at the repo root:
+      14/14 turbo tasks succeeded. Also verified
+      `bunx turbo build --filter=qwksearch-extension-wxt` (Chrome target)
+      succeeds (11/11 tasks).
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      side-panel toolbar actions)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (mirrored `lib/history.ts`/`lib/new-tab.ts`'s pure-helper-module
+      pattern; confirmed `useChat().sendMessage` and `ChatProvider` are
+      public `research-agent-ui` exports; ruled out reusing
+      `systemInstructions` localStorage — see Source above)
+- [x] Implement `lib/open-tabs-context.ts` (`isContextableTab`,
+      `formatOpenTabsMessage`)
+- [x] Implement the `ResearchTab.tsx` button + wiring
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (no tabs, only
+      internal-scheme tabs, blank/missing titles falling back to hostname,
+      mixed contextable/non-contextable tabs with contiguous renumbering)
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking (see acceptance-criteria notes — lint is
+      not actionable for this change; typecheck error count is +1, the same
+      pre-existing error class)
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality (also reverted an
+      unrelated `bun.lock` package-version-sync diff produced by `bun
+      install` — pure version-number sync to already-committed
+      `package.json` bumps, out of scope, matching prior tasks' precedent)
+- [x] Commit and push the branch
+- [ ] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task's own scope.
+- Follow-ups noted above remain open: full page-content extraction as
+  context (not just title/URL), letting the user edit the generated message
+  before sending, and any settings/toggle for auto-including tabs.
+
 ## Completed
 
 ## Browser extension: Edit a bookmark's title from the Favorites tab

--- a/apps/qwksearch-ext/components/ResearchTab.tsx
+++ b/apps/qwksearch-ext/components/ResearchTab.tsx
@@ -3,8 +3,12 @@ import {
   ExtractPanelProvider,
   ChatProvider,
   ChatWindow,
+  useChat,
 } from 'research-agent-ui';
 import type { ResearchAgentAuthClient } from 'research-agent-ui';
+import { MessageSquareText } from 'lucide-react';
+import { Button } from './ui/button';
+import { formatOpenTabsMessage } from '@/lib/open-tabs-context';
 
 // Minimal no-op auth client — the extension runs without a backend auth session.
 const noopAuthClient: ResearchAgentAuthClient = {
@@ -14,12 +18,38 @@ const noopAuthClient: ResearchAgentAuthClient = {
   signOut: async () => {},
 };
 
+function OpenTabsContextButton() {
+  const { sendMessage, loading } = useChat();
+
+  const handleClick = () => {
+    chrome.tabs.query({ currentWindow: true }, (tabs) => {
+      const message = formatOpenTabsMessage(tabs);
+      if (message) sendMessage(message);
+    });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="m-2 self-start"
+      disabled={loading}
+      onClick={handleClick}
+    >
+      <MessageSquareText size={14} className="mr-1" />
+      Chat about my open tabs
+    </Button>
+  );
+}
+
 export default function ResearchTab() {
   return (
     <div className="h-full overflow-auto">
       <SessionProvider authClient={noopAuthClient}>
         <ExtractPanelProvider>
           <ChatProvider>
+            <OpenTabsContextButton />
             <ChatWindow />
           </ChatProvider>
         </ExtractPanelProvider>

--- a/apps/qwksearch-ext/lib/open-tabs-context.ts
+++ b/apps/qwksearch-ext/lib/open-tabs-context.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for turning the user's currently open browser tabs into a
+ * chat message, kept free of the `chrome` global so they're directly
+ * unit-testable.
+ */
+import { hostnameFromUrl } from "./history"
+
+export interface OpenTabLike {
+  title?: string
+  url?: string
+}
+
+const CONTEXTABLE_URL_PATTERN = /^https?:\/\//i
+
+/** True when a tab has a real http(s) URL (excludes chrome://, about:, etc). */
+export function isContextableTab(tab: OpenTabLike): boolean {
+  return !!tab.url && CONTEXTABLE_URL_PATTERN.test(tab.url)
+}
+
+/**
+ * Formats the user's open tabs as a chat message, or `undefined` when none
+ * of them are contextable.
+ */
+export function formatOpenTabsMessage(tabs: OpenTabLike[]): string | undefined {
+  const contextable = tabs.filter(isContextableTab)
+  if (contextable.length === 0) return undefined
+
+  const lines = contextable.map((tab, index) => {
+    const title = tab.title?.trim() || hostnameFromUrl(tab.url!)
+    return `${index + 1}. ${title} — ${tab.url}`
+  })
+
+  return [
+    "Here are my currently open browser tabs:",
+    ...lines,
+    "",
+    "Please use these as context for my next questions.",
+  ].join("\n")
+}

--- a/apps/qwksearch-ext/test/open-tabs-context.test.ts
+++ b/apps/qwksearch-ext/test/open-tabs-context.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest"
+import { formatOpenTabsMessage, isContextableTab } from "../lib/open-tabs-context"
+
+describe("isContextableTab", () => {
+  it("returns true for an http URL", () => {
+    expect(isContextableTab({ url: "http://example.com" })).toBe(true)
+  })
+
+  it("returns true for an https URL", () => {
+    expect(isContextableTab({ url: "https://example.com" })).toBe(true)
+  })
+
+  it("returns false for a chrome:// URL", () => {
+    expect(isContextableTab({ url: "chrome://extensions" })).toBe(false)
+  })
+
+  it("returns false for a chrome-extension:// URL", () => {
+    expect(isContextableTab({ url: "chrome-extension://abc123/popup.html" })).toBe(false)
+  })
+
+  it("returns false for an about: URL", () => {
+    expect(isContextableTab({ url: "about:blank" })).toBe(false)
+  })
+
+  it("returns false for a file:// URL", () => {
+    expect(isContextableTab({ url: "file:///Users/me/notes.txt" })).toBe(false)
+  })
+
+  it("returns false when the URL is missing", () => {
+    expect(isContextableTab({ title: "New Tab" })).toBe(false)
+  })
+
+  it("returns false when the URL is an empty string", () => {
+    expect(isContextableTab({ url: "" })).toBe(false)
+  })
+})
+
+describe("formatOpenTabsMessage", () => {
+  it("returns undefined when there are no tabs", () => {
+    expect(formatOpenTabsMessage([])).toBeUndefined()
+  })
+
+  it("returns undefined when no tabs are contextable", () => {
+    expect(
+      formatOpenTabsMessage([{ url: "chrome://extensions" }, { url: "about:blank" }])
+    ).toBeUndefined()
+  })
+
+  it("numbers and formats contextable tabs with title and URL", () => {
+    const message = formatOpenTabsMessage([
+      { title: "Example Site", url: "https://example.com/path" },
+      { title: "Another Site", url: "https://another.example.com" },
+    ])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. Example Site — https://example.com/path",
+        "2. Another Site — https://another.example.com",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+
+  it("falls back to the hostname when a tab's title is blank", () => {
+    const message = formatOpenTabsMessage([{ title: "   ", url: "https://example.com/path" }])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. example.com — https://example.com/path",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+
+  it("falls back to the hostname when a tab's title is missing", () => {
+    const message = formatOpenTabsMessage([{ url: "https://example.com" }])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. example.com — https://example.com",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+
+  it("skips non-contextable tabs but keeps numbering contiguous for the rest", () => {
+    const message = formatOpenTabsMessage([
+      { title: "Extensions", url: "chrome://extensions" },
+      { title: "Example Site", url: "https://example.com" },
+    ])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. Example Site — https://example.com",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a "Chat about my open tabs" button to `apps/qwksearch-ext`'s side panel Research tab, letting a user seed the chat with a message listing their currently open tabs (title + URL) so they can immediately ask follow-up questions about them.
- Uses `research-agent-ui`'s already-public `useChat().sendMessage` API — no changes to the shared `research-agent-ui` package.
- New pure helper module `apps/qwksearch-ext/lib/open-tabs-context.ts` (`isContextableTab`, `formatOpenTabsMessage`) filters out internal-scheme tabs (`chrome://`, `chrome-extension://`, `about:`, `file://`) and formats the rest into a numbered title/hostname-fallback + URL list.

Scoped from TODO.md's Ideas Backlog items 2 ("Chat with open tabs as context") and 19 ("Use open tabs as context") to the smallest independently useful first slice. A prior investigation ruled out reusing the existing `systemInstructions` localStorage key, since `SearchSettings.tsx` already binds that same key two-way to a user-facing custom-instructions field — writing tab context there would silently clobber a user's saved instructions.

## Test plan
- [x] `bunx vitest run test/open-tabs-context.test.ts` — 14/14 passed
- [x] `bun run test` in `apps/qwksearch-ext` — 100/100 passed (11/11 files)
- [x] Full workspace `bun run test` — 175/185 files, 2474/2529 tests pass; the 10 failing files are the same pre-existing, documented, unrelated failures from every prior task (external API calls, missing `jsdom` dependency, etc.)
- [x] `bun run compile` in `apps/qwksearch-ext` — net +1 error vs. baseline, same pre-existing `TS2304: Cannot find name 'chrome'` class present throughout this app
- [x] `bun run build:web` at repo root — 14/14 turbo tasks succeeded
- [x] `bunx turbo build --filter=qwksearch-extension-wxt` (Chrome target) — 11/11 tasks succeeded

---
_Generated by [Claude Code](https://claude.ai/code/session_01L32qVFB1Ptd5nFowqYDdxo)_