### PR TITLE
Add uptime status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg" alt="Coverage" /></a>
     <a href="https://www.npmjs.com/package/qwksearch-api-client"><img src="https://img.shields.io/npm/v/qwksearch-api-client.svg" alt="npm version"></a>
     <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
+    <a href="https://stats.uptimerobot.com/wgqOZtDv0i"><img src="https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white" alt="Uptime Status" /></a>
     <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"
             alt="PRs Welcome" /></a>
     <br />


### PR DESCRIPTION
## Summary
- Add an "Uptime Status" badge to the README badge row, linking to the project's existing [UptimeRobot status page](https://stats.uptimerobot.com/wgqOZtDv0i) (already referenced as a footer link in the web app's site config).

## Test plan
- Visually verified the badge markup follows the same `<a><img></a>` pattern as the other badges in the README.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UsPchGfmWViPZ1PPXZJ73D)_