### PR TITLE
Sidebar: AI tips about the current page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,167 @@
 ## In Progress
 
+## Sidebar: AI tips about the current page
+
+**Status:** Completed
+**Source:** TODO.md — Longterm item 26 ("Prioritize sidebar with AI tips
+about the current page."). Builds on the same sidebar "ai" panel
+(`renderAi()` in `packages/reason-editor/src/layout/sidebar/
+SidebarContent.tsx`) already used for the AI rewrite-suggestion feature, and
+mirrors the existing LLM-prompt/parse pattern already used by
+`packages/research-agent-ui/src/api/handlers/article-followups.ts` (article
+follow-up questions) and `.../handlers/suggestions.ts` (chat follow-up
+questions).
+**Branch:** `claude/adoring-mayer-42m3zi` (this session's designated branch)
+**PR:** Not created yet — will be opened on push.
+**Started:** 2026-08-15
+**Completed:** 2026-08-15
+
+### Goal
+Let a user click a "Generate" button in the sidebar's "AI Suggestions" panel
+to get a short list of AI-generated tips/insights about the currently active
+document, so they get useful, page-specific takeaways without leaving the
+editor or writing a prompt themselves.
+
+### Scope
+- New handler `packages/research-agent-ui/src/api/handlers/page-tips.ts`
+  (`createPageTipsHandler`), mirroring `article-followups.ts`'s
+  prompt-and-parse pattern: loads a chat model via `ModelRegistry`, prompts
+  with the page title + content (truncated to 15000 chars), parses the
+  response into up to `maxTips` short one-line tips. Exported via the
+  package's existing `./api` barrel.
+- New route `apps/qwksearch-web/app/api/agent/page-tips/route.ts`, mirroring
+  `article-followups/route.ts`'s dependency wiring exactly.
+- New client helpers in `apps/qwksearch-web/lib/reason-docs/page-tips.ts`:
+  `getPageTips(title, content)` (mirrors `research-agent-ui`'s
+  `getSuggestions` — POSTs via `grab-url`, returns `[]` on any failure) and
+  `htmlToPlainText(html)` (strips tags/script/style content and collapses
+  whitespace, since document content is stored as HTML).
+- `packages/reason-editor/src/layout/sidebar/types.ts`: new
+  `SidebarTipsProps` (`tips`, `isTipsLoading`, `onGenerateTips`) and a
+  `tipsProps?: SidebarTipsProps` field on `SidebarProps`, threaded through
+  `Sidebar.tsx` and `RightPanel.tsx` into `SidebarContent`'s existing
+  `renderAi()`, exactly like `aiProps` already is — hidden entirely when the
+  host doesn't supply `tipsProps` (same optional-feature convention as
+  `onNewChat`).
+- `packages/reason-editor/src/editor/ReasonDocs.tsx`: new optional
+  `onGenerateTips?: (title: string, contentHtml: string) => Promise<string[]>`
+  prop; local `tips`/`isTipsLoading` state, a `handleGenerateTips` that
+  calls it for the active document, and a reset of `tips` whenever the
+  active document changes.
+- `apps/qwksearch-web/components/layout/MainWorkspaceView.tsx`: wires
+  `onGenerateTips` to `getPageTips(title, htmlToPlainText(html))`.
+
+### Non-goals
+- Automatically generating tips on every document switch — generation is
+  manually triggered via the panel's "Generate" button, matching the
+  existing AI rewrite feature's manual-trigger convention (no background
+  LLM calls on every keystroke/tab switch).
+- A new `SidebarPanelType` / sidebar-view-menu toggle for tips — this slice
+  adds tips as a block inside the existing "ai" panel, the same way
+  "Suggested next" was added as a block inside the existing "related" panel,
+  not as a new togglable panel.
+- Persisting generated tips across sessions/reloads.
+- Wiring the *existing* AI rewrite feature's own stubbed `handleAIRewrite`/
+  `handleAIRegenerate` (which just show a "not yet available" toast) — that
+  is unrelated pre-existing scaffolding, out of scope here.
+
+### Acceptance criteria
+- [x] Clicking "Generate" in the "AI Suggestions" panel's tips section calls
+      `onGenerateTips` for the active document and shows a loading state.
+- [x] On success, up to `maxTips` short tips render as a bulleted list.
+- [x] On failure (rejected fetch, non-2xx response), the tips list is empty
+      and no error is thrown to the user (matches `getSuggestions`'s
+      swallow-and-return-`[]` convention).
+- [x] The tips section is not rendered at all when the host doesn't supply
+      `tipsProps` (backward compatible with existing `reason-editor`
+      consumers).
+- [x] Switching the active document clears any previously generated tips.
+- [x] Vitest coverage is added for `htmlToPlainText` (tag stripping,
+      script/style removal, whitespace collapsing) and `getPageTips`
+      (success, non-array response, rejected fetch) in
+      `apps/qwksearch-web/lib/reason-docs/__tests__/page-tips.test.ts`,
+      mirroring `research-agent-ui`'s `suggestions.test.ts` — 8 new cases,
+      all passing.
+- [x] Vitest coverage is added for `createPageTipsHandler` (model loading,
+      prompt truncation/parsing, `maxTips` slicing, error responses) in
+      `apps/qwksearch-web/app/api/agent/__tests__/page-tips.test.ts`,
+      mirroring `app/api/agent/__tests__/suggestions.test.ts`'s
+      `vi.mock`-based handler test (a pattern `article-followups.ts` itself
+      lacks today) — 6 new cases, all passing.
+- [x] Lint passes — no `lint` script exists at the repo root or in
+      `qwksearch-web`, `reason-editor`, or `research-agent-ui`; nothing to
+      run (same as every prior task touching these packages).
+- [x] Typecheck passes — `bun run build` in `packages/reason-editor`
+      surfaces exactly 96 errors both before and after this change,
+      confirmed via `git stash push -u` on the five touched
+      `reason-editor` files, re-running the build, then `git stash pop`;
+      none of the 96 reference any touched file. `packages/research-agent-ui`'s
+      `bun run build` (vite bundle + trailing `tsc --project
+      tsconfig.build.json || true`) also succeeds, with the pre-existing
+      `tsc` errors (unrelated modules: `unified-markdown.tsx`,
+      `ChatHomepage.tsx`, `ChatWindow.tsx`, `MessageInputIconSet.tsx`,
+      `MessageSources.tsx`, `WebCitationBadge.tsx`) unchanged and not
+      referencing `page-tips.ts`.
+- [x] Tests pass — focused suites (`bunx vitest run
+      apps/qwksearch-web/lib/reason-docs/__tests__/page-tips.test.ts
+      apps/qwksearch-web/app/api/agent/__tests__/page-tips.test.ts`):
+      14/14 passed. Full workspace `bun run test`: 181/190 files,
+      2532/2586 tests pass (50 failed, 4 skipped) — the 9 failing files are
+      exactly the documented pre-existing set (`chat-agent-toolkit/test/
+      openrouter-default-model.test.js`, `qwksearch-web/app/api/config/
+      __tests__/route.test.ts`, `search-web-api/test/{api,
+      autocomplete-engines,engine-health-suite,search,sources-unit,
+      sources}.test.ts`, `shadcn-settings/test/settings-field.test.tsx`),
+      none touching any file changed by this task.
+- [x] Production/web build passes — `bun run build:web` at the repo root:
+      14/14 turbo tasks succeeded.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      sidebar panel sections).
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (done — see Source/Scope above)
+- [x] Implement `createPageTipsHandler` in `research-agent-ui`
+- [x] Implement the `page-tips` API route in `qwksearch-web`
+- [x] Implement `getPageTips`/`htmlToPlainText` client helpers in
+      `qwksearch-web`
+- [x] Extend `reason-editor`'s `SidebarProps`/`SidebarContentProps` with
+      `tipsProps` and render the tips block in `renderAi()`
+- [x] Wire `tipsProps` through `Sidebar.tsx` and `RightPanel.tsx`
+- [x] Wire `onGenerateTips` state/handler into `ReasonDocs.tsx`
+- [x] Wire `MainWorkspaceView.tsx` to supply `onGenerateTips`
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage
+- [x] Run focused tests and fix failures (none needed — passed first run)
+- [x] Run linting and typechecking (lint n/a; typecheck error count
+      unchanged, confirmed via `git stash`-based before/after diff)
+- [x] Run the full relevant test suite (focused suites and full workspace
+      `bun run test`)
+- [x] Run the production/web build (`bun run build:web`, 14/14 turbo tasks)
+- [x] Review the final diff for scope and quality (`bun install` was
+      required in this fresh checkout — the resulting `bun.lock`
+      package-version-sync diff was reverted, matching prior tasks'
+      precedent; final `git diff --stat` shows exactly the 7 intended
+      source files beyond this tracker entry)
+- [x] Commit and push the branch
+- [x] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task's own scope. All acceptance criteria verified locally
+  on this commit.
+- The "Suggested next" precedent's PR noted a recurring, pre-existing,
+  unrelated Cloudflare "Workers Builds" deploy-check failure (Ideas Backlog
+  item 39, an 11+-occurrence infrastructure issue this environment cannot
+  diagnose without dashboard credentials) — if it recurs again on this PR,
+  it is not appended as a new occurrence there per that item's own note.
+- A larger, separate follow-up remains open: wiring the *existing* AI
+  rewrite feature's own stubbed `handleAIRewrite`/`handleAIRegenerate`
+  handlers (which currently just show a "not yet available" toast) to a
+  real LLM call — unrelated pre-existing scaffolding, out of scope here
+  (see Non-goals above).
+
 ## Sidebar: highlight the top related document as "Suggested next"
 
 **Status:** Completed

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ mirrors the existing LLM-prompt/parse pattern already used by
 follow-up questions) and `.../handlers/suggestions.ts` (chat follow-up
 questions).
 **Branch:** `claude/adoring-mayer-42m3zi` (this session's designated branch)
-**PR:** Not created yet — will be opened on push.
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/269
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 

--- a/apps/qwksearch-web/app/api/agent/__tests__/page-tips.test.ts
+++ b/apps/qwksearch-web/app/api/agent/__tests__/page-tips.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGenerateText = vi.fn()
+const mockLoadChatModel = vi.fn()
+
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+}))
+
+vi.mock('chat-agent-toolkit/models/registry', () => ({
+  default: class {
+    loadChatModel(...args: unknown[]) {
+      return mockLoadChatModel(...args)
+    }
+  },
+}))
+
+import { createPageTipsHandler } from 'research-agent-ui/api'
+
+const handler = createPageTipsHandler({
+  getUserId: async () => 'user-1',
+  requireUserId: async () => 'user-1',
+  getDB: (() => ({})) as any,
+  userSchema: {} as any,
+  getEnv: (() => ({})) as any,
+})
+
+function postRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/agent/page-tips', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }) as any
+}
+
+const baseBody = {
+  title: 'My Document',
+  content: 'Some article content about SpaceX.',
+  chatModel: { providerId: 'openai', key: 'gpt-4' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockLoadChatModel.mockResolvedValue({ id: 'fake-model' })
+})
+
+describe('createPageTipsHandler POST', () => {
+  it('returns a 400 when content is missing', async () => {
+    const res = await handler(postRequest({ title: 'Untitled' }))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('loads the chat model via the requested provider and key', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'A useful tip about this page' })
+
+    await handler(postRequest(baseBody))
+
+    expect(mockLoadChatModel).toHaveBeenCalledWith('openai', 'gpt-4')
+  })
+
+  it('parses newline-delimited tips, stripping numbering/bullets and short lines', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: '1. This is a real tip about the page\n- Another useful tip here\ntoo short\n',
+    })
+
+    const res = await handler(postRequest(baseBody))
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+    expect(data.tips).toEqual([
+      'This is a real tip about the page',
+      'Another useful tip here',
+    ])
+  })
+
+  it('truncates content to 15000 characters in the prompt', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'A tip about the page content' })
+    const longContent = 'x'.repeat(20000)
+
+    await handler(postRequest({ ...baseBody, content: longContent }))
+
+    const [{ messages }] = mockGenerateText.mock.calls[0]
+    const userMessage = messages.find((m: any) => m.role === 'user')
+    expect(userMessage.content).toContain('x'.repeat(15000))
+    expect(userMessage.content).not.toContain('x'.repeat(15001))
+  })
+
+  it('slices the parsed tips down to maxTips', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: 'First long enough tip\nSecond long enough tip\nThird long enough tip',
+    })
+
+    const res = await handler(postRequest({ ...baseBody, maxTips: 2 }))
+
+    const data = await res.json()
+    expect(data.tips).toEqual(['First long enough tip', 'Second long enough tip'])
+  })
+
+  it('returns a 500 with the error message when the model fails to load', async () => {
+    mockLoadChatModel.mockRejectedValue(new Error('No API key configured'))
+
+    const res = await handler(postRequest(baseBody))
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error).toBe('No API key configured')
+  })
+})

