### PR TITLE
Sync TODO.md for PR #271

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@ follow-ups; forward navigation is a separate, smaller follow-up if ever
 requested"). This task completes that final remaining piece by mirroring
 `goBackActiveTab`/`refreshActiveTab` exactly.
 **Branch:** `claude/adoring-mayer-4tsafm` (this session's designated branch)
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/271
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 


### PR DESCRIPTION
## Summary

Records the merged "Browser extension: Forward button for the active tab" PR's link (#271) in the TODO.md tracker entry — pure documentation change, no code.

---
_Generated by [Claude Code](https://claude.ai/code/session_017RBYUa2wRss9SzE8f2Ho6R)_