### PR TITLE
Compact weather widget, gate rain badges at 2%, expandable news widget

### DIFF
--- a/packages/react-weather-forecast/src/components/WeatherForecast.tsx
+++ b/packages/react-weather-forecast/src/components/WeatherForecast.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useWeatherForecast } from '../hooks/useWeatherForecast';
-import type { DailyWeather, HourlyWeather, TemperatureUnit, WeatherForecastOptions, WindSpeedUnit } from '../types';
+import type { DailyWeather, TemperatureUnit, WeatherForecastOptions, WindSpeedUnit } from '../types';
 import { WeatherIcon } from '../icons/WeatherIcon';
 import { WindIcon } from '../icons/weather-icons';
 
@@ -16,14 +16,6 @@ const WIND_SPEED_UNIT_LABELS: Record<WindSpeedUnit, string> = {
   ms: 'm/s',
   kn: 'kn',
 };
-
-function closestHour(hourly: HourlyWeather[], targetTime: Date): HourlyWeather | undefined {
-  return hourly.reduce<HourlyWeather | undefined>((closest, hour) => {
-    const diff = Math.abs(new Date(hour.time).getTime() - targetTime.getTime());
-    const closestDiff = closest ? Math.abs(new Date(closest.time).getTime() - targetTime.getTime()) : Infinity;
-    return diff < closestDiff ? hour : closest;
-  }, undefined);
-}
 
 // Format a real instant in a specific IANA timezone, falling back to the
 // browser's local zone if the timezone string is missing or invalid.
@@ -134,8 +126,6 @@ const styles = {
   compactCity: { fontSize: 15, fontWeight: 700, lineHeight: 1.2 } as React.CSSProperties,
   compactHeader: { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8 } as React.CSSProperties,
   compactTemp: { fontSize: 32, fontWeight: 600, lineHeight: 1 } as React.CSSProperties,
-  // The short-term outlook ("59 deg in 6h") trails the current temperature.
-  compactOutlook: { display: 'flex', alignItems: 'center', gap: 4, fontSize: 12, opacity: 0.75, whiteSpace: 'nowrap' } as React.CSSProperties,
   compactTime: { fontSize: 26, fontWeight: 600, lineHeight: 1.1 } as React.CSSProperties,
   compactSeconds: { fontSize: 13, fontWeight: 500, opacity: 0.6 } as React.CSSProperties,
   compactDate: { fontSize: 11, opacity: 0.7, marginTop: 2 } as React.CSSProperties,
@@ -145,13 +135,13 @@ const styles = {
   upcoming: {
     display: 'grid',
     gridTemplateColumns: 'repeat(3, 1fr)',
-    gap: 8,
-    paddingTop: 12,
+    gap: 4,
+    paddingTop: 8,
     borderTop: '1px solid currentColor',
     borderTopColor: 'rgba(128,128,128,0.25)',
-    fontSize: 12,
+    fontSize: 11,
   } as React.CSSProperties,
-  upcomingDay: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4, textAlign: 'center' } as React.CSSProperties,
+  upcomingDay: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, textAlign: 'center' } as React.CSSProperties,
   upcomingDayName: { opacity: 0.7, whiteSpace: 'nowrap' } as React.CSSProperties,
   upcomingTemps: { whiteSpace: 'nowrap' } as React.CSSProperties,
   compactStat: { display: 'flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' } as React.CSSProperties,
@@ -161,9 +151,11 @@ const styles = {
   list: { display: 'flex', flexDirection: 'column' } as React.CSSProperties,
 };
 
-// Precipitation chance is only surfaced when there is a non-zero chance of it.
+// Precipitation chance is only surfaced once it represents a meaningful risk.
+const RAIN_RISK_THRESHOLD = 2;
+
 function RainBadge({ probability, compact }: { probability?: number; compact?: boolean }) {
-  if (probability === undefined || probability === null || probability <= 0) return null;
+  if (probability === undefined || probability === null || probability <= RAIN_RISK_THRESHOLD) return null;
   return <span style={styles.rain}>{compact ? ` · ${probability}%` : ` · ${probability}% rain`}</span>;
 }
 
