### PR TITLE
Add voice dictation and document sidebar to Reason Editor

### DIFF
--- a/apps/qwksearch-web/app/docs/demo/[documentId]/page.tsx
+++ b/apps/qwksearch-web/app/docs/demo/[documentId]/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * `/docs/demo/:id` — a document id with no engine specified. Plate is the
+ * default Reason Editor engine, so this redirects there; the Tiptap control
+ * version stays reachable at `/docs/demo/tiptap/:id`.
+ */
+export default async function DemoDocumentPage({
+  params,
+}: {
+  params: Promise<{ documentId: string }>;
+}) {
+  const { documentId } = await params;
+
+  redirect(`/docs/demo/plate/${documentId}`);
+}

--- a/apps/qwksearch-web/app/docs/demo/page.tsx
+++ b/apps/qwksearch-web/app/docs/demo/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from 'next/navigation';
+
+/**
+ * `/docs/demo` — no document specified. Plate is the default Reason Editor
+ * engine (see the module comment in `react-reason-editor/docs-agent`), so this
+ * bounces to a scratch document on it; the Tiptap control version stays
+ * reachable at `/docs/demo/tiptap/:id`, one click away via the engine switcher
+ * in `DemoShell`.
+ */
+export default function DemoIndexPage() {
+  redirect('/docs/demo/plate/default');
+}

