### PR TITLE
Sidebar: Search topics for the current page

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ rendered as a block inside the existing "related" panel (the same way
 "Page tips" is a block inside the existing "ai" panel), the smallest
 independently-useful first slice per this task's own scoping rules.
 **Branch:** `claude/adoring-mayer-syrh5u` (this session's designated branch)
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/270
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,180 @@
 ## In Progress
 
+## Sidebar: Search topics for the current page
+
+**Status:** Completed
+**Source:** TODO.md — Longterm item 25 ("Auto-search for topics in sidebar.").
+No existing "topics"/"topic outline" concept exists anywhere in the repo
+(confirmed via search — `extract-webpage/src/seektopic/*` is unrelated
+scraped-content keyword extraction, not a UI feature). Follows the exact
+same pattern as the just-completed "Sidebar: AI tips about the current
+page" task (item 26, PR #269): a new LLM-prompt/parse handler mirroring
+`page-tips.ts`, threaded into the sidebar via a new `topicsProps` prop bag,
+rendered as a block inside the existing "related" panel (the same way
+"Page tips" is a block inside the existing "ai" panel), the smallest
+independently-useful first slice per this task's own scoping rules.
+**Branch:** `claude/adoring-mayer-syrh5u` (this session's designated branch)
+**PR:** Not created yet
+**Started:** 2026-08-15
+**Completed:** 2026-08-15
+
+### Goal
+Let a user click a "Generate" button in the sidebar's "Related" panel to
+get a short list of AI-generated suggested search queries (topics) related
+to the currently active document, and clicking one of those topics opens a
+new chat tab pre-seeded with that query as its first message — so the user
+can dig deeper into a page-adjacent topic without leaving the editor or
+typing a query themselves.
+
+### Scope
+- New handler `packages/research-agent-ui/src/api/handlers/topic-searches.ts`
+  (`createTopicSearchesHandler`), mirroring `page-tips.ts`'s
+  prompt-and-parse pattern exactly: loads a chat model via `ModelRegistry`,
+  prompts with the page title + content (truncated to 15000 chars), parses
+  the response into up to `maxTopics` short search-query strings. Exported
+  via the package's existing `./api` barrel.
+- New route `apps/qwksearch-web/app/api/agent/topic-searches/route.ts`,
+  mirroring `page-tips/route.ts`'s dependency wiring exactly.
+- New client helper `apps/qwksearch-web/lib/reason-docs/topic-searches.ts`:
+  `getTopicSearches(title, content)` (mirrors `getPageTips` — POSTs via
+  `grab-url`, returns `[]` on any failure).
+- `packages/reason-editor/src/layout/sidebar/types.ts`: new
+  `SidebarTopicsProps` (`topics`, `isTopicsLoading`, `onGenerateTopics`,
+  `onSearchTopic`) and a `topicsProps?: SidebarTopicsProps` field on
+  `SidebarProps`, threaded through `Sidebar.tsx` and `RightPanel.tsx` into
+  `SidebarContent`'s existing `renderRelated()`, exactly like `tipsProps` is
+  threaded into `renderAi()` — hidden entirely when the host doesn't supply
+  `topicsProps`.
+- `packages/reason-editor/src/editor/ReasonDocs.tsx`: new optional
+  `onGenerateTopics?: (title: string, contentHtml: string) => Promise<string[]>`
+  and `onSearchTopic?: (topic: string) => void` props; local
+  `topics`/`isTopicsLoading` state, a `handleGenerateTopics` mirroring
+  `handleGenerateTips`, and a reset of `topics` whenever the active document
+  changes (reusing the existing tips-reset effect).
+- `apps/qwksearch-web/components/layout/MainWorkspaceView.tsx`: wires
+  `onGenerateTopics` to `getTopicSearches(title, htmlToPlainText(html))`,
+  and `onSearchTopic` to open a new chat tab (`newChat()` +
+  `toggleToResearch()`) and send the topic as that chat's first message
+  once the new chat becomes active (via a `pendingTopicQuery` state +
+  effect keyed on `activeChatId`, avoiding a stale-closure race where
+  `sendMessage` would otherwise fire against the *previous* chat's ID in
+  the same synchronous handler as `newChat()`).
+
+### Non-goals
+- A new `SidebarPanelType` / sidebar-view-menu toggle for topics — this
+  slice adds topics as a block inside the existing "related" panel, not as
+  a new togglable panel (same convention as "Page tips" inside "ai").
+- Automatically generating topics on every document switch — generation is
+  manually triggered via the panel's "Generate" button, matching the
+  existing "Page tips" feature's manual-trigger convention.
+- Letting the user edit the generated query before it's sent, or preview
+  results inline in the sidebar — clicking a topic sends it immediately as
+  a new chat message, matching the "Suggested next" related-document row's
+  one-click-navigates convention.
+- Persisting generated topics across sessions/reloads.
+- Any change to backlog item 15 ("Queries should run on cached pages that
+  belong to topic outlines") or item 24 ("next-word prediction for
+  topics") — both remain open, separate, unrelated backlog items; "topic
+  outline" there refers to a different, larger, still-undesigned concept.
+
+### Acceptance criteria
+- [x] Clicking "Generate" in the "Related" panel's topics section calls
+      `onGenerateTopics` for the active document and shows a loading state.
+- [x] On success, up to `maxTopics` short suggested-search topics render as
+      a clickable list.
+- [x] On failure (rejected fetch, non-2xx response), the topics list is
+      empty and no error is thrown to the user (matches `getPageTips`'s
+      swallow-and-return-`[]` convention).
+- [x] Clicking a rendered topic opens a new chat tab and sends that topic
+      as the chat's first message (via `newChat()` + a `pendingTopicQuery`
+      effect keyed on `activeChatId` in `MainWorkspaceView.tsx`).
+- [x] The topics section is not rendered at all when the host doesn't
+      supply `topicsProps` (backward compatible with existing
+      `reason-editor` consumers — `{topicsProps && renderTopics()}`,
+      identical guard to `tipsProps`).
+- [x] Switching the active document clears any previously generated topics
+      (reuses the existing `useEffect` keyed on `state.activeDocId`, now
+      clearing both `tips` and `topics`).
+- [x] Vitest coverage is added for `getTopicSearches` (success, non-array
+      response, rejected fetch) in
+      `apps/qwksearch-web/lib/reason-docs/__tests__/topic-searches.test.ts`,
+      mirroring `page-tips.test.ts` — 3 new cases, all passing.
+- [x] Vitest coverage is added for `createTopicSearchesHandler` (model
+      loading, prompt truncation/parsing, `maxTopics` slicing, error
+      responses) in
+      `apps/qwksearch-web/app/api/agent/__tests__/topic-searches.test.ts`,
+      mirroring `app/api/agent/__tests__/page-tips.test.ts` — 6 new cases,
+      all passing.
+- [x] Lint passes — no `lint` script exists at the repo root or in
+      `qwksearch-web`, `reason-editor`, or `research-agent-ui`; nothing to
+      run (same as every prior task touching these packages).
+- [x] Typecheck passes — `bun run build` in `packages/reason-editor`
+      surfaces exactly 96 errors (stripped of ANSI codes before counting),
+      identical to the baseline documented in the prior "Sidebar: AI tips"
+      task, none referencing any file touched by this task.
+      `packages/research-agent-ui`'s `bun run build` (vite bundle + trailing
+      `tsc --project tsconfig.build.json || true`) surfaces the same 9
+      pre-existing errors in unrelated modules (`unified-markdown.tsx`,
+      `ChatHomepage.tsx`, `ChatWindow.tsx`, `MessageInputIconSet.tsx`,
+      `MessageSources.tsx`, `WebCitationBadge.tsx`), none referencing
+      `topic-searches.ts`.
+- [x] Tests pass — focused suites (`bunx vitest run
+      apps/qwksearch-web/lib/reason-docs/__tests__/topic-searches.test.ts
+      apps/qwksearch-web/app/api/agent/__tests__/topic-searches.test.ts
+      apps/qwksearch-web/lib/reason-docs/__tests__/page-tips.test.ts
+      apps/qwksearch-web/app/api/agent/__tests__/page-tips.test.ts`):
+      22/22 passed. Full workspace `bun run test`: 183/192 files,
+      2537/2595 tests pass (54 failed, 4 skipped) — the 9 failing files are
+      exactly the documented pre-existing set (`app/api/config/__tests__/
+      route.test.ts`, `search-web-api` engine tests, `shadcn-settings`'s
+      `settings-field.test.tsx`, `chat-agent-toolkit`'s
+      `openrouter-default-model.test.js`), none touching any file changed
+      by this task.
+- [x] Production/web build passes — `bun run build:web` at the repo root:
+      14/14 turbo tasks succeeded.
+- [x] Documentation is updated if behavior or configuration changes — n/a
+      beyond this tracker entry (no user-facing docs describe individual
+      sidebar panel sections).
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+      (done — see Source/Scope above; explored via a background agent that
+      confirmed no "topics" concept exists yet and mapped the exact
+      page-tips-task file order to follow)
+- [x] Implement `createTopicSearchesHandler` in `research-agent-ui`
+- [x] Implement the `topic-searches` API route in `qwksearch-web`
+- [x] Implement `getTopicSearches` client helper in `qwksearch-web`
+- [x] Extend `reason-editor`'s `SidebarProps`/`SidebarContentProps` with
+      `topicsProps` and render the topics block in `renderRelated()`
+- [x] Wire `topicsProps` through `Sidebar.tsx` and `RightPanel.tsx`
+- [x] Wire `onGenerateTopics`/`onSearchTopic` state/handlers into
+      `ReasonDocs.tsx`
+- [x] Wire `MainWorkspaceView.tsx` to supply `onGenerateTopics` and
+      `onSearchTopic` (including the new-chat-then-send-once-active effect)
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure/edge-case coverage
+- [x] Run focused tests and fix failures (none needed — passed first run)
+- [x] Run linting and typechecking (lint n/a; typecheck error counts
+      unchanged for both `reason-editor` and `research-agent-ui`)
+- [x] Run the full relevant test suite (focused suites and full workspace
+      `bun run test`)
+- [x] Run the production/web build (`bun run build:web`, 14/14 turbo tasks)
+- [x] Review the final diff for scope and quality (`bun install` was
+      required in this fresh checkout; the resulting `bun.lock`
+      package-version-sync diff was reverted, matching prior tasks'
+      precedent; final `git status --short` shows exactly the 8 intended
+      source files beyond this tracker entry)
+- [x] Commit and push the branch
+- [x] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- None for this task's own scope. All acceptance criteria verified locally
+  on this commit.
+- Follow-up ideas noted in Non-goals remain open: letting the user edit a
+  generated query before it's sent, and previewing search results inline
+  in the sidebar instead of always opening a new chat tab.
+
 ## Sidebar: AI tips about the current page
 
 **Status:** Completed

--- a/apps/qwksearch-web/app/api/agent/__tests__/topic-searches.test.ts
+++ b/apps/qwksearch-web/app/api/agent/__tests__/topic-searches.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockGenerateText = vi.fn()
+const mockLoadChatModel = vi.fn()
+
+vi.mock('ai', () => ({
+  generateText: (...args: unknown[]) => mockGenerateText(...args),
+}))
+
+vi.mock('chat-agent-toolkit/models/registry', () => ({
+  default: class {
+    loadChatModel(...args: unknown[]) {
+      return mockLoadChatModel(...args)
+    }
+  },
+}))
+
+import { createTopicSearchesHandler } from 'research-agent-ui/api'
+
+const handler = createTopicSearchesHandler({
+  getUserId: async () => 'user-1',
+  requireUserId: async () => 'user-1',
+  getDB: (() => ({})) as any,
+  userSchema: {} as any,
+  getEnv: (() => ({})) as any,
+})
+
+function postRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/agent/topic-searches', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }) as any
+}
+
+const baseBody = {
+  title: 'My Document',
+  content: 'Some article content about SpaceX.',
+  chatModel: { providerId: 'openai', key: 'gpt-4' },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockLoadChatModel.mockResolvedValue({ id: 'fake-model' })
+})
+
+describe('createTopicSearchesHandler POST', () => {
+  it('returns a 400 when content is missing', async () => {
+    const res = await handler(postRequest({ title: 'Untitled' }))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('loads the chat model via the requested provider and key', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'SpaceX Starship launch schedule' })
+
+    await handler(postRequest(baseBody))
+
+    expect(mockLoadChatModel).toHaveBeenCalledWith('openai', 'gpt-4')
+  })
+
+  it('parses newline-delimited topics, stripping numbering/bullets and blank lines', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: '1. SpaceX Starship launch schedule\n- Falcon 9 reuse record\n\n',
+    })
+
+    const res = await handler(postRequest(baseBody))
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.success).toBe(true)
+    expect(data.topics).toEqual([
+      'SpaceX Starship launch schedule',
+      'Falcon 9 reuse record',
+    ])
+  })
+
+  it('truncates content to 15000 characters in the prompt', async () => {
+    mockGenerateText.mockResolvedValue({ text: 'SpaceX launch schedule' })
+    const longContent = 'x'.repeat(20000)
+
+    await handler(postRequest({ ...baseBody, content: longContent }))
+
+    const [{ messages }] = mockGenerateText.mock.calls[0]
+    const userMessage = messages.find((m: any) => m.role === 'user')
+    expect(userMessage.content).toContain('x'.repeat(15000))
+    expect(userMessage.content).not.toContain('x'.repeat(15001))
+  })
+
+  it('slices the parsed topics down to maxTopics', async () => {
+    mockGenerateText.mockResolvedValue({
+      text: 'First search topic\nSecond search topic\nThird search topic',
+    })
+
+    const res = await handler(postRequest({ ...baseBody, maxTopics: 2 }))
+
+    const data = await res.json()
+    expect(data.topics).toEqual(['First search topic', 'Second search topic'])
+  })
+
+  it('returns a 500 with the error message when the model fails to load', async () => {
+    mockLoadChatModel.mockRejectedValue(new Error('No API key configured'))
+
+    const res = await handler(postRequest(baseBody))
+
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error).toBe('No API key configured')
+  })
+})

