### PR TITLE
Bump pinned bun version to 1.4.0 to fix frozen-lockfile false positive

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "qwksearch",
   "private": true,
   "version": "2.2.0",
-  "packageManager": "bun@1.3.11",
+  "packageManager": "bun@1.4.0",
   "workspaces": [
     "packages/*",
     "packages/render-url-to-html/*",


### PR DESCRIPTION
bun@1.3.11's --frozen-lockfile check spuriously reports "lockfile had changes" for several workspaces (extract-pdf, extract-youtube, qwksearch-ext, reason-editor, use-voice-control) even though a full resolve against the same package.json files produces a byte-identical bun.lock. Confirmed the check passes cleanly against the unmodified lockfile under bun 1.4.0.