--- a/apps/qwksearch-web/app/api/agent/page-tips/route.ts
+++ b/apps/qwksearch-web/app/api/agent/page-tips/route.ts
@@ -1,0 +1,17 @@
+import { createPageTipsHandler } from "research-agent-ui/api";
+import { getUserId } from "@/lib/auth/session";
+import { getDB } from "@/lib/database";
+import { user as userSchema } from "@/lib/database/schema";
+import { getEnv } from "@/lib/config/env";
+
+export const POST = createPageTipsHandler({
+  getUserId,
+  requireUserId: async () => {
+    const id = await getUserId();
+    if (!id) throw new Error("Unauthorized");
+    return id;
+  },
+  getDB,
+  userSchema,
+  getEnv,
+});

--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -8,6 +8,7 @@ import { themeActions } from 'react-reason-editor/theme';
 import { localeActions } from 'react-reason-editor/locale-bundle';
 import { useMainView } from '@/components/layout/MainViewProvider';
 import { useChatTabs } from '@/components/layout/useChatTabs';
+import { getPageTips, htmlToPlainText } from '@/lib/reason-docs/page-tips';
 
 import 'katex/dist/katex.min.css';
 import 'easydrawer/styles.css';
@@ -98,6 +99,10 @@ export function MainWorkspaceView() {
     return () => configureResearchAgentUI({ onOpenChat: undefined });
   }, [handleOpenChat]);
 
