### PR TITLE
Fix img_src dropped from paginated Images "load more" results

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,69 @@
 ## In Progress
 
+## Fix `img_src` dropped from paginated Images "load more" results
+
+**Status:** In Progress
+**Source:** TODO.md — discovered as a leftover gap in the "Inline video
+playback for video search results" task's Remaining work (above): that task
+fixed `loadMoreResults` to carry `iframe_src` through into `Document.metadata`
+(matching `handleCategoryChange`'s mapping) but explicitly left `img_src`
+unfixed to keep that PR scoped to video playback.
+**Branch:** `claude/adoring-mayer-y0bn2s`
+**PR:** Not created yet
+**Started:** 2026-08-15
+
+### Goal
+`MessageSources.tsx`'s Images-category "load more" (infinite-scroll
+pagination) results should keep their `img_src` metadata, matching what the
+first page (via `handleCategoryChange`) already gets, instead of silently
+losing it after page 1.
+
+### Scope
+- `packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx`:
+  `loadMoreResults` and `handleCategoryChange` had duplicated, drifted
+  `SearchResult` → `Document` mapping logic (the pagination copy omitted
+  `img_src`). Extract a single shared pure helper,
+  `mapSearchResultToDocument`, and use it from both call sites so the two
+  paths can no longer diverge.
+- New `packages/research-agent-ui/src/lib/searchResultToDocument.ts` with its
+  own Vitest coverage, following the same pattern as `videoPlayback.ts`/
+  `videoPlayback.test.ts`.
+
+### Non-goals
+- The domain-only-URL warning logging at each call site (different log
+  messages per site) — left as-is, not part of the field-mapping bug.
+- Any other pagination field beyond `img_src`/`iframe_src` — no other gaps
+  were found between the two mappings.
+
+### Acceptance criteria
+- [x] Paginated ("load more") Images-category results carry `img_src` through
+      into `Document.metadata`, matching first-page behavior
+- [x] Vitest coverage is added or updated
+- [x] Lint passes (no dedicated lint script in this repo; see verification)
+- [x] Typecheck passes (via the full `bun run build:web` turbo pipeline)
+- [x] Tests pass
+- [x] Production/web build passes
+- [x] Documentation is updated if behavior or configuration changes (no
+      README/docs describe this level of UI detail; none needed updating)
+
+### Implementation plan
+- [x] Inspect affected modules, local instructions, and existing tests
+- [x] Confirm API, schema, data-flow, or interface requirements
+- [x] Implement the smallest useful vertical slice
+- [x] Add focused Vitest success-path coverage
+- [x] Add focused failure, validation, or edge-case coverage
+- [x] Run focused tests and fix failures
+- [x] Run linting and typechecking
+- [x] Run the full relevant test suite
+- [x] Run the production/web build
+- [x] Review the final diff for scope and quality
+- [x] Commit and push the branch
+- [ ] Create or update the pull request
+- [ ] Update tracker status, completed checkboxes, and remaining work
+
+### Remaining work
+- Create the PR and move this entry to Completed once it's open.
+
 ## Completed
 
 ## Inline video playback for video search results

--- a/packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx
+++ b/packages/research-agent-ui/src/components/SearchResults/MessageSources.tsx
@@ -17,6 +17,7 @@ import type { SearchCategory, SearchResult } from '../../types/research';
 import { categories } from '../SearchConfig/categories';
 import { Dialog, DialogContent, DialogTitle } from '../../ui/dialog';
 import { getVideoPlaybackTarget } from '../../lib/videoPlayback';
+import { mapSearchResultToDocument } from '../../lib/searchResultToDocument';
 
 const CATEGORY_TABS = categories.filter(c =>
   ['general', 'news', 'videos', 'images', 'science', 'files'].includes(c.code)
@@ -194,17 +195,7 @@ const MessageSources = ({
         }
       }
 
-      return {
-        pageContent: result.snippet || result.content || '',
-        metadata: {
-          title: result.title || '',
-          source: result.source || '',
-          thumbnail: result.thumbnail || '',
-          url: result.url || '',
-          ...(result.thumbnail && { thumbnail: result.thumbnail }),
-          ...(result.iframe_src && { iframe_src: (result as any).iframe_src }),
-        },
-      };
+      return mapSearchResultToDocument(result);
     });
 
     setSources(prev => [...prev, ...newSources]);
@@ -239,18 +230,7 @@ const MessageSources = ({
           }
         }
 
-        return {
-          pageContent: result.snippet || result.content || '',
-          metadata: {
-            title: result.title || '',
-            source: result.source || '',
-            thumbnail: result.thumbnail || '',
-            url: result.url || '',
-            ...(result.img_src && { img_src: (result as any).img_src }),
-            ...(result.thumbnail && { thumbnail: result.thumbnail }),
-            ...(result.iframe_src && { iframe_src: (result as any).iframe_src }),
-          },
-        };
+        return mapSearchResultToDocument(result);
       });
 
       setSources(newSources);

