### PR TITLE
Include page content in "Chat about my open tabs" (qwksearch-ext)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,109 @@
 ## In Progress
 
+## Browser extension: include page content in "Chat about my open tabs"
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 12 ("Use CRX/extension to open
+tabs and scrape them.") and item 19 ("Use open tabs as context."),
+continuing the follow-up explicitly deferred as a Non-goal in the "Chat
+about my open tabs" button task above ("Extracting each tab's full page
+text/content (mirroring `TabSearch.tsx`'s `chrome.scripting.executeScript`
+pattern) — this first slice only sends title + URL per tab; full-page-content
+context is a separate, larger follow-up"). Reuses the exact
+`chrome.scripting.executeScript` pattern already established in
+`apps/qwksearch-ext/components/TabSearch.tsx` for in-tab content search, so
+no new Chrome API/permission is needed (`scripting` is already granted in
+`wxt.config.ts`).
+**Branch:** `claude/adoring-mayer-g3uiuf`
+**PR:** Not created yet
+**Started:** 2026-08-15
+
+### Goal
+Let a user click a second button in `apps/qwksearch-ext`'s side panel
+Research tab that seeds the chat with their open tabs' title + URL **and**
+a truncated excerpt of each tab's visible page text, so follow-up questions
+can be answered from actual page content, not just titles/URLs.
+
+### Scope
+- `apps/qwksearch-ext/lib/open-tabs-context.ts`:
+  - Extend `OpenTabLike` with an optional `content?: string` field.
+  - Add `truncateTabContent(content, maxChars = 2000)`: trims and truncates
+    a content string to a max length, appending an ellipsis when truncated
+    (keeps the chat message payload bounded across many/large tabs).
+  - Update `formatOpenTabsMessage` to append a truncated, indented content
+    excerpt under a tab's line when `content` is present — unchanged output
+    when `content` is absent, so this stays backward compatible with the
+    existing title/URL-only button and its tests.
+  - Add `extractTabContent(tabId)`: wraps
+    `chrome.scripting.executeScript({ target: { tabId }, func: () =>
+    document.body.innerText })`, returning the extracted text or `undefined`
+    on any failure (e.g. Chrome Web Store / restricted pages that reject
+    script injection) — caught, not thrown, so one tab's failure doesn't
+    block the others.
+- `apps/qwksearch-ext/components/ResearchTab.tsx`: add a second button
+  ("Chat with page content" or similar) that queries open tabs, runs
+  `extractTabContent` across all contextable tabs in parallel
+  (`Promise.all`/`allSettled`), then calls `sendMessage` with the resulting
+  content-enriched message. Disabled while chat is sending (`loading`) and
+  while its own extraction is in flight.
+
+### Non-goals
+- Any change to `packages/research-agent-ui` — same constraint as the prior
+  task; only the already-public `useChat().sendMessage` API is used.
+- Removing or changing the existing title/URL-only button — this is an
+  additive second action, not a replacement.
+- Any settings/toggle to auto-include page content on every message, or to
+  persist a preference — a one-shot action only, matching the prior task's
+  precedent.
+- Manifest/permission changes — `scripting` is already granted.
+- Summarizing/chunking beyond a flat per-tab character truncation — no
+  smarter compression of long pages in this first slice.
+
+### Acceptance criteria
+- [ ] Clicking the new button when there's at least one contextable open
+      tab sends a chat message listing those tabs (title/hostname + URL)
+      with a truncated page-content excerpt per tab, via
+      `useChat().sendMessage`.
+- [ ] Clicking the new button when there are zero contextable open tabs
+      does not call `sendMessage`.
+- [ ] A tab whose content extraction fails (e.g. a restricted page) is
+      still included with title/URL only (no content line), rather than
+      aborting the whole action.
+- [ ] Content longer than the max length is truncated with an ellipsis;
+      content at or under the max length is included in full.
+- [ ] The new button is disabled while a chat message is already sending
+      or while extraction is in flight.
+- [ ] Vitest coverage is added or updated
+- [ ] Lint passes
+- [ ] Typecheck passes
+- [ ] Tests pass
+- [ ] Production/web build passes
+- [ ] Documentation is updated if behavior or configuration changes
+
+### Implementation plan
+- [ ] Inspect affected modules, local instructions, and existing tests
+      (`TabSearch.tsx`'s `chrome.scripting.executeScript` pattern,
+      `open-tabs-context.ts`/`ResearchTab.tsx` from the prior task)
+- [ ] Implement `truncateTabContent` and `extractTabContent` in
+      `lib/open-tabs-context.ts`
+- [ ] Update `formatOpenTabsMessage` to include per-tab content when present
+- [ ] Implement the `ResearchTab.tsx` second button + wiring
+- [ ] Add focused Vitest success-path coverage
+- [ ] Add focused failure/edge-case coverage (extraction failure,
+      truncation boundary, no contextable tabs, mixed content/no-content
+      tabs)
+- [ ] Run focused tests and fix failures
+- [ ] Run linting and typechecking
+- [ ] Run the full relevant test suite
+- [ ] Run the production/web build
+- [ ] Review the final diff for scope and quality
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Everything above — just started.
+
 ## Browser extension: "Chat about my open tabs" button
 
 **Status:** Completed

--- a/apps/qwksearch-ext/components/ResearchTab.tsx
+++ b/apps/qwksearch-ext/components/ResearchTab.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   SessionProvider,
   ExtractPanelProvider,
@@ -6,9 +7,10 @@ import {
   useChat,
 } from 'research-agent-ui';
 import type { ResearchAgentAuthClient } from 'research-agent-ui';
-import { MessageSquareText } from 'lucide-react';
+import { FileText, MessageSquareText } from 'lucide-react';
 import { Button } from './ui/button';
-import { formatOpenTabsMessage } from '@/lib/open-tabs-context';
+import { formatOpenTabsMessage, isContextableTab } from '@/lib/open-tabs-context';
+import extractTabContent from '@/lib/extract-tab-content';
 
 // Minimal no-op auth client — the extension runs without a backend auth session.
 const noopAuthClient: ResearchAgentAuthClient = {
@@ -43,6 +45,42 @@ function OpenTabsContextButton() {
   );
 }
 
+function OpenTabsContentButton() {
+  const { sendMessage, loading } = useChat();
+  const [extracting, setExtracting] = useState(false);
+
+  const handleClick = () => {
+    setExtracting(true);
+    chrome.tabs.query({ currentWindow: true }, async (tabs) => {
+      const contextable = tabs.filter(isContextableTab);
+      const withContent = await Promise.all(
+        contextable.map(async (tab) => ({
+          title: tab.title,
+          url: tab.url,
+          content: await extractTabContent(tab.id!),
+        }))
+      );
+      setExtracting(false);
+      const message = formatOpenTabsMessage(withContent);
+      if (message) sendMessage(message);
+    });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="m-2 self-start"
+      disabled={loading || extracting}
+      onClick={handleClick}
+    >
+      <FileText size={14} className="mr-1" />
+      Chat with my tabs' page content
+    </Button>
+  );
+}
+
 export default function ResearchTab() {
   return (
     <div className="h-full overflow-auto">
@@ -50,6 +88,7 @@ export default function ResearchTab() {
         <ExtractPanelProvider>
           <ChatProvider>
             <OpenTabsContextButton />
+            <OpenTabsContentButton />
             <ChatWindow />
           </ChatProvider>
         </ExtractPanelProvider>

--- a/apps/qwksearch-ext/lib/extract-tab-content.ts
+++ b/apps/qwksearch-ext/lib/extract-tab-content.ts
@@ -1,0 +1,20 @@
+/**
+ * Extracts a tab's visible page text via `chrome.scripting.executeScript`,
+ * mirroring the pattern already used by `TabSearch.tsx` for in-tab content
+ * search. Kept as its own small module so the `chrome` call is mockable in
+ * isolation, per this codebase's per-feature pure-helper-module convention.
+ */
+export default async function extractTabContent(tabId: number): Promise<string | undefined> {
+  try {
+    const results = await chrome.scripting.executeScript({
+      target: { tabId },
+      func: () => document.body.innerText,
+    })
+    const content = results[0]?.result
+    return typeof content === "string" ? content : undefined
+  } catch {
+    // Restricted pages (Chrome Web Store, other extensions' pages, etc.)
+    // reject script injection — treat as "no content" rather than failing.
+    return undefined
+  }
+}

--- a/apps/qwksearch-ext/lib/open-tabs-context.ts
+++ b/apps/qwksearch-ext/lib/open-tabs-context.ts
@@ -8,9 +8,11 @@ import { hostnameFromUrl } from "./history"
 export interface OpenTabLike {
   title?: string
   url?: string
+  content?: string
 }
 
 const CONTEXTABLE_URL_PATTERN = /^https?:\/\//i
+export const MAX_TAB_CONTENT_CHARS = 2000
 
 /** True when a tab has a real http(s) URL (excludes chrome://, about:, etc). */
 export function isContextableTab(tab: OpenTabLike): boolean {
@@ -18,16 +20,31 @@ export function isContextableTab(tab: OpenTabLike): boolean {
 }
 
 /**
+ * Trims and truncates page content to a bounded length, so a chat message
+ * built from many tabs' content stays a reasonable size. Appends an
+ * ellipsis when truncation happens.
+ */
+export function truncateTabContent(content: string, maxChars: number = MAX_TAB_CONTENT_CHARS): string {
+  const trimmed = content.trim()
+  if (trimmed.length <= maxChars) return trimmed
+  return `${trimmed.slice(0, maxChars)}…`
+}
+
+/**
  * Formats the user's open tabs as a chat message, or `undefined` when none
- * of them are contextable.
+ * of them are contextable. When a tab has `content`, a truncated excerpt is
+ * included indented under its title/URL line.
  */
 export function formatOpenTabsMessage(tabs: OpenTabLike[]): string | undefined {
   const contextable = tabs.filter(isContextableTab)
   if (contextable.length === 0) return undefined
 
-  const lines = contextable.map((tab, index) => {
+  const lines = contextable.flatMap((tab, index) => {
     const title = tab.title?.trim() || hostnameFromUrl(tab.url!)
-    return `${index + 1}. ${title} — ${tab.url}`
+    const header = `${index + 1}. ${title} — ${tab.url}`
+    const content = tab.content?.trim()
+    if (!content) return [header]
+    return [header, `   ${truncateTabContent(content)}`]
   })
 
   return [

--- a/apps/qwksearch-ext/test/extract-tab-content.test.ts
+++ b/apps/qwksearch-ext/test/extract-tab-content.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import extractTabContent from "../lib/extract-tab-content"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("extractTabContent", () => {
+  it("returns the extracted text on success", async () => {
+    const executeScript = vi.fn().mockResolvedValue([{ result: "Page body text" }])
+    vi.stubGlobal("chrome", { scripting: { executeScript } })
+
+    const content = await extractTabContent(42)
+
+    expect(content).toBe("Page body text")
+    expect(executeScript).toHaveBeenCalledWith(
+      expect.objectContaining({ target: { tabId: 42 } })
+    )
+  })
+
+  it("returns undefined when the injection result has no result", async () => {
+    const executeScript = vi.fn().mockResolvedValue([{}])
+    vi.stubGlobal("chrome", { scripting: { executeScript } })
+
+    expect(await extractTabContent(1)).toBeUndefined()
+  })
+
+  it("returns undefined when there are no injection results", async () => {
+    const executeScript = vi.fn().mockResolvedValue([])
+    vi.stubGlobal("chrome", { scripting: { executeScript } })
+
+    expect(await extractTabContent(1)).toBeUndefined()
+  })
+
+  it("returns undefined when executeScript rejects (e.g. a restricted page)", async () => {
+    const executeScript = vi.fn().mockRejectedValue(new Error("Cannot access contents"))
+    vi.stubGlobal("chrome", { scripting: { executeScript } })
+
+    expect(await extractTabContent(1)).toBeUndefined()
+  })
+})

--- a/apps/qwksearch-ext/test/open-tabs-context.test.ts
+++ b/apps/qwksearch-ext/test/open-tabs-context.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { formatOpenTabsMessage, isContextableTab } from "../lib/open-tabs-context"
+import {
+  MAX_TAB_CONTENT_CHARS,
+  formatOpenTabsMessage,
+  isContextableTab,
+  truncateTabContent,
+} from "../lib/open-tabs-context"
 
 describe("isContextableTab", () => {
   it("returns true for an http URL", () => {
@@ -103,5 +108,72 @@ describe("formatOpenTabsMessage", () => {
         "Please use these as context for my next questions.",
       ].join("\n")
     )
+  })
+
+  it("includes a truncated content excerpt indented under a tab's line when present", () => {
+    const message = formatOpenTabsMessage([
+      { title: "Example Site", url: "https://example.com", content: "Some page text." },
+    ])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. Example Site — https://example.com",
+        "   Some page text.",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+
+  it("omits the content line when content is blank or whitespace-only", () => {
+    const message = formatOpenTabsMessage([
+      { title: "Example Site", url: "https://example.com", content: "   " },
+    ])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. Example Site — https://example.com",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+
+  it("mixes tabs with and without content", () => {
+    const message = formatOpenTabsMessage([
+      { title: "With Content", url: "https://example.com/a", content: "Body text" },
+      { title: "No Content", url: "https://example.com/b" },
+    ])
+
+    expect(message).toBe(
+      [
+        "Here are my currently open browser tabs:",
+        "1. With Content — https://example.com/a",
+        "   Body text",
+        "2. No Content — https://example.com/b",
+        "",
+        "Please use these as context for my next questions.",
+      ].join("\n")
+    )
+  })
+})
+
+describe("truncateTabContent", () => {
+  it("returns trimmed content unchanged when at or under the max length", () => {
+    expect(truncateTabContent("  hello world  ", 20)).toBe("hello world")
+  })
+
+  it("truncates content over the max length and appends an ellipsis", () => {
+    const content = "a".repeat(MAX_TAB_CONTENT_CHARS + 50)
+    const result = truncateTabContent(content)
+
+    expect(result).toBe(`${"a".repeat(MAX_TAB_CONTENT_CHARS)}…`)
+    expect(result.length).toBe(MAX_TAB_CONTENT_CHARS + 1)
+  })
+
+  it("respects a custom max length", () => {
+    expect(truncateTabContent("abcdefghij", 5)).toBe("abcde…")
   })
 })


### PR DESCRIPTION
## Summary
- Adds a second "Chat with my tabs' page content" button to `apps/qwksearch-ext`'s side panel Research tab, alongside the existing title/URL-only "Chat about my open tabs" button.
- Extracts each open tab's visible page text via `chrome.scripting.executeScript` — mirroring the pattern `TabSearch.tsx` already uses for in-tab content search — and includes a truncated (2000-char) excerpt per tab in the seeded chat message, so follow-up questions can draw on actual page content instead of just titles/URLs.
- A tab whose extraction fails (e.g. a restricted page) is still included with title/URL only, rather than aborting the whole action.
- No manifest/permission changes — `scripting` is already granted in `wxt.config.ts`.

Continues the follow-up explicitly deferred as a Non-goal in the "Chat about my open tabs" button task (#253): "Extracting each tab's full page text/content ... is a separate, larger follow-up." Scoped from TODO.md's Ideas Backlog items 12 ("Use CRX/extension to open tabs and scrape them") and 19 ("Use open tabs as context").

## Test plan
- [x] `bunx vitest run test/open-tabs-context.test.ts test/extract-tab-content.test.ts` — 24/24 passed
- [x] `bun run test` in `apps/qwksearch-ext` — 110/110 passed (12/12 files)
- [x] Full workspace `bun run test` — 176/186 files, 2479/2539 tests pass (4 skipped); the 9 failing files are the same pre-existing, documented, unrelated failures seen in every prior task (external API calls, missing `jsdom` dependency, etc.)
- [x] `bun run compile` in `apps/qwksearch-ext` — net +2 errors vs. the 121-error baseline (confirmed via a clean before/after comparison), both the same pre-existing `TS2304: Cannot find name 'chrome'` class present throughout this app
- [x] `bun run build:web` at repo root — 14/14 turbo tasks succeeded
- [x] `bunx turbo build --filter=qwksearch-extension-wxt` (Chrome target) — 11/11 tasks succeeded

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnG4cBZzqb3pWRoFBxFkda)_