+  const handleGenerateTips = async (title: string, contentHtml: string) => {
+    return getPageTips(title, htmlToPlainText(contentHtml));
+  };
+
   const extraTabProps = {
     extraTabs,
     activeExtraTabId: activeView === 'research' ? activeChatId ?? undefined : undefined,
@@ -107,6 +112,7 @@ export function MainWorkspaceView() {
     onFileTabSelect: toggleToDocs,
     initialDocId,
     onActiveDocumentChange: setActiveDocId,
+    onGenerateTips: handleGenerateTips,
   };
 
   return activeView === 'docs' ? (

--- a/apps/qwksearch-web/lib/reason-docs/__tests__/page-tips.test.ts
+++ b/apps/qwksearch-web/lib/reason-docs/__tests__/page-tips.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Unit tests for the `getPageTips`/`htmlToPlainText` client helpers.
+ */
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import grab from 'grab-url';
+import { getPageTips, htmlToPlainText } from '../page-tips';
+
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getPageTips', () => {
+  it('posts the title and content and returns the tips array', async () => {
+    mockGrab.mockResolvedValue({ tips: ['Tip one', 'Tip two'] });
+
+    const result = await getPageTips('My Doc', 'Some plain text content');
+
+    expect(mockGrab).toHaveBeenCalledTimes(1);
+    const [path, opts] = mockGrab.mock.calls[0];
+    expect(path).toBe('agent/page-tips');
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body).toEqual({ title: 'My Doc', content: 'Some plain text content' });
+    expect(result).toEqual(['Tip one', 'Tip two']);
+  });
+
+  it('returns an empty array when the response tips field is not an array', async () => {
+    mockGrab.mockResolvedValue({ tips: 'not an array' } as any);
+
+    const result = await getPageTips('My Doc', 'content');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when the fetch rejects', async () => {
+    mockGrab.mockRejectedValue(new Error('network error'));
+
+    const result = await getPageTips('My Doc', 'content');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('htmlToPlainText', () => {
+  it('strips tags and collapses whitespace', () => {
+    expect(htmlToPlainText('<h1>Title</h1><p>Some   text.</p>')).toBe('Title Some text.');
+  });
+
+  it('removes script and style element content entirely', () => {
+    const html = '<p>Keep me</p><script>alert("x")</script><style>.a{color:red}</style><p>And me</p>';
+    expect(htmlToPlainText(html)).toBe('Keep me And me');
+  });
+
+  it('decodes &nbsp; entities to spaces', () => {
+    expect(htmlToPlainText('<p>a&nbsp;&nbsp;b</p>')).toBe('a b');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(htmlToPlainText('')).toBe('');
+  });
+});

--- a/apps/qwksearch-web/lib/reason-docs/page-tips.ts
+++ b/apps/qwksearch-web/lib/reason-docs/page-tips.ts
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Client helpers for the REASON editor's AI "page tips" feature.
+ */
+import grab from "grab-url";
+
+/**
+ * Strips HTML markup (including `<script>`/`<style>` element content) and
+ * collapses whitespace, leaving plain readable text suitable for an LLM
+ * prompt. Document content in the editor is stored as HTML.
+ */
+export function htmlToPlainText(html: string): string {
+  return html
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Fetches short AI-generated tips about a document's content. Returns an empty array on any failure. */
+export const getPageTips = async (title: string, content: string): Promise<string[]> => {
+  try {
+    const data = await grab<{ tips: string[] }>("agent/page-tips", {
+      method: "POST",
+      body: JSON.stringify({ title, content }),
+    });
+
+    return Array.isArray(data.tips) ? data.tips : [];
+  } catch (e) {
+    return [];
+  }
+};

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -63,6 +63,13 @@ interface ReasonDocsProps {
   initialDocId?: string | null;
   /** Called whenever the active document changes, so the host can mirror it (e.g. into a URL param). */
   onActiveDocumentChange?: (docId: string | null) => void;
+  /**
+   * Generates short AI tips about the active document's content, given its
+   * title and HTML content. Powers the sidebar "ai" panel's "Page tips"
+   * section. Omitted when the host app has no tips-generation capability —
+   * the section is hidden entirely in that case.
+   */
+  onGenerateTips?: (title: string, contentHtml: string) => Promise<string[]>;
 }
 
 /**
@@ -82,10 +89,13 @@ const Index = ({
   onFileTabSelect,
   initialDocId,
   onActiveDocumentChange,
+  onGenerateTips,
 }: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState(openFilesSidebarSignal);
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
+  const [tips, setTips] = useState<string[]>([]);
+  const [isTipsLoading, setIsTipsLoading] = useState(false);
 
   // Restore the active document from a host-supplied ID (e.g. a `?docs=`
   // URL param) once, the first time it resolves to a real document.
@@ -104,6 +114,29 @@ const Index = ({
   useEffect(() => {
     onActiveDocumentChange?.(state.activeDocId);
   }, [state.activeDocId, onActiveDocumentChange]);
+
+  // Clear any previously generated page tips when the active document
+  // changes, so stale tips from the last document are never shown.
+  useEffect(() => {
+    setTips([]);
+  }, [state.activeDocId]);
+
+  const handleGenerateTips = async () => {
+    if (!onGenerateTips || !state.activeDocument) return;
+    setIsTipsLoading(true);
+    try {
+      const generated = await onGenerateTips(state.activeDocument.title, state.activeDocument.content || '');
+      setTips(generated);
+    } catch {
+      setTips([]);
+    } finally {
+      setIsTipsLoading(false);
+    }
+  };
+
+  const tipsProps = onGenerateTips
+    ? { tips, isTipsLoading, onGenerateTips: handleGenerateTips }
+    : undefined;
 
   // Use persistence hook for sidebar sizes
   const [sidebarSizes, setSidebarSizes] = usePersistence({
@@ -220,6 +253,7 @@ const Index = ({
       onAiReject: state.handleAIReject,
       onAiRegenerate: state.handleAIRegenerate,
     },
+    tipsProps,
   };
 
   const editorProps = {
@@ -277,6 +311,7 @@ const Index = ({
         onAiReject: state.handleAIReject,
         onAiRegenerate: state.handleAIRegenerate,
       }}
+      tipsProps={tipsProps}
       onClose={() => state.setRightPanels([])}
       isMobile={state.isMobile}
       isOpen={state.isRightSidebarOpen}

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -11,7 +11,7 @@ import { RefObject, useState } from 'react';
 import { Resizable } from 're-resizable';
 import { SidebarContent } from '../layout/sidebar/SidebarContent';
 import { PANEL_OPTIONS } from '../layout/sidebar/panelOptions';
-import type { SidebarPanelType, SidebarAiProps, OpenTabItem } from '../layout/sidebar/types';
+import type { SidebarPanelType, SidebarAiProps, SidebarTipsProps, OpenTabItem } from '../layout/sidebar/types';
 import type { OutlineViewHandle } from '../search/OutlineView';
 import type { ActiveHeadingEditorHandle } from '../search/useActiveHeading';
 import type { TocEntry } from '../app-types/toc';
@@ -56,6 +56,8 @@ interface RightPanelProps {
   tabItems?: OpenTabItem[];
   onNewChat?: () => void;
   aiProps: SidebarAiProps;
+  /** AI-generated page tips state/handlers (used by the "ai" panel). */
+  tipsProps?: SidebarTipsProps;
   /** Closes the panel by clearing the right sidebar's panel list. */
   onClose: () => void;
   /** Renders as a slide-in drawer instead of an inset resizable panel. */
@@ -114,6 +116,7 @@ export function RightPanel({
   tabItems,
   onNewChat,
   aiProps,
+  tipsProps,
   onClose,
   isMobile,
   isOpen,
@@ -166,6 +169,7 @@ export function RightPanel({
           tabItems={tabItems}
           onNewChat={onNewChat}
           aiProps={aiProps}
+          tipsProps={tipsProps}
         />
       </div>
     </div>

--- a/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
+++ b/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
@@ -61,6 +61,7 @@ export const Sidebar = ({
   onReopenLastClosed,
   canReopenLastClosed = false,
   aiProps,
+  tipsProps,
   tabItems,
   onNewChat,
 }: SidebarProps) => {
@@ -245,6 +246,7 @@ export const Sidebar = ({
     canReopenLastClosed,
     onNavigate,
     aiProps,
+    tipsProps,
     tabItems,
     onNewChat,
   };

--- a/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -14,12 +14,12 @@ import { findRelatedDocuments, splitTopSuggestion, type RelatedDocumentResult } 
 import { AIRewriteSuggestion } from '../../features/ai-rewrite/AIRewriteSuggestion';
 import { Input } from '../../app-ui/input';
 import { Document } from '../../documents/DocumentTree';
-import type { SidebarPanelType, SidebarAiProps, OpenTabItem } from './types';
+import type { SidebarPanelType, SidebarAiProps, SidebarTipsProps, OpenTabItem } from './types';
 import type { TocEntry } from '../../app-types/toc';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../../utils/storage';
-import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag, Sparkles } from 'lucide-react';
+import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
 import { FileTypeIcon } from '../../app-ui/FileTypeIcon';
 import { cn } from '../../app-utils/utils';
 import {
@@ -102,6 +102,8 @@ interface SidebarContentProps {
   onNavigate?: (key: string) => void;
   /** AI suggestion state/handlers (used by the "ai" panel). */
   aiProps?: SidebarAiProps;
+  /** AI-generated page tips state/handlers (used by the "ai" panel). */
+  tipsProps?: SidebarTipsProps;
   /** Unified tab list (files + chats). Overrides file-only tab derivation when set. */
   tabItems?: OpenTabItem[];
   /** Opens a new chat tab from the "Open Tabs" panel header. */
@@ -142,6 +144,7 @@ export const SidebarContent = ({
   canReopenLastClosed = false,
   onNavigate,
   aiProps,
+  tipsProps,
   tabItems,
   onNewChat,
 }: SidebarContentProps) => {
@@ -447,34 +450,71 @@ export const SidebarContent = ({
     );
   };
 
+  const renderTips = () => (
+    <div className="px-3 py-3 border-t border-sidebar-border shrink-0">
+      <div className="flex items-center justify-between mb-2 gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          <Lightbulb className="h-3.5 w-3.5 text-primary" />
+          Page tips
+        </p>
+        {tipsProps?.onGenerateTips && (
+          <button
+            className="shrink-0 text-xs font-medium text-primary hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
+            onClick={tipsProps.onGenerateTips}
+            disabled={tipsProps.isTipsLoading}
+          >
+            {tipsProps.isTipsLoading ? 'Generating…' : tipsProps.tips?.length ? 'Regenerate' : 'Generate'}
+          </button>
+        )}
+      </div>
+      {tipsProps?.isTipsLoading ? (
+        <p className="text-xs text-muted-foreground">Generating tips about this page…</p>
+      ) : tipsProps?.tips && tipsProps.tips.length > 0 ? (
+        <ul className="space-y-1.5">
+          {tipsProps.tips.map((tip, i) => (
+            <li key={i} className="flex items-start gap-1.5 text-xs text-muted-foreground">
+              <span className="text-primary">•</span>
+              <span>{tip}</span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-muted-foreground">Click "Generate" for AI tips about this page.</p>
+      )}
+    </div>
+  );
+
   const renderAi = () => (
     <div className="h-full overflow-hidden flex flex-col">
       <div className="px-3 py-2 border-b border-sidebar-border shrink-0">
         <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">AI Suggestions</p>
       </div>
-      <div className="flex-1 overflow-hidden">
-        {aiProps?.isAiLoading ? (
-          <div className="h-full flex items-center justify-center p-6">
-            <div className="text-center">
-              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto mb-3" />
-              <p className="text-sm text-muted-foreground">Generating AI suggestion...</p>
+      <div className="flex-1 overflow-auto flex flex-col">
+        <div className={tipsProps ? 'shrink-0' : 'flex-1'}>
+          {aiProps?.isAiLoading ? (
+            <div className="h-full flex items-center justify-center p-6">
+              <div className="text-center">
+                <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto mb-3" />
+                <p className="text-sm text-muted-foreground">Generating AI suggestion...</p>
+              </div>
             </div>
-          </div>
-        ) : aiProps?.aiSuggestion ? (
-          <AIRewriteSuggestion
-            originalText={aiProps.aiSuggestion.originalText}
-            suggestedText={aiProps.aiSuggestion.suggestedText}
-            onApprove={() => aiProps.onAiApprove?.()}
-            onReject={() => aiProps.onAiReject?.()}
-            onRegenerate={(mode) => aiProps.onAiRegenerate?.(mode)}
-            currentMode={aiProps.aiSuggestion.mode}
-            isLoading={false}
-          />
-        ) : (
-          <div className="h-full flex items-center justify-center p-6 text-center">
-            <p className="text-sm text-muted-foreground">Select text and click the AI button to get suggestions</p>
-          </div>
-        )}
+          ) : aiProps?.aiSuggestion ? (
+            <AIRewriteSuggestion
+              originalText={aiProps.aiSuggestion.originalText}
+              suggestedText={aiProps.aiSuggestion.suggestedText}
+              onApprove={() => aiProps.onAiApprove?.()}
+              onReject={() => aiProps.onAiReject?.()}
+              onRegenerate={(mode) => aiProps.onAiRegenerate?.(mode)}
+              currentMode={aiProps.aiSuggestion.mode}
+              isLoading={false}
+            />
+          ) : (
+            <div className="flex items-center justify-center p-6 text-center">
+              <p className="text-sm text-muted-foreground">Select text and click the AI button to get suggestions</p>
+            </div>
+          )}
+        </div>
+        {tipsProps && renderTips()}
       </div>
     </div>
   );

--- a/packages/reason-editor/src/layout/sidebar/types.ts
+++ b/packages/reason-editor/src/layout/sidebar/types.ts
@@ -40,6 +40,20 @@ export interface SidebarAiProps {
   onAiRegenerate?: (mode: any) => void;
 }
 
+/**
+ * AI-generated tips about the currently active document, shown as a section
+ * of the "ai" panel. Omitted entirely (and the section hidden) when the
+ * host app has no tips-generation capability to offer.
+ */
+export interface SidebarTipsProps {
+  /** Tips generated for the active document by the most recent request. */
+  tips?: string[];
+  /** Whether a tips-generation request is in flight. */
+  isTipsLoading?: boolean;
+  /** Requests (re)generation of tips for the active document. */
+  onGenerateTips?: () => void;
+}
+
 export interface SidebarProps {
   documents: Document[];
   activeId: string | null;
@@ -114,4 +128,6 @@ export interface SidebarProps {
   onNewChat?: () => void;
   // AI panel data (used by the "ai" panel)
   aiProps?: SidebarAiProps;
+  // AI-generated page tips (used by the "ai" panel)
+  tipsProps?: SidebarTipsProps;
 }

--- a/packages/research-agent-ui/src/api/handlers/page-tips.ts
+++ b/packages/research-agent-ui/src/api/handlers/page-tips.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Handler that generates short LLM-powered tips about a document/page.
+ *
+ * Loads a chat model via ModelRegistry, prompts it with the page's title and
+ * content (truncated to 15000 chars), then parses the response into a
+ * cleaned list of short tips.
+ */
+import { generateText } from "ai";
+import ModelRegistry from "chat-agent-toolkit/models/registry";
+import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
+import type { ArticleDeps } from "../types";
+
+interface PageTipsBody {
+  title?: string;
+  content: string;
+  maxTips?: number;
+  chatModel?: ModelWithProvider;
+}
+
+export function createPageTipsHandler(deps: ArticleDeps) {
+  return async (req: Request): Promise<Response> => {
+    try {
+      const body: PageTipsBody = await req.json();
+      const { title = "", content, maxTips = 4, chatModel } = body;
+
+      if (!content) {
+        return Response.json({ error: "Content is required" }, { status: 400 });
+      }
+
+      const registry = new ModelRegistry();
+      let llm;
+
+      try {
+        llm = await registry.loadChatModel(chatModel?.providerId, chatModel?.key);
+      } catch (error) {
+        return Response.json(
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to load language model",
+          },
+          { status: 500 },
+        );
+      }
+
+      const systemPrompt = `You are a helpful AI that surfaces short, useful tips about a page the reader currently has open.
+Generate ${maxTips} concise tips (each a single sentence) highlighting the most useful takeaways or things worth noticing on the page.
+Return ONLY the tips, one per line, without numbering or bullet points.`;
+
+      const userPrompt = `Page title: ${title}
+
+Page content:
+${content.slice(0, 15000)}
+
+Generate ${maxTips} short tips about this page.`;
+
+      const { text: fullResponse } = await generateText({
+        model: llm,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      });
+
+      const tips = fullResponse
+        .split("\n")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+        .map((t) => t.replace(/^[\d\-\*\.\)]+\s*/, "").trim())
+        .filter((t) => t.length > 10)
+        .slice(0, maxTips);
+
+      return Response.json({ tips, success: true });
+    } catch (error) {
+      console.error("Error generating page tips:", error);
+      return Response.json(
+        {
+          error: "An error occurred while generating page tips",
+          details: error instanceof Error ? error.message : String(error),
+        },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/packages/research-agent-ui/src/api/index.ts
+++ b/packages/research-agent-ui/src/api/index.ts
@@ -3,6 +3,7 @@
  */
 export * from "./types";
 export * from "./handlers/article-followups";
+export * from "./handlers/page-tips";
 export * from "./handlers/article-qa";
 export * from "./handlers/chats";
 export * from "./handlers/chat-title";


### PR DESCRIPTION
## Summary
- Adds a "Page tips" section to the REASON editor sidebar's existing "AI Suggestions" panel: clicking "Generate" produces a short, LLM-generated list of tips about the active document.
- New `createPageTipsHandler` in `research-agent-ui` mirrors the existing `article-followups.ts` prompt/parse pattern (loads a chat model, prompts with the page title + truncated content, parses newline-delimited tips), wired through a new `apps/qwksearch-web/app/api/agent/page-tips` route and `getPageTips`/`htmlToPlainText` client helpers.
- `reason-editor`'s `SidebarProps`/`ReasonDocs` gain an optional `tipsProps`/`onGenerateTips` plug point (same optional-feature convention as `onNewChat`) — the section is hidden entirely for any host that doesn't wire it, so this stays backward compatible.
- Generation is manually triggered (no background LLM calls on document switch), and tips reset whenever the active document changes.

## Test plan
- [x] `bunx vitest run apps/qwksearch-web/lib/reason-docs/__tests__/page-tips.test.ts apps/qwksearch-web/app/api/agent/__tests__/page-tips.test.ts` — 14/14 passed
- [x] `bun run test` (full workspace) — 181/190 files, 2532/2586 tests pass; the 9 failing files are a pre-existing, documented failure set unrelated to this change
- [x] `bun run build` in `packages/reason-editor` — typecheck error count unchanged (96, confirmed via `git stash` before/after) and none reference touched files
- [x] `bun run build` in `packages/research-agent-ui` — succeeds; pre-existing `tsc` errors unchanged, none reference `page-tips.ts`
- [x] `bun run build:web` — 14/14 turbo tasks succeeded

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01YPTQueZPZcNNndwTLgv9tK

---
_Generated by [Claude Code](https://claude.ai/code/session_01YPTQueZPZcNNndwTLgv9tK)_