### PR TITLE
Add a /features marketing page with hero and shadcn effects

### DIFF
--- a/apps/qwksearch-web/app/features/page.tsx
+++ b/apps/qwksearch-web/app/features/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next';
+
+import { FeaturesView } from '@/components/features/FeaturesView';
+import { config } from '@/lib/config/site';
+
+export const metadata: Metadata = {
+  title: `Features - ${config.appName}`,
+  description:
+    'Search 100+ sites across 13 categories, extract and cite articles, PDFs, and YouTube transcripts, answer with any LLM provider, and write it up in the REASON editor.',
+  alternates: { canonical: '/features' },
+  openGraph: {
+    title: `Features - ${config.appName}`,
+    description:
+      'Every capability of the QwkSearch research agent: multi-engine search, source extraction and citation, model choice, the REASON writing editor, and desktop, browser, and IDE apps.',
+    url: `${config.baseUrl}/features`,
+    type: 'website',
+  },
+};
+
+const FeaturesPage = () => {
+  return <FeaturesView />;
+};
+
+export default FeaturesPage;

--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -497,3 +497,160 @@ pre[class*="language-"] {
     background-color: transparent;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Marketing page effects (/features)
+   Keyframes used by components/features/effects.tsx. Kept here rather than in
+   the component so Tailwind v4 arbitrary `animation-*` utilities can reference
+   them by name from anywhere in the app.
+--------------------------------------------------------------------------- */
+
+.qs-features {
+  --qs-accent: oklch(0.6 0.19 255);
+  --qs-accent-2: oklch(0.61 0.21 300);
+}
+
+.dark .qs-features {
+  --qs-accent: oklch(0.72 0.16 255);
+  --qs-accent-2: oklch(0.73 0.18 300);
+}
+
+.qs-accent-text {
+  color: var(--qs-accent);
+}
+
+.qs-accent-soft {
+  background: color-mix(in oklab, var(--qs-accent) 12%, transparent);
+  color: var(--qs-accent);
+  border-color: color-mix(in oklab, var(--qs-accent) 28%, transparent);
+}
+
+.qs-chip:hover {
+  color: var(--qs-accent);
+  border-color: color-mix(in oklab, var(--qs-accent) 40%, transparent);
+  background: color-mix(in oklab, var(--qs-accent) 8%, transparent);
+}
+
+.qs-accent-fill {
+  background: linear-gradient(135deg, var(--qs-accent), var(--qs-accent-2));
+  color: white;
+}
+
+@keyframes qs-marquee {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(calc(-50% - var(--qs-marquee-gap, 1rem) / 2));
+  }
+}
+
+@keyframes qs-aurora {
+  0%,
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 0.55;
+  }
+  33% {
+    transform: translate3d(6%, -4%, 0) scale(1.15);
+    opacity: 0.8;
+  }
+  66% {
+    transform: translate3d(-5%, 5%, 0) scale(0.95);
+    opacity: 0.45;
+  }
+}
+
+@keyframes qs-border-spin {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+@keyframes qs-shimmer {
+  0% {
+    background-position: -180% 0;
+  }
+  100% {
+    background-position: 180% 0;
+  }
+}
+
+@keyframes qs-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+.qs-marquee-track {
+  animation: qs-marquee var(--qs-marquee-duration, 40s) linear infinite;
+}
+
+.qs-marquee:hover .qs-marquee-track {
+  animation-play-state: paused;
+}
+
+.qs-aurora-blob {
+  animation: qs-aurora 18s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.qs-border-beam::before {
+  content: "";
+  position: absolute;
+  inset: -120%;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    var(--qs-accent, var(--primary)) 55deg,
+    var(--qs-accent-2, var(--primary)) 100deg,
+    transparent 175deg
+  );
+  animation: qs-border-spin 5s linear infinite;
+  opacity: 0;
+  transition: opacity 0.35s ease;
+}
+
+.qs-border-beam:hover::before,
+.qs-border-beam:focus-within::before {
+  opacity: 1;
+}
+
+.qs-shimmer-text {
+  background-size: 200% auto;
+  animation: qs-shimmer 6s linear infinite;
+}
+
+/* Scroll reveal — the base state is only applied once JS has marked the
+   element, so no-JS/reduced-motion users still see fully rendered content. */
+[data-qs-reveal="hidden"] {
+  opacity: 0;
+  transform: translateY(18px);
+}
+
+[data-qs-reveal="shown"] {
+  opacity: 1;
+  transform: none;
+  transition:
+    opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+    transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+  transition-delay: var(--qs-reveal-delay, 0ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .qs-marquee-track,
+  .qs-aurora-blob,
+  .qs-border-beam::before,
+  .qs-shimmer-text {
+    animation: none !important;
+  }
+
+  [data-qs-reveal="hidden"] {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -1,0 +1,529 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import {
+  ArrowRight,
+  Bot,
+  Check,
+  Download,
+  Globe,
+  Layers,
+  PenLine,
+  Search,
+  Sparkles,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  AuroraBackdrop,
+  CountUp,
+  Marquee,
+  Pill,
+  Reveal,
+  SpotlightCard,
+} from "@/components/features/effects";
+import {
+  ENGINE_NAMES,
+  FEATURE_TABS,
+  PACKAGES,
+  PIPELINE,
+  PLATFORMS,
+  PROVIDERS,
+  SEARCH_CATEGORIES,
+  STATS,
+} from "@/components/features/data";
+import { config } from "@/lib/config/site";
+
+function SectionHeading({
+  eyebrow,
+  title,
+  blurb,
+}: {
+  eyebrow: string;
+  title: React.ReactNode;
+  blurb?: string;
+}) {
+  return (
+    <Reveal className="mx-auto mb-12 max-w-2xl text-center">
+      <Pill className="mb-4">{eyebrow}</Pill>
+      <h2 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl">
+        {title}
+      </h2>
+      {blurb && (
+        <p className="text-muted-foreground mt-4 text-base leading-relaxed text-pretty">
+          {blurb}
+        </p>
+      )}
+    </Reveal>
+  );
+}
+
+function Hero() {
+  return (
+    <section className="relative overflow-hidden px-4 pt-24 pb-16 sm:px-6 lg:px-8">
+      <AuroraBackdrop />
+
+      <div className="mx-auto max-w-5xl text-center">
+        <Reveal>
+          <Pill className="mb-6">
+            <Sparkles className="size-3.5" />
+            Everything {config.appName} can do
+          </Pill>
+        </Reveal>
+
+        <Reveal delay={80}>
+          <h1 className="text-4xl leading-[1.08] font-bold tracking-tight text-balance sm:text-5xl lg:text-6xl">
+            Search the whole web.
+            <br />
+            <span className="qs-shimmer-text bg-gradient-to-r from-sky-500 via-violet-500 to-sky-500 bg-clip-text text-transparent">
+              Read every source.
+              <br />
+              Write the answer.
+            </span>
+          </h1>
+        </Reveal>
+
+        <Reveal delay={160}>
+          <p className="text-muted-foreground mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-pretty">
+            A research agent that queries 100+ sites, extracts and cites the
+            articles, PDFs, and videos behind them, and drops the result into a
+            full writing editor — on the web, your desktop, your browser, and
+            your IDE.
+          </p>
+        </Reveal>
+
+        <Reveal delay={240}>
+          <div className="mt-9 flex flex-col justify-center gap-3 sm:flex-row">
+            <Button asChild size="lg" className="group">
+              <Link href="/">
+                Start researching
+                <ArrowRight className="transition-transform group-hover:translate-x-0.5" />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
+              <Link href="/docs">
+                <PenLine />
+                Open REASON editor
+              </Link>
+            </Button>
+          </div>
+        </Reveal>
+
+        <Reveal delay={320}>
+          <dl className="mx-auto mt-16 grid max-w-4xl grid-cols-2 gap-px overflow-hidden rounded-2xl border sm:grid-cols-3 lg:grid-cols-5">
+            {STATS.map((stat) => (
+              <div
+                key={stat.label}
+                className="bg-card/60 px-4 py-6 backdrop-blur-sm transition-colors hover:bg-card"
+              >
+                <dt className="text-3xl font-bold tracking-tight tabular-nums">
+                  <CountUp value={stat.value} />
+                  {stat.suffix}
+                </dt>
+                <dd className="text-muted-foreground mt-1 text-xs tracking-wide uppercase">
+                  {stat.label}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+function EngineMarquee() {
+  const half = Math.ceil(ENGINE_NAMES.length / 2);
+  const rows = [ENGINE_NAMES.slice(0, half), ENGINE_NAMES.slice(half)];
+
+  return (
+    <section className="relative py-10">
+      <Reveal className="mx-auto mb-6 max-w-2xl px-4 text-center">
+        <p className="text-muted-foreground text-xs font-medium tracking-[0.2em] uppercase">
+          One query, every index
+        </p>
+      </Reveal>
+
+      <div className="space-y-3">
+        {rows.map((row, index) => (
+          <Marquee
+            key={index}
+            durationSeconds={index === 0 ? 46 : 54}
+            reverse={index === 1}
+          >
+            {row.map((name) => (
+              <span
+                key={name}
+                className="qs-chip bg-card/70 text-muted-foreground rounded-full border px-4 py-1.5 text-sm whitespace-nowrap transition-colors"
+              >
+                {name}
+              </span>
+            ))}
+          </Marquee>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BentoGrid() {
+  return (
+    <section className="relative px-4 py-20 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <SectionHeading
+          eyebrow="The loop"
+          title="Ask, search, read, cite, write — without leaving the tab"
+          blurb="Most research tools stop at a list of links. This one carries a question all the way to a finished, sourced document."
+        />
+
+        <div className="grid gap-4 md:grid-cols-3">
+          <Reveal className="md:col-span-2">
+            <SpotlightCard className="h-full">
+              <div className="flex h-full flex-col p-7">
+                <div className="qs-accent-soft mb-5 inline-flex size-11 w-fit items-center justify-center rounded-xl border">
+                  <Search className="size-5" />
+                </div>
+                <h3 className="text-xl font-semibold">
+                  Search 100+ sites in 13 categories
+                </h3>
+                <p className="text-muted-foreground mt-2 leading-relaxed">
+                  General engines, academic databases, code registries, video
+                  platforms, news wires, and archives — queried in parallel,
+                  deduplicated, and ranked by domain authority.
+                </p>
+                <div className="mt-auto flex flex-wrap gap-2 pt-6">
+                  {SEARCH_CATEGORIES.map((category) => (
+                    <Badge
+                      key={category.label}
+                      variant="soft"
+                      className="qs-accent-soft gap-1.5 px-3 py-1"
+                    >
+                      <category.icon />
+                      {category.label}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            </SpotlightCard>
+          </Reveal>
+
+          <Reveal delay={80}>
+            <SpotlightCard className="h-full">
+              <div className="p-7">
+                <div className="qs-accent-soft mb-5 inline-flex size-11 items-center justify-center rounded-xl border">
+                  <Bot className="size-5" />
+                </div>
+                <h3 className="text-xl font-semibold">Any model you trust</h3>
+                <p className="text-muted-foreground mt-2 leading-relaxed">
+                  Swap providers per conversation, or bring your own key.
+                </p>
+                <ul className="mt-5 space-y-2">
+                  {PROVIDERS.slice(0, 6).map((provider) => (
+                    <li key={provider} className="flex items-center gap-2 text-sm">
+                      <Check className="qs-accent-text size-3.5 shrink-0" />
+                      {provider}
+                    </li>
+                  ))}
+                  <li className="text-muted-foreground text-sm">
+                    + {PROVIDERS.length - 6} more providers
+                  </li>
+                </ul>
+              </div>
+            </SpotlightCard>
+          </Reveal>
+
+          <Reveal delay={40}>
+            <SpotlightCard className="h-full">
+              <div className="p-7">
+                <div className="qs-accent-soft mb-5 inline-flex size-11 items-center justify-center rounded-xl border">
+                  <Layers className="size-5" />
+                </div>
+                <h3 className="text-xl font-semibold">Read before you click</h3>
+                <p className="text-muted-foreground mt-2 leading-relaxed">
+                  Every result expands into cleaned article text with an APA
+                  citation and a summary — including PDFs and YouTube
+                  transcripts.
+                </p>
+              </div>
+            </SpotlightCard>
+          </Reveal>
+
+          <Reveal delay={120} className="md:col-span-2">
+            <SpotlightCard className="h-full">
+              <div className="flex h-full flex-col p-7">
+                <div className="qs-accent-soft mb-5 inline-flex size-11 w-fit items-center justify-center rounded-xl border">
+                  <PenLine className="size-5" />
+                </div>
+                <h3 className="text-xl font-semibold">
+                  REASON: the writing half of research
+                </h3>
+                <p className="text-muted-foreground mt-2 max-w-xl leading-relaxed">
+                  A Lexical-based editor with a nested document tree, AI
+                  rewriting, collaborative editing, research quotes, and Word,
+                  PDF, and Google Docs import and export.
+                </p>
+                <div className="mt-auto grid gap-2 pt-6 sm:grid-cols-2">
+                  {[
+                    "Nested document tree",
+                    "Slash commands & Mermaid",
+                    "Yjs collaboration",
+                    "20+ interface languages",
+                  ].map((item) => (
+                    <div key={item} className="flex items-center gap-2 text-sm">
+                      <Check className="qs-accent-text size-3.5 shrink-0" />
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </SpotlightCard>
+          </Reveal>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Pipeline() {
+  return (
+    <section className="relative px-4 py-20 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <SectionHeading
+          eyebrow="How it works"
+          title="How a question becomes a cited answer"
+          blurb="Five stages, each one a package you can use on its own."
+        />
+
+        <div className="relative grid gap-4 lg:grid-cols-5">
+          {/* Connecting rail behind the cards, desktop only. */}
+          <div
+            aria-hidden
+            className="via-border absolute top-14 right-0 left-0 hidden h-px bg-gradient-to-r from-transparent to-transparent lg:block"
+          />
+
+          {PIPELINE.map((stage, index) => (
+            <Reveal key={stage.step} delay={index * 70} className="relative">
+              <SpotlightCard beam={false} className="h-full">
+                <div className="p-6">
+                  <div className="mb-4 flex items-center gap-3">
+                    <span className="qs-accent-fill inline-flex size-9 items-center justify-center rounded-xl">
+                      <stage.icon className="size-4" />
+                    </span>
+                    <span className="text-muted-foreground/60 text-sm font-semibold tabular-nums">
+                      {stage.step}
+                    </span>
+                  </div>
+                  <h3 className="font-semibold">{stage.title}</h3>
+                  <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+                    {stage.body}
+                  </p>
+                </div>
+              </SpotlightCard>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FeatureExplorer() {
+  return (
+    <section className="relative px-4 py-20 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <SectionHeading
+          eyebrow="Every feature"
+          title="Four surfaces, one stack"
+          blurb="Pick a surface to see everything it ships with today."
+        />
+
+        <Reveal>
+          <Tabs defaultValue={FEATURE_TABS[0].value} className="gap-8">
+            <TabsList className="mx-auto flex w-full max-w-2xl flex-wrap">
+              {FEATURE_TABS.map((tab) => (
+                <TabsTrigger key={tab.value} value={tab.value}>
+                  <tab.icon />
+                  <span className="hidden sm:inline">{tab.label}</span>
+                  <span className="sm:hidden">{tab.label.split(" ")[0]}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            {FEATURE_TABS.map((tab) => (
+              <TabsContent
+                key={tab.value}
+                value={tab.value}
+                className="data-[state=active]:animate-in data-[state=active]:fade-in-0 data-[state=active]:slide-in-from-bottom-2 data-[state=active]:duration-500"
+              >
+                <div className="mx-auto mb-10 max-w-2xl text-center">
+                  <h3 className="text-2xl font-semibold tracking-tight">
+                    {tab.headline}
+                  </h3>
+                  <p className="text-muted-foreground mt-3 leading-relaxed text-pretty">
+                    {tab.blurb}
+                  </p>
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {tab.features.map((feature) => (
+                    <SpotlightCard key={feature.title} className="h-full">
+                      <div className="group/feature p-6">
+                        <div className="qs-accent-soft mb-4 inline-flex size-10 items-center justify-center rounded-xl border transition-transform duration-300 group-hover/feature:scale-110">
+                          <feature.icon className="size-5" />
+                        </div>
+                        <h4 className="font-semibold">{feature.title}</h4>
+                        <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+                          {feature.description}
+                        </p>
+                      </div>
+                    </SpotlightCard>
+                  ))}
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+        </Reveal>
+      </div>
+    </section>
+  );
+}
+
+function Platforms() {
+  return (
+    <section className="relative px-4 py-20 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <SectionHeading
+          eyebrow="Everywhere"
+          title="Four ways to run it"
+          blurb="Every client talks to the same documented API, so your history, keys, and documents follow you between them."
+        />
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {PLATFORMS.map((platform, index) => {
+            const card = (
+              <SpotlightCard className="h-full">
+                <div className="flex h-full flex-col p-6">
+                  <div className="qs-accent-soft mb-4 inline-flex size-11 items-center justify-center rounded-xl border">
+                    <platform.icon className="size-5" />
+                  </div>
+                  <h3 className="text-lg font-semibold">{platform.name}</h3>
+                  <p className="qs-accent-text mt-0.5 text-xs font-medium tracking-wide uppercase">
+                    {platform.tagline}
+                  </p>
+                  <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
+                    {platform.detail}
+                  </p>
+                </div>
+              </SpotlightCard>
+            );
+
+            return (
+              <Reveal key={platform.name} delay={index * 70}>
+                {platform.href ? (
+                  <Link href={platform.href} className="block h-full">
+                    {card}
+                  </Link>
+                ) : (
+                  card
+                )}
+              </Reveal>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function OpenSource() {
+  return (
+    <section className="relative px-4 py-20 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-6xl">
+        <SectionHeading
+          eyebrow="Open source"
+          title="Built from packages you can use yourself"
+          blurb="The product is a thin shell over a monorepo of standalone, independently published libraries."
+        />
+
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {PACKAGES.map((pkg, index) => (
+            <Reveal key={pkg.name} delay={(index % 3) * 60}>
+              <SpotlightCard beam={false} spotlightSize={280} className="h-full">
+                <div className="p-5">
+                  <code className="qs-accent-text text-sm font-semibold">
+                    {pkg.name}
+                  </code>
+                  <p className="text-muted-foreground mt-1.5 text-sm leading-relaxed">
+                    {pkg.blurb}
+                  </p>
+                </div>
+              </SpotlightCard>
+            </Reveal>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ClosingCta() {
+  return (
+    <section className="relative px-4 pt-10 pb-28 sm:px-6 lg:px-8">
+      <Reveal className="mx-auto max-w-4xl">
+        <div className="qs-border-beam relative isolate overflow-hidden rounded-3xl p-px">
+          <div className="bg-card/90 relative z-10 rounded-[calc(1.5rem-1px)] border px-8 py-14 text-center backdrop-blur-sm">
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 bg-gradient-to-b from-sky-500/10 to-transparent"
+            />
+            <div className="relative">
+              <Pill className="mb-5">
+                <Globe className="size-3.5" />
+                Free to start
+              </Pill>
+              <h2 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl">
+                Ask something you actually need answered
+              </h2>
+              <p className="text-muted-foreground mx-auto mt-4 max-w-xl leading-relaxed text-pretty">
+                No setup, no key required. Bring your own model when you want
+                more control, or self-host the whole stack.
+              </p>
+              <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" className="group">
+                  <Link href="/">
+                    Start researching
+                    <ArrowRight className="transition-transform group-hover:translate-x-0.5" />
+                  </Link>
+                </Button>
+                <Button asChild size="lg" variant="outline">
+                  <Link href="/enterprise">
+                    <Download />
+                    Enterprise & white-label
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </Reveal>
+    </section>
+  );
+}
+
+export function FeaturesView() {
+  return (
+    <div className="qs-features relative min-h-screen md:pl-20">
+      <Hero />
+      <EngineMarquee />
+      <BentoGrid />
+      <Pipeline />
+      <FeatureExplorer />
+      <Platforms />
+      <OpenSource />
+      <ClosingCta />
+    </div>
+  );
+}

--- a/apps/qwksearch-web/components/features/data.tsx
+++ b/apps/qwksearch-web/components/features/data.tsx
@@ -1,0 +1,444 @@
+import {
+  AtSign,
+  BookOpen,
+  Bot,
+  Boxes,
+  Braces,
+  Captions,
+  Clock,
+  Code,
+  Compass,
+  Database,
+  FileSearch,
+  FileText,
+  FolderTree,
+  Globe,
+  GraduationCap,
+  Images,
+  Keyboard,
+  Layers,
+  Lock,
+  MessageCircleQuestionMark,
+  Mic,
+  Monitor,
+  MousePointerClick,
+  Network,
+  Newspaper,
+  PenLine,
+  Puzzle,
+  Quote,
+  Replace,
+  Search,
+  Server,
+  ShieldCheck,
+  Sparkles,
+  Terminal,
+  Upload,
+  Users,
+  Video,
+  Zap,
+} from "lucide-react";
+
+export type Feature = {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+};
+
+export type FeatureTab = {
+  value: string;
+  label: string;
+  icon: React.ElementType;
+  headline: string;
+  blurb: string;
+  features: Feature[];
+};
+
+/** Headline numbers, all drawn from what the monorepo actually ships. */
+export const STATS: { value: number; suffix?: string; label: string }[] = [
+  { value: 100, suffix: "+", label: "Sites searched" },
+  { value: 13, label: "Search categories" },
+  { value: 10, suffix: "+", label: "LLM providers" },
+  { value: 4, label: "Ways to run it" },
+  { value: 20, suffix: "+", label: "Open packages" },
+];
+
+/** Real engine names from `packages/search-web-api/src/sources`. */
+export const ENGINE_NAMES = [
+  "Google",
+  "Bing",
+  "Brave",
+  "DuckDuckGo",
+  "Startpage",
+  "Mojeek",
+  "Qwant",
+  "Yandex",
+  "Baidu",
+  "arXiv",
+  "PubMed",
+  "Semantic Scholar",
+  "OpenAlex",
+  "Crossref",
+  "Google Scholar",
+  "CORE",
+  "DOAJ",
+  "Wikidata",
+  "Wikipedia",
+  "Hacker News",
+  "Google News",
+  "Reddit",
+  "Mastodon",
+  "Medium",
+  "YouTube",
+  "Vimeo",
+  "PeerTube",
+  "Invidious",
+  "Unsplash",
+  "Flickr",
+  "Pixabay",
+  "DeviantArt",
+  "GitHub",
+  "GitLab",
+  "npm",
+  "PyPI",
+  "crates.io",
+  "Docker Hub",
+  "Stack Overflow",
+  "Open Library",
+  "Internet Archive",
+  "IMDb",
+  "Goodreads",
+  "OpenStreetMap",
+];
+
+export const SEARCH_CATEGORIES: { label: string; icon: React.ElementType }[] = [
+  { label: "Web", icon: Globe },
+  { label: "Academic", icon: GraduationCap },
+  { label: "News", icon: Newspaper },
+  { label: "Videos", icon: Video },
+  { label: "Images", icon: Images },
+  { label: "Code & IT", icon: Code },
+  { label: "Social", icon: AtSign },
+  { label: "Files", icon: FileText },
+  { label: "Maps", icon: Compass },
+  { label: "Specialized", icon: Sparkles },
+];
+
+export const PROVIDERS = [
+  "OpenAI",
+  "Anthropic",
+  "Google Gemini",
+  "Vertex AI",
+  "xAI Grok",
+  "Groq",
+  "Amazon Bedrock",
+  "OpenRouter",
+  "Together AI",
+  "Ollama",
+];
+
+/** The five stages a question passes through, end to end. */
+export const PIPELINE: { step: string; title: string; body: string; icon: React.ElementType }[] = [
+  {
+    step: "01",
+    title: "Ask",
+    body: "Type, paste a URL, drop a file, or hold to speak. Autocomplete predicts the next word as you go.",
+    icon: Search,
+  },
+  {
+    step: "02",
+    title: "Search",
+    body: "The query fans out across 100+ engines in 13 categories, deduped and ranked by domain authority.",
+    icon: Network,
+  },
+  {
+    step: "03",
+    title: "Extract",
+    body: "Top results are fetched and parsed — PDFs, YouTube transcripts, and JS-rendered pages included.",
+    icon: FileSearch,
+  },
+  {
+    step: "04",
+    title: "Answer",
+    body: "Your chosen model streams a response grounded in the extracted text, with inline citations.",
+    icon: Bot,
+  },
+  {
+    step: "05",
+    title: "Write",
+    body: "Send quotes, sources, and the answer straight into REASON to build the finished document.",
+    icon: PenLine,
+  },
+];
+
+export const FEATURE_TABS: FeatureTab[] = [
+  {
+    value: "research",
+    label: "Research Agent",
+    icon: Search,
+    headline: "A search engine that reads the results for you",
+    blurb:
+      "The chat surface aggregates every category of the web, previews each source before you open it, and answers with citations you can check.",
+    features: [
+      {
+        icon: Globe,
+        title: "100+ site search",
+        description:
+          "Web, academic, news, video, image, code, social, maps, files, and specialized engines queried in parallel from one box.",
+      },
+      {
+        icon: BookOpen,
+        title: "Article preview & APA citation",
+        description:
+          "Extract, clean, and summarize any article, PDF, or YouTube video — with a formatted citation — before you commit to reading it.",
+      },
+      {
+        icon: Bot,
+        title: "Bring your own model",
+        description:
+          "Claude, GPT, Gemini, Grok, Llama, and more. Swap providers per conversation, or point it at your own key.",
+      },
+      {
+        icon: Upload,
+        title: "Ask your own documents",
+        description:
+          "Upload PDFs, DOCX, Google Docs, URLs, and YouTube links, then ask questions across all of them at once.",
+      },
+      {
+        icon: Clock,
+        title: "History and memory",
+        description:
+          "Every conversation is saved and searchable, with per-user skills and memories — unless privacy mode is on.",
+      },
+      {
+        icon: MessageCircleQuestionMark,
+        title: "Follow-up questions",
+        description:
+          "Generated next questions keep a thread moving instead of leaving you at a blank prompt.",
+      },
+      {
+        icon: Mic,
+        title: "Voice in, voice out",
+        description:
+          "On-device voice activity detection and Kokoro speech synthesis for hands-free research sessions.",
+      },
+      {
+        icon: Lock,
+        title: "Privacy mode",
+        description:
+          "Turn off history entirely, or self-host the whole stack behind your own SearXNG proxy.",
+      },
+    ],
+  },
+  {
+    value: "reason",
+    label: "REASON Editor",
+    icon: PenLine,
+    headline: "Where the research becomes a document",
+    blurb:
+      "A full rich-text editor with a nested document tree, built for annotated summaries in outline notation — not a chat transcript.",
+    features: [
+      {
+        icon: PenLine,
+        title: "Rich text, minimal chrome",
+        description:
+          "A Google Docs–class editor built on Lexical with tables, code blocks, Mermaid diagrams, KaTeX, and slash commands.",
+      },
+      {
+        icon: FolderTree,
+        title: "Nested document tree",
+        description:
+          "Organize notes in a drag-and-drop outline with tabs and custom storage sources.",
+      },
+      {
+        icon: Sparkles,
+        title: "AI rewriting",
+        description:
+          "Rewrite, expand, or tighten any selection in place, using the same providers as the research agent.",
+      },
+      {
+        icon: Quote,
+        title: "Research quotes",
+        description:
+          "Capture key passages from a source with attribution intact and drop them into the outline.",
+      },
+      {
+        icon: FileSearch,
+        title: "Full-text search",
+        description:
+          "Find any document instantly by title or body across your whole tree.",
+      },
+      {
+        icon: Replace,
+        title: "Find & replace",
+        description:
+          "Match highlighting and bulk replace across a document, for when a term changes late.",
+      },
+      {
+        icon: Users,
+        title: "Teams & collaboration",
+        description:
+          "Manage members and access rights, with real-time collaborative editing over Yjs.",
+      },
+      {
+        icon: Layers,
+        title: "Import, export, share",
+        description:
+          "Word, PDF, and Google Docs in and out, plus Formatted, HTML, and Markdown view modes.",
+      },
+      {
+        icon: MousePointerClick,
+        title: "Context menu everywhere",
+        description:
+          "Right-click any node in the tree or the page for the actions that apply to it.",
+      },
+      {
+        icon: Keyboard,
+        title: "Keyboard-first",
+        description:
+          "Shortcuts for navigation, formatting, and document management, in 20+ interface languages.",
+      },
+    ],
+  },
+  {
+    value: "extract",
+    label: "Extraction Engine",
+    icon: FileSearch,
+    headline: "Tractor, the text extractor",
+    blurb:
+      "The hard part of research is getting clean text out of the web. These packages do it in Node, the browser, and on Cloudflare Workers with zero runtime dependencies.",
+    features: [
+      {
+        icon: FileText,
+        title: "PDF → structured HTML",
+        description:
+          "extract-pdf turns a URL or ArrayBuffer into tagged HTML: headings, lists, footnotes, and code blocks preserved.",
+      },
+      {
+        icon: Database,
+        title: "OCR for scanned documents",
+        description:
+          "extract-pdf-docling runs IBM's granite-docling model over layout-heavy PDFs, recovering tables, formulas, and charts.",
+      },
+      {
+        icon: Globe,
+        title: "Readable web pages",
+        description:
+          "extract-webpage strips navigation and ads, then outlines what is left into a citable summary.",
+      },
+      {
+        icon: Captions,
+        title: "YouTube transcripts",
+        description:
+          "extract-youtube pulls subtitles as text, SRT, or WebVTT with no headless browser — fast enough for the edge.",
+      },
+      {
+        icon: Zap,
+        title: "JS-rendered pages",
+        description:
+          "render-url-to-html falls back through Cloudflare Browser Rendering, stealth Puppeteer, and JSDOM until the DOM resolves.",
+      },
+      {
+        icon: ShieldCheck,
+        title: "Source ranking",
+        description:
+          "domain-rank scores every result against Tranco and CommonCrawl backlink data, with human-readable labels and favicons.",
+      },
+    ],
+  },
+  {
+    value: "platform",
+    label: "Apps & API",
+    icon: Boxes,
+    headline: "Same engine, wherever you work",
+    blurb:
+      "The web app is one client of a documented API. Desktop, browser, editor, and agent clients all speak to it.",
+    features: [
+      {
+        icon: Monitor,
+        title: "Desktop app",
+        description:
+          "A Tauri build that lets you select text anywhere on screen and press ` to search without leaving your workflow.",
+      },
+      {
+        icon: Puzzle,
+        title: "Browser extension",
+        description:
+          "Tab Manager AI organizes, searches, and closes tabs intelligently, backed by the same research agent.",
+      },
+      {
+        icon: Terminal,
+        title: "VS Code extension",
+        description:
+          "Ask cited research questions from an editor sidebar, signed in with your API key or as a guest.",
+      },
+      {
+        icon: Server,
+        title: "MCP server",
+        description:
+          "Expose search, extraction, and memory as Model Context Protocol tools to any MCP-aware agent.",
+      },
+      {
+        icon: Braces,
+        title: "Typed API client",
+        description:
+          "qwksearch-api-client is generated from the OpenAPI spec, so every endpoint arrives fully typed.",
+      },
+      {
+        icon: Boxes,
+        title: "Agent toolkit",
+        description:
+          "chat-agent-toolkit orchestrates providers, tools, and memory over the Vercel AI SDK, Mastra, and MCP.",
+      },
+    ],
+  },
+];
+
+export const PLATFORMS: {
+  icon: React.ElementType;
+  name: string;
+  tagline: string;
+  detail: string;
+  href?: string;
+}[] = [
+  {
+    icon: Globe,
+    name: "Web",
+    tagline: "Next.js on Cloudflare Workers",
+    detail: "The full research agent and REASON editor in the browser, no install.",
+    href: "/",
+  },
+  {
+    icon: Monitor,
+    name: "Desktop",
+    tagline: "Tauri",
+    detail: "Select text anywhere, press ` , get an answer over whatever you were doing.",
+  },
+  {
+    icon: Puzzle,
+    name: "Browser",
+    tagline: "Tab Manager AI",
+    detail: "An extension that turns a wall of open tabs into an organized reading queue.",
+  },
+  {
+    icon: Terminal,
+    name: "Editor",
+    tagline: "VS Code",
+    detail: "Cited answers in a sidebar, next to the code that raised the question.",
+  },
+];
+
+export const PACKAGES: { name: string; blurb: string }[] = [
+  { name: "search-web-api", blurb: "70+ engines across 13 categories behind one Hono API." },
+  { name: "extract-webpage", blurb: "Search, extract, cite, and outline any page." },
+  { name: "extract-pdf", blurb: "PDF to structural HTML, zero runtime deps." },
+  { name: "extract-youtube", blurb: "Serverless transcript extraction, no browser." },
+  { name: "render-url-to-html", blurb: "Stealth rendering strategies for stubborn pages." },
+  { name: "chat-agent-toolkit", blurb: "Multi-provider agent loop with tools and memory." },
+  { name: "write-language", blurb: "One interface over 10+ LLM providers." },
+  { name: "domain-rank", blurb: "Tranco + CommonCrawl authority for any domain." },
+  { name: "reason-editor", blurb: "The Lexical editor, documents manager, and outlines." },
+  { name: "research-agent-ui", blurb: "The whole chat UI, droppable into any Next.js app." },
+  { name: "shadcn-app-dock", blurb: "macOS-style dock with a shadcn theme switcher." },
+  { name: "qwksearch-api-client", blurb: "Typed bindings generated from the OpenAPI spec." },
+];

--- a/apps/qwksearch-web/components/features/effects.tsx
+++ b/apps/qwksearch-web/components/features/effects.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared visual primitives for the marketing surfaces (/features).
+ *
+ * These are deliberately dependency-free (CSS + IntersectionObserver only) so
+ * they can be dropped into any page without pulling an animation runtime into
+ * the bundle. Keyframes live in `app/globals.css` under "Marketing page
+ * effects".
+ */
+
+/** Fades + lifts children into view the first time they intersect. */
+export function Reveal({
+  children,
+  delay = 0,
+  className,
+  as: Tag = "div",
+}: {
+  children: React.ReactNode;
+  /** Stagger, in ms. */
+  delay?: number;
+  className?: string;
+  as?: React.ElementType;
+}) {
+  const ref = React.useRef<HTMLElement | null>(null);
+  const [shown, setShown] = React.useState(false);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el || shown) return;
+
+    // No IntersectionObserver (older browsers, some test envs) → show at once.
+    if (typeof IntersectionObserver === "undefined") {
+      setShown(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setShown(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "0px 0px -12% 0px", threshold: 0.05 },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [shown]);
+
+  return (
+    <Tag
+      ref={ref}
+      data-qs-reveal={shown ? "shown" : "hidden"}
+      style={{ "--qs-reveal-delay": `${delay}ms` } as React.CSSProperties}
+      className={className}
+    >
+      {children}
+    </Tag>
+  );
+}
+
+/**
+ * Card that tracks the cursor with a soft radial highlight, plus an optional
+ * rotating conic border beam on hover.
+ */
+export function SpotlightCard({
+  children,
+  className,
+  beam = true,
+  spotlightSize = 420,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  /** Rotating gradient border on hover. */
+  beam?: boolean;
+  /** Radius of the cursor highlight, in px. */
+  spotlightSize?: number;
+}) {
+  const ref = React.useRef<HTMLDivElement>(null);
+  const [spot, setSpot] = React.useState({ x: 0, y: 0, on: false });
+
+  const handleMove = (event: React.MouseEvent<HTMLDivElement>) => {
+    const rect = ref.current?.getBoundingClientRect();
+    if (!rect) return;
+    setSpot({
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+      on: true,
+    });
+  };
+
+  return (
+    <div
+      ref={ref}
+      onMouseMove={handleMove}
+      onMouseEnter={() => setSpot((s) => ({ ...s, on: true }))}
+      onMouseLeave={() => setSpot((s) => ({ ...s, on: false }))}
+      className={cn(
+        "group/spotlight relative isolate overflow-hidden rounded-2xl p-px",
+        beam && "qs-border-beam",
+        className,
+      )}
+    >
+      <div className="bg-card/80 relative z-10 h-full rounded-[calc(1rem-1px)] border backdrop-blur-sm transition-colors duration-300 group-hover/spotlight:border-transparent">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 rounded-[inherit] transition-opacity duration-300"
+          style={{
+            opacity: spot.on ? 1 : 0,
+            background: `radial-gradient(${spotlightSize}px circle at ${spot.x}px ${spot.y}px, color-mix(in oklab, var(--qs-accent, var(--primary)) 16%, transparent), transparent 60%)`,
+          }}
+        />
+        <div className="relative h-full">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+/** Full-bleed backdrop: grid lines, radial mask, and drifting aurora blobs. */
+export function AuroraBackdrop({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden
+      className={cn("pointer-events-none absolute inset-0 -z-10 overflow-hidden", className)}
+    >
+      <div className="bg-background absolute inset-0" />
+      <div
+        className="absolute inset-0 opacity-[0.35] [mask-image:radial-gradient(ellipse_75%_55%_at_50%_0%,#000,transparent)]"
+        style={{
+          backgroundImage:
+            "linear-gradient(to right, var(--border) 1px, transparent 1px), linear-gradient(to bottom, var(--border) 1px, transparent 1px)",
+          backgroundSize: "56px 56px",
+        }}
+      />
+      <div className="qs-aurora-blob absolute -top-40 left-1/4 h-[32rem] w-[32rem] rounded-full bg-sky-500/25 blur-[120px]" />
+      <div
+        className="qs-aurora-blob absolute -top-24 right-1/5 h-[26rem] w-[26rem] rounded-full bg-sky-500/20 blur-[120px]"
+        style={{ animationDelay: "-6s" }}
+      />
+      <div
+        className="qs-aurora-blob absolute top-40 left-0 h-[22rem] w-[22rem] rounded-full bg-violet-500/15 blur-[110px]"
+        style={{ animationDelay: "-12s" }}
+      />
+    </div>
+  );
+}
+
+/** Infinite horizontal ticker. Duplicates its children to loop seamlessly. */
+export function Marquee({
+  children,
+  durationSeconds = 40,
+  reverse = false,
+  className,
+}: {
+  children: React.ReactNode;
+  durationSeconds?: number;
+  reverse?: boolean;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "qs-marquee group relative flex overflow-hidden [mask-image:linear-gradient(to_right,transparent,#000_12%,#000_88%,transparent)]",
+        className,
+      )}
+    >
+      <div
+        className="qs-marquee-track flex w-max shrink-0 items-center gap-3 pr-3"
+        style={
+          {
+            "--qs-marquee-duration": `${durationSeconds}s`,
+            "--qs-marquee-gap": "0.75rem",
+            animationDirection: reverse ? "reverse" : "normal",
+          } as React.CSSProperties
+        }
+      >
+        {children}
+        <span aria-hidden className="contents">
+          {children}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/** Counts up to `value` once scrolled into view. */
+export function CountUp({
+  value,
+  durationMs = 1200,
+  className,
+}: {
+  value: number;
+  durationMs?: number;
+  className?: string;
+}) {
+  const ref = React.useRef<HTMLSpanElement>(null);
+  const [display, setDisplay] = React.useState(0);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    let frame = 0;
+    const run = () => {
+      const start = performance.now();
+      const tick = (now: number) => {
+        const progress = Math.min((now - start) / durationMs, 1);
+        // easeOutCubic — fast start, soft landing on the final number.
+        setDisplay(Math.round(value * (1 - Math.pow(1 - progress, 3))));
+        if (progress < 1) frame = requestAnimationFrame(tick);
+      };
+      frame = requestAnimationFrame(tick);
+    };
+
+    if (typeof IntersectionObserver === "undefined") {
+      setDisplay(value);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          observer.disconnect();
+          run();
+        }
+      },
+      { threshold: 0.4 },
+    );
+
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(frame);
+    };
+  }, [value, durationMs]);
+
+  return (
+    <span ref={ref} className={className}>
+      {display}
+    </span>
+  );
+}
+
+/** Small pill used for section eyebrows and chips. */
+export function Pill({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        "qs-accent-soft inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-medium",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/qwksearch-web/components/ui/badge.tsx
+++ b/apps/qwksearch-web/components/ui/badge.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center justify-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-colors focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] [&_svg]:pointer-events-none [&_svg]:size-3 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground border-transparent",
+        secondary: "bg-secondary text-secondary-foreground border-transparent",
+        destructive: "bg-destructive border-transparent text-white",
+        outline: "text-foreground",
+        soft: "border-primary/25 bg-primary/10 text-primary",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends React.ComponentProps<"span">,
+    VariantProps<typeof badgeVariants> {
+  asChild?: boolean;
+}
+
+function Badge({ className, variant, asChild = false, ...props }: BadgeProps) {
+  const Comp = asChild ? Slot : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/qwksearch-web/components/ui/tabs.tsx
+++ b/apps/qwksearch-web/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+
+import { cn } from "../../lib/utils";
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex w-fit items-center justify-center rounded-xl p-[3px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 inline-flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-lg border border-transparent px-3 py-1.5 text-sm font-medium whitespace-nowrap transition-all focus-visible:ring-[3px] focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/qwksearch-web/lib/config/site.ts
+++ b/apps/qwksearch-web/lib/config/site.ts
@@ -50,6 +50,7 @@ export const listFooterLinks: FooterLink[] = [
     text: "Support",
     icon: "MessageCircle",
   },
+  { url: "/features", text: "Features", icon: "Sparkles" },
   { url: "/#downloads", text: "Downloads", icon: "Download" },
   { url: "/legal/privacy", text: "Privacy", icon: "Lock" },
   { url: "https://rights.institute/ethics", text: "Ethics", icon: "Bot" },

--- a/bun.lock
+++ b/bun.lock
@@ -239,7 +239,7 @@
     },
     "packages/chat-agent-toolkit": {
       "name": "chat-agent-toolkit",
-      "version": "1.2.248",
+      "version": "1.2.273",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.0",
         "@ai-sdk/google": "^2.0.0",
@@ -287,7 +287,7 @@
     },
     "packages/domain-rank": {
       "name": "domain-rank",
-      "version": "0.1.237",
+      "version": "0.1.262",
       "dependencies": {
         "fuse.js": "^7.1.0",
         "grab-url": "^1.6.19",
@@ -306,7 +306,7 @@
     },
     "packages/extract-pdf": {
       "name": "extract-pdf",
-      "version": "0.1.235",
+      "version": "0.1.260",
       "devDependencies": {
         "terser": "^5.46.0",
         "typescript": "^5.9.3",
@@ -320,7 +320,7 @@
     },
     "packages/extract-pdf-docling": {
       "name": "pdf-to-html-docling",
-      "version": "1.0.235",
+      "version": "1.0.260",
       "dependencies": {
         "@hono/node-server": "^1.8.2",
         "@hono/swagger-ui": "^0.2.1",
@@ -336,7 +336,7 @@
     },
     "packages/extract-webpage": {
       "name": "extract-webpage",
-      "version": "1.2.248",
+      "version": "1.2.270",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "ai": "^5.0.0",
@@ -385,7 +385,7 @@
     },
     "packages/extract-youtube": {
       "name": "extract-youtube",
-      "version": "1.0.234",
+      "version": "1.0.256",
       "bin": "dist/cli.js",
       "dependencies": {
         "fast-xml-parser": "^4.2.5",
@@ -406,7 +406,7 @@
     },
     "packages/html-renderer-api": {
       "name": "html-renderer-api",
-      "version": "1.0.118",
+      "version": "1.0.140",
       "dependencies": {
         "@cloudflare/puppeteer": "*",
       },
@@ -417,7 +417,7 @@
     },
     "packages/notebooklm-api-client": {
       "name": "notebooklm-api-client",
-      "version": "0.1.190",
+      "version": "0.1.212",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.0.0",
       },
@@ -431,7 +431,7 @@
     },
     "packages/qwksearch-api-client": {
       "name": "qwksearch-api-client",
-      "version": "0.9.195",
+      "version": "0.9.217",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.88.0",
@@ -445,7 +445,7 @@
     },
     "packages/qwksearch-mcp-server": {
       "name": "qwksearch-mcp-server",
-      "version": "1.0.82",
+      "version": "1.0.104",
       "bin": {
         "qwksearch-mcp": "./bin/qwksearch-mcp.ts",
       },
@@ -462,7 +462,7 @@
     },
     "packages/react-weather-forecast": {
       "name": "use-weather-forecast",
-      "version": "0.1.65",
+      "version": "0.1.87",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250115.0",
         "@testing-library/react": "^16.1.0",
@@ -485,7 +485,7 @@
     },
     "packages/reason-editor": {
       "name": "react-reason-editor",
-      "version": "1.0.53",
+      "version": "1.0.75",
       "dependencies": {
         "@ariakit/react": "^0.4.37",
         "@emoji-mart/data": "1.2.1",
@@ -782,7 +782,7 @@
     },
     "packages/research-agent-ui": {
       "name": "research-agent-ui",
-      "version": "0.1.120",
+      "version": "0.1.142",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@radix-ui/react-dialog": "^1.1.16",
@@ -852,7 +852,7 @@
     },
     "packages/search-web-api": {
       "name": "search-web-api",
-      "version": "1.0.103",
+      "version": "1.0.125",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@scalar/hono-api-reference": "^0.9.26",
@@ -872,7 +872,7 @@
     },
     "packages/shadcn-app-dock": {
       "name": "shadcn-app-dock",
-      "version": "0.1.105",
+      "version": "0.1.127",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@radix-ui/react-slot": "^1.2.5",
@@ -957,7 +957,7 @@
     },
     "packages/use-voice-control": {
       "name": "use-voice-control",
-      "version": "0.1.64",
+      "version": "0.1.86",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@moonshine-ai/moonshine-js": "^0.1.29",
@@ -985,7 +985,7 @@
     },
     "packages/write-language": {
       "name": "write-language",
-      "version": "0.1.122",
+      "version": "0.1.144",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^3.0.0",
         "@ai-sdk/anthropic": "^2.0.0",


### PR DESCRIPTION
Adds a homepage-style features route that walks the whole product: a hero with an aurora/grid backdrop and animated counters, a scrolling marquee of the real engine names from search-web-api, a bento grid of the flagship capabilities, the five-stage ask -> search -> extract -> answer -> write pipeline, a tabbed explorer covering the research agent, REASON editor, extraction packages, and the desktop/browser/IDE clients, plus an open-source package grid and a closing CTA.

- app/features/page.tsx: server route carrying page metadata.
- components/features/FeaturesView.tsx: the page composition.
- components/features/data.tsx: copy and lists, sourced from the packages themselves rather than invented.
- components/features/effects.tsx: dependency-free effect primitives (scroll reveal, cursor spotlight card with a conic border beam, aurora backdrop, marquee, count-up) built on IntersectionObserver and CSS only.
- components/ui/tabs.tsx, components/ui/badge.tsx: shadcn primitives the app was missing; @radix-ui/react-tabs was already a dependency.
- globals.css: keyframes for the above, plus a page-scoped accent token so the effects stay colorful under the neutral default palette.
- site.ts: link the page from the footer nav.

Also syncs bun.lock with the workspace package versions bumped in b07dd78, which left `bun install --frozen-lockfile` failing in CI.