### PR TITLE
Sync TODO.md for PR #253 and flag a seventh Workers Build failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2469,3 +2469,13 @@ ext - dl to reason dl folswe
     pure-documentation ones, continues to rule out this repo's source as
     the cause. Still needs a human with Cloudflare dashboard access to
     diagnose — this environment has no credentials for it.
+
+    **Update: it recurred an eighth time, on PR #254 (commit `6145234`, the
+    TODO.md tracker-sync-only follow-up to PR #253), build ID
+    `f644dbac-6f0e-4fe5-a26d-e1b637203ea4`. This PR's diff touches only
+    `TODO.md` — zero code — the third pure-documentation PR to trigger the
+    identical failure (after PRs #249 and #252). Eight consecutive failures
+    across eight different PRs/commits, including three carrying no code
+    change whatsoever, conclusively rules out this repo's source across
+    every occurrence so far. Still needs a human with Cloudflare dashboard
+    access to diagnose — this environment has no credentials for it.

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ already binds that same key two-way to a user-facing "custom instructions"
 settings field, so writing tab context into it would silently clobber a
 user's saved custom instructions. `sendMessage` avoids that entirely.)
 **Branch:** `claude/adoring-mayer-1sn4od`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/253
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 
@@ -2458,3 +2458,14 @@ ext - dl to reason dl folswe
     repo whatsoever. Still needs a human with
     Cloudflare dashboard access to diagnose — this environment has no
     credentials for it.
+
+    **Update: it recurred a seventh time, on PR #253 (commit `11dce04`, the
+    "Chat about my open tabs" button task), build ID
+    `e683a94c-497a-40fc-bc29-26536b87fd1f`. Same pattern as every prior
+    occurrence: the diff only touches `apps/qwksearch-ext/` plus `TODO.md`,
+    and `bun run build:web` passed 14/14 turbo tasks locally on this exact
+    commit before the check ran (and before merging). Seven consecutive
+    failures across seven different PRs/commits, including two
+    pure-documentation ones, continues to rule out this repo's source as
+    the cause. Still needs a human with Cloudflare dashboard access to
+    diagnose — this environment has no credentials for it.


### PR DESCRIPTION
## Summary
- Records the PR link for the "Chat about my open tabs" button task (#253, merged).
- Documents a seventh occurrence of the recurring, pre-existing "Workers Builds: qwksearch-research-agent" Cloudflare deploy check failure (Ideas Backlog item 39) on PR #253's merge commit — same pattern as all six prior occurrences: diff only touches `apps/qwksearch-ext/`/`TODO.md`, and `bun run build:web` passed 14/14 locally on that exact commit. Still needs a human with Cloudflare dashboard access to diagnose; this environment has no credentials for it.

Pure documentation change, zero code.

## Test plan
- N/A — TODO.md only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L32qVFB1Ptd5nFowqYDdxo)_