### PR TITLE
Browser extension: Auto-generate keyphrase completions for tab search

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,131 +1,172 @@
 ## In Progress
 
-## Browser extension: Edit a bookmark's URL from the Favorites tab
+## Browser extension: Auto-generate keyphrase completions for on-page/tab search
 
 **Status:** In Progress
-**Source:** TODO.md — the "Browser extension: Edit a bookmark's title from the
-Favorites tab" task (PR #251, completed) explicitly deferred this as a
-Non-goal/follow-up: "Editing a bookmark's URL — only the title, matching the
-smallest independently useful slice of the deferred Non-goal." This is that
-next slice.
-**Branch:** `claude/adoring-mayer-ie5a52` (this session's designated branch)
+**Source:** TODO.md — Ideas Backlog item 32 ("Auto-generate keyphrase
+completions for on-page Ctrl+F search."). `apps/qwksearch-ext/components/
+TabSearch.tsx` already has dead scaffolding for this — `autocompleteResults`/
+`setAutocompleteResults` state and `arrowCounter` keyboard-navigation logic
+(`ArrowUp`/`ArrowDown`/`Enter`) are declared and wired into `onKeyDown`, but
+`setAutocompleteResults` is never called anywhere and no autocomplete
+dropdown is ever rendered — confirmed via a direct grep of the file. This
+task is the first slice that actually populates and renders that dropdown.
+**Branch:** `claude/adoring-mayer-r6s5vt` (this session's designated branch)
 **PR:** Not created yet
 **Started:** 2026-08-15
 
 ### Goal
-Let a user also edit a bookmark's URL inline from the same edit mode already
-used for the title in `apps/qwksearch-ext`'s side panel Favorites tab, via
-`chrome.bookmarks.update(id, { title, url })`, without leaving the panel.
+As the user types in the side panel's "Search tab text or web" box
+(`TabSearch.tsx`), show a dropdown of keyphrase completions generated from
+the currently active tab's page content, so the user can quickly complete a
+search term that actually matches vocabulary on the page, instead of typing
+a query blind and finding zero matches.
 
 ### Scope
-- `apps/qwksearch-ext/lib/bookmarks.ts`: add `sanitizeBookmarkUrl(input)`, a
-  pure helper that trims a proposed new URL and returns `null` when the
-  trimmed result isn't a syntactically valid URL (using the same `new
-  URL(...)` try/catch pattern already used by `hostnameFromUrl` in this
-  file), including for an empty/whitespace-only string.
-- `apps/qwksearch-ext/components/BookmarksList.tsx`: extend the existing edit
-  mode so the URL line is also an `<Input>` when editing, prefilled with the
-  bookmark's raw URL. Enter/blur on either field saves both title and URL
-  together via one `chrome.bookmarks.update(id, { title, url })` call. If the
-  sanitized URL is invalid, the save is blocked (no `chrome.bookmarks.update`
-  call) and edit mode stays open so the user can correct it. Escape still
-  cancels both fields without saving, reusing the existing
-  `cancellingEditRef` guard.
+- New pure helper module `apps/qwksearch-ext/lib/keyphrase-completions.ts`:
+  - `extractKeyphrases(content: string, maxKeyphrases = 50): string[]` —
+    lower-cases the input, extracts alphanumeric words via `/[a-z0-9]+/g`,
+    filters out a stopword list (mirroring the pattern already established
+    in `packages/reason-editor/src/search/relatedDocuments.ts`'s
+    `STOPWORDS`/`extractKeywords`, kept local to this app rather than a new
+    cross-package dependency) and words shorter than a minimum length,
+    counts frequency, and returns up to `maxKeyphrases` unique words ranked
+    by frequency (ties broken by first-appearance order).
+  - `filterKeyphraseCompletions(keyphrases: string[], query: string,
+    maxResults = 8): string[]` — given the already-extracted keyphrase list
+    and the current search box text, takes the last whitespace-separated
+    word of `query` as the prefix to complete, returns up to `maxResults`
+    keyphrases that start with that prefix (case-insensitive) and aren't
+    already an exact match for it, preserving the frequency-ranked order.
+    Returns `[]` when the query's last word is empty (e.g. query is blank
+    or ends in a space).
+- `apps/qwksearch-ext/components/TabSearch.tsx`:
+  - On mount, find the active tab (`chrome.tabs.query({active: true,
+    currentWindow: true})`) and fetch its content via the existing
+    `extractTabContent(tabId)` helper (`lib/extract-tab-content.ts`,
+    already used by the Research tab's "Chat with page content" feature),
+    then cache `extractKeyphrases(content)` in state.
+  - In `onSearchType`, additionally call `filterKeyphraseCompletions` with
+    the cached keyphrases and the new value, and call the existing
+    (currently-dead) `setAutocompleteResults` with the result.
+  - Render a dropdown list under the input when `autocompleteResults.length
+    > 0`, highlighting the entry at `arrowCounter` (reusing the existing
+    keyboard-navigation state). Clicking or pressing Enter on a highlighted
+    entry replaces the last word of `searchText` with the chosen keyphrase
+    and closes the dropdown (matching the existing `onKeyDown`'s `Enter`
+    branch, extended to check `arrowCounter !== -1` first before falling
+    back to `searchSelected()`).
 
 ### Non-goals
-- Any bookmark-folder-tree editing/moving, or creating new bookmarks — out of
-  scope, unchanged from the original task's Non-goals.
-- Any URL normalization/rewriting beyond trim + validity check (e.g.
-  auto-prepending `https://` to a bare domain) — out of scope; if invalid,
-  block save and let the user fix it themselves.
-- Any change to `lib/history.ts`, `HistoryList.tsx`, `DownloadsList.tsx`, or
-  any other tab — this touches only the Favorites/bookmarks feature.
+- Any server-side/ML-based phrase extraction, bigrams/trigrams, or TF-IDF
+  weighting — a flat single-word frequency count is sufficient for this
+  first slice, matching `relatedDocuments.ts`'s precedent of starting with
+  plain keyword overlap before any smarter scoring.
+- Multi-tab keyphrase aggregation — only the single active tab's content is
+  used, not every open tab (keeps the extraction cheap and avoids injecting
+  a content script into every tab on every keystroke).
+- Live-refreshing keyphrases as the user switches to a different tab while
+  the panel stays open (e.g. via `chrome.tabs.onActivated`) — no other
+  component in this app currently listens for live active-tab changes;
+  keyphrases are fetched once, when `TabSearch` mounts. Refreshing them on
+  tab switch is a natural follow-up, not required for this first slice.
+- Any change to `findInTabContent`/`lib/find-in-tab-content.ts`'s existing
+  full multi-tab search behavior — this is purely an additive autocomplete
+  layer above the existing search box.
+- A literal in-page Ctrl+F-style highlight-and-jump overlay on the visited
+  page itself — the backlog item's title mentions "Ctrl+F search" but the
+  existing `TabSearch.tsx` search box (not a real find-in-page overlay) is
+  the only on-page/tab search surface this app has; that's the surface this
+  slice augments.
 
 ### Acceptance criteria
-- [x] Clicking "Edit" on a bookmark shows inline inputs for both title and
-      URL, prefilled with current values (`editValue`/`editUrlValue` seeded
-      from `bookmark.rawTitle`/`bookmark.url` in `startEditing`).
-- [x] Saving (Enter or blur) with a valid URL calls `chrome.bookmarks.update`
-      with both the sanitized title and sanitized URL, and exits edit mode.
-      A shared `onBlur` on the wrapping `<div>` (checking
-      `e.relatedTarget`/`currentTarget.contains`) also ensures Tab-ing
-      between the title and URL inputs doesn't prematurely save/exit — only
-      a blur to somewhere outside both inputs triggers `saveEdit`.
-- [x] Saving with an invalid/empty URL does NOT call `chrome.bookmarks.update`
-      and does NOT exit edit mode — `saveEdit` returns early when
-      `sanitizeBookmarkUrl` returns `null`, leaving `editingId` set.
-- [x] Escape cancels both fields without calling `chrome.bookmarks.update`,
-      reusing the existing `cancellingEditRef` guard (now also resets
-      `editUrlValue`).
-- [x] Vitest coverage is added or updated — 5 new focused cases for
-      `sanitizeBookmarkUrl` (valid w/ trim, already-trimmed valid,
-      unparseable string, empty string, whitespace-only) in
-      `apps/qwksearch-ext/test/bookmarks.test.ts`. No pre-existing
-      `BookmarksList.tsx` component test file exists in
-      `apps/qwksearch-ext/test/` (checked directly — only pure-helper test
-      files like `bookmarks.test.ts` exist there), so component-level
-      coverage isn't available as a test surface here, matching the
-      precedent noted in the "Edit a bookmark's title" task.
-- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
-      root; nothing to run
+- [x] Typing a prefix that matches words appearing on the active tab's page
+      shows a dropdown of up to 8 matching keyphrases, most-frequent first.
+- [x] Typing a prefix with no matching page vocabulary shows no dropdown.
+- [x] ArrowDown/ArrowUp navigate the dropdown (reusing existing
+      `arrowCounter` state); Enter on a highlighted entry completes the
+      last word of the search box with that keyphrase instead of triggering
+      `searchSelected()`; Enter with nothing highlighted still searches as
+      today.
+- [x] Clicking a dropdown entry has the same effect as Enter-selecting it.
+- [x] Common stopwords and very short words are excluded from suggestions.
+- [x] Vitest coverage is added or updated for `extractKeyphrases` and
+      `filterKeyphraseCompletions` — 15 focused cases in
+      `apps/qwksearch-ext/test/keyphrase-completions.test.ts` (frequency
+      ranking, stopword exclusion, short-word exclusion, case-insensitivity,
+      empty content, tie-breaking, `maxKeyphrases` truncation, prefix
+      matching, multi-word query, case-insensitive prefix, exact-match
+      exclusion alongside other prefix matches, blank query, query ending in
+      a space, no-match, `maxResults` truncation). Two of the first-drafted
+      cases initially failed against the real implementation — "and" wasn't
+      yet in the local stopword list, and one fixture asserted an incorrect
+      prefix relationship ("apple" is not a prefix of "application") — both
+      were fixed (stopword list expanded; the fixture corrected) before this
+      checkbox was marked done.
+- [x] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
+      root; nothing to run (same as every prior `qwksearch-ext` task)
 - [x] Typecheck passes — `bun run compile` in `apps/qwksearch-ext` (after
       clearing the stale `tsconfig.tsbuildinfo` incremental cache) surfaces
-      exactly 123 errors both before and after this change (confirmed via
-      `git stash push` on just the three touched files, re-running
-      `bun run compile`, then `git stash pop`). A line-by-line `diff` of the
-      two runs shows the only differences are the 11
-      `components/BookmarksList.tsx` `TS2304: Cannot find name 'chrome'`
-      lines shifting line numbers (e.g. `(24,5)` → `(30,5)`, `(76,5)` →
-      `(89,5)`) because the diff adds lines above them — the error count and
-      class are identical, no new error category introduced.
-- [x] Tests pass — `bunx vitest run test/bookmarks.test.ts`: 18/18 passed (13
-      pre-existing + 5 new). `bun run test` in `qwksearch-ext`: 12/12 files,
-      115/115 tests passed (97 pre-existing + 18 in bookmarks.test.ts).
-      Full workspace `bun run test`: 177/186 files, 2489/2544 tests pass (51
-      failed, 4 skipped). The 9 failing files are exactly the documented
-      pre-existing set: `chat-agent-toolkit/test/openrouter-default-model.test.js`,
+      exactly 127 errors, one more than the 126-error baseline confirmed via
+      `git stash -u -- apps/qwksearch-ext`, re-running `bun run compile`,
+      then `git stash pop`. A line-by-line `diff` of the two runs shows the
+      one new error is `components/TabSearch.tsx(44,5): error TS2304:
+      Cannot find name 'chrome'` at the new `chrome.tabs.query` call in the
+      mount effect — the same pre-existing `TS2304` class already present
+      throughout this app's `chrome.*`-using files, not a new category; the
+      other 8 `chrome`-related lines in this file just shifted line numbers.
+- [x] Tests pass — `bunx vitest run test/keyphrase-completions.test.ts`:
+      15/15 passed. `bun run test` in `qwksearch-ext`: 13/13 files, 136/136
+      tests passed (121 pre-existing + 15 new). Full workspace
+      `bun run test`: 178/187 files, 2509/2565 tests pass (52 failed, 4
+      skipped). The 9 failing files are exactly the documented pre-existing
+      set: `chat-agent-toolkit/test/openrouter-default-model.test.js`,
       `qwksearch-web/app/api/config/__tests__/route.test.ts`,
       `search-web-api/test/{api,autocomplete-engines,engine-health-suite,
       search,sources-unit,sources}.test.ts` (external-API-dependent engine
       tests), `shadcn-settings/test/settings-field.test.tsx` — confirmed via
       a full `grep -E "^ (❯|FAIL)"` over the captured run output, none touch
-      `qwksearch-ext` or bookmarks-related files.
+      `qwksearch-ext` or keyphrase-related files.
 - [x] Production/web build passes — `bun run build:web` at the repo root:
-      14/14 turbo tasks succeeded (9m0s).
+      14/14 turbo tasks succeeded (7m1s).
 - [x] Documentation is updated if behavior or configuration changes — n/a
       beyond this tracker entry (no user-facing docs describe individual
-      side-panel toolbar actions)
+      side-panel toolbar behavior)
 
 ### Implementation plan
 - [x] Inspect affected modules, local instructions, and existing tests
-      (`lib/bookmarks.ts`, `components/BookmarksList.tsx`,
-      `test/bookmarks.test.ts`, checked `test/` for an existing
-      `BookmarksList` component test — none found)
-- [x] Implement the smallest useful vertical slice (`sanitizeBookmarkUrl`,
-      dual title/URL inline-edit UI in `BookmarksList.tsx` with a shared
-      save/blur/escape flow)
-- [x] Add focused Vitest coverage (5 new `sanitizeBookmarkUrl` cases)
-- [x] Run focused tests and fix failures (none needed — passed first run)
-- [x] Run linting and typechecking (lint n/a; typecheck error count
-      unchanged at 123, same pre-existing `TS2304` class, confirmed via
-      `git stash`-based before/after diff)
+      (`TabSearch.tsx`'s dead `autocompleteResults`/`arrowCounter`
+      scaffolding, `lib/find-in-tab-content.ts`, `relatedDocuments.ts`'s
+      stopword-filtering precedent in `reason-editor`, existing `lib/`
+      pure-helper + `test/` conventions in `qwksearch-ext`)
+- [x] Confirm `chrome.tabs.query({active, currentWindow})` API shape against
+      the installed `@types/chrome` and `extractTabContent`'s existing
+      signature (mirrored `ResearchTab.tsx`'s existing `chrome.tabs.query`
+      call shape)
+- [x] Implement `extractKeyphrases`/`filterKeyphraseCompletions` in
+      `lib/keyphrase-completions.ts`
+- [x] Wire active-tab content fetching + caching and the dropdown UI into
+      `TabSearch.tsx`
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage
+- [x] Run focused tests and fix failures (2 of 15 initially failed; fixed —
+      see the Vitest-coverage acceptance-criteria note above)
+- [x] Run linting and typechecking (lint n/a; typecheck error count is +1,
+      the same pre-existing `TS2304` class, confirmed via `git stash
+      -u`-based before/after diff)
 - [x] Run the full relevant test suite (`qwksearch-ext` and full workspace
-      `bun run test`, run synchronously to completion twice for a clean
-      captured log)
+      `bun run test`)
 - [x] Run the production/web build (`bun run build:web`, 14/14 turbo tasks)