--- a/apps/qwksearch-web/components/reason-demo/DemoShell.tsx
+++ b/apps/qwksearch-web/components/reason-demo/DemoShell.tsx
@@ -1,16 +1,21 @@
 /**
- * Chrome shared by both demo routes: the document title, the engine switcher,
- * and the collaboration status line. Deliberately thin — everything that is
- * part of the *editor* (toolbar included) comes from
+ * Chrome shared by both demo routes: the document sidebar, the title, the
+ * engine switcher, and the collaboration status line. Deliberately thin —
+ * everything that is part of the *editor* (toolbar included) comes from
  * `react-reason-editor/docs-agent`, so the only visible difference between the
- * two routes is the editor itself.
+ * two routes is the editor itself. The sidebar is the same
+ * `react-reason-editor/docs-agent` `ReasonSidebar` mounted here rather than
+ * inside either editor, so switching engines never remounts it.
  */
 
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import type { ReactNode } from 'react';
+
+import { ReasonSidebar } from 'react-reason-editor/docs-agent';
 
 export function DemoShell({
   children,
@@ -25,6 +30,7 @@ export function DemoShell({
   title: string;
   collaborative: boolean;
 }) {
+  const router = useRouter();
   const other = engine === 'tiptap' ? 'plate' : 'tiptap';
 
   return (
@@ -46,7 +52,14 @@ export function DemoShell({
           Open {other} version
         </Link>
       </header>
-      <main className="min-h-0 flex-1">{children}</main>
+      <div className="flex min-h-0 flex-1">
+        <ReasonSidebar
+          activeDocumentId={documentId}
+          linkForDocument={(id) => `/docs/demo/${engine}/${id}`}
+          onNavigate={(id) => router.push(`/docs/demo/${engine}/${id}`)}
+        />
+        <main className="min-h-0 flex-1">{children}</main>
+      </div>
     </div>
   );
 }

--- a/packages/reason-editor/src/docs-agent.ts
+++ b/packages/reason-editor/src/docs-agent.ts
@@ -9,10 +9,16 @@
  *
  * Both render the same `REASON_TOOLBAR` schema through the same
  * `ReasonToolbar` renderer, and differ only in which `EditorToolbarAdapter`
- * they hand it. Their Yjs rooms are namespaced per engine
- * (`reason-editor:<engine>:<documentId>`) because a ProseMirror document and a
- * Slate document are not interchangeable; they stay separate until there is an
- * explicit conversion/export pipeline.
+ * they hand it — including the dictation button (`transcribe`), the
+ * voice-commands plugin ported from the Tiptap side's `Transcribe` extension to
+ * a new Plate plugin in `./docs-agent/plate/transcribe-controller.ts`. Their
+ * Yjs rooms are namespaced per engine (`reason-editor:<engine>:<documentId>`)
+ * because a ProseMirror document and a Slate document are not interchangeable;
+ * they stay separate until there is an explicit conversion/export pipeline.
+ *
+ * `ReasonSidebar` (from `./docs-agent/shared`) is the third shared plugin: the
+ * document navigation list both routes mount around their editor, backed by
+ * the same document store the production file-tree uses.
  */
 
 export {
@@ -32,6 +38,16 @@ export {
   ReasonToolbar,
   type ReasonToolbarProps,
 } from './docs-agent/shared/toolbar-renderer';
+export { ReasonSidebar, type ReasonSidebarProps } from './docs-agent/shared/Sidebar';
+export {
+  createSidebarDocument,
+  deleteSidebarDocument,
+  listSidebarDocuments,
+  renameSidebarDocument,
+  subscribeSidebarDocuments,
+  SIDEBAR_DOCUMENTS_STORAGE_KEY,
+  type SidebarDocument,
+} from './docs-agent/shared/sidebar-store';
 
 export {
   collaborationRoom,

--- a/packages/reason-editor/src/docs-agent/plate/kits/transcribe-kit.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/kits/transcribe-kit.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { createPlatePlugin } from 'platejs/react';
+
+/**
+ * Registers the dictation plugin's presence so `hasPlugin(editor, 'transcribe')`
+ * agrees with the Tiptap side's `hasExtension(editor, 'transcribe')`. The
+ * actual recognizer/document logic lives in `../transcribe-controller.ts`,
+ * keyed off the editor instance rather than this plugin's own options, since it
+ * has to interleave with `HistoryEditor.withoutSaving` the same way the Tiptap
+ * extension interleaves with ProseMirror's `addToHistory` transaction meta.
+ */
+export const TranscribeKit = [createPlatePlugin({ key: 'transcribe' })];

--- a/packages/reason-editor/src/docs-agent/plate/plate-adapter.ts
+++ b/packages/reason-editor/src/docs-agent/plate/plate-adapter.ts
@@ -19,6 +19,7 @@ import {
   isPlateCommandActive,
   isPlateCommandEnabled,
 } from './toolbar-actions';
+import { getTranscribeController } from './transcribe-controller';
 
 export function createPlateAdapter(editor: PlateEditor): EditorToolbarAdapter {
   return {
@@ -29,6 +30,12 @@ export function createPlateAdapter(editor: PlateEditor): EditorToolbarAdapter {
     },
 
     isActive(command: ToolbarCommand) {
+      // Dictation is a mic state, not a selection-dependent mark/block — it can
+      // be toggled (and stay on) before the editor ever has a selection.
+      if (command === 'transcribe') {
+        return getTranscribeController(editor).getState().listening;
+      }
+
       // A Plate editor with no selection cannot report block/mark state; the
       // toolbar treats that as "nothing active", matching Tiptap's behaviour.
       if (!editor.selection) return false;
@@ -78,8 +85,15 @@ export function createPlateAdapter(editor: PlateEditor): EditorToolbarAdapter {
         });
       }) as typeof editor.apply;
 
+      // The mic starting/stopping doesn't always go through `apply` (the
+      // listening flag flips from the recognizer's own async callback), so the
+      // toolbar needs a second feed to reflect it promptly — same reasoning as
+      // the Tiptap adapter's `subscribeTranscribe` hookup.
+      const unsubscribeTranscribe = getTranscribeController(editor).subscribe(listener);
+
       return () => {
         editor.apply = previousApply;
+        unsubscribeTranscribe();
       };
     },
   };

--- a/packages/reason-editor/src/docs-agent/plate/plate-editor-config.ts
+++ b/packages/reason-editor/src/docs-agent/plate/plate-editor-config.ts
@@ -48,6 +48,7 @@ import { SlashKit } from './kits/slash-kit';
 import { TableKit } from './kits/table-kit';
 import { TocKit } from './kits/toc-kit';
 import { ToggleKit } from './kits/toggle-kit';
+import { TranscribeKit } from './kits/transcribe-kit';
 import { AudioElement } from './ui/media-audio-node';
 import { MediaEmbedElement } from './ui/media-embed-node';
 import { FileElement } from './ui/media-file-node';
@@ -113,6 +114,9 @@ export const platePlugins = [
   ...ExitBreakKit,
   ...BlockPlaceholderKit,
   ...MarkdownKit,
+
+  // 8. Voice commands — the Dictate toggle at the end of the toolbar.
+  ...TranscribeKit,
 ];
 
 /** A single empty paragraph — what a brand-new document starts from. */

--- a/packages/reason-editor/src/docs-agent/plate/toolbar-actions.ts
+++ b/packages/reason-editor/src/docs-agent/plate/toolbar-actions.ts
@@ -35,6 +35,8 @@ import {
 import { KEYS } from 'platejs';
 import type { PlateEditor } from 'platejs/react';
 
+import { getTranscribeController, isTranscriptionSupported } from './transcribe-controller';
+
 import type { ToolbarCommand, ToolbarCommandPayload } from '../shared/editor-types';
 
 /** Shared toolbar command → Plate mark key. */
@@ -136,6 +138,8 @@ function requiredPlugin(command: ToolbarCommand): string | undefined {
       return KEYS.callout;
     case 'columns':
       return KEYS.columnGroup;
+    case 'transcribe':
+      return 'transcribe';
     case 'emoji':
       return KEYS.emoji;
     case 'code-block':
@@ -314,6 +318,10 @@ export function executePlateCommand(
       insertColumnGroup(editor, { columns: 2, select: true });
       return;
 
+    case 'transcribe':
+      getTranscribeController(editor).toggle();
+      return;
+
     case 'indent':
       indent(editor);
       return;
@@ -380,6 +388,7 @@ export function isPlateCommandActive(editor: PlateEditor, command: ToolbarComman
   if (command === 'callout') return editor.api.some({ match: { type: KEYS.callout } });
   if (command === 'columns') return editor.api.some({ match: { type: KEYS.column } });
   if (command === 'link') return editor.api.some({ match: { type: KEYS.link } });
+  if (command === 'transcribe') return getTranscribeController(editor).getState().listening;
 
   const alignment = ALIGNMENT_BY_COMMAND[command];
   if (alignment) {
@@ -395,6 +404,9 @@ export function isPlateCommandEnabled(editor: PlateEditor, command: ToolbarComma
 
   if (command === 'undo') return editor.history.undos.length > 0;
   if (command === 'redo') return editor.history.redos.length > 0;
+  if (command === 'transcribe') {
+    return isTranscriptionSupported() && !editor.api.isReadOnly?.();
+  }
 
   // Table operations only apply inside a table — the same rule the Tiptap
   // adapter enforces via `editor.isActive('table')`.

--- a/packages/reason-editor/src/docs-agent/plate/transcribe-controller.ts
+++ b/packages/reason-editor/src/docs-agent/plate/transcribe-controller.ts
@@ -1,0 +1,245 @@
+/**
+ * Dictation for the Plate editor — the voice-commands plugin, ported from the
+ * Tiptap side's `src/extensions/Transcribe/Transcribe.ts`. Same contract, same
+ * `use-voice-control` engine underneath; only the document API differs, because
+ * Slate has no ProseMirror-style transaction metadata to opt a write out of
+ * history. Read `Transcribe.ts`'s doc comment first — this mirrors its design
+ * decisions (interim text kept out of undo, one committed insertion per phrase)
+ * point for point.
+ *
+ * Point/range lookups (`editor.api.before/end/string`) and the undo-history
+ * escape hatch (`editor.tf.withoutSaving`) both go through Plate's own
+ * `@platejs/slate` API rather than the `slate`/`slate-history` packages
+ * directly: Plate layers its own history implementation over Slate's (see
+ * `@platejs/slate`'s `HistoryApi`), so the real `slate-history` package's
+ * `HistoryEditor.withoutSaving` — the ProseMirror side's equivalent would be
+ * `tr.setMeta('addToHistory', false)` — has no effect on a Plate editor; only
+ * `editor.tf.withoutSaving` does. `Range.end` is the one exception: `RangeApi`
+ * spreads `slate`'s `Range` verbatim, so importing it directly is equivalent
+ * and there is no `editor.api` wrapper for it.
+ */
+
+import { Range, type Point } from 'slate';
+import {
+  LiveTranscriber,
+  isTranscriptionSupported,
+  type TranscriberEngine,
+} from 'use-voice-control/client';
+
+import type { PlateEditor } from 'platejs/react';
+
+export { isTranscriptionSupported };
+
+export interface TranscribeControllerOptions {
+  /** Which recognizer to use: browser-native, on-device Moonshine, or auto. */
+  engine?: TranscriberEngine;
+  /** BCP-47 language tag for the browser recognizer. */
+  language?: string;
+  /** Moonshine model name, used when that engine is selected. */
+  model?: string;
+}
+
+export interface TranscribeState {
+  listening: boolean;
+  /** The phrase currently being spoken; empty between phrases. */
+  partial: string;
+  /** The most recent thing heard, partial or settled. */
+  lastPhrase: string;
+  /** Increments on every `lastPhrase` update so repeats still re-trigger the UI. */
+  phraseId: number;
+  error: Error | null;
+}
+
+export interface TranscribeController {
+  start(): void;
+  stop(): void;
+  toggle(): void;
+  getState(): TranscribeState;
+  subscribe(listener: () => void): () => void;
+}
+
+/** In-progress phrase's document range, plus the leading space it was given. */
+interface InterimRange {
+  anchor: Point;
+  focus: Point;
+  prefix: string;
+}
+
+const controllers = new WeakMap<PlateEditor, TranscribeController>();
+
+/** A phrase starting straight after a word needs a space in front of it. */
+function needsLeadingSpace(editor: PlateEditor, point: Point): boolean {
+  const before = editor.api.before(point, { unit: 'character' });
+  if (!before) return false;
+
+  const text = editor.api.string({ anchor: before, focus: point });
+  return text.length > 0 && !/\s/.test(text);
+}
+
+function currentPoint(editor: PlateEditor): Point {
+  if (editor.selection) return Range.end(editor.selection);
+  return editor.api.end([]);
+}
+
+/** Writes and history-tracking follow `Transcribe.ts`'s `writeInterim`/`commitPhrase`. */
+function createController(
+  editor: PlateEditor,
+  options: TranscribeControllerOptions,
+): TranscribeController {
+  const state: TranscribeState = {
+    listening: false,
+    partial: '',
+    lastPhrase: '',
+    phraseId: 0,
+    error: null,
+  };
+
+  const listeners = new Set<() => void>();
+  const notify = () => listeners.forEach((listener) => listener());
+
+  let interim: InterimRange | null = null;
+  let transcriber: LiveTranscriber | null = null;
+
+  /** Removes the stored interim range from the document without touching history. */
+  function clearInterim(): void {
+    if (!interim) return;
+    const range = { anchor: interim.anchor, focus: interim.focus };
+    interim = null;
+
+    editor.tf.withoutSaving(() => {
+      editor.tf.select(range);
+      editor.tf.delete();
+    });
+  }
+
+  /** Rewrites the in-progress phrase at the cursor, replacing whatever it wrote last. */
+  function writeInterim(text: string): void {
+    editor.tf.withoutSaving(() => {
+      const at = interim ? interim.anchor : currentPoint(editor);
+      const prefix = interim ? interim.prefix : needsLeadingSpace(editor, at) ? ' ' : '';
+
+      if (interim) {
+        editor.tf.select({ anchor: interim.anchor, focus: interim.focus });
+        editor.tf.delete();
+      }
+
+      if (!text) {
+        interim = null;
+        return;
+      }
+
+      editor.tf.select(at);
+      editor.tf.insertText(`${prefix}${text}`);
+
+      const end = editor.selection ? Range.end(editor.selection) : at;
+      interim = { anchor: at, focus: end, prefix };
+    });
+  }
+
+  /** Replaces the in-progress phrase with the settled one, recorded as one undo step. */
+  function commitPhrase(text: string): void {
+    const existing = interim;
+    interim = null;
+
+    const at = existing
+      ? existing.anchor
+      : currentPoint(editor);
+    const prefix = existing ? existing.prefix : needsLeadingSpace(editor, at) ? ' ' : '';
+
+    if (existing) {
+      editor.tf.withoutSaving(() => {
+        editor.tf.select({ anchor: existing.anchor, focus: existing.focus });
+        editor.tf.delete();
+      });
+    }
+
+    editor.tf.select(at);
+    editor.tf.insertText(`${prefix}${text} `);
+  }
+
+  /** Built lazily so the recognizer is never asked for a microphone until dictation starts. */
+  function ensureTranscriber(): LiveTranscriber {
+    if (transcriber) return transcriber;
+
+    transcriber = new LiveTranscriber({
+      engine: options.engine ?? 'auto',
+      language: options.language ?? 'en-US',
+      model: options.model ?? 'model/small',
+      onStateChange: (listening) => {
+        state.listening = listening;
+        notify();
+      },
+      onPartial: (text) => {
+        state.partial = text;
+        if (text) {
+          state.lastPhrase = text;
+          state.phraseId += 1;
+        }
+        writeInterim(text);
+        notify();
+      },
+      onCommit: (text) => {
+        state.partial = '';
+        state.lastPhrase = text;
+        state.phraseId += 1;
+        commitPhrase(text);
+        notify();
+      },
+      onError: (error) => {
+        state.error = error;
+        notify();
+      },
+    });
+
+    return transcriber;
+  }
+
+  function start(): void {
+    const t = ensureTranscriber();
+    if (t.isListening()) return;
+
+    state.error = null;
+    if (!editor.selection) editor.tf.focus();
+    void t.start();
+  }
+
+  function stop(): void {
+    if (!transcriber) return;
+    void transcriber.stop();
+
+    // Drop the half-heard phrase rather than leaving a guess in the text.
+    clearInterim();
+    state.partial = '';
+    notify();
+  }
+
+  function toggle(): void {
+    if (transcriber?.isListening()) stop();
+    else start();
+  }
+
+  return {
+    start,
+    stop,
+    toggle,
+    getState: () => state,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+/** One controller per editor instance, created on first use and cached for its lifetime. */
+export function getTranscribeController(
+  editor: PlateEditor,
+  options: TranscribeControllerOptions = {},
+): TranscribeController {
+  let controller = controllers.get(editor);
+  if (!controller) {
+    controller = createController(editor, options);
+    controllers.set(editor, controller);
+  }
+
+  return controller;
+}

--- a/packages/reason-editor/src/docs-agent/shared/Sidebar.tsx
+++ b/packages/reason-editor/src/docs-agent/shared/Sidebar.tsx
@@ -1,0 +1,173 @@
+/**
+ * The Reason Editor's document navigation sidebar — engine-neutral and shared
+ * by both routes exactly like `ReasonToolbar`: this file imports neither
+ * Tiptap nor Plate, and renders identically regardless of which one is
+ * mounted next to it. It lists the documents `sidebar-store.ts` reads from the
+ * production file-tree's own storage, with inline create/rename/delete — the
+ * "editor for the sidebar items" alongside the two content editors.
+ *
+ * Routing is left to the host: this component only reports which document was
+ * picked, created or should be navigated to after a delete, and asks the host
+ * for each row's href, so it works the same whether the host is Next.js
+ * (`next/link`/`useRouter`) or a plain router.
+ */
+
+'use client';
+
+import * as React from 'react';
+
+import { FileText, Pencil, Plus, Trash2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import {
+  createSidebarDocument,
+  deleteSidebarDocument,
+  listSidebarDocuments,
+  renameSidebarDocument,
+  subscribeSidebarDocuments,
+  type SidebarDocument,
+} from './sidebar-store';
+
+export interface ReasonSidebarProps {
+  activeDocumentId: string;
+  /** Builds the href for a document row; the host owns routing. */
+  linkForDocument: (documentId: string) => string;
+  /** Called after creating a document, or after deleting the active one. */
+  onNavigate: (documentId: string) => void;
+  className?: string;
+}
+
+export function ReasonSidebar({
+  activeDocumentId,
+  linkForDocument,
+  onNavigate,
+  className,
+}: ReasonSidebarProps) {
+  const [documents, setDocuments] = React.useState<SidebarDocument[]>([]);
+  const [editingId, setEditingId] = React.useState<string | null>(null);
+  const [draftTitle, setDraftTitle] = React.useState('');
+
+  const refresh = React.useCallback(() => {
+    setDocuments(listSidebarDocuments());
+  }, []);
+
+  React.useEffect(() => {
+    refresh();
+    return subscribeSidebarDocuments(refresh);
+  }, [refresh]);
+
+  const startRename = (doc: SidebarDocument) => {
+    setEditingId(doc.id);
+    setDraftTitle(doc.title);
+  };
+
+  const commitRename = () => {
+    if (editingId) renameSidebarDocument(editingId, draftTitle);
+    setEditingId(null);
+  };
+
+  const handleCreate = () => {
+    const doc = createSidebarDocument();
+    onNavigate(doc.id);
+  };
+
+  const handleDelete = (doc: SidebarDocument) => {
+    if (typeof window !== 'undefined' && !window.confirm(`Delete "${doc.title}"?`)) return;
+
+    deleteSidebarDocument(doc.id);
+
+    if (doc.id !== activeDocumentId) return;
+
+    const next = documents.find((candidate) => candidate.id !== doc.id);
+    onNavigate(next ? next.id : createSidebarDocument().id);
+  };
+
+  return (
+    <nav
+      aria-label="Documents"
+      className={cn(
+        'flex w-56 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-gray-200 bg-gray-50 p-2 dark:border-slate-700 dark:bg-slate-900',
+        className,
+      )}
+      data-testid="reason-sidebar"
+    >
+      <div className="flex items-center justify-between px-1 pb-2">
+        <span className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+          Documents
+        </span>
+        <button
+          aria-label="New document"
+          className="rounded p-1 text-gray-500 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-slate-800"
+          onClick={handleCreate}
+          type="button"
+        >
+          <Plus className="size-3.5" />
+        </button>
+      </div>
+
+      {documents.map((doc) => {
+        const active = doc.id === activeDocumentId;
+        const editing = editingId === doc.id;
+
+        return (
+          <div
+            className={cn(
+              'group flex items-center gap-1.5 rounded px-1.5 py-1 text-sm',
+              active
+                ? 'bg-gray-200 text-gray-900 dark:bg-slate-700 dark:text-white'
+                : 'text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-slate-800',
+            )}
+            data-document-id={doc.id}
+            key={doc.id}
+          >
+            <FileText className="size-3.5 shrink-0 opacity-60" />
+
+            {editing ? (
+              <input
+                autoFocus
+                className="min-w-0 flex-1 rounded border border-gray-300 bg-white px-1 py-0.5 text-sm dark:border-slate-600 dark:bg-slate-800"
+                onBlur={commitRename}
+                onChange={(event) => setDraftTitle(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') commitRename();
+                  if (event.key === 'Escape') setEditingId(null);
+                }}
+                value={draftTitle}
+              />
+            ) : (
+              <a className="min-w-0 flex-1 truncate" href={linkForDocument(doc.id)}>
+                {doc.title}
+              </a>
+            )}
+
+            {!editing && (
+              <div className="hidden shrink-0 items-center gap-0.5 group-hover:flex">
+                <button
+                  aria-label={`Rename ${doc.title}`}
+                  className="rounded p-0.5 text-gray-400 hover:bg-gray-200 dark:hover:bg-slate-700"
+                  onClick={() => startRename(doc)}
+                  type="button"
+                >
+                  <Pencil className="size-3" />
+                </button>
+                <button
+                  aria-label={`Delete ${doc.title}`}
+                  className="rounded p-0.5 text-gray-400 hover:bg-gray-200 dark:hover:bg-slate-700"
+                  onClick={() => handleDelete(doc)}
+                  type="button"
+                >
+                  <Trash2 className="size-3" />
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {documents.length === 0 && (
+        <p className="px-1.5 py-2 text-xs text-gray-400">No documents yet.</p>
+      )}
+    </nav>
+  );
+}

--- a/packages/reason-editor/src/docs-agent/shared/editor-types.ts
+++ b/packages/reason-editor/src/docs-agent/shared/editor-types.ts
@@ -76,7 +76,9 @@ export type ToolbarCommand =
   | 'align-justify'
   | 'indent'
   | 'outdent'
-  | TableCommand;
+  | TableCommand
+  // Voice
+  | 'transcribe';
 
 /**
  * Optional data for commands that need a value (a link URL, an image source, a

--- a/packages/reason-editor/src/docs-agent/shared/sidebar-store.ts
+++ b/packages/reason-editor/src/docs-agent/shared/sidebar-store.ts
@@ -1,0 +1,114 @@
+/**
+ * The Reason Editor's document list — a lighter-weight view onto the same data
+ * the production file-tree already owns (`src/documents/DocumentTree.tsx`), not
+ * a second store. Both read and write the `REASON-documents` localStorage
+ * array, the same key `apps/qwksearch-web/lib/reason-demo/document-api.ts`
+ * loads a single document from, so a document created here shows up in the real
+ * app's sidebar and vice versa.
+ *
+ * Kept deliberately small: a flat, root-level list with create/rename/delete —
+ * "the editor for the sidebar items" the dual-engine workspace needs — rather
+ * than the full nested tree (drag-and-drop, folders, tags) the production
+ * sidebar supports. Nothing here may import `@tiptap/*` or `platejs*`, same
+ * rule as the rest of `docs-agent/shared`.
+ */
+
+export const SIDEBAR_DOCUMENTS_STORAGE_KEY = 'REASON-documents';
+
+export interface SidebarDocument {
+  id: string;
+  title: string;
+}
+
+/**
+ * The subset of the production `Document` shape (see
+ * `src/documents/DocumentTree.tsx`) this module reads and writes. Unknown
+ * fields on an existing record are preserved verbatim so this never corrupts
+ * data the real file-tree relies on (tags, sharing, `isArchived`, …).
+ */
+interface StoredDocumentRecord {
+  id: string;
+  title?: string;
+  content?: string;
+  parentId?: string | null;
+  isFolder?: boolean;
+  isDeleted?: boolean;
+  [key: string]: unknown;
+}
+
+const CHANGE_EVENT = 'reason-documents-changed';
+
+function readAll(): StoredDocumentRecord[] {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const raw = window.localStorage.getItem(SIDEBAR_DOCUMENTS_STORAGE_KEY);
+    if (!raw) return [];
+
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as StoredDocumentRecord[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(records: StoredDocumentRecord[]): void {
+  if (typeof window === 'undefined') return;
+
+  window.localStorage.setItem(SIDEBAR_DOCUMENTS_STORAGE_KEY, JSON.stringify(records));
+  // `storage` only fires in *other* tabs; same-tab listeners need this instead.
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+}
+
+function toSidebarDocument(record: StoredDocumentRecord): SidebarDocument {
+  return { id: record.id, title: record.title?.trim() || 'Untitled Document' };
+}
+
+/** Root-level, non-folder, non-deleted documents — what the sidebar lists. */
+export function listSidebarDocuments(): SidebarDocument[] {
+  return readAll()
+    .filter((record) => !record.isFolder && !record.isDeleted && !record.parentId)
+    .map(toSidebarDocument);
+}
+
+export function createSidebarDocument(title = 'Untitled Document'): SidebarDocument {
+  const record: StoredDocumentRecord = {
+    id: `doc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+    title,
+    content: '',
+    parentId: null,
+  };
+
+  writeAll([...readAll(), record]);
+
+  return toSidebarDocument(record);
+}
+
+export function renameSidebarDocument(id: string, title: string): void {
+  const trimmed = title.trim() || 'Untitled Document';
+  writeAll(readAll().map((record) => (record.id === id ? { ...record, title: trimmed } : record)));
+}
+
+/** Soft-delete, matching the production tree's `isDeleted` convention — recoverable, not destructive. */
+export function deleteSidebarDocument(id: string): void {
+  writeAll(
+    readAll().map((record) => (record.id === id ? { ...record, isDeleted: true } : record)),
+  );
+}
+
+/** Notifies on both same-tab writes and cross-tab `storage` events. */
+export function subscribeSidebarDocuments(listener: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === SIDEBAR_DOCUMENTS_STORAGE_KEY) listener();
+  };
+
+  window.addEventListener(CHANGE_EVENT, listener);
+  window.addEventListener('storage', onStorage);
+
+  return () => {
+    window.removeEventListener(CHANGE_EVENT, listener);
+    window.removeEventListener('storage', onStorage);
+  };
+}

--- a/packages/reason-editor/src/docs-agent/shared/toolbar-schema.ts
+++ b/packages/reason-editor/src/docs-agent/shared/toolbar-schema.ts
@@ -4,8 +4,10 @@
  *
  * The arrangement mirrors `editor-views/components/Toolbar.tsx`: history, the
  * direct inline marks, the Block Format menu, the Text Styles overflow menu, the
- * Insert menu, and the contextual Table menu. Changing the product's toolbar
- * means editing this file — not the Tiptap or Plate components.
+ * Insert menu, the Dictate toggle (the voice-commands plugin, ported from
+ * `src/extensions/Transcribe`), and the contextual Table menu. Changing the
+ * product's toolbar means editing this file — not the Tiptap or Plate
+ * components.
  */
 
 import {
@@ -36,6 +38,7 @@ import {
   List,
   ListChecks,
   ListOrdered,
+  Mic,
   Minus,
   Pilcrow,
   Plus,
@@ -304,6 +307,15 @@ export const REASON_TOOLBAR: ToolbarItem[] = [
       { kind: 'button', id: 'video', label: 'Video', icon: Video },
       { kind: 'button', id: 'math', label: 'Math', icon: Sigma },
     ],
+  },
+
+  { kind: 'separator', id: 'voice-divider' },
+  {
+    kind: 'button',
+    id: 'transcribe',
+    label: 'Dictate',
+    icon: Mic,
+    shortcut: 'Ctrl+Shift+D',
   },
 
   {

--- a/packages/reason-editor/src/docs-agent/tiptap/editor-adapter.ts
+++ b/packages/reason-editor/src/docs-agent/tiptap/editor-adapter.ts
@@ -7,6 +7,8 @@
 
 import type { Editor } from '@tiptap/core';
 
+import { subscribeTranscribe } from '@/extensions/Transcribe';
+
 import type {
   EditorToolbarAdapter,
   ToolbarCommand,
@@ -42,10 +44,15 @@ export function createTiptapAdapter(editor: Editor): EditorToolbarAdapter {
     subscribe(listener: () => void) {
       editor.on('transaction', listener);
       editor.on('selectionUpdate', listener);
+      // Starting/stopping dictation doesn't always land inside a transaction
+      // (the listening flag flips from the recognizer's own async callback),
+      // so the toolbar needs its own feed to reflect the mic state promptly.
+      const unsubscribeTranscribe = subscribeTranscribe(editor, listener);
 
       return () => {
         editor.off('transaction', listener);
         editor.off('selectionUpdate', listener);
+        unsubscribeTranscribe();
       };
     },
   };

--- a/packages/reason-editor/src/docs-agent/tiptap/toolbar-actions.ts
+++ b/packages/reason-editor/src/docs-agent/tiptap/toolbar-actions.ts
@@ -8,6 +8,8 @@
 
 import type { Editor } from '@tiptap/core';
 
+import { getTranscribeStorage, isTranscriptionSupported } from '@/extensions/Transcribe';
+
 import type { ToolbarCommand, ToolbarCommandPayload } from '../shared/editor-types';
 
 /** Commands that map straight onto a Tiptap mark of the same-ish name. */
@@ -104,6 +106,8 @@ function requiredExtension(command: ToolbarCommand): string | undefined {
       return 'callout';
     case 'columns':
       return 'columns';
+    case 'transcribe':
+      return 'transcribe';
     case 'indent':
     case 'outdent':
       return 'indent';
@@ -283,6 +287,10 @@ export function executeTiptapCommand(
       (chain() as any).insertColumns?.({ cols: 2 }).run();
       return;
 
+    case 'transcribe':
+      (commands as any).toggleTranscribe?.();
+      return;
+
     default:
       return;
   }
@@ -303,6 +311,7 @@ export function isTiptapCommandActive(editor: Editor, command: ToolbarCommand): 
   }
 
   if (command === 'link') return editor.isActive('link');
+  if (command === 'transcribe') return !!getTranscribeStorage(editor)?.listening;
 
   return false;
 }
@@ -313,6 +322,7 @@ export function isTiptapCommandEnabled(editor: Editor, command: ToolbarCommand):
 
   if (command === 'undo') return editor.can().undo();
   if (command === 'redo') return editor.can().redo();
+  if (command === 'transcribe') return isTranscriptionSupported();
 
   const tableCommand = TABLE_COMMANDS[command];
   if (tableCommand) {

--- a/packages/reason-editor/test/docs-agent/sidebar-store.test.ts
+++ b/packages/reason-editor/test/docs-agent/sidebar-store.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SIDEBAR_DOCUMENTS_STORAGE_KEY,
+  createSidebarDocument,
+  deleteSidebarDocument,
+  listSidebarDocuments,
+  renameSidebarDocument,
+  subscribeSidebarDocuments,
+} from '../../src/docs-agent/shared/sidebar-store';
+
+describe('sidebar-store', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('starts empty', () => {
+    expect(listSidebarDocuments()).toEqual([]);
+  });
+
+  it('creates a document and lists it', () => {
+    const doc = createSidebarDocument('My Notes');
+
+    expect(listSidebarDocuments()).toEqual([{ id: doc.id, title: 'My Notes' }]);
+  });
+
+  it('defaults an untitled document', () => {
+    const doc = createSidebarDocument();
+
+    expect(doc.title).toBe('Untitled Document');
+  });
+
+  it('renames a document', () => {
+    const doc = createSidebarDocument('Draft');
+    renameSidebarDocument(doc.id, 'Final');
+
+    expect(listSidebarDocuments()).toEqual([{ id: doc.id, title: 'Final' }]);
+  });
+
+  it('falls back to a default title when renamed blank', () => {
+    const doc = createSidebarDocument('Draft');
+    renameSidebarDocument(doc.id, '   ');
+
+    expect(listSidebarDocuments()[0]?.title).toBe('Untitled Document');
+  });
+
+  it('soft-deletes a document — it disappears from the list but the record survives', () => {
+    const doc = createSidebarDocument('Throwaway');
+    deleteSidebarDocument(doc.id);
+
+    expect(listSidebarDocuments()).toEqual([]);
+
+    const stored = JSON.parse(window.localStorage.getItem(SIDEBAR_DOCUMENTS_STORAGE_KEY) ?? '[]');
+    expect(stored).toEqual([expect.objectContaining({ id: doc.id, isDeleted: true })]);
+  });
+
+  it('excludes folders and nested documents from the sidebar list', () => {
+    window.localStorage.setItem(
+      SIDEBAR_DOCUMENTS_STORAGE_KEY,
+      JSON.stringify([
+        { id: 'folder-1', title: 'A Folder', isFolder: true, parentId: null },
+        { id: 'child-1', title: 'Nested', parentId: 'folder-1' },
+        { id: 'root-1', title: 'Root Doc', parentId: null },
+      ]),
+    );
+
+    expect(listSidebarDocuments()).toEqual([{ id: 'root-1', title: 'Root Doc' }]);
+  });
+
+  it('preserves unrelated fields on an existing record when renaming', () => {
+    window.localStorage.setItem(
+      SIDEBAR_DOCUMENTS_STORAGE_KEY,
+      JSON.stringify([
+        { id: 'doc-1', title: 'Old', parentId: null, tags: ['work'], sharing: { isPublic: true } },
+      ]),
+    );
+
+    renameSidebarDocument('doc-1', 'New');
+
+    const stored = JSON.parse(window.localStorage.getItem(SIDEBAR_DOCUMENTS_STORAGE_KEY) ?? '[]');
+    expect(stored).toEqual([
+      { id: 'doc-1', title: 'New', parentId: null, tags: ['work'], sharing: { isPublic: true } },
+    ]);
+  });
+
+  it('notifies subscribers on create, rename and delete', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarDocuments(listener);
+
+    const doc = createSidebarDocument('One');
+    renameSidebarDocument(doc.id, 'Two');
+    deleteSidebarDocument(doc.id);
+
+    expect(listener).toHaveBeenCalledTimes(3);
+
+    unsubscribe();
+    createSidebarDocument('Three');
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/reason-editor/test/docs-agent/transcribe-controller.test.ts
+++ b/packages/reason-editor/test/docs-agent/transcribe-controller.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Exercises the Plate dictation plugin's document-manipulation logic against a
+ * fake recognizer, mirroring how `test/transcribe.test.ts` exercises the
+ * Tiptap `Transcribe` extension. The recognizer itself (`LiveTranscriber`) is
+ * mocked out — this only checks that interim/committed phrases land in the
+ * right place and interact with undo history the way `Transcribe.ts` does.
+ */
+
+import { createPlateEditor } from 'platejs/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `vi.mock` factories are hoisted above the rest of the module, so anything
+// they close over has to be declared through `vi.hoisted` rather than as a
+// normal top-level `class`/`const`.
+const { constructorCalls, FakeLiveTranscriber } = vi.hoisted(() => {
+  class FakeLiveTranscriber {
+    options: any;
+    listening = false;
+
+    constructor(options: any) {
+      this.options = options;
+      calls.push(this);
+    }
+
+    isListening() {
+      return this.listening;
+    }
+
+    async start() {
+      this.listening = true;
+      this.options.onStateChange?.(true);
+    }
+
+    async stop() {
+      this.listening = false;
+      this.options.onStateChange?.(false);
+    }
+  }
+
+  const calls: InstanceType<typeof FakeLiveTranscriber>[] = [];
+
+  return { constructorCalls: calls, FakeLiveTranscriber };
+});
+
+vi.mock('use-voice-control/client', () => ({
+  LiveTranscriber: FakeLiveTranscriber,
+  isTranscriptionSupported: () => true,
+}));
+
+import { platePlugins } from '../../src/docs-agent/plate/plate-editor-config';
+import { getTranscribeController } from '../../src/docs-agent/plate/transcribe-controller';
+
+function createEditor() {
+  return createPlateEditor({
+    plugins: platePlugins as any,
+    value: [{ children: [{ text: '' }], type: 'p' }],
+  });
+}
+
+describe('plate transcribe controller', () => {
+  beforeEach(() => {
+    constructorCalls.length = 0;
+  });
+
+  it('starts and stops the recognizer', () => {
+    const editor = createEditor();
+    const controller = getTranscribeController(editor);
+
+    expect(controller.getState().listening).toBe(false);
+
+    controller.start();
+    expect(constructorCalls).toHaveLength(1);
+    expect(controller.getState().listening).toBe(true);
+
+    controller.stop();
+    expect(controller.getState().listening).toBe(false);
+  });
+
+  it('returns the same controller for the same editor', () => {
+    const editor = createEditor();
+    expect(getTranscribeController(editor)).toBe(getTranscribeController(editor));
+  });
+
+  it('writes an interim phrase at the cursor without recording it in history', () => {
+    const editor = createEditor();
+    const controller = getTranscribeController(editor);
+
+    controller.start();
+    constructorCalls[0]!.options.onPartial('hello');
+
+    expect(editor.api.string([])).toBe('hello');
+    expect(editor.history.undos.length).toBe(0);
+  });
+
+  it('rewrites the interim phrase in place on subsequent partials', () => {
+    const editor = createEditor();
+    const controller = getTranscribeController(editor);
+
+    controller.start();
+    constructorCalls[0]!.options.onPartial('hel');
+    constructorCalls[0]!.options.onPartial('hello');
+
+    expect(editor.api.string([])).toBe('hello');
+  });
+
+  it('commits the settled phrase as one history-tracked insertion', () => {
+    const editor = createEditor();
+    const controller = getTranscribeController(editor);
+
+    controller.start();
+    constructorCalls[0]!.options.onPartial('hello');
+    constructorCalls[0]!.options.onCommit('hello world');
+
+    expect(editor.api.string([])).toBe('hello world ');
+    expect(editor.history.undos.length).toBeGreaterThan(0);
+
+    editor.tf.undo();
+    expect(editor.api.string([])).toBe('');
+  });
+
+  it('drops the half-heard phrase on stop', () => {
+    const editor = createEditor();
+    const controller = getTranscribeController(editor);
+
+    controller.start();
+    constructorCalls[0]!.options.onPartial('hel');
+    controller.stop();
+
+    expect(editor.api.string([])).toBe('');
+  });
+
+  it('inserts a leading space when a phrase starts mid-sentence', () => {
+    const editor = createEditor();
+    editor.tf.select(editor.api.range([0])!);
+    editor.tf.insertText('Hello');
+    const controller = getTranscribeController(editor);
+
+    controller.start();
+    constructorCalls[0]!.options.onCommit('world');
+
+    expect(editor.api.string([])).toBe('Hello world ');
+  });
+
+  it('toggles between start and stop', () => {
+    const editor = createEditor();
+    const controller = getTranscribeController(editor);
+
+    controller.toggle();
+    expect(controller.getState().listening).toBe(true);
+
+    controller.toggle();
+    expect(controller.getState().listening).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds two major features to the Reason Editor:

1. **Voice dictation (transcribe)** - A voice-commands plugin for the Plate editor, ported from the existing Tiptap `Transcribe` extension, enabling users to dictate text using the browser's speech recognition API or on-device Moonshine models.

2. **Document sidebar** - A shared document navigation component that lists, creates, renames, and deletes documents, backed by the same localStorage store the production file-tree uses.

## Key Changes

### Voice Dictation
- **`transcribe-controller.ts`** - New Plate plugin implementing dictation logic:
  - Manages interim (partial) and committed (final) phrases with proper undo/history handling
  - Uses `editor.tf.withoutSaving()` to keep interim text out of undo history (matching Tiptap's `addToHistory` meta approach)
  - Automatically inserts leading spaces when phrases start mid-sentence
  - Lazy-initializes the `LiveTranscriber` recognizer only when dictation starts
  - Caches one controller per editor instance via WeakMap

- **`transcribe-kit.tsx`** - Registers the transcribe plugin with Plate's plugin system

- **Toolbar integration** - Added `transcribe` command to the shared toolbar schema with a microphone icon, integrated into both Tiptap and Plate adapters

- **Tests** - Comprehensive test suite (`transcribe-controller.test.ts`) verifying interim/committed phrase handling, history interaction, and leading space insertion

### Document Sidebar
- **`sidebar-store.ts`** - Lightweight document store:
  - Reads/writes the same `REASON-documents` localStorage key as the production file-tree
  - Filters to root-level, non-folder, non-deleted documents for the sidebar view
  - Preserves unknown fields on records to avoid corrupting production data
  - Supports create, rename (with soft-delete), and delete operations
  - Provides subscription mechanism for same-tab and cross-tab change notifications

- **`Sidebar.tsx`** - Engine-neutral sidebar component:
  - Lists documents with inline rename/delete actions
  - Delegates routing to the host via `linkForDocument` callback
  - Notifies host of navigation events (create, delete active document)
  - Styled consistently with dark mode support

- **Tests** - Full test coverage (`sidebar-store.test.ts`) for CRUD operations, filtering, field preservation, and subscriptions

### Integration
- **`DemoShell.tsx`** - Updated to mount the sidebar alongside the editor, with routing integration via Next.js
- **New demo routes** - Added `/docs/demo` and `/docs/demo/[documentId]` pages that default to Plate engine
- **Toolbar schema** - Updated documentation to mention the new dictate button
- **Editor types** - Added `transcribe` to the `ToolbarCommand` union type

## Implementation Details

- The transcribe controller mirrors the Tiptap `Transcribe` extension's design exactly: interim text is written without history, committed phrases are recorded as single undo steps
- The sidebar is intentionally minimal (flat list, no nesting/drag-drop) to serve as "the editor for sidebar items" while the production tree handles the full hierarchy
- Both features are engine-neutral in the shared layer (`docs-agent/shared`) and only depend on editor-specific adapters for integration
- The sidebar uses soft-delete (marking `isDeleted: true`) rather than hard deletion to match production conventions and allow recovery

https://claude.ai/code/session_01QBeyxgYeM71jDZJBrqPSjx