--- a/apps/qwksearch-web/app/api/agent/topic-searches/route.ts
+++ b/apps/qwksearch-web/app/api/agent/topic-searches/route.ts
@@ -1,0 +1,17 @@
+import { createTopicSearchesHandler } from "research-agent-ui/api";
+import { getUserId } from "@/lib/auth/session";
+import { getDB } from "@/lib/database";
+import { user as userSchema } from "@/lib/database/schema";
+import { getEnv } from "@/lib/config/env";
+
+export const POST = createTopicSearchesHandler({
+  getUserId,
+  requireUserId: async () => {
+    const id = await getUserId();
+    if (!id) throw new Error("Unauthorized");
+    return id;
+  },
+  getDB,
+  userSchema,
+  getEnv,
+});

--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -2,13 +2,14 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { ChatInputBox, ChatWindow, configureResearchAgentUI } from 'research-agent-ui';
+import { ChatInputBox, ChatWindow, configureResearchAgentUI, useChat } from 'research-agent-ui';
 import { ReasonDocs } from 'react-reason-editor/reason-docs';
 import { themeActions } from 'react-reason-editor/theme';
 import { localeActions } from 'react-reason-editor/locale-bundle';
 import { useMainView } from '@/components/layout/MainViewProvider';
 import { useChatTabs } from '@/components/layout/useChatTabs';
 import { getPageTips, htmlToPlainText } from '@/lib/reason-docs/page-tips';
