### PR TITLE
Browser extension: Browse bookmarks by folder in the Favorites tab

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -127,6 +127,146 @@ used for the title in `apps/qwksearch-ext`'s side panel Favorites tab, via
 - Bookmark-folder-tree editing/moving remains an open, separate follow-up
   (unchanged from the original title-edit task's Remaining work).
 
+## Browser extension: Browse bookmarks by folder in the Favorites tab
+
+**Status:** In Progress
+**Source:** TODO.md — Ideas Backlog item 14 (Favorites tab), continuing the
+follow-up explicitly deferred as a Non-goal in the original "Browser
+extension: Favorites (bookmarks) tab" task ("Browsing the full bookmark
+folder tree, or filtering/searching bookmarks — out of scope for this first
+read/act-on-favorites slice") and echoed as still-open in later Favorites
+tasks' Remaining work ("Bookmark-folder-tree editing/moving remains an open,
+separate follow-up"). This slice covers the "browsing" half only — view-only
+folder navigation, no move/reorder/create.
+**Branch:** `claude/adoring-mayer-0cef78` (this session's designated branch)
+**PR:** Not created yet
+**Started:** 2026-08-15
+
+### Goal
+Let a user switch the Favorites tab from the existing flat "most recent 20"
+list to a folder-tree view, so they can navigate into their actual Chrome
+bookmark folders (Bookmarks bar, Other bookmarks, and any user-created
+subfolders) and open/edit/remove bookmarks from within them, without leaving
+the panel.
+
+### Scope
+- `apps/qwksearch-ext/lib/bookmarks.ts`: add `isFolderNode(node)` (the
+  inverse of the existing `isBookmarkNode`) and `folderDisplayTitle(node)` (a
+  folder's trimmed title, falling back to a placeholder when blank).
+- `apps/qwksearch-ext/components/BookmarksList.tsx`:
+  - Add a small "Recent" / "Folders" view toggle at the top of the tab
+    (default: "Recent", preserving today's behavior unchanged).
+  - In "Folders" mode, list the current folder's immediate children via
+    `chrome.bookmarks.getChildren(folderId)`, starting at the bookmarks root
+    (`"0"`, whose children are Chrome's top-level folders). Folders render as
+    clickable rows (folder icon + title) that navigate in; bookmarks render
+    with the existing row markup (favicon, open-on-click, edit, remove —
+    refactored into a small shared row renderer so both views reuse the same
+    edit/remove/open logic).
+  - A "Back" button (enabled once inside a folder) navigates to the parent
+    folder, tracked via a simple in-memory folder stack (no need to persist
+    across panel reloads).
+  - Re-fetch the active view's data on
+    `chrome.bookmarks.onCreated`/`onRemoved`/`onChanged`/`onMoved`, mirroring
+    the existing sync behavior.
+
+### Non-goals
+- Creating new bookmarks or folders, or moving/reordering bookmarks between
+  folders (drag-and-drop or otherwise) — view/open/edit-title-and-url/remove
+  only, matching the existing per-bookmark actions.
+- Any breadcrumb UI beyond a single "Back" button — a full multi-level
+  breadcrumb trail is a possible follow-up, not required for this first
+  browsing slice.
+- Any change to the "Recent" view's existing behavior, `lib/history.ts`,
+  `HistoryList.tsx`, `DownloadsList.tsx`, or any other tab.
+
+### Acceptance criteria
+- [x] The Favorites tab defaults to the existing "Recent" flat list
+      (unchanged behavior) with a new "Folders" toggle.
+- [x] Switching to "Folders" shows the top-level bookmark folders (Bookmarks
+      bar, Other bookmarks, etc.) as clickable rows (`chrome.bookmarks.
+      getChildren("0", ...)`).
+- [x] Clicking a folder navigates into it and shows its immediate child
+      folders and bookmarks (`folderStack` push, re-fetches via
+      `getChildren(currentFolderId)`).
+- [x] Clicking a bookmark row (in either view) still opens it via
+      `chrome.tabs.create`; Edit/Remove still work identically in Folders
+      view (shared `renderBookmarkRow`, `removeBookmark`/`saveEdit` refresh
+      whichever view is active).
+- [x] "Back" returns to the parent folder; it's the top-level list when the
+      stack is empty (`folderStack.slice(0, -1)`).
+- [x] An empty folder shows a "This folder is empty" message, mirroring the
+      existing "No favorites yet" message.
+- [x] Vitest coverage is added or updated — 6 new focused cases for
+      `isFolderNode` (has url / no url / empty-string url) and
+      `folderDisplayTitle` (trimmed title / blank title / missing title) in
+      `apps/qwksearch-ext/test/bookmarks.test.ts`. No pre-existing
+      `BookmarksList.tsx` component test file exists (checked directly),
+      matching the precedent from every prior Favorites-tab task.
+- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
+      root; nothing to run (same as every prior `qwksearch-ext` task)
+- [x] Typecheck passes — `bun run compile` (after clearing the stale
+      `tsconfig.tsbuildinfo` incremental cache) surfaces exactly 126 errors,
+      3 more than the 123-error baseline confirmed via `git stash` on just
+      this task's three touched files, re-running `bun run compile`, then
+      `git stash pop`. A line-by-line `diff` of the two runs shows the 11
+      pre-existing `components/BookmarksList.tsx` `TS2304: Cannot find name
+      'chrome'` lines became 14 (the 3 new `chrome.bookmarks.getChildren`/
+      `onMoved.addListener`/`onMoved.removeListener` call sites) — same
+      pre-existing error class, no new category introduced.
+- [x] Tests pass — `bunx vitest run test/bookmarks.test.ts`: 24/24 passed (18
+      pre-existing + 6 new). `bun run test` in `qwksearch-ext`: 121/121
+      passed (12/12 files). Full workspace `bun run test`: 177/186 files,
+      2493/2550 tests pass (53 failed, 4 skipped). The 9 failing files are
+      exactly the documented pre-existing set (`chat-agent-toolkit/test/
+      openrouter-default-model.test.js`, `qwksearch-web/app/api/config/
+      __tests__/route.test.ts`, `search-web-api/test/{api,
+      autocomplete-engines,engine-health-suite,search,sources-unit,
+      sources}.test.ts`, `shadcn-settings/test/settings-field.test.tsx`) —
+      confirmed via a full `grep -E "^ (❯|FAIL)"` over the captured run
+      output, none touch `qwksearch-ext` or bookmarks-related files.
+- [x] Production/web build passes — `bun run build:web` at the repo root:
+      14/14 turbo tasks succeeded. Also verified `bunx turbo build
+      --filter=qwksearch-extension-wxt` (Chrome target): 11/11 tasks
+      succeeded, producing `.output/chrome-mv3/`.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      side-panel toolbar actions)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (`lib/bookmarks.ts`, `components/BookmarksList.tsx`,
+      `test/bookmarks.test.ts`)
+- [x] Confirm `chrome.bookmarks.getChildren`/`onMoved` API shape
+- [x] Implement `isFolderNode`/`folderDisplayTitle` in `lib/bookmarks.ts`
+- [x] Implement the Folders view + toggle + back navigation in
+      `BookmarksList.tsx`, refactoring the bookmark row into a shared
+      `renderBookmarkRow` renderer used by both the Recent and Folders views
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage (empty-string url edge case for
+      `isFolderNode`; blank/missing title for `folderDisplayTitle`)
+- [x] Run focused tests and fix failures (none needed — passed first run)
+- [x] Run linting and typechecking (lint n/a; typecheck error count is +3,
+      the same pre-existing `TS2304` class, confirmed via `git stash`-based
+      before/after diff)
+- [x] Run the full relevant test suite (`qwksearch-ext` and full workspace
+      `bun run test`)
+- [x] Run the production/web build (`bun run build:web`, 14/14 turbo tasks;
+      also verified the Chrome extension build itself, 11/11 tasks)
+- [x] Review the final diff for scope and quality (`bun install` produced an
+      unrelated `bun.lock` package-version-sync diff, reverted per prior
+      tasks' precedent; final `git diff --stat` shows only the 4 intended
+      files)
+- [x] Commit and push the branch
+- [ ] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task's own scope beyond opening the PR (next step).
+- Follow-ups noted above remain open: creating new bookmarks/folders,
+  moving/reordering bookmarks between folders, and a full multi-level
+  breadcrumb trail beyond the single "Back" button.
+
 ## Fix `render-url-to-html/scraper-jsdom` and `scraper-puppeteer` missing from bun workspaces
 
 **Status:** Completed

--- a/apps/qwksearch-ext/components/BookmarksList.tsx
+++ b/apps/qwksearch-ext/components/BookmarksList.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import { Pencil, X } from "lucide-react"
+import { ChevronLeft, Folder, Pencil, X } from "lucide-react"
 import { Button } from "./ui/button"
 import { Input } from "./ui/input"
 import {
+  folderDisplayTitle,
   isBookmarkNode,
+  isFolderNode,
   sanitizeBookmarkTitle,
   sanitizeBookmarkUrl,
   titleOrHostname
@@ -17,14 +19,35 @@ interface BookmarkResult {
   favIconUrl: string
 }
 
+interface BookmarkFolder {
+  id: string
+  title: string
+}
+
 const MAX_BOOKMARKS = 20
+const ROOT_FOLDER_ID = "0"
+
+function faviconUrl(url: string): string {
+  return (
+    `chrome-extension://${chrome.runtime.id}` +
+    `/_favicon/?pageUrl=${encodeURIComponent(url)}&size=16`
+  )
+}
 
 export default function BookmarksList() {
+  const [viewMode, setViewMode] = useState<"recent" | "folders">("recent")
   const [bookmarks, setBookmarks] = useState<BookmarkResult[]>([])
+  const [folderStack, setFolderStack] = useState<BookmarkFolder[]>([])
+  const [childFolders, setChildFolders] = useState<BookmarkFolder[]>([])
+  const [folderBookmarks, setFolderBookmarks] = useState<BookmarkResult[]>([])
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState("")
   const [editUrlValue, setEditUrlValue] = useState("")
   const cancellingEditRef = useRef(false)
+
+  const currentFolderId = folderStack.length
+    ? folderStack[folderStack.length - 1].id
+    : ROOT_FOLDER_ID
 
   const fetchBookmarks = useCallback(() => {
     chrome.bookmarks.getRecent(MAX_BOOKMARKS, (nodes) => {
@@ -36,33 +59,71 @@ export default function BookmarksList() {
             url: node.url!,
             title: titleOrHostname(node),
             rawTitle: node.title ?? "",
-            favIconUrl:
-              `chrome-extension://${chrome.runtime.id}` +
-              `/_favicon/?pageUrl=${encodeURIComponent(node.url!)}&size=16`
+            favIconUrl: faviconUrl(node.url!)
           }))
       )
     })
   }, [])
 
+  const fetchFolderChildren = useCallback(() => {
+    chrome.bookmarks.getChildren(currentFolderId, (nodes) => {
+      const folders: BookmarkFolder[] = []
+      const items: BookmarkResult[] = []
+      for (const node of nodes) {
+        if (isFolderNode(node)) {
+          folders.push({ id: node.id, title: folderDisplayTitle(node) })
+        } else if (isBookmarkNode(node)) {
+          items.push({
+            id: node.id,
+            url: node.url!,
+            title: titleOrHostname(node),
+            rawTitle: node.title ?? "",
+            favIconUrl: faviconUrl(node.url!)
+          })
+        }
+      }
+      setChildFolders(folders)
+      setFolderBookmarks(items)
+    })
+  }, [currentFolderId])
+
   useEffect(() => {
-    fetchBookmarks()
-    chrome.bookmarks.onCreated.addListener(fetchBookmarks)
-    chrome.bookmarks.onRemoved.addListener(fetchBookmarks)
-    chrome.bookmarks.onChanged.addListener(fetchBookmarks)
-    return () => {
-      chrome.bookmarks.onCreated.removeListener(fetchBookmarks)
-      chrome.bookmarks.onRemoved.removeListener(fetchBookmarks)
-      chrome.bookmarks.onChanged.removeListener(fetchBookmarks)
+    const refresh = () => {
+      if (viewMode === "recent") fetchBookmarks()
+      else fetchFolderChildren()
     }
-  }, [fetchBookmarks])
+    refresh()
+    chrome.bookmarks.onCreated.addListener(refresh)
+    chrome.bookmarks.onRemoved.addListener(refresh)
+    chrome.bookmarks.onChanged.addListener(refresh)
+    chrome.bookmarks.onMoved.addListener(refresh)
+    return () => {
+      chrome.bookmarks.onCreated.removeListener(refresh)
+      chrome.bookmarks.onRemoved.removeListener(refresh)
+      chrome.bookmarks.onChanged.removeListener(refresh)
+      chrome.bookmarks.onMoved.removeListener(refresh)
+    }
+  }, [viewMode, fetchBookmarks, fetchFolderChildren])
 
   function openBookmark(url: string) {
     chrome.tabs.create({ url })
   }
 
+  function openFolder(folder: BookmarkFolder, e: React.MouseEvent) {
+    e.stopPropagation()
+    setFolderStack((stack) => [...stack, folder])
+  }
+
+  function goBack() {
+    setFolderStack((stack) => stack.slice(0, -1))
+  }
+
   function removeBookmark(id: string, e: React.MouseEvent) {
     e.stopPropagation()
-    chrome.bookmarks.remove(id, () => fetchBookmarks())
+    chrome.bookmarks.remove(id, () => {
+      if (viewMode === "recent") fetchBookmarks()
+      else fetchFolderChildren()
+    })
   }
 
   function startEditing(bookmark: BookmarkResult, e: React.MouseEvent) {
@@ -87,7 +148,8 @@ export default function BookmarksList() {
       return
     }
     chrome.bookmarks.update(id, { title, url }, () => {
-      fetchBookmarks()
+      if (viewMode === "recent") fetchBookmarks()
+      else fetchFolderChildren()
       setEditingId(null)
     })
   }
@@ -116,76 +178,146 @@ export default function BookmarksList() {
     }
   }
 
+  function renderBookmarkRow(bookmark: BookmarkResult) {
+    return (
+      <div
+        key={bookmark.id}
+        className="list-group-item select-none cursor-pointer"
+        onClick={() => openBookmark(bookmark.url)}
+      >
+        <div className="py-2 px-3 flex items-center space-x-3 transition-colors duration-200 rounded-md border bg-slate-200 border-slate-300 hover:bg-gray-100">
+          <img src={bookmark.favIconUrl} alt="" className="w-4 h-4 shrink-0" />
+
+          <div className="grow flex flex-col justify-center overflow-hidden">
+            {editingId === bookmark.id ? (
+              <div
+                className="flex flex-col gap-0.5"
+                onBlur={(e) => handleEditBlur(bookmark.id, e)}
+              >
+                <Input
+                  autoFocus
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onKeyDown={(e) => handleEditKeyDown(bookmark.id, e)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="h-6 px-1 py-0 text-sm"
+                />
+                <Input
+                  value={editUrlValue}
+                  onChange={(e) => setEditUrlValue(e.target.value)}
+                  onKeyDown={(e) => handleEditKeyDown(bookmark.id, e)}
+                  onClick={(e) => e.stopPropagation()}
+                  className="h-5 px-1 py-0 text-xs"
+                />
+              </div>
+            ) : (
+              <>
+                <p className="text-sm font-medium text-gray-900 truncate" title={bookmark.title}>
+                  {bookmark.title}
+                </p>
+                <p className="text-xs text-gray-500 truncate">{bookmark.url}</p>
+              </>
+            )}
+          </div>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 h-6 w-6 hover:bg-slate-300"
+            onClick={(e) => startEditing(bookmark, e)}
+            title="Edit bookmark"
+          >
+            <Pencil size={14} className="text-gray-500" />
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="icon"
+            className="shrink-0 h-6 w-6 hover:bg-slate-300"
+            onClick={(e) => removeBookmark(bookmark.id, e)}
+            title="Remove bookmark"
+          >
+            <X size={14} className="text-gray-500" />
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  function renderFolderRow(folder: BookmarkFolder) {
+    return (
+      <div
+        key={folder.id}
+        className="list-group-item select-none cursor-pointer"
+        onClick={(e) => openFolder(folder, e)}
+      >
+        <div className="py-2 px-3 flex items-center space-x-3 transition-colors duration-200 rounded-md border bg-slate-100 border-slate-300 hover:bg-gray-100">
+          <Folder size={16} className="shrink-0 text-gray-500" />
+          <p className="grow text-sm font-medium text-gray-900 truncate" title={folder.title}>
+            {folder.title}
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <>
-      <div className="list-group col">
-        {bookmarks.map((bookmark) => (
-          <div
-            key={bookmark.id}
-            className="list-group-item select-none cursor-pointer"
-            onClick={() => openBookmark(bookmark.url)}
-          >
-            <div className="py-2 px-3 flex items-center space-x-3 transition-colors duration-200 rounded-md border bg-slate-200 border-slate-300 hover:bg-gray-100">
-              <img src={bookmark.favIconUrl} alt="" className="w-4 h-4 shrink-0" />
-
-              <div className="grow flex flex-col justify-center overflow-hidden">
-                {editingId === bookmark.id ? (
-                  <div
-                    className="flex flex-col gap-0.5"
-                    onBlur={(e) => handleEditBlur(bookmark.id, e)}
-                  >
-                    <Input
-                      autoFocus
-                      value={editValue}
-                      onChange={(e) => setEditValue(e.target.value)}
-                      onKeyDown={(e) => handleEditKeyDown(bookmark.id, e)}
-                      onClick={(e) => e.stopPropagation()}
-                      className="h-6 px-1 py-0 text-sm"
-                    />
-                    <Input
-                      value={editUrlValue}
-                      onChange={(e) => setEditUrlValue(e.target.value)}
-                      onKeyDown={(e) => handleEditKeyDown(bookmark.id, e)}
-                      onClick={(e) => e.stopPropagation()}
-                      className="h-5 px-1 py-0 text-xs"
-                    />
-                  </div>
-                ) : (
-                  <>
-                    <p className="text-sm font-medium text-gray-900 truncate" title={bookmark.title}>
-                      {bookmark.title}
-                    </p>
-                    <p className="text-xs text-gray-500 truncate">{bookmark.url}</p>
-                  </>
-                )}
-              </div>
-
-              <Button
-                variant="ghost"
-                size="icon"
-                className="shrink-0 h-6 w-6 hover:bg-slate-300"
-                onClick={(e) => startEditing(bookmark, e)}
-                title="Edit bookmark"
-              >
-                <Pencil size={14} className="text-gray-500" />
-              </Button>
-
-              <Button
-                variant="ghost"
-                size="icon"
-                className="shrink-0 h-6 w-6 hover:bg-slate-300"
-                onClick={(e) => removeBookmark(bookmark.id, e)}
-                title="Remove bookmark"
-              >
-                <X size={14} className="text-gray-500" />
-              </Button>
-            </div>
-          </div>
-        ))}
+      <div className="flex items-center gap-2 px-1 pb-2">
+        <Button
+          variant={viewMode === "recent" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setViewMode("recent")}
+        >
+          Recent
+        </Button>
+        <Button
+          variant={viewMode === "folders" ? "secondary" : "ghost"}
+          size="sm"
+          onClick={() => setViewMode("folders")}
+        >
+          Folders
+        </Button>
       </div>
 
-      {bookmarks.length === 0 && (
-        <div className="p-2 text-sm italic text-gray-600">No favorites yet</div>
+      {viewMode === "recent" ? (
+        <>
+          <div className="list-group col">{bookmarks.map(renderBookmarkRow)}</div>
+          {bookmarks.length === 0 && (
+            <div className="p-2 text-sm italic text-gray-600">No favorites yet</div>
+          )}
+        </>
+      ) : (
+        <>
+          {folderStack.length > 0 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="mb-1 ml-1"
+              onClick={goBack}
+              title={`Back to ${
+                folderStack.length > 1
+                  ? folderStack[folderStack.length - 2].title
+                  : "top level"
+              }`}
+            >
+              <ChevronLeft size={14} className="mr-1" />
+              Back
+            </Button>
+          )}
+          {folderStack.length > 0 && (
+            <p className="px-2 pb-1 text-xs font-medium text-gray-500 truncate">
+              {folderStack[folderStack.length - 1].title}
+            </p>
+          )}
+          <div className="list-group col">
+            {childFolders.map(renderFolderRow)}
+            {folderBookmarks.map(renderBookmarkRow)}
+          </div>
+          {childFolders.length === 0 && folderBookmarks.length === 0 && (
+            <div className="p-2 text-sm italic text-gray-600">This folder is empty</div>
+          )}
+        </>
       )}
     </>
   )

--- a/apps/qwksearch-ext/lib/bookmarks.ts
+++ b/apps/qwksearch-ext/lib/bookmarks.ts
@@ -29,6 +29,17 @@ export function isBookmarkNode(node: BookmarkNodeLike): boolean {
   return !!node.url
 }
 
+/** True for a folder node (no URL) — the inverse of `isBookmarkNode`. */
+export function isFolderNode(node: BookmarkNodeLike): boolean {
+  return !isBookmarkNode(node)
+}
+
+/** A folder's trimmed title, falling back to a placeholder when blank/missing. */
+export function folderDisplayTitle(node: { title?: string }): string {
+  const title = node.title?.trim()
+  return title || "Untitled folder"
+}
+
 /** Trims a proposed new bookmark title before saving via `chrome.bookmarks.update`. */
 export function sanitizeBookmarkTitle(input: string): string {
   return input.trim()

--- a/apps/qwksearch-ext/test/bookmarks.test.ts
+++ b/apps/qwksearch-ext/test/bookmarks.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest"
 import {
+  folderDisplayTitle,
   hostnameFromUrl,
   isBookmarkNode,
+  isFolderNode,
   sanitizeBookmarkTitle,
   sanitizeBookmarkUrl,
   titleOrHostname
@@ -50,6 +52,34 @@ describe("isBookmarkNode", () => {
 
   it("returns false for a node with an empty-string url", () => {
     expect(isBookmarkNode({ title: "Odd node", url: "" })).toBe(false)
+  })
+})
+
+describe("isFolderNode", () => {
+  it("returns false for a node with a url", () => {
+    expect(isFolderNode({ title: "Example", url: "https://example.com" })).toBe(false)
+  })
+
+  it("returns true for a folder node with no url", () => {
+    expect(isFolderNode({ title: "My Folder" })).toBe(true)
+  })
+
+  it("returns true for a node with an empty-string url", () => {
+    expect(isFolderNode({ title: "Odd node", url: "" })).toBe(true)
+  })
+})
+
+describe("folderDisplayTitle", () => {
+  it("returns the trimmed title when present", () => {
+    expect(folderDisplayTitle({ title: "  Work Bookmarks  " })).toBe("Work Bookmarks")
+  })
+
+  it("falls back to a placeholder when the title is blank", () => {
+    expect(folderDisplayTitle({ title: "   " })).toBe("Untitled folder")
+  })
+
+  it("falls back to a placeholder when the title is missing", () => {
+    expect(folderDisplayTitle({})).toBe("Untitled folder")
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds a "Recent" / "Folders" view toggle to `apps/qwksearch-ext`'s side panel Favorites tab. "Recent" keeps today's flat most-recent-20 list unchanged; "Folders" lets the user navigate their actual Chrome bookmark folder structure (Bookmarks bar, Other bookmarks, and any subfolders) via `chrome.bookmarks.getChildren`, with a "Back" button to go up a level.
- Bookmark rows in Folders view reuse the exact same open/edit/remove behavior as the Recent view (refactored into a shared `renderBookmarkRow`), and both views stay in sync via `chrome.bookmarks.onCreated`/`onRemoved`/`onChanged`/`onMoved`.
- View-only browsing — no creating/moving/reordering bookmarks or folders (documented Non-goal, matches this feature area's established scope).
- `apps/qwksearch-ext/lib/bookmarks.ts`: adds `isFolderNode` and `folderDisplayTitle` pure helpers, plus Vitest coverage.
- Continues the follow-up explicitly deferred as a Non-goal in the original Favorites tab task ("Browsing the full bookmark folder tree ... out of scope for this first slice").

## Test plan
- [x] `bunx vitest run test/bookmarks.test.ts` in `apps/qwksearch-ext`: 24/24 passed (18 pre-existing + 6 new)
- [x] `bun run test` in `apps/qwksearch-ext`: 121/121 passed (12/12 files)
- [x] Full workspace `bun run test`: 177/186 files, 2493/2550 tests pass — the 9 failing files are the documented pre-existing set (external-API-dependent `search-web-api` engine tests, `qwksearch-web` config route test, `shadcn-settings`, `chat-agent-toolkit`'s `openrouter-default-model.test.js`), none touching `qwksearch-ext`
- [x] Typecheck (`bun run compile`): 126 errors vs. a 123-error baseline (confirmed via `git stash` before/after) — the +3 are the same pre-existing `TS2304: Cannot find name 'chrome'` class from the new `chrome.bookmarks` call sites, not a new error category
- [x] `bun run build:web`: 14/14 turbo tasks succeeded
- [x] `bunx turbo build --filter=qwksearch-extension-wxt` (Chrome target): 11/11 tasks succeeded

Full details and verification notes are in the `TODO.md` tracker entry for this task.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPU6tUCf2zK3UxgXk9kp8A)_