--- a/packages/research-agent-ui/src/lib/searchResultToDocument.ts
+++ b/packages/research-agent-ui/src/lib/searchResultToDocument.ts
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Converts a search API result into the `Document` shape the
+ * source-card grid renders. `MessageSources.tsx` previously duplicated this
+ * mapping at two call sites (category switch and "load more" pagination)
+ * and the two had drifted apart — the pagination copy was missing `img_src`,
+ * silently dropping images from paginated Images-category results.
+ */
+import type { Document } from 'chat-agent-toolkit';
+
+export interface SearchResultDocumentInput {
+  title?: string;
+  source?: string;
+  thumbnail?: string;
+  url?: string;
+  img_src?: string;
+  iframe_src?: string;
+  snippet?: string;
+  content?: string;
+}
+
+export function mapSearchResultToDocument(result: SearchResultDocumentInput): Document {
+  return {
+    pageContent: result.snippet || result.content || '',
+    metadata: {
+      title: result.title || '',
+      source: result.source || '',
+      thumbnail: result.thumbnail || '',
+      url: result.url || '',
+      ...(result.img_src && { img_src: result.img_src }),
+      ...(result.iframe_src && { iframe_src: result.iframe_src }),
+    },
+  };
+}

--- a/packages/research-agent-ui/test/searchResultToDocument.test.ts
+++ b/packages/research-agent-ui/test/searchResultToDocument.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Unit tests for the search-result-to-Document field mapping
+ * shared by category switching and "load more" pagination.
+ */
+import { describe, expect, it } from 'vitest';
+import { mapSearchResultToDocument } from '../src/lib/searchResultToDocument';
+
+describe('mapSearchResultToDocument', () => {
+  it('maps a full web result, preferring snippet over content', () => {
+    const doc = mapSearchResultToDocument({
+      title: 'Example title',
+      source: 'example.com',
+      thumbnail: 'https://example.com/thumb.jpg',
+      url: 'https://example.com/page',
+      snippet: 'a snippet',
+      content: 'full content',
+    });
+
+    expect(doc).toEqual({
+      pageContent: 'a snippet',
+      metadata: {
+        title: 'Example title',
+        source: 'example.com',
+        thumbnail: 'https://example.com/thumb.jpg',
+        url: 'https://example.com/page',
+      },
+    });
+  });
+
+  it('falls back to content when snippet is missing', () => {
+    const doc = mapSearchResultToDocument({ content: 'full content' });
+
+    expect(doc.pageContent).toBe('full content');
+  });
+
+  it('includes img_src when present, for image-category results', () => {
+    const doc = mapSearchResultToDocument({
+      title: 'A photo',
+      url: 'https://example.com/photo',
+      img_src: 'https://example.com/photo.jpg',
+    });
+
+    expect(doc.metadata.img_src).toBe('https://example.com/photo.jpg');
+  });
+
+  it('omits img_src entirely when not present, rather than setting it empty', () => {
+    const doc = mapSearchResultToDocument({ title: 'No image', url: 'https://example.com' });
+
+    expect(doc.metadata).not.toHaveProperty('img_src');
+  });
+
+  it('includes iframe_src when present, for video-category results', () => {
+    const doc = mapSearchResultToDocument({
+      title: 'A video',
+      url: 'https://example.com/watch?v=abc',
+      iframe_src: 'https://inv.example.com/embed/abc',
+    });
+
+    expect(doc.metadata.iframe_src).toBe('https://inv.example.com/embed/abc');
+  });
+
+  it('defaults missing title/source/thumbnail/url to empty strings', () => {
+    const doc = mapSearchResultToDocument({});
+
+    expect(doc.metadata).toEqual({
+      title: '',
+      source: '',
+      thumbnail: '',
+      url: '',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `MessageSources.tsx`'s `loadMoreResults` (infinite-scroll pagination) and `handleCategoryChange` (category switch) had duplicated `SearchResult` → `Document` mapping logic that had drifted apart: the pagination copy omitted `img_src`, so Images-category "load more" results silently lost their image after page 1.
- Extracted a single shared, pure helper (`mapSearchResultToDocument` in `packages/research-agent-ui/src/lib/searchResultToDocument.ts`) used by both call sites, so the mappings can no longer diverge — following the same pattern this package already uses for extracted logic (`videoPlayback.ts`).
- This gap was originally flagged as a known follow-up in the "Remaining work" section of the just-merged "Inline video playback for video search results" PR (#282), which fixed the analogous `iframe_src` omission but left `img_src` out of scope.

## Test plan
- [x] `bun run test packages/research-agent-ui` — 9 test files, 88 tests, all passed (includes the new `test/searchResultToDocument.test.ts`, 6 tests)
- [x] `bun run test` (full root Vitest workspace) — only pre-existing, unrelated failures (live-network `search-web-api` engine tests, `qwksearch-web`'s config route tests, `chat-agent-toolkit`'s OpenRouter default-model test, `shadcn-settings`'s settings-field test); none touch `research-agent-ui` or the changed files
- [x] `bun run build:web` — 14/14 turbo tasks succeeded


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHvf1DEGKBszEdGYLTTwwZ)_