+import { getTopicSearches } from '@/lib/reason-docs/topic-searches';
 
 import 'katex/dist/katex.min.css';
 import 'easydrawer/styles.css';
@@ -17,10 +18,12 @@ import 'katex/contrib/mhchem';
 export function MainWorkspaceView() {
   const { activeView, toggleToDocs, toggleToResearch, filesSidebarRequestId } = useMainView();
   const { chatTabs, activeChatId, openChat, newChat, closeChat } = useChatTabs();
+  const { sendMessage } = useChat();
   const searchParams = useSearchParams();
   const [activeDocId, setActiveDocId] = useState<string | null>(null);
   const [initialDocId, setInitialDocId] = useState<string | null>(null);
   const [hasRestoredFromUrl, setHasRestoredFromUrl] = useState(false);
+  const [pendingTopicQuery, setPendingTopicQuery] = useState<string | null>(null);
 
   useEffect(() => {
     localeActions.setLang('en');
@@ -103,6 +106,28 @@ export function MainWorkspaceView() {
     return getPageTips(title, htmlToPlainText(contentHtml));
   };
 
+  const handleGenerateTopics = async (title: string, contentHtml: string) => {
+    return getTopicSearches(title, htmlToPlainText(contentHtml));
+  };
+
+  // Opens a new chat tab for the clicked topic, then sends it as that
+  // chat's first message once the tab becomes active. `sendMessage` reads
+  // the currently active chat ID from context, so it can't run in the same
+  // synchronous handler as `newChat()` without racing against the still-stale
+  // previous chat ID — this effect waits for `activeChatId` to actually
+  // reflect the new chat before sending.
+  const handleSearchTopic = useCallback((topic: string) => {
+    newChat();
+    toggleToResearch();
+    setPendingTopicQuery(topic);
+  }, [newChat, toggleToResearch]);
+
+  useEffect(() => {
+    if (!pendingTopicQuery || !activeChatId) return;
+    sendMessage(pendingTopicQuery);
+    setPendingTopicQuery(null);
+  }, [pendingTopicQuery, activeChatId, sendMessage]);
+
   const extraTabProps = {
     extraTabs,
     activeExtraTabId: activeView === 'research' ? activeChatId ?? undefined : undefined,
@@ -113,6 +138,8 @@ export function MainWorkspaceView() {
     initialDocId,
     onActiveDocumentChange: setActiveDocId,
     onGenerateTips: handleGenerateTips,
+    onGenerateTopics: handleGenerateTopics,
+    onSearchTopic: handleSearchTopic,
   };
 
   return activeView === 'docs' ? (

--- a/apps/qwksearch-web/lib/reason-docs/__tests__/topic-searches.test.ts
+++ b/apps/qwksearch-web/lib/reason-docs/__tests__/topic-searches.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Unit tests for the `getTopicSearches` client helper.
+ */
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import grab from 'grab-url';
+import { getTopicSearches } from '../topic-searches';
+
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getTopicSearches', () => {
+  it('posts the title and content and returns the topics array', async () => {
+    mockGrab.mockResolvedValue({ topics: ['topic one', 'topic two'] });
+
+    const result = await getTopicSearches('My Doc', 'Some plain text content');
+
+    expect(mockGrab).toHaveBeenCalledTimes(1);
+    const [path, opts] = mockGrab.mock.calls[0];
+    expect(path).toBe('agent/topic-searches');
+    const body = JSON.parse((opts as RequestInit).body as string);
+    expect(body).toEqual({ title: 'My Doc', content: 'Some plain text content' });
+    expect(result).toEqual(['topic one', 'topic two']);
+  });
+
+  it('returns an empty array when the response topics field is not an array', async () => {
+    mockGrab.mockResolvedValue({ topics: 'not an array' } as any);
+
+    const result = await getTopicSearches('My Doc', 'content');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when the fetch rejects', async () => {
+    mockGrab.mockRejectedValue(new Error('network error'));
+
+    const result = await getTopicSearches('My Doc', 'content');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/qwksearch-web/lib/reason-docs/topic-searches.ts
+++ b/apps/qwksearch-web/lib/reason-docs/topic-searches.ts
@@ -1,0 +1,18 @@
+/**
+ * @fileoverview Client helper for the REASON editor's "search topics" sidebar feature.
+ */
+import grab from "grab-url";
+
+/** Fetches short AI-generated suggested search queries related to a document's content. Returns an empty array on any failure. */
+export const getTopicSearches = async (title: string, content: string): Promise<string[]> => {
+  try {
+    const data = await grab<{ topics: string[] }>("agent/topic-searches", {
+      method: "POST",
+      body: JSON.stringify({ title, content }),
+    });
+
+    return Array.isArray(data.topics) ? data.topics : [];
+  } catch (e) {
+    return [];
+  }
+};

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -70,6 +70,19 @@ interface ReasonDocsProps {
    * the section is hidden entirely in that case.
    */
   onGenerateTips?: (title: string, contentHtml: string) => Promise<string[]>;
+  /**
+   * Generates short suggested search queries ("topics") related to the
+   * active document's content, given its title and HTML content. Powers
+   * the sidebar "related" panel's "Search topics" section. Omitted when
+   * the host app has no topics-generation capability to offer.
+   */
+  onGenerateTopics?: (title: string, contentHtml: string) => Promise<string[]>;
+  /**
+   * Runs a search for a generated topic (e.g. opens a new chat seeded with
+   * it as the first message). Omitted when the host app has no search
+   * capability to offer, hiding the "Search topics" section's click action.
+   */
+  onSearchTopic?: (topic: string) => void;
 }
 
 /**
@@ -90,12 +103,16 @@ const Index = ({
   initialDocId,
   onActiveDocumentChange,
   onGenerateTips,
+  onGenerateTopics,
+  onSearchTopic,
 }: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState(openFilesSidebarSignal);
   const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
   const [tips, setTips] = useState<string[]>([]);
   const [isTipsLoading, setIsTipsLoading] = useState(false);
+  const [topics, setTopics] = useState<string[]>([]);
+  const [isTopicsLoading, setIsTopicsLoading] = useState(false);
 
   // Restore the active document from a host-supplied ID (e.g. a `?docs=`
   // URL param) once, the first time it resolves to a real document.
@@ -115,10 +132,11 @@ const Index = ({
     onActiveDocumentChange?.(state.activeDocId);
   }, [state.activeDocId, onActiveDocumentChange]);
 
-  // Clear any previously generated page tips when the active document
-  // changes, so stale tips from the last document are never shown.
+  // Clear any previously generated page tips/topics when the active
+  // document changes, so stale results from the last document are never shown.
   useEffect(() => {
     setTips([]);
+    setTopics([]);
   }, [state.activeDocId]);
 
   const handleGenerateTips = async () => {
@@ -136,6 +154,23 @@ const Index = ({
 
   const tipsProps = onGenerateTips
     ? { tips, isTipsLoading, onGenerateTips: handleGenerateTips }
+    : undefined;
+
+  const handleGenerateTopics = async () => {
+    if (!onGenerateTopics || !state.activeDocument) return;
+    setIsTopicsLoading(true);
+    try {
+      const generated = await onGenerateTopics(state.activeDocument.title, state.activeDocument.content || '');
+      setTopics(generated);
+    } catch {
+      setTopics([]);
+    } finally {
+      setIsTopicsLoading(false);
+    }
+  };
+
+  const topicsProps = onGenerateTopics
+    ? { topics, isTopicsLoading, onGenerateTopics: handleGenerateTopics, onSearchTopic }
     : undefined;
 
   // Use persistence hook for sidebar sizes
@@ -254,6 +289,7 @@ const Index = ({
       onAiRegenerate: state.handleAIRegenerate,
     },
     tipsProps,
+    topicsProps,
   };
 
   const editorProps = {
@@ -312,6 +348,7 @@ const Index = ({
         onAiRegenerate: state.handleAIRegenerate,
       }}
       tipsProps={tipsProps}
+      topicsProps={topicsProps}
       onClose={() => state.setRightPanels([])}
       isMobile={state.isMobile}
       isOpen={state.isRightSidebarOpen}

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -11,7 +11,7 @@ import { RefObject, useState } from 'react';
 import { Resizable } from 're-resizable';
 import { SidebarContent } from '../layout/sidebar/SidebarContent';
 import { PANEL_OPTIONS } from '../layout/sidebar/panelOptions';
-import type { SidebarPanelType, SidebarAiProps, SidebarTipsProps, OpenTabItem } from '../layout/sidebar/types';
+import type { SidebarPanelType, SidebarAiProps, SidebarTipsProps, SidebarTopicsProps, OpenTabItem } from '../layout/sidebar/types';
 import type { OutlineViewHandle } from '../search/OutlineView';
 import type { ActiveHeadingEditorHandle } from '../search/useActiveHeading';
 import type { TocEntry } from '../app-types/toc';
@@ -58,6 +58,8 @@ interface RightPanelProps {
   aiProps: SidebarAiProps;
   /** AI-generated page tips state/handlers (used by the "ai" panel). */
   tipsProps?: SidebarTipsProps;
+  /** AI-generated search topics state/handlers (used by the "related" panel). */
+  topicsProps?: SidebarTopicsProps;
   /** Closes the panel by clearing the right sidebar's panel list. */
   onClose: () => void;
   /** Renders as a slide-in drawer instead of an inset resizable panel. */
@@ -117,6 +119,7 @@ export function RightPanel({
   onNewChat,
   aiProps,
   tipsProps,
+  topicsProps,
   onClose,
   isMobile,
   isOpen,
@@ -170,6 +173,7 @@ export function RightPanel({
           onNewChat={onNewChat}
           aiProps={aiProps}
           tipsProps={tipsProps}
+          topicsProps={topicsProps}
         />
       </div>
     </div>

--- a/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
+++ b/packages/reason-editor/src/layout/sidebar/Sidebar.tsx
@@ -62,6 +62,7 @@ export const Sidebar = ({
   canReopenLastClosed = false,
   aiProps,
   tipsProps,
+  topicsProps,
   tabItems,
   onNewChat,
 }: SidebarProps) => {
@@ -247,6 +248,7 @@ export const Sidebar = ({
     onNavigate,
     aiProps,
     tipsProps,
+    topicsProps,
     tabItems,
     onNewChat,
   };

--- a/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
+++ b/packages/reason-editor/src/layout/sidebar/SidebarContent.tsx
@@ -14,7 +14,7 @@ import { findRelatedDocuments, splitTopSuggestion, type RelatedDocumentResult } 
 import { AIRewriteSuggestion } from '../../features/ai-rewrite/AIRewriteSuggestion';
 import { Input } from '../../app-ui/input';
 import { Document } from '../../documents/DocumentTree';
-import type { SidebarPanelType, SidebarAiProps, SidebarTipsProps, OpenTabItem } from './types';
+import type { SidebarPanelType, SidebarAiProps, SidebarTipsProps, SidebarTopicsProps, OpenTabItem } from './types';
 import type { TocEntry } from '../../app-types/toc';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
@@ -104,6 +104,8 @@ interface SidebarContentProps {
   aiProps?: SidebarAiProps;
   /** AI-generated page tips state/handlers (used by the "ai" panel). */
   tipsProps?: SidebarTipsProps;
+  /** AI-generated search topics state/handlers (used by the "related" panel). */
+  topicsProps?: SidebarTopicsProps;
   /** Unified tab list (files + chats). Overrides file-only tab derivation when set. */
   tabItems?: OpenTabItem[];
   /** Opens a new chat tab from the "Open Tabs" panel header. */
@@ -145,6 +147,7 @@ export const SidebarContent = ({
   onNavigate,
   aiProps,
   tipsProps,
+  topicsProps,
   tabItems,
   onNewChat,
 }: SidebarContentProps) => {
@@ -446,9 +449,51 @@ export const SidebarContent = ({
             </>
           )}
         </div>
+        {topicsProps && renderTopics()}
       </div>
     );
   };
+
+  const renderTopics = () => (
+    <div className="px-3 py-3 border-t border-sidebar-border shrink-0">
+      <div className="flex items-center justify-between mb-2 gap-2">
+        <p className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          <Search className="h-3.5 w-3.5 text-primary" />
+          Search topics
+        </p>
+        {topicsProps?.onGenerateTopics && (
+          <button
+            className="shrink-0 text-xs font-medium text-primary hover:underline disabled:opacity-50 disabled:cursor-not-allowed disabled:no-underline"
+            onClick={topicsProps.onGenerateTopics}
+            disabled={topicsProps.isTopicsLoading}
+          >
+            {topicsProps.isTopicsLoading ? 'Generating…' : topicsProps.topics?.length ? 'Regenerate' : 'Generate'}
+          </button>
+        )}
+      </div>
+      {topicsProps?.isTopicsLoading ? (
+        <p className="text-xs text-muted-foreground">Finding related searches…</p>
+      ) : topicsProps?.topics && topicsProps.topics.length > 0 ? (
+        <ul className="space-y-1">
+          {topicsProps.topics.map((topic, i) => (
+            <li key={i}>
+              <button
+                type="button"
+                className="w-full flex items-start gap-1.5 text-left text-xs text-muted-foreground rounded-md px-1 py-1 -mx-1 transition-colors hover:bg-sidebar-accent hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={() => topicsProps.onSearchTopic?.(topic)}
+                disabled={!topicsProps.onSearchTopic}
+              >
+                <Search className="shrink-0 h-3 w-3 mt-0.5 text-primary" />
+                <span>{topic}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs text-muted-foreground">Click "Generate" for suggested searches about this page.</p>
+      )}
+    </div>
+  );
 
   const renderTips = () => (
     <div className="px-3 py-3 border-t border-sidebar-border shrink-0">

--- a/packages/reason-editor/src/layout/sidebar/types.ts
+++ b/packages/reason-editor/src/layout/sidebar/types.ts
@@ -54,6 +54,23 @@ export interface SidebarTipsProps {
   onGenerateTips?: () => void;
 }
 
+/**
+ * AI-generated suggested search queries ("topics") related to the currently
+ * active document, shown as a section of the "related" panel. Omitted
+ * entirely (and the section hidden) when the host app has no
+ * topics-generation capability to offer.
+ */
+export interface SidebarTopicsProps {
+  /** Suggested search queries generated for the active document by the most recent request. */
+  topics?: string[];
+  /** Whether a topics-generation request is in flight. */
+  isTopicsLoading?: boolean;
+  /** Requests (re)generation of topics for the active document. */
+  onGenerateTopics?: () => void;
+  /** Runs a search for the given topic (e.g. opens a new chat seeded with it). */
+  onSearchTopic?: (topic: string) => void;
+}
+
 export interface SidebarProps {
   documents: Document[];
   activeId: string | null;
@@ -130,4 +147,6 @@ export interface SidebarProps {
   aiProps?: SidebarAiProps;
   // AI-generated page tips (used by the "ai" panel)
   tipsProps?: SidebarTipsProps;
+  // AI-generated search topics (used by the "related" panel)
+  topicsProps?: SidebarTopicsProps;
 }

--- a/packages/research-agent-ui/src/api/handlers/topic-searches.ts
+++ b/packages/research-agent-ui/src/api/handlers/topic-searches.ts
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview Handler that generates short LLM-powered suggested search
+ * queries ("topics") related to a document/page.
+ *
+ * Loads a chat model via ModelRegistry, prompts it with the page's title and
+ * content (truncated to 15000 chars), then parses the response into a
+ * cleaned list of short search-query strings.
+ */
+import { generateText } from "ai";
+import ModelRegistry from "chat-agent-toolkit/models/registry";
+import type { ModelWithProvider } from "chat-agent-toolkit/config/config-types";
+import type { ArticleDeps } from "../types";
+
+interface TopicSearchesBody {
+  title?: string;
+  content: string;
+  maxTopics?: number;
+  chatModel?: ModelWithProvider;
+}
+
+export function createTopicSearchesHandler(deps: ArticleDeps) {
+  return async (req: Request): Promise<Response> => {
+    try {
+      const body: TopicSearchesBody = await req.json();
+      const { title = "", content, maxTopics = 4, chatModel } = body;
+
+      if (!content) {
+        return Response.json({ error: "Content is required" }, { status: 400 });
+      }
+
+      const registry = new ModelRegistry();
+      let llm;
+
+      try {
+        llm = await registry.loadChatModel(chatModel?.providerId, chatModel?.key);
+      } catch (error) {
+        return Response.json(
+          {
+            error:
+              error instanceof Error
+                ? error.message
+                : "Failed to load language model",
+          },
+          { status: 500 },
+        );
+      }
+
+      const systemPrompt = `You are a helpful AI that suggests related searches for a reader based on a page they currently have open.
+Generate ${maxTopics} short search queries (each a few words, phrased the way someone would type it into a search box) that dig deeper into topics related to the page.
+Return ONLY the search queries, one per line, without numbering or bullet points.`;
+
+      const userPrompt = `Page title: ${title}
+
+Page content:
+${content.slice(0, 15000)}
+
+Generate ${maxTopics} short related search queries for this page.`;
+
+      const { text: fullResponse } = await generateText({
+        model: llm,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      });
+
+      const topics = fullResponse
+        .split("\n")
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0)
+        .map((t) => t.replace(/^[\d\-\*\.\)]+\s*/, "").trim())
+        .filter((t) => t.length > 2)
+        .slice(0, maxTopics);
+
+      return Response.json({ topics, success: true });
+    } catch (error) {
+      console.error("Error generating topic searches:", error);
+      return Response.json(
+        {
+          error: "An error occurred while generating topic searches",
+          details: error instanceof Error ? error.message : String(error),
+        },
+        { status: 500 },
+      );
+    }
+  };
+}

--- a/packages/research-agent-ui/src/api/index.ts
+++ b/packages/research-agent-ui/src/api/index.ts
@@ -4,6 +4,7 @@
 export * from "./types";
 export * from "./handlers/article-followups";
 export * from "./handlers/page-tips";
+export * from "./handlers/topic-searches";
 export * from "./handlers/article-qa";
 export * from "./handlers/chats";
 export * from "./handlers/chat-title";


### PR DESCRIPTION
## Summary
- Adds a "Search topics" section to the REASON editor sidebar's **Related** panel: a "Generate" button produces a short list of LLM-suggested search queries about the active document, mirroring the existing "Page tips" feature's prompt/parse pattern (`createTopicSearchesHandler` in `research-agent-ui`, a `topic-searches` API route, and a `getTopicSearches` client helper).
- Clicking a generated topic opens a new chat tab and sends that topic as its first message, via a `pendingTopicQuery` state + effect in `MainWorkspaceView.tsx` that waits for the new chat to become active before sending (avoiding a stale-closure race with `sendMessage`).
- Threads a new `topicsProps` prop bag through `reason-editor`'s `Sidebar`/`RightPanel`/`SidebarContent`, hidden entirely when a host app doesn't supply it (same convention as the existing `tipsProps`).

Addresses TODO.md backlog item 25 ("Auto-search for topics in sidebar.").

## Test plan
- [x] `bunx vitest run apps/qwksearch-web/lib/reason-docs/__tests__/topic-searches.test.ts apps/qwksearch-web/app/api/agent/__tests__/topic-searches.test.ts` — 9/9 new tests pass
- [x] Full focused suite including `page-tips` tests — 22/22 pass
- [x] `bun run test` (full workspace) — same 9 pre-existing failing files as before this change, none touching modified code
- [x] `bun run build` in `packages/reason-editor` and `packages/research-agent-ui` — typecheck error counts unchanged from baseline
- [x] `bun run build:web` at repo root — 14/14 turbo tasks succeeded

See `TODO.md` for the full task write-up (goal, scope, non-goals, acceptance criteria).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MuQP7reQFWLzp4s2d8GeMb)_