@@ -230,9 +222,7 @@ function SingleWeatherForecast(props: Props) {
   const currentZone = zoneLabel(now, timezone);
 
   if (props.compact) {
-    const forecastBase = new Date(data.current.time);
     const today = data.daily[0];
-    const in6Hours = closestHour(data.hourly, new Date(forecastBase.getTime() + 6 * 60 * 60 * 1000));
     const windSpeedUnitLabel = WIND_SPEED_UNIT_LABELS[props.windSpeedUnit ?? 'mph'];
     // Today is already summarised in the card's own stats line, so the bottom
     // row starts at tomorrow and shows the next three days.
@@ -250,13 +240,6 @@ function SingleWeatherForecast(props: Props) {
             <WeatherIcon condition={data.current.icon} width={30} height={30} title="Current weather" />
             <strong style={styles.compactTemp}>{data.current.temperature}</strong>
             {renderUnitSwitch(13)}
-            {in6Hours && (
-              <span style={styles.compactOutlook}>
-                <WeatherIcon condition={in6Hours.icon} width={14} height={14} title="In 6 hours" />
-                {in6Hours.temperature}&deg; 6h
-                <RainBadge probability={in6Hours.precipitationProbability} compact />
-              </span>
-            )}
           </div>
 
           <div>
@@ -290,13 +273,13 @@ function SingleWeatherForecast(props: Props) {
             {upcomingDays.map((day) => (
               <div key={day.date} style={styles.upcomingDay} title={upcomingDayDetail(day, windSpeedUnitLabel)}>
                 <span style={styles.upcomingDayName}>{upcomingDayLabel(day.date)}</span>
-                <WeatherIcon condition={day.icon} width={18} height={18} />
+                <WeatherIcon condition={day.icon} width={14} height={14} />
                 <span style={styles.upcomingTemps}>
                   <strong>{day.max}&deg;</strong>
                   <span style={{ opacity: 0.6 }}> / {day.min}&deg;</span>
                 </span>
-                {day.precipitationProbabilityMax !== undefined && day.precipitationProbabilityMax > 0 && (
-                  <span style={{ ...styles.rain, fontSize: 11 }}>{day.precipitationProbabilityMax}%</span>
+                {day.precipitationProbabilityMax !== undefined && day.precipitationProbabilityMax > RAIN_RISK_THRESHOLD && (
+                  <span style={{ ...styles.rain, fontSize: 10 }}>{day.precipitationProbabilityMax}%</span>
                 )}
               </div>
             ))}
@@ -349,7 +332,7 @@ function SingleWeatherForecast(props: Props) {
               <WeatherIcon condition={day.icon} width={20} height={20} />
               <div>
                 {day.min}&deg; / {day.max}&deg;
-                {day.precipitationProbabilityMax !== undefined && day.precipitationProbabilityMax > 0 && (
+                {day.precipitationProbabilityMax !== undefined && day.precipitationProbabilityMax > RAIN_RISK_THRESHOLD && (
                   <span style={styles.rain}> &middot; {day.precipitationProbabilityMax}%</span>
                 )}
               </div>

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -170,6 +170,7 @@ export default function ChatHomepage() {
               />
               <TrendingNews
                 compact
+                expandable
                 maxTopics={6}
                 apiEndpoint={trendingNewsApiUrl || undefined}
                 className="rounded-2xl md:flex-1"

--- a/packages/trending-news-api/src/components/TrendingNews.tsx
+++ b/packages/trending-news-api/src/components/TrendingNews.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTrendingNews } from '../hooks/useTrendingNews';
 import type { TrendingNewsOptions } from '../types';
 
@@ -8,7 +8,34 @@ type Props = TrendingNewsOptions & {
   compact?: boolean;
   /** Max trending topics to render (default 8). */
   maxTopics?: number;
+  /**
+   * When set on a `compact` card, a chevron toggles between the compact
+   * topic row and a full topic-by-topic article list, without leaving the
+   * card's layout. Ignored outside `compact` mode, which already shows the
+   * full list.
+   */
+  expandable?: boolean;
+  /** Max topics to render once expanded (default 15). */
+  expandedMaxTopics?: number;
 };
+
+function ChevronIcon({ up }: { up?: boolean }) {
+  return (
+    <svg
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ transform: up ? 'rotate(180deg)' : undefined, transition: 'transform 150ms ease' }}
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
 
 const styles = {
   root: {
@@ -28,6 +55,7 @@ const styles = {
     padding: '10px 14px',
     borderRadius: 8,
   } as React.CSSProperties,
+  compactHeaderRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 } as React.CSSProperties,
   compactHeader: {
     fontSize: 11,
     fontWeight: 600,
@@ -35,6 +63,19 @@ const styles = {
     letterSpacing: 0.3,
     textTransform: 'uppercase',
   } as React.CSSProperties,
+  expandToggle: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    background: 'transparent',
+    border: 'none',
+    padding: 2,
+    margin: 0,
+    color: 'inherit',
+    opacity: 0.6,
+    cursor: 'pointer',
+  } as React.CSSProperties,
+  expandedList: { display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 360, overflowY: 'auto' } as React.CSSProperties,
   topicRow: { display: 'flex', gap: 10, overflowX: 'auto', paddingBottom: 2 } as React.CSSProperties,
   topicCard: {
     minWidth: 160,
@@ -78,8 +119,9 @@ const styles = {
  * disrupts the layout it's dropped into.
  */
 export function TrendingNews(props: Props) {
-  const { className, style, compact, maxTopics = 8, ...options } = props;
+  const { className, style, compact, maxTopics = 8, expandable, expandedMaxTopics = 15, ...options } = props;
   const { data, loading, error } = useTrendingNews(options);
+  const [expanded, setExpanded] = useState(false);
 
   if (!options.apiEndpoint) return null;
   if (loading && !data) return null;
@@ -89,26 +131,70 @@ export function TrendingNews(props: Props) {
   const topics = data.topics.slice(0, maxTopics);
 
   if (compact) {
+    const showExpanded = expandable && expanded;
+    const expandedTopics = showExpanded ? data.topics.slice(0, expandedMaxTopics) : [];
+
     return (
       <div className={className} style={{ ...styles.compactRoot, ...style }}>
-        <div style={styles.compactHeader}>Trending</div>
-        <div style={styles.topicRow}>
-          {topics.map((topic) => (
-            <a
-              key={topic.topic}
-              href={topic.articles[0]?.url}
-              target="_blank"
-              rel="noreferrer"
-              style={styles.topicCard}
+        <div style={styles.compactHeaderRow}>
+          <div style={styles.compactHeader}>Trending</div>
+          {expandable && (
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              aria-expanded={showExpanded}
+              aria-label={showExpanded ? 'Collapse trending news' : 'Expand trending news'}
+              style={styles.expandToggle}
             >
-              <div style={styles.topicName}>{topic.topic}</div>
-              {topic.articles[0] && <div style={styles.headline}>{topic.articles[0].title}</div>}
-              <div style={styles.count}>
-                {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
-              </div>
-            </a>
-          ))}
+              <ChevronIcon up={showExpanded} />
+            </button>
+          )}
         </div>
+
+        {showExpanded ? (
+          <div style={styles.expandedList}>
+            {expandedTopics.map((topic) => (
+              <div key={topic.topic} style={styles.fullTopic}>
+                <div style={styles.fullTopicHeader}>
+                  <strong>{topic.topic}</strong>
+                  <span style={styles.count}>
+                    {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
+                  </span>
+                </div>
+                {topic.articles.slice(0, 5).map((article, i) => (
+                  <div key={article.url ?? i} style={styles.article}>
+                    {article.url ? (
+                      <a href={article.url} target="_blank" rel="noreferrer" style={styles.articleLink}>
+                        {article.title}
+                      </a>
+                    ) : (
+                      article.title
+                    )}
+                    {article.source && <span style={{ opacity: 0.6 }}> &middot; {article.source}</span>}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={styles.topicRow}>
+            {topics.map((topic) => (
+              <a
+                key={topic.topic}
+                href={topic.articles[0]?.url}
+                target="_blank"
+                rel="noreferrer"
+                style={styles.topicCard}
+              >
+                <div style={styles.topicName}>{topic.topic}</div>
+                {topic.articles[0] && <div style={styles.headline}>{topic.articles[0].title}</div>}
+                <div style={styles.count}>
+                  {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
+                </div>
+              </a>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/trending-news-api/test/TrendingNews.test.tsx
+++ b/packages/trending-news-api/test/TrendingNews.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TrendingNews } from '../src/components/TrendingNews';
 import * as trendingApi from '../src/api/trending';
@@ -117,6 +117,36 @@ describe('<TrendingNews />', () => {
     const card = (await screen.findByText('Elections')).closest('a');
     expect(card).not.toBeNull();
     expect(card?.getAttribute('href')).toBeNull();
+  });
+
+  it('does not show an expand toggle in compact mode unless expandable is set', async () => {
+    vi.spyOn(trendingApi, 'getTrendingNews').mockResolvedValue(data());
+
+    render(<TrendingNews apiEndpoint={ENDPOINT} compact />);
+
+    await screen.findByText('Trending');
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('expands a compact card into the full article list on toggle', async () => {
+    vi.spyOn(trendingApi, 'getTrendingNews').mockResolvedValue(data());
+
+    render(<TrendingNews apiEndpoint={ENDPOINT} compact expandable />);
+
+    await screen.findByText('Trending');
+    const toggle = screen.getByRole('button', { name: 'Expand trending news' });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole('button', { name: 'Collapse trending news' }).getAttribute('aria-expanded')).toBe('true');
+    const link = screen.getByText('Total eclipse crosses North America');
+    expect(link.getAttribute('href')).toBe('https://example.com/a');
+    expect(screen.getByText('2 articles')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse trending news' }));
+
+    expect(screen.getByRole('button', { name: 'Expand trending news' }).getAttribute('aria-expanded')).toBe('false');
   });
 
   it('applies the className and style props', async () => {


### PR DESCRIPTION
## Summary
- **Weather widget** (`react-weather-forecast`): removed the "in 6h" short-term outlook from the compact card's header (and the now-unused `closestHour` helper); tightened spacing, font size, and icon size in the compact card's "next days" row.
- **Rain risk threshold**: rain badges (current day and future days) now only render once precipitation probability exceeds 2%, instead of any non-zero chance.
- **Trending news widget** (`trending-news-api`): the homepage's compact card only showed a horizontal scroll strip of headlines. Added an opt-in `expandable` prop that adds a chevron toggle to the card header — toggling swaps the strip for a vertical list of topics with their full article sets (from already-fetched data, up to `expandedMaxTopics`). Wired into `ChatHomepage`'s existing `TrendingNews` usage.

## Test plan
- [x] `bun run typecheck` in `packages/react-weather-forecast`
- [x] `bun run test` in `packages/react-weather-forecast` (84 tests passing)
- [x] `bun run typecheck` + `bun run test` + `bun run build` in `packages/trending-news-api` (46 tests passing)
- [x] `bun run type-check` + `bun run build` + `bun run test` in `packages/research-agent-ui` (88 tests passing; pre-existing, unrelated `tsc` errors in `unified-markdown.tsx`/`MessageInputIconSet.tsx` are tolerated by that package's own build script)