### PR TITLE
Add inline playback for video search results

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,120 @@
 
 ## Completed
 
+## Inline video playback for video search results
+
+**Status:** Completed
+**Source:** TODO.md — Ideas Backlog/Longterm item 16, "Research agents should
+queue the next video," investigated 2026-08-15 and found to need an inline
+video player built first (there is currently no inline player and no
+queue/autoplay concept anywhere in the repo). This task is that prerequisite
+first slice — inline playback only, no queueing/autoplay yet.
+**Branch:** `claude/adoring-mayer-xc2s1c`
+**PR:** Not created yet
+**Started:** 2026-08-15
+**Completed:** 2026-08-15
+
+### Goal
+When a video search result carries an embeddable `iframe_src` (already
+returned by the `invidious`/`peertube`/searxng video sources and threaded
+through `Document.metadata`, but currently ignored by the UI), clicking its
+card plays the video inline in a modal instead of navigating away in a new
+tab.
+
+### Scope
+- `packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx`'s
+  video card: use `iframe_src` when present to open an inline `<iframe>`
+  player in a `Dialog`, instead of always `<a target="_blank">`.
+- Fall back to the existing new-tab link behavior when `iframe_src` is
+  missing or not a safe embeddable URL.
+- Fix `loadMoreResults` (infinite-scroll pagination) to also carry
+  `iframe_src` through into `Document.metadata`, matching
+  `handleCategoryChange`'s mapping — currently it's dropped, so paginated
+  video results silently lose inline playback after page 1.
+- A small pure helper (`getVideoPlaybackTarget`) with its own Vitest
+  coverage, since the routing decision (inline vs. external, and URL safety
+  validation) is exactly the kind of logic this package already extracts
+  into `src/lib/*.ts` and unit-tests directly (see `shareArticle.ts`).
+
+### Non-goals
+- Autoplay / "queue the next video" (the rest of Longterm item 16) —
+  explicit follow-up, not this slice.
+- A custom video player UI (controls, progress bar) — the embedded iframe
+  provides the source site's own player.
+- Changing which video sources set `iframe_src` on the backend
+  (`search-web-api`) — this task only consumes the field that already
+  exists.
+
+### Acceptance criteria
+- [x] Video cards with a valid `iframe_src` open an inline player dialog on
+      click instead of navigating away
+- [x] Video cards without `iframe_src` (or with an unsafe/malformed one)
+      keep the existing new-tab link behavior
+- [x] Paginated ("load more") video results also get inline playback when
+      available
+- [x] Vitest coverage is added or updated
+- [x] Lint passes (no dedicated lint script in this repo; see verification)
+- [x] Typecheck passes (via the full `bun run build:web` turbo pipeline; see
+      verification — the package's own standalone `tsc` step is pre-existing
+      best-effort/non-blocking, see Remaining work)
+- [x] Tests pass
+- [x] Production/web build passes
+- [x] Documentation is updated if behavior or configuration changes (no
+      README/docs describe this level of UI detail; none needed updating)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements
+- [x] Implement the smallest useful vertical slice
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure, validation, or edge-case coverage
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality
+- [x] Commit and push the branch
+- [x] Create or update the pull request
+- [x] Update tracker status, completed checkboxes, and remaining work
+
+### Verification
+- `bun run test packages/research-agent-ui` — 8 test files, 82 tests, all
+  passed (includes the new `test/videoPlayback.test.ts`, 7 tests).
+- `bun run build:web` — 14/14 turbo tasks succeeded (build+test across the
+  full dependency graph including `research-agent-ui`).
+- `bun run test` (full root Vitest workspace) — pre-existing failures only,
+  all in packages this task never touches: `search-web-api`'s
+  `sources.test.ts`/`sources-unit.test.ts`/`engine-health-suite.test.ts`/
+  `api.test.ts`/`autocomplete-engines.test.ts` (live network calls to real
+  search engines — e.g. `youtube returns valid JSON results` fails with
+  "expected 0 to be greater than 0", consistent with no outbound network
+  access to those third-party sites in this environment), `qwksearch-web`'s
+  `app/api/config/__tests__/route.test.ts` (500s unrelated to search/video
+  config), `chat-agent-toolkit`'s `test/openrouter-default-model.test.js`,
+  and `shadcn-settings`'s `test/settings-field.test.tsx`. None import or
+  exercise `MessageSources.tsx` or `src/lib/videoPlayback.ts`.
+
+### Remaining work
+- None for this slice. Follow-ups explicitly out of scope (see Non-goals):
+  autoplay/queue-the-next-video, and a custom in-app video player UI.
+- Minor, separately-discovered gap not part of this task's scope: the same
+  `loadMoreResults` pagination mapping this task fixed for `iframe_src` also
+  omits `img_src` (present in `handleCategoryChange`'s mapping but not
+  here), so paginated Images-category "load more" results may be missing
+  `img_src`. Left unfixed to keep this PR scoped to video playback; worth a
+  small dedicated follow-up if it's confirmed to affect real Images
+  pagination.
+- `packages/research-agent-ui`'s standalone `bun run build` (`tsc --project
+  tsconfig.build.json`) reports pre-existing `TS2307: Cannot find module
+  'chat-agent-toolkit'` (and similar) errors in this file and several others
+  (`ChatWindow.tsx`, `WebCitationBadge.tsx`, `ChatHomepage.tsx`,
+  `unified-markdown.tsx`) — caused by sibling workspace packages not having
+  been built yet (no `dist/` for `chat-agent-toolkit`) when the package is
+  built standalone outside the turbo dependency graph; the script already
+  swallows these (`tsc ... || true`) and they do not occur in the real
+  `bun run build:web` pipeline, which builds dependencies first and passed
+  cleanly.
+
 ## Move completed tasks out of the `In Progress` section
 
 **Status:** Completed

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@ video player built first (there is currently no inline player and no
 queue/autoplay concept anywhere in the repo). This task is that prerequisite
 first slice — inline playback only, no queueing/autoplay yet.
 **Branch:** `claude/adoring-mayer-xc2s1c`
-**PR:** Not created yet
+**PR:** https://github.com/OpenSourceAGI/qwksearch-research-agent/pull/282
 **Started:** 2026-08-15
 **Completed:** 2026-08-15
 

--- a/packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx
+++ b/packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx
@@ -15,6 +15,8 @@ import { GlowingEffect } from '../../ui/glowing-effect';
 import { useExtractPanel } from '../ArticleReader/ExtractPanelContext';
 import type { SearchCategory, SearchResult } from '../../types/research';
 import { categories } from '../SearchConfig/categories';
+import { Dialog, DialogContent, DialogTitle } from '../../ui/dialog';
+import { getVideoPlaybackTarget } from '../../lib/videoPlayback';
 
 const CATEGORY_TABS = categories.filter(c =>
   ['general', 'news', 'videos', 'images', 'science', 'files'].includes(c.code)
@@ -35,6 +37,7 @@ const MessageSources = ({
   const [hasMore, setHasMore] = useState(true);
   const [isDesktop, setIsDesktop] = useState(false);
   const [glowEnabled, setGlowEnabled] = useState(false);
+  const [playingVideo, setPlayingVideo] = useState<{ src: string; title: string } | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const wasOpenRef = useRef(false);
   const userClosedPanelRef = useRef(false);
@@ -199,6 +202,7 @@ const MessageSources = ({
           thumbnail: result.thumbnail || '',
           url: result.url || '',
           ...(result.thumbnail && { thumbnail: result.thumbnail }),
+          ...(result.iframe_src && { iframe_src: (result as any).iframe_src }),
         },
       };
     });
@@ -307,6 +311,27 @@ const MessageSources = ({
     }
 
     if (isVideoCategory && imgSrc) {
+      const playbackTarget = getVideoPlaybackTarget(source.metadata);
+      const thumbnail = (
+        <div className="relative">
+          <img
+            src={imgSrc}
+            alt={source.metadata.title}
+            className="w-full h-24 object-cover"
+          />
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="w-10 h-10 bg-black/60 rounded-full flex items-center justify-center">
+              <Video size={18} className="text-white ml-0.5" />
+            </div>
+          </div>
+        </div>
+      );
+      const title = (
+        <p className="text-xs line-clamp-2 p-2 text-muted-foreground">
+          {convertURLSafeHTMLToHTML(source.metadata.title)}
+        </p>
+      );
+
       return (
         <div key={index} className="relative rounded-xl">
           <GlowingEffect
@@ -317,28 +342,26 @@ const MessageSources = ({
             inactiveZone={0.01}
             borderWidth={2}
           />
-          <a
-            className="relative bg-card text-card-foreground border border-border rounded-xl overflow-hidden flex flex-col cursor-pointer shadow-sm hover:shadow-md transition-all duration-200"
-            href={source.metadata.url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <div className="relative">
-              <img
-                src={imgSrc}
-                alt={source.metadata.title}
-                className="w-full h-24 object-cover"
-              />
-              <div className="absolute inset-0 flex items-center justify-center">
-                <div className="w-10 h-10 bg-black/60 rounded-full flex items-center justify-center">
-                  <Video size={18} className="text-white ml-0.5" />
-                </div>
-              </div>
-            </div>
-            <p className="text-xs line-clamp-2 p-2 text-muted-foreground">
-              {convertURLSafeHTMLToHTML(source.metadata.title)}
-            </p>
-          </a>
+          {playbackTarget.type === 'inline' ? (
+            <button
+              type="button"
+              className="relative w-full text-left bg-card text-card-foreground border border-border rounded-xl overflow-hidden flex flex-col cursor-pointer shadow-sm hover:shadow-md transition-all duration-200"
+              onClick={() => setPlayingVideo({ src: playbackTarget.src, title: source.metadata.title })}
+            >
+              {thumbnail}
+              {title}
+            </button>
+          ) : (
+            <a
+              className="relative bg-card text-card-foreground border border-border rounded-xl overflow-hidden flex flex-col cursor-pointer shadow-sm hover:shadow-md transition-all duration-200"
+              href={playbackTarget.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {thumbnail}
+              {title}
+            </a>
+          )}
         </div>
       );
     }
@@ -462,6 +485,21 @@ const MessageSources = ({
           </div>
         )}
       </div>
+
+      <Dialog open={playingVideo !== null} onOpenChange={(open) => !open && setPlayingVideo(null)}>
+        <DialogContent className="max-w-3xl p-0 overflow-hidden gap-0">
+          <DialogTitle className="sr-only">{playingVideo?.title || 'Video player'}</DialogTitle>
+          {playingVideo && (
+            <iframe
+              src={playingVideo.src}
+              title={playingVideo.title || 'Video player'}
+              className="w-full aspect-video"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/packages/research-agent-ui/src/lib/videoPlayback.ts
+++ b/packages/research-agent-ui/src/lib/videoPlayback.ts
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Decides how a video search result should be played: inline
+ * (embedded iframe) when it carries a safe, embeddable `iframe_src`, or as an
+ * external link otherwise.
+ */
+
+export interface VideoPlaybackSource {
+  url?: string;
+  iframe_src?: string;
+}
+
+export type VideoPlaybackTarget =
+  | { type: 'inline'; src: string }
+  | { type: 'external'; url: string };
+
+/**
+ * `iframe_src` on video results can come from third-party search backends
+ * (e.g. a configured SearXNG instance), so it's validated as an http(s) URL
+ * before being used as an iframe src — never trust it directly into a DOM sink.
+ */
+function isEmbeddableUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
+export function getVideoPlaybackTarget(source: VideoPlaybackSource): VideoPlaybackTarget {
+  if (source.iframe_src && isEmbeddableUrl(source.iframe_src)) {
+    return { type: 'inline', src: source.iframe_src };
+  }
+  return { type: 'external', url: source.url || '' };
+}

--- a/packages/research-agent-ui/test/videoPlayback.test.ts
+++ b/packages/research-agent-ui/test/videoPlayback.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Unit tests for the video-result playback routing decision.
+ */
+import { describe, expect, it } from 'vitest';
+import { getVideoPlaybackTarget } from '../src/lib/videoPlayback';
+
+describe('getVideoPlaybackTarget', () => {
+  it('plays inline when the source has a valid https iframe_src', () => {
+    const result = getVideoPlaybackTarget({
+      url: 'https://example.com/watch?v=abc',
+      iframe_src: 'https://inv.example.com/embed/abc',
+    });
+
+    expect(result).toEqual({ type: 'inline', src: 'https://inv.example.com/embed/abc' });
+  });
+
+  it('plays inline for a plain http iframe_src too', () => {
+    const result = getVideoPlaybackTarget({
+      url: 'http://example.com/watch?v=abc',
+      iframe_src: 'http://peertube.example.com/videos/embed/abc',
+    });
+
+    expect(result).toEqual({ type: 'inline', src: 'http://peertube.example.com/videos/embed/abc' });
+  });
+
+  it('falls back to the external url when iframe_src is missing', () => {
+    const result = getVideoPlaybackTarget({ url: 'https://example.com/watch?v=abc' });
+
+    expect(result).toEqual({ type: 'external', url: 'https://example.com/watch?v=abc' });
+  });
+
+  it('falls back to external when iframe_src is an empty string', () => {
+    const result = getVideoPlaybackTarget({ url: 'https://example.com/watch?v=abc', iframe_src: '' });
+
+    expect(result).toEqual({ type: 'external', url: 'https://example.com/watch?v=abc' });
+  });
+
+  it('falls back to external when iframe_src is not a well-formed URL', () => {
+    const result = getVideoPlaybackTarget({
+      url: 'https://example.com/watch?v=abc',
+      iframe_src: 'not a url',
+    });
+
+    expect(result).toEqual({ type: 'external', url: 'https://example.com/watch?v=abc' });
+  });
+
+  it('rejects a javascript: iframe_src rather than embedding it', () => {
+    const result = getVideoPlaybackTarget({
+      url: 'https://example.com/watch?v=abc',
+      iframe_src: 'javascript:alert(1)',
+    });
+
+    expect(result).toEqual({ type: 'external', url: 'https://example.com/watch?v=abc' });
+  });
+
+  it('returns an empty external url when neither url nor iframe_src is present', () => {
+    const result = getVideoPlaybackTarget({});
+
+    expect(result).toEqual({ type: 'external', url: '' });
+  });
+});


### PR DESCRIPTION
## Summary
- Video result cards (`MessageSources.tsx`) already received an embeddable `iframe_src` from the `invidious`/`peertube`/searxng video sources via `Document.metadata`, but ignored it — clicking always opened the video in a new tab.
- Clicking now opens an inline player dialog when a safe `iframe_src` (validated as http/https, not e.g. `javascript:`) is available; falls back to the existing new-tab link otherwise.
- Fixed `loadMoreResults` (infinite-scroll pagination) to also carry `iframe_src` through, matching `handleCategoryChange`'s mapping — it was previously dropped, so paginated video results lost inline playback after page 1.
- Extracted the inline-vs-external routing/URL-safety decision into a small pure helper, `getVideoPlaybackTarget` (`src/lib/videoPlayback.ts`), with its own Vitest coverage.

This is the inline-player prerequisite noted under TODO.md's Longterm item 16 ("queue the next video") — autoplay/queueing remains an explicit follow-up, not part of this slice.

## Test plan
- [x] `bun run test packages/research-agent-ui` — 8 test files / 82 tests pass, including the new `videoPlayback.test.ts` (7 tests: valid https/http `iframe_src`, missing/empty `iframe_src`, malformed URL, `javascript:` URL rejected, no url/iframe_src at all).
- [x] `bun run build:web` — 14/14 turbo tasks pass.
- [x] Full root `bun run test` — pre-existing failures only, all in unrelated packages (`search-web-api` live-network engine tests, `qwksearch-web` config route, `chat-agent-toolkit` OpenRouter default model test, `shadcn-settings`), none touching this change. Documented in `TODO.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjJam2MVtaxjMQ3RtAJ7yF)_