### PR TITLE
Fix editor layout and improve pagination panel positioning

### DIFF
--- a/packages/reason-editor/src/constants/resetCSS.ts
+++ b/packages/reason-editor/src/constants/resetCSS.ts
@@ -43,6 +43,12 @@ export const RESET_CSS = `
     box-sizing: border-box;
     border-width: 0;
     border-style: solid;
+    /* This reset is injected unlayered, so it beats a host page's own layered
+       reset — including the one that would otherwise supply a border colour.
+       Without a colour of its own, anything inside the editor that ends up
+       with a border width falls back to \`currentColor\` and draws a hard black
+       frame. Zero specificity, so every rule that names a colour still wins. */
+    border-color: var(--richtext-border);
   }
 
 

--- a/packages/reason-editor/src/extensions/Pagination/components/RichTextPagination.tsx
+++ b/packages/reason-editor/src/extensions/Pagination/components/RichTextPagination.tsx
@@ -2,9 +2,13 @@
  * Toolbar control (React) for the Pagination extension, which adds paginated page-break layout. Renders the button and dispatches the matching editor command when activated.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useCurrentEditor } from '@tiptap/react';
 import { Settings, ChevronDown } from 'lucide-react';
+
+/** Gutter kept clear between the panel and the menu it opens from, and every viewport edge. */
+const PANEL_GAP = 8;
 
 interface PaginationOptions {
   pageHeight: number;
@@ -87,22 +91,67 @@ export function RichTextPagination() {
     footerRight: '',
   });
   const menuRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [panelStyle, setPanelStyle] = useState<React.CSSProperties>({
+    top: 0,
+    left: -9999,
+    visibility: 'hidden',
+  });
+
+  // The panel is a portal of its own (see below), so a press inside it lands
+  // outside `menuRef` and used to close the panel the moment anything in it
+  // was touched — as did a press on a control that re-renders, because React
+  // has already detached the pressed node by the time this handler runs.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (!target?.isConnected) return;
+      if (menuRef.current?.contains(target)) return;
+      if (panelRef.current?.contains(target)) return;
+      setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  // Place the panel beside the dropdown it was opened from rather than on top
+  // of it: it is wider than the menu row that owns it, and an absolutely
+  // positioned panel is also clipped by the menu's own scroll box.
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+
+    const place = () => {
+      const panel = panelRef.current;
+      const trigger = menuRef.current;
+      if (!panel || !trigger) return;
+
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const triggerRect = trigger.getBoundingClientRect();
+      // The toolbar dropdown this control is listed in, when there is one.
+      const host = trigger.closest('.dropdown-portal')?.getBoundingClientRect() ?? triggerRect;
+      const { offsetWidth: width, offsetHeight: height } = panel;
+
+      let left = host.right + PANEL_GAP;
+      if (left + width > vw - PANEL_GAP) left = host.left - width - PANEL_GAP;
+      left = Math.max(PANEL_GAP, Math.min(left, vw - width - PANEL_GAP));
+
+      const top = Math.max(PANEL_GAP, Math.min(triggerRect.top, vh - height - PANEL_GAP));
+
+      setPanelStyle({ top, left, maxHeight: vh - top - PANEL_GAP });
+    };
+
+    place();
+    window.addEventListener('resize', place);
+    return () => window.removeEventListener('resize', place);
+  }, [isOpen, activeTab]);
 
   if (!editor) {
     return null;
   }
-
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    if (isOpen) {
-      document.addEventListener('click', handleClickOutside);
-      return () => document.removeEventListener('click', handleClickOutside);
-    }
-  }, [isOpen]);
 
   const updatePaginationOptions = (partial: Partial<PaginationOptions>) => {
     const nextOptions = { ...options, ...partial };
@@ -170,10 +219,20 @@ export function RichTextPagination() {
         <ChevronDown className="w-3 h-3" />
       </button>
 
-      {isOpen && (
-        <div className="absolute top-full right-0 mt-1 bg-white dark:bg-gray-900 border dark:border-gray-700 rounded-lg shadow-lg z-50 min-w-96">
+      {/* Portalled to <body> so the panel sits beside the dropdown it was
+          opened from instead of on top of it, and is not clipped by that
+          menu's scroll box. `dropdown-portal` marks it as part of the toolbar's
+          own overlay stack, which is what keeps the menu underneath open while
+          the panel is being used (see `toolbarOverlays.ts`). */}
+      {isOpen && createPortal(
+        <div
+          ref={panelRef}
+          data-richtext-portal
+          className="dropdown-portal fixed flex flex-col overflow-hidden bg-white dark:bg-gray-900 border dark:border-gray-700 rounded-lg shadow-2xl z-50 w-96 max-w-[calc(100vw-16px)]"
+          style={panelStyle}
+        >
           {/* Tabs */}
-          <div className="flex border-b dark:border-gray-700">
+          <div className="flex border-b dark:border-gray-700 shrink-0">
             {['page', 'spacing', 'header-footer'].map((tab) => (
               <button
                 key={tab}
@@ -191,7 +250,7 @@ export function RichTextPagination() {
             ))}
           </div>
 
-          <div className="p-4 space-y-4 max-h-96 overflow-y-auto">
+          <div className="flex-1 min-h-0 p-4 space-y-4 overflow-y-auto">
             {activeTab === 'page' && (
               <>
                 {/* Presets */}
@@ -488,7 +547,8 @@ export function RichTextPagination() {
               </>
             )}
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </div>
   );

--- a/packages/reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx
+++ b/packages/reason-editor/src/extensions/Zoom/components/RichTextZoom.tsx
@@ -2,7 +2,8 @@
  * Toolbar control (React) for the Zoom extension, which adds zooming the editor content. Renders the button and dispatches the matching editor command when activated.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
+import { useCurrentEditor } from '@tiptap/react';
 import { ZoomIn, ZoomOut } from 'lucide-react';
 import { createPortal } from 'react-dom';
 
@@ -30,12 +31,36 @@ function Toast({ message }: { message: string }) {
 export const DEFAULT_ZOOM_SCALE = 1.25;
 
 export function RichTextZoom() {
+  const { editor } = useCurrentEditor();
   const [scale, setScale] = useState(DEFAULT_ZOOM_SCALE);
   const [toast, setToast] = useState<string | null>(null);
 
   const showToast = (message: string) => {
     setToast(message);
   };
+
+  /**
+   * Scales the editable area with the `zoom` property rather than a
+   * `transform: scale()`. A transform is applied after layout, so the content
+   * keeps the width it was laid out at and the enlarged text spills past the
+   * right edge of its pane (and past the bottom of the scroll region) instead
+   * of reflowing; `zoom` scales the layout itself, so the document still fills
+   * exactly the space the host gave the editor at any zoom level.
+   *
+   * The element is taken from the editor this toolbar belongs to — a document
+   * open in split view puts more than one `.ProseMirror` on the page, and a
+   * global query would zoom whichever came first.
+   */
+  const applyZoom = useCallback((zoomLevel: number) => {
+    const dom = (editor?.view?.dom as HTMLElement | undefined) ?? document.querySelector('.ProseMirror');
+    if (!dom) return;
+    const el = dom as HTMLElement;
+    el.style.zoom = String(zoomLevel);
+    // Clear the transform this control used to set, so a surface that was
+    // zoomed before an update is not left scaled twice over.
+    el.style.transform = '';
+    el.style.transformOrigin = '';
+  }, [editor]);
 
   const handleZoomIn = () => {
     const newScale = Math.min(scale + 0.25, 2);
@@ -51,17 +76,9 @@ export function RichTextZoom() {
     showToast(`Zoom: ${Math.round(newScale * 100)}%`);
   };
 
-  const applyZoom = (zoomLevel: number) => {
-    const editor = document.querySelector('.ProseMirror');
-    if (editor) {
-      (editor as HTMLElement).style.transform = `scale(${zoomLevel})`;
-      (editor as HTMLElement).style.transformOrigin = 'top left';
-    }
-  };
-
   useEffect(() => {
-    applyZoom(DEFAULT_ZOOM_SCALE);
-  }, []);
+    applyZoom(scale);
+  }, [applyZoom, scale]);
 
   return (
     <>

--- a/packages/reason-editor/src/novel/NovelEditor.tsx
+++ b/packages/reason-editor/src/novel/NovelEditor.tsx
@@ -215,6 +215,13 @@ export function NovelEditor({
             editable={current.editable}
             immediatelyRender={current.immediatelyRender}
             textDirection={current.textDirection}
+            // Novel's `EditorContent` renders a wrapper div of its own around
+            // the container `@tiptap/react` mounts ProseMirror into, and that
+            // wrapper — not the container — is what the host's layout sizes.
+            // Naming it gives `styles/editor.scss` something to stretch, so an
+            // empty document cannot collapse the editable area to the width of
+            // its placeholder.
+            className="reason-editor-shell"
             // `reason-editor-surface` is the stylesheet's hook for stretching
             // the contenteditable to fill this container (see
             // `styles/editor.scss`); it is always present so the rule does not

--- a/packages/reason-editor/src/styles/editor.scss
+++ b/packages/reason-editor/src/styles/editor.scss
@@ -1,25 +1,38 @@
 // ── Editable surface sizing ───────────────────────────────────────────────
 //
-// `.reason-editor-surface` is the container `NovelEditor` puts around the
-// contenteditable. @tiptap/react mounts ProseMirror inside an unclassed
-// wrapper div of its own, so without these rules the editable area is only as
-// tall as its text: a short document leaves dead space below it where clicks
-// do not reach the document and the host background shows through. Making the
-// chain a flex column lets the contenteditable claim the full height and width
-// the host gave the editor, while still growing past it (and scrolling, where
-// the host set `overflow-auto`) once the document is longer.
+// Two nested wrappers sit between the host's layout and the contenteditable:
+// `.reason-editor-shell` is the div Novel's `EditorContent` renders, and
+// `.reason-editor-surface` — the container `@tiptap/react` mounts ProseMirror
+// into — is its child. The host's own classes land on the *inner* one, so the
+// shell is the element the host's flex row/column actually lays out, and
+// without a rule of its own it shrink-wraps its content: an empty document
+// collapses the whole editable area to the width of the placeholder and the
+// height of `min-height`, leaving a small box floating in a large empty pane
+// where clicks do not reach the document. Making the chain a flex column that
+// stretches lets the contenteditable claim the full height and width the host
+// gave the editor, while still growing past it (and scrolling, where the host
+// set `overflow-auto`) once the document is longer.
+.reason-editor-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  // The host may lay the shell out in a row (editor + comments sidebar) or a
+  // column (toolbar + editor); stretch across the cross axis either way.
+  align-self: stretch;
+  width: 100%;
+  // Flex items floor at their content size unless told otherwise, which is
+  // what lets a long line push the editor wider than its pane.
+  min-width: 0;
+  min-height: 0;
+}
+
 .reason-editor-surface {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   width: 100%;
-
-  > div:has(> .ProseMirror) {
-    display: flex;
-    flex-direction: column;
-    flex: 1 1 auto;
-    width: 100%;
-    min-height: 0;
-  }
+  min-width: 0;
+  min-height: 0;
 
   .ProseMirror {
     flex: 1 1 auto;
@@ -28,12 +41,13 @@
 }
 
 // The editable area is focusable, so the browser draws its default focus ring
-// (a solid blue box in Chrome) around the whole document as soon as the caret
-// is placed. A permanent border around the page is not wanted here — the caret
-// already shows focus — so suppress it on the editable surface and on the
-// wrappers that can take focus with it.
+// (a solid black box in Chrome) around the whole document as soon as the caret
+// is placed, and a host page whose reset gives every element a border paints
+// one there too. A permanent frame around the page is not wanted here — the
+// caret already shows focus — so suppress both on the editable surface and on
+// the wrappers that can take focus with it.
+.reason-editor-shell,
 .reason-editor-surface,
-.reason-editor-surface > div,
 .reactjs-tiptap-editor .ProseMirror,
 .reactjs-tiptap-editor .ProseMirror-focused,
 .reactjs-tiptap-editor [contenteditable='true'] {
@@ -41,6 +55,7 @@
   &:focus,
   &:focus-visible,
   &:focus-within {
+    border: 0 !important;
     outline: none !important;
     box-shadow: none;
   }

--- a/packages/reason-editor/test/novel-editor.test.tsx
+++ b/packages/reason-editor/test/novel-editor.test.tsx
@@ -102,6 +102,17 @@ describe('NovelEditor', () => {
     expect(scope!.querySelector('.surface .ProseMirror')).not.toBeNull();
   });
 
+  it('names Novel\'s own wrapper so the stylesheet can stretch it', () => {
+    mount();
+
+    // The host's classes land on the inner container, so the outer wrapper
+    // needs a hook of its own — without one it shrink-wraps its content and an
+    // empty document collapses the editable area (see styles/editor.scss).
+    const shell = container.querySelector('.reason-editor-shell');
+    expect(shell).not.toBeNull();
+    expect(shell!.querySelector('.reason-editor-surface .ProseMirror')).not.toBeNull();
+  });
+
   it('loads initialContent and round-trips it back as HTML', () => {
     const { editor } = mount({ initialContent: '<p>hello <strong>novel</strong></p>' });
 

--- a/packages/reason-editor/test/richtext-pagination.test.tsx
+++ b/packages/reason-editor/test/richtext-pagination.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * The Page Settings control's popup: it is a panel of its own, portalled out
+ * of the toolbar dropdown that lists it so the two sit side by side instead of
+ * on top of each other, and it stays open while it is being used.
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorContext } from '@tiptap/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { RichTextPagination } from '@/extensions/Pagination/components/RichTextPagination';
+
+// React 19 flags this when `act()` is used outside a test renderer.
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Only `editor.commands` is dereferenced, and every command is optional. */
+const editor = { commands: {} } as any;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  // Stands in for the toolbar dropdown the control is listed in.
+  container.className = 'dropdown-portal';
+  document.body.append(container);
+  root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <EditorContext.Provider value={{ editor }}>
+        <RichTextPagination />
+      </EditorContext.Provider>,
+    );
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+/** The gear that opens the panel. */
+function trigger() {
+  return container.querySelector('button[title="Page settings"]') as HTMLButtonElement;
+}
+
+function panel() {
+  return document.body.querySelector('[data-richtext-portal]') as HTMLElement | null;
+}
+
+/** Presses `target` the way an outside-click listener sees it. */
+function press(target: Element) {
+  act(() => {
+    target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+  });
+}
+
+describe('RichTextPagination', () => {
+  it('opens the panel outside the menu that lists it', () => {
+    expect(panel()).toBeNull();
+
+    act(() => trigger().click());
+
+    const opened = panel();
+    expect(opened).not.toBeNull();
+    // Portalled to <body>: nested inside the menu it would be drawn on top of
+    // it and clipped by its scroll box.
+    expect(container.contains(opened)).toBe(false);
+    // Marked as part of the toolbar's overlay stack, which is what keeps the
+    // menu underneath open while the panel is in use.
+    expect(opened!.classList.contains('dropdown-portal')).toBe(true);
+  });
+
+  it('stays open while its own controls are used', () => {
+    act(() => trigger().click());
+
+    const tab = panel()!.querySelector('button') as HTMLButtonElement;
+    press(tab);
+    act(() => tab.click());
+    expect(panel()).not.toBeNull();
+
+    // A control that re-renders reports a target already detached from the
+    // document by the time the listener runs; that is not "outside" either.
+    const detached = document.createElement('button');
+    press(detached);
+    expect(panel()).not.toBeNull();
+  });
+
+  it('closes on a press outside itself and its trigger', () => {
+    act(() => trigger().click());
+    expect(panel()).not.toBeNull();
+
+    const outside = document.createElement('div');
+    document.body.append(outside);
+    press(outside);
+    outside.remove();
+
+    expect(panel()).toBeNull();
+  });
+});

--- a/packages/reason-editor/test/richtext-zoom.test.tsx
+++ b/packages/reason-editor/test/richtext-zoom.test.tsx
@@ -1,6 +1,8 @@
 /**
  * Confirms the REASON editor's zoom toolbar control defaults to 125% on
- * mount and that in/out clicks still step and clamp correctly from there.
+ * mount, that it scales the editable area with `zoom` — which reflows the
+ * layout, so the document still fills its pane — rather than a transform, and
+ * that in/out clicks still step and clamp correctly from there.
  */
 
 import { act } from 'react';
@@ -50,34 +52,35 @@ describe('RichTextZoom', () => {
     mount();
 
     expect(DEFAULT_ZOOM_SCALE).toBe(1.25);
-    expect(proseMirror.style.transform).toBe('scale(1.25)');
+    expect(proseMirror.style.zoom).toBe('1.25');
+    expect(proseMirror.style.transform).toBe('');
     expect(zoomInButton().title).toBe('Zoom In (125%)');
     expect(zoomOutButton().title).toBe('Zoom Out (125%)');
   });
 
-  it('steps up from the 125% default and updates the applied transform', () => {
+  it('steps up from the 125% default and updates the applied zoom', () => {
     mount();
 
     act(() => zoomInButton().click());
 
     expect(zoomInButton().title).toBe('Zoom In (150%)');
-    expect(proseMirror.style.transform).toBe('scale(1.5)');
+    expect(proseMirror.style.zoom).toBe('1.5');
   });
 
   it('steps down from the 125% default and clamps at the 50% floor', () => {
     mount();
 
     act(() => zoomOutButton().click());
-    expect(proseMirror.style.transform).toBe('scale(1)');
+    expect(proseMirror.style.zoom).toBe('1');
 
     act(() => zoomOutButton().click());
-    expect(proseMirror.style.transform).toBe('scale(0.75)');
+    expect(proseMirror.style.zoom).toBe('0.75');
 
     act(() => zoomOutButton().click());
-    expect(proseMirror.style.transform).toBe('scale(0.5)');
+    expect(proseMirror.style.zoom).toBe('0.5');
 
     act(() => zoomOutButton().click());
-    expect(proseMirror.style.transform).toBe('scale(0.5)');
+    expect(proseMirror.style.zoom).toBe('0.5');
     expect(zoomOutButton().title).toBe('Zoom Out (50%)');
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes critical layout issues in the editor and improves the pagination panel's positioning and interaction behavior. The changes ensure the editable area properly fills its container at all times, the pagination settings panel positions itself intelligently beside its trigger button, and zoom functionality uses the correct scaling method.

## Key Changes

- **Editor Layout Fix**: Added `.reason-editor-shell` wrapper styling to prevent the editable area from collapsing when empty. The shell now properly stretches to fill available space using flexbox, ensuring clicks always reach the document regardless of content length.

- **Pagination Panel Positioning**: Converted the pagination settings panel to a portal that renders outside the toolbar dropdown, preventing it from being clipped by the menu's scroll box. The panel now intelligently positions itself beside the trigger button with fallback logic to keep it within viewport bounds.

- **Pagination Panel Interaction**: Fixed the outside-click handler to properly detect clicks outside the panel and its trigger button. Changed from `click` to `mousedown` events and added checks for detached DOM nodes to handle re-rendering controls correctly.

- **Zoom Implementation**: Changed zoom from using `transform: scale()` to the `zoom` CSS property, which reflows the layout so content still fills its pane at any zoom level rather than spilling past edges. Updated to use the editor instance's DOM reference to avoid zooming unrelated `.ProseMirror` elements in split-view scenarios.

- **CSS Reset Enhancement**: Added `border-color: var(--richtext-border)` to the injected reset CSS to prevent borders from falling back to black when no color is specified.

- **Test Coverage**: Added comprehensive test suite for the pagination panel covering portal rendering, interaction handling, and click-outside behavior. Updated zoom tests to verify the new `zoom` property behavior.

## Notable Implementation Details

- The pagination panel uses `useLayoutEffect` to position itself after render, accounting for viewport dimensions and the parent dropdown's position
- The panel maintains a configurable gap (`PANEL_GAP = 8px`) from viewport edges and the trigger button
- The outside-click handler checks `target.isConnected` to ignore clicks on nodes that have been detached by React re-renders
- The zoom control now uses `useCallback` to ensure the correct editor instance is targeted in multi-editor scenarios

https://claude.ai/code/session_01JM2DSGQ6CoEANAz4bCJ8Z9