### PR TITLE
Sync TODO.md for PR #274

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@ converts item 6's inspiration link into a small, concrete, testable slice.
 its prior PR #273 was already merged and the remote branch deleted before
 this run started; confirmed via GitHub that local HEAD already matched
 master's true tip, so work continued directly on this branch)
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/274
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 


### PR DESCRIPTION
## Summary
- Records the merged OpenRouter app-attribution PR's (#274) link in the `TODO.md` tracker entry, matching the repo's existing tracker-sync-follow-up convention.

## Test plan
- Documentation-only change (`TODO.md`); no code touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018Vp5BNUUsCtQJbk7XeeUiT)_