-- [x] Review the final diff for scope and quality (`bun install` at the repo
-      root reported "Checked 3009 installs across 3339 packages (no
-      changes)" — no `bun.lock` diff was produced this run, so there was
-      nothing incidental to revert; final `git diff --stat` shows only the
-      4 intended files)
-- [x] Commit and push the branch
-- [x] Create or update the pull request
+- [x] Review the final diff for scope and quality (`bun install` produced an
+      unrelated `bun.lock` package-version-sync diff, reverted per prior
+      tasks' precedent; final `git diff --stat` shows only the 2 intended
+      source files plus the 2 new files)
+- [ ] Commit and push the branch
+- [ ] Create or update the pull request
 - [x] Update tracker status, completed checkboxes, and remaining work
 
 ### Remaining work
-- None for this task's own scope.
-- Bookmark-folder-tree editing/moving remains an open, separate follow-up
-  (unchanged from the original title-edit task's Remaining work).
+- Commit the changes, push the branch, and open the pull request.
 
 ## Browser extension: Browse bookmarks by folder in the Favorites tab
 
@@ -687,6 +728,142 @@ without leaving the panel or manually typing/copy-pasting each tab.
   before sending, and any settings/toggle for auto-including tabs.
 
 ## Completed
+
+## Browser extension: Edit a bookmark's URL from the Favorites tab
+
+**Status:** Completed
+**Source:** TODO.md — the "Browser extension: Edit a bookmark's title from the
+Favorites tab" task (PR #251, completed) explicitly deferred this as a
+Non-goal/follow-up: "Editing a bookmark's URL — only the title, matching the
+smallest independently useful slice of the deferred Non-goal." This is that
+next slice.
+**Branch:** `claude/adoring-mayer-ie5a52`
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/259 (merged)
+**Started:** 2026-08-15
+**Completed:** 2026-08-15
+
+### Goal
+Let a user also edit a bookmark's URL inline from the same edit mode already
+used for the title in `apps/qwksearch-ext`'s side panel Favorites tab, via
+`chrome.bookmarks.update(id, { title, url })`, without leaving the panel.
+
+### Scope
+- `apps/qwksearch-ext/lib/bookmarks.ts`: add `sanitizeBookmarkUrl(input)`, a
+  pure helper that trims a proposed new URL and returns `null` when the
+  trimmed result isn't a syntactically valid URL (using the same `new
+  URL(...)` try/catch pattern already used by `hostnameFromUrl` in this
+  file), including for an empty/whitespace-only string.
+- `apps/qwksearch-ext/components/BookmarksList.tsx`: extend the existing edit
+  mode so the URL line is also an `<Input>` when editing, prefilled with the
+  bookmark's raw URL. Enter/blur on either field saves both title and URL
+  together via one `chrome.bookmarks.update(id, { title, url })` call. If the
+  sanitized URL is invalid, the save is blocked (no `chrome.bookmarks.update`
+  call) and edit mode stays open so the user can correct it. Escape still
+  cancels both fields without saving, reusing the existing
+  `cancellingEditRef` guard.
+
+### Non-goals
+- Any bookmark-folder-tree editing/moving, or creating new bookmarks — out of
+  scope, unchanged from the original task's Non-goals.
+- Any URL normalization/rewriting beyond trim + validity check (e.g.
+  auto-prepending `https://` to a bare domain) — out of scope; if invalid,
+  block save and let the user fix it themselves.
+- Any change to `lib/history.ts`, `HistoryList.tsx`, `DownloadsList.tsx`, or
+  any other tab — this touches only the Favorites/bookmarks feature.
+
+### Acceptance criteria
+- [x] Clicking "Edit" on a bookmark shows inline inputs for both title and
+      URL, prefilled with current values (`editValue`/`editUrlValue` seeded
+      from `bookmark.rawTitle`/`bookmark.url` in `startEditing`).
+- [x] Saving (Enter or blur) with a valid URL calls `chrome.bookmarks.update`
+      with both the sanitized title and sanitized URL, and exits edit mode.
+      A shared `onBlur` on the wrapping `<div>` (checking
+      `e.relatedTarget`/`currentTarget.contains`) also ensures Tab-ing
+      between the title and URL inputs doesn't prematurely save/exit — only
+      a blur to somewhere outside both inputs triggers `saveEdit`.
+- [x] Saving with an invalid/empty URL does NOT call `chrome.bookmarks.update`
+      and does NOT exit edit mode — `saveEdit` returns early when
+      `sanitizeBookmarkUrl` returns `null`, leaving `editingId` set.
+- [x] Escape cancels both fields without calling `chrome.bookmarks.update`,
+      reusing the existing `cancellingEditRef` guard (now also resets
+      `editUrlValue`).
+- [x] Vitest coverage is added or updated — 5 new focused cases for
+      `sanitizeBookmarkUrl` (valid w/ trim, already-trimmed valid,
+      unparseable string, empty string, whitespace-only) in
+      `apps/qwksearch-ext/test/bookmarks.test.ts`. No pre-existing
+      `BookmarksList.tsx` component test file exists in
+      `apps/qwksearch-ext/test/` (checked directly — only pure-helper test
+      files like `bookmarks.test.ts` exist there), so component-level
+      coverage isn't available as a test surface here, matching the
+      precedent noted in the "Edit a bookmark's title" task.
+- [ ] Lint passes — no `lint` script exists for `qwksearch-ext` or the repo
+      root; nothing to run
+- [x] Typecheck passes — `bun run compile` in `apps/qwksearch-ext` (after
+      clearing the stale `tsconfig.tsbuildinfo` incremental cache) surfaces
+      exactly 123 errors both before and after this change (confirmed via
+      `git stash push` on just the three touched files, re-running
+      `bun run compile`, then `git stash pop`). A line-by-line `diff` of the
+      two runs shows the only differences are the 11
+      `components/BookmarksList.tsx` `TS2304: Cannot find name 'chrome'`
+      lines shifting line numbers (e.g. `(24,5)` → `(30,5)`, `(76,5)` →
+      `(89,5)`) because the diff adds lines above them — the error count and
+      class are identical, no new error category introduced.
+- [x] Tests pass — `bunx vitest run test/bookmarks.test.ts`: 18/18 passed (13
+      pre-existing + 5 new). `bun run test` in `qwksearch-ext`: 12/12 files,
+      115/115 tests passed (97 pre-existing + 18 in bookmarks.test.ts).
+      Full workspace `bun run test`: 177/186 files, 2489/2544 tests pass (51
+      failed, 4 skipped). The 9 failing files are exactly the documented
+      pre-existing set: `chat-agent-toolkit/test/openrouter-default-model.test.js`,
+      `qwksearch-web/app/api/config/__tests__/route.test.ts`,
+      `search-web-api/test/{api,autocomplete-engines,engine-health-suite,
+      search,sources-unit,sources}.test.ts` (external-API-dependent engine
+      tests), `shadcn-settings/test/settings-field.test.tsx` — confirmed via
+      a full `grep -E "^ (❯|FAIL)"` over the captured run output, none touch
+      `qwksearch-ext` or bookmarks-related files.
+- [x] Production/web build passes — `bun run build:web` at the repo root:
+      14/14 turbo tasks succeeded (9m0s).
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      side-panel toolbar actions)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (`lib/bookmarks.ts`, `components/BookmarksList.tsx`,
+      `test/bookmarks.test.ts`, checked `test/` for an existing
+      `BookmarksList` component test — none found)
+- [x] Implement the smallest useful vertical slice (`sanitizeBookmarkUrl`,
+      dual title/URL inline-edit UI in `BookmarksList.tsx` with a shared
+      save/blur/escape flow)
+- [x] Add focused Vitest coverage (5 new `sanitizeBookmarkUrl` cases)
+- [x] Run focused tests and fix failures (none needed — passed first run)
+- [x] Run linting and typechecking (lint n/a; typecheck error count
+      unchanged at 123, same pre-existing `TS2304` class, confirmed via
+      `git stash`-based before/after diff)
+- [x] Run the full relevant test suite (`qwksearch-ext` and full workspace
+      `bun run test`, run synchronously to completion twice for a clean
+      captured log)
+- [x] Run the production/web build (`bun run build:web`, 14/14 turbo tasks)
+- [x] Review the final diff for scope and quality (`bun install` at the repo
+      root reported "Checked 3009 installs across 3339 packages (no
+      changes)" — no `bun.lock` diff was produced this run, so there was
+      nothing incidental to revert; final `git diff --stat` shows only the
+      4 intended files)
+- [x] Commit and push the branch
+- [x] Create or update the pull request (PR #259, merged)
+- [x] Update tracker status, completed checkboxes, and remaining work
+      (this run — 2026-08-15 — found PR #259 already merged into master;
+      an earlier tracker-sync PR #260 for this same fix was left open on
+      branch `claude/adoring-mayer-ie5a52`, but this session's designated
+      branch is `claude/adoring-mayer-r6s5vt`, so this fix is applied here
+      instead of pushing further to that other branch)
+
+### Remaining work
+- None for this task's own scope. PR #259 merged into master (visible as
+  commit `4baf74a` on master's history).
+- Bookmark-folder-tree editing/moving remains an open, separate follow-up
+  (unchanged from the original title-edit task's Remaining work) — see
+  "Browser extension: Browse bookmarks by folder in the Favorites tab" below,
+  which has since completed the browsing half of that follow-up.
 
 ## Browser extension: Edit a bookmark's title from the Favorites tab
 

--- a/apps/qwksearch-ext/components/TabSearch.tsx
+++ b/apps/qwksearch-ext/components/TabSearch.tsx
@@ -3,6 +3,8 @@ import { Search, X, Maximize, ChevronDown } from "lucide-react"
 import { Button } from "./ui/button"
 import { Input } from "./ui/input"
 import findInTabContent from "@/lib/find-in-tab-content"
+import extractTabContent from "@/lib/extract-tab-content"
+import { extractKeyphrases, filterKeyphraseCompletions } from "@/lib/keyphrase-completions"
 
 interface TabResult {
   id: number
@@ -29,12 +31,22 @@ export default function TabSearch({ results, setResults, fetchAllTabs, searchEng
   const [isOpen, setIsOpen] = useState(false)
   const [autocompleteResults, setAutocompleteResults] = useState<any[]>([])
   const [arrowCounter, setArrowCounter] = useState(-1)
+  const [pageKeyphrases, setPageKeyphrases] = useState<string[]>([])
   const searchTextRef = useRef(searchText)
 
   // Keep ref in sync for use in chrome listener
   useEffect(() => {
     searchTextRef.current = searchText
   }, [searchText])
+
+  // Fetch the active tab's page content once, to power keyphrase autocomplete.
+  useEffect(() => {
+    chrome.tabs.query({ active: true, currentWindow: true }, async ([tab]) => {
+      if (!tab?.id) return
+      const content = await extractTabContent(tab.id)
+      if (content) setPageKeyphrases(extractKeyphrases(content))
+    })
+  }, [])
 
   useEffect(() => {
     const listener = (request: any) => {
@@ -87,13 +99,16 @@ export default function TabSearch({ results, setResults, fetchAllTabs, searchEng
   async function onSearchType(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value
     setSearchText(value)
+    setArrowCounter(-1)
 
     if (value === "") {
+      setAutocompleteResults([])
       await fetchAllTabs()
       setIsOpen(false)
       return
     }
 
+    setAutocompleteResults(filterKeyphraseCompletions(pageKeyphrases, value))
     setIsOpen(true)
     setResults([])
 
@@ -127,7 +142,9 @@ export default function TabSearch({ results, setResults, fetchAllTabs, searchEng
       setArrowCounter((c) => c - 1)
     } else if (e.key === "Enter") {
       e.preventDefault()
-      if (arrowCounter === -1) {
+      if (arrowCounter !== -1 && autocompleteResults[arrowCounter]) {
+        selectAutocomplete(autocompleteResults[arrowCounter])
+      } else {
         searchSelected()
       }
     } else if (e.key === "Escape") {
@@ -136,8 +153,17 @@ export default function TabSearch({ results, setResults, fetchAllTabs, searchEng
     }
   }
 
+  function selectAutocomplete(keyphrase: string) {
+    const words = searchText.split(/(\s+)/)
+    words[words.length - 1] = keyphrase
+    setSearchText(words.join(""))
+    setAutocompleteResults([])
+    setArrowCounter(-1)
+  }
+
   function closeAutocomplete() {
     setIsOpen(false)
+    setAutocompleteResults([])
     setArrowCounter(-1)
   }
 
@@ -173,6 +199,23 @@ export default function TabSearch({ results, setResults, fetchAllTabs, searchEng
             >
               <X size={16} />
             </button>
+          )}
+          {autocompleteResults.length > 0 && (
+            <ul className="absolute left-0 right-0 z-10 mt-1 rounded-md bg-white shadow-lg ring-1 ring-slate-400 ring-opacity-5">
+              {autocompleteResults.map((keyphrase, index) => (
+                <li key={keyphrase}>
+                  <button
+                    type="button"
+                    className={`block w-full px-3 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100 ${
+                      index === arrowCounter ? "bg-gray-100" : ""
+                    }`}
+                    onClick={() => selectAutocomplete(keyphrase)}
+                  >
+                    {keyphrase}
+                  </button>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
       </div>

--- a/apps/qwksearch-ext/lib/keyphrase-completions.ts
+++ b/apps/qwksearch-ext/lib/keyphrase-completions.ts
@@ -1,0 +1,56 @@
+const MIN_KEYPHRASE_LENGTH = 3
+
+const STOPWORDS = new Set([
+  "about", "above", "after", "again", "against", "all", "along", "also",
+  "always", "among", "and", "any", "are", "around", "because", "before",
+  "below", "between", "both", "but", "can", "cannot", "could", "does",
+  "doing", "down", "during", "each", "either", "every", "first", "for",
+  "from", "further", "has", "have", "having", "her", "here", "his", "how",
+  "into", "its", "just", "more", "most", "not", "now", "once", "only",
+  "other", "our", "out", "over", "same", "shall", "she", "should", "since",
+  "some", "such", "than", "that", "the", "their", "them", "then", "there",
+  "these", "they", "this", "those", "through", "under", "until", "use",
+  "very", "was", "were", "what", "when", "where", "which", "while", "who",
+  "why", "will", "with", "would", "yet", "you", "your",
+])
+
+/**
+ * Extracts significant lower-cased keyphrases (single words) from page
+ * content, ranked by frequency (ties broken by first appearance).
+ */
+export function extractKeyphrases(content: string, maxKeyphrases = 50): string[] {
+  const words = content.toLowerCase().match(/[a-z0-9]+/g) ?? []
+  const counts = new Map<string, number>()
+
+  for (const word of words) {
+    if (word.length < MIN_KEYPHRASE_LENGTH || STOPWORDS.has(word)) continue
+    counts.set(word, (counts.get(word) ?? 0) + 1)
+  }
+
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxKeyphrases)
+    .map(([word]) => word)
+}
+
+/**
+ * Filters a frequency-ranked keyphrase list to those completing the last
+ * word of the current search query, for an autocomplete dropdown.
+ */
+export function filterKeyphraseCompletions(
+  keyphrases: string[],
+  query: string,
+  maxResults = 8
+): string[] {
+  const words = query.toLowerCase().split(/\s+/)
+  const prefix = words[words.length - 1]
+  if (!prefix) return []
+
+  const results: string[] = []
+  for (const keyphrase of keyphrases) {
+    if (keyphrase === prefix) continue
+    if (keyphrase.startsWith(prefix)) results.push(keyphrase)
+    if (results.length >= maxResults) break
+  }
+  return results
+}

--- a/apps/qwksearch-ext/test/keyphrase-completions.test.ts
+++ b/apps/qwksearch-ext/test/keyphrase-completions.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { extractKeyphrases, filterKeyphraseCompletions } from "../lib/keyphrase-completions"
+
+describe("extractKeyphrases", () => {
+  it("ranks words by frequency, most frequent first", () => {
+    const content = "apple banana apple cherry apple banana"
+    expect(extractKeyphrases(content)).toEqual(["apple", "banana", "cherry"])
+  })
+
+  it("excludes stopwords", () => {
+    const content = "there should be about this and that"
+    expect(extractKeyphrases(content)).toEqual([])
+  })
+
+  it("excludes words shorter than the minimum length", () => {
+    const content = "an ok id apple"
+    expect(extractKeyphrases(content)).toEqual(["apple"])
+  })
+
+  it("lower-cases and dedupes case-variant words", () => {
+    const content = "Apple APPLE apple Banana"
+    expect(extractKeyphrases(content)).toEqual(["apple", "banana"])
+  })
+
+  it("returns an empty array for empty content", () => {
+    expect(extractKeyphrases("")).toEqual([])
+  })
+
+  it("breaks frequency ties by first-appearance order", () => {
+    const content = "zebra apple mango"
+    expect(extractKeyphrases(content)).toEqual(["zebra", "apple", "mango"])
+  })
+
+  it("truncates to maxKeyphrases", () => {
+    const content = "apple banana cherry date"
+    expect(extractKeyphrases(content, 2)).toEqual(["apple", "banana"])
+  })
+})
+
+describe("filterKeyphraseCompletions", () => {
+  const keyphrases = ["apple", "application", "banana", "apricot"]
+
+  it("returns keyphrases starting with the query's last word", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "ap")).toEqual([
+      "apple",
+      "application",
+      "apricot",
+    ])
+  })
+
+  it("uses only the last whitespace-separated word of a multi-word query", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "red ba")).toEqual(["banana"])
+  })
+
+  it("is case-insensitive", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "AP")).toEqual([
+      "apple",
+      "application",
+      "apricot",
+    ])
+  })
+
+  it("excludes a keyphrase that exactly matches the query, but keeps other prefix matches", () => {
+    const withExactMatch = ["app", "apple", "application"]
+    expect(filterKeyphraseCompletions(withExactMatch, "app")).toEqual([
+      "apple",
+      "application",
+    ])
+  })
+
+  it("returns an empty array for a blank query", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "")).toEqual([])
+  })
+
+  it("returns an empty array when the query ends in a space", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "apple ")).toEqual([])
+  })
+
+  it("returns an empty array when nothing matches the prefix", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "zzz")).toEqual([])
+  })
+
+  it("truncates to maxResults", () => {
+    expect(filterKeyphraseCompletions(keyphrases, "ap", 1)).toEqual(["apple"])
+  })
+})


### PR DESCRIPTION
## Summary

Ideas Backlog item 32: "Auto-generate keyphrase completions for on-page Ctrl+F search."

`apps/qwksearch-ext/components/TabSearch.tsx` already had dead scaffolding for this — `autocompleteResults`/`setAutocompleteResults` state and `arrowCounter` keyboard-navigation logic (`ArrowUp`/`ArrowDown`/`Enter`) were declared and wired into `onKeyDown`, but `setAutocompleteResults` was never called and no dropdown was ever rendered. This PR is the first slice that actually populates and renders it.

- `apps/qwksearch-ext/lib/keyphrase-completions.ts` (new): `extractKeyphrases(content, maxKeyphrases)` extracts stopword-filtered, frequency-ranked significant words from page text (mirrors the `STOPWORDS`/`extractKeywords` pattern already established in `packages/reason-editor/src/search/relatedDocuments.ts`, kept local to this app). `filterKeyphraseCompletions(keyphrases, query, maxResults)` filters that list to prefix-completions of the query's last word.
- `apps/qwksearch-ext/components/TabSearch.tsx`: on mount, fetches the active tab's content via the existing `extractTabContent` helper and caches its keyphrases; on each keystroke, populates the (previously dead) `autocompleteResults` state and renders a dropdown, navigable with the existing arrow-key/Enter handling. Clicking or Enter-selecting an entry completes the last word of the search box.

### Non-goals
- Server-side/ML phrase extraction, bigrams, or TF-IDF weighting.
- Multi-tab keyphrase aggregation — only the active tab.
- Live-refreshing keyphrases on tab switch (`chrome.tabs.onActivated`) — fetched once on mount, matching this app's existing "single fetch per action" precedent (no other component here listens for live tab changes).
- A literal in-page Ctrl+F find/highlight overlay — `TabSearch.tsx`'s search box (not a real find-in-page overlay) is the only on-page/tab search surface this app has today; that's the surface this slice augments.

## Test plan

- `bunx vitest run test/keyphrase-completions.test.ts` in `apps/qwksearch-ext`: **15/15 passed**.
- `bun run test` in `apps/qwksearch-ext`: **13/13 files, 136/136 tests passed** (121 pre-existing + 15 new).
- Full workspace `bun run test`: **178/187 files, 2509/2565 tests pass** (4 skipped). The 9 failing files are the same pre-existing, previously-documented set unrelated to this change (`chat-agent-toolkit/test/openrouter-default-model.test.js`, `qwksearch-web/app/api/config/__tests__/route.test.ts`, 6 `search-web-api` external-API-dependent engine test files, `shadcn-settings/test/settings-field.test.tsx`). None touch `qwksearch-ext`.
- Typecheck: `bun run compile` in `apps/qwksearch-ext` surfaces **127 errors**, one more than the 126-error baseline (confirmed via `git stash -u`). The one new error is a further instance of the same pre-existing `TS2304: Cannot find name 'chrome'` class already present throughout this app's `chrome.*`-using files.
- Lint: N/A — no `lint` script exists for `qwksearch-ext` or the repo root (pre-existing, matches prior tasks in this repo).
- `bun run build:web` at the repo root: **14/14 turbo tasks succeeded**.

Also includes a small `TODO.md` correction: the "Edit a bookmark's URL from the Favorites tab" entry was still marked `In Progress`, even though its PR (#259) was already merged into master — updated to `Completed` with the real PR link.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SNDUmBKbdshCQ6ViAg2eQ)_