### PR TITLE
Trending news thumbnails and homepage widget settings

### DIFF
--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -61,7 +61,14 @@ export default function ChatHomepage() {
   const [fading, setFading] = useState(false);
   const [downloadsOpen, setDownloadsOpen] = useState(false);
   const [weatherLocations, setWeatherLocations] = useState<WeatherLocationInput[]>([]);
+  const [showWeatherWidget, setShowWeatherWidget] = useState(true);
+  const [weatherForecastDays, setWeatherForecastDays] = useState(5);
+  const [weatherForecastHours, setWeatherForecastHours] = useState(12);
+  const [weatherTemperatureUnit, setWeatherTemperatureUnit] = useState<'celsius' | 'fahrenheit'>('fahrenheit');
   const [trendingNewsApiUrl, setTrendingNewsApiUrl] = useState<string | null>(null);
+  const [showTrendingNewsWidget, setShowTrendingNewsWidget] = useState(true);
+  const [trendingNewsMaxTopics, setTrendingNewsMaxTopics] = useState(6);
+  const [trendingNewsShowImages, setTrendingNewsShowImages] = useState(true);
   const [orbHoverGlow, setOrbHoverGlow] = useState(false);
   // Off by default; enabled via the "Cursor Glow Trail" setting.
   const [cursorGlowTrail, setCursorGlowTrail] = useState(false);
@@ -71,7 +78,14 @@ export default function ChatHomepage() {
   useEffect(() => {
     const readLocations = () => {
       setWeatherLocations(parseWeatherLocations(localStorage.getItem('weatherLocations')));
+      setShowWeatherWidget(localStorage.getItem('showWeatherWidget') !== 'false');
+      setWeatherForecastDays(Number(localStorage.getItem('weatherForecastDays')) || 5);
+      setWeatherForecastHours(Number(localStorage.getItem('weatherForecastHours')) || 12);
+      setWeatherTemperatureUnit(localStorage.getItem('weatherTemperatureUnit') === 'celsius' ? 'celsius' : 'fahrenheit');
       setTrendingNewsApiUrl(localStorage.getItem('trendingNewsApiUrl'));
+      setShowTrendingNewsWidget(localStorage.getItem('showTrendingNewsWidget') !== 'false');
+      setTrendingNewsMaxTopics(Number(localStorage.getItem('trendingNewsMaxTopics')) || 6);
+      setTrendingNewsShowImages(localStorage.getItem('trendingNewsShowImages') !== 'false');
       setOrbHoverGlow(localStorage.getItem('orbHoverGlow') === 'true');
       setCursorGlowTrail(localStorage.getItem('cursorGlowTrail') === 'true');
     };
@@ -151,38 +165,46 @@ export default function ChatHomepage() {
 
           <div className="w-full max-w-2xl mt-8 space-y-2">
             <RecentHistoryChips />
-            <div className="flex flex-col md:flex-row gap-2 w-full">
-              {/* The compact weather widget is a fixed-width card, so it sits
-                  beside the trending news column rather than taking its own row
-                  (and stretches to full width once they stack on mobile). */}
-              <WeatherForecast
-                compact
-                forecastDays={5}
-                forecastHours={12}
-                locations={weatherLocations.length > 0 ? weatherLocations : undefined}
-                className="rounded-2xl"
-                style={{
-                  background: 'rgba(255,255,255,0.08)',
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  color: 'inherit',
-                  backdropFilter: 'blur(8px)',
-                }}
-              />
-              <TrendingNews
-                compact
-                expandable
-                maxTopics={6}
-                apiEndpoint={trendingNewsApiUrl || undefined}
-                className="rounded-2xl md:flex-1"
-                style={{
-                  background: 'rgba(255,255,255,0.08)',
-                  border: '1px solid rgba(255,255,255,0.15)',
-                  color: 'inherit',
-                  backdropFilter: 'blur(8px)',
-                  maxWidth: '100%',
-                }}
-              />
-            </div>
+            {(showWeatherWidget || showTrendingNewsWidget) && (
+              <div className="flex flex-col md:flex-row gap-2 w-full">
+                {/* The compact weather widget is a fixed-width card, so it sits
+                    beside the trending news column rather than taking its own row
+                    (and stretches to full width once they stack on mobile). */}
+                {showWeatherWidget && (
+                  <WeatherForecast
+                    compact
+                    forecastDays={weatherForecastDays}
+                    forecastHours={weatherForecastHours}
+                    temperatureUnit={weatherTemperatureUnit}
+                    locations={weatherLocations.length > 0 ? weatherLocations : undefined}
+                    className="rounded-2xl"
+                    style={{
+                      background: 'rgba(255,255,255,0.08)',
+                      border: '1px solid rgba(255,255,255,0.15)',
+                      color: 'inherit',
+                      backdropFilter: 'blur(8px)',
+                    }}
+                  />
+                )}
+                {showTrendingNewsWidget && (
+                  <TrendingNews
+                    compact
+                    expandable
+                    maxTopics={trendingNewsMaxTopics}
+                    showImages={trendingNewsShowImages}
+                    apiEndpoint={trendingNewsApiUrl || undefined}
+                    className="rounded-2xl md:flex-1"
+                    style={{
+                      background: 'rgba(255,255,255,0.08)',
+                      border: '1px solid rgba(255,255,255,0.15)',
+                      color: 'inherit',
+                      backdropFilter: 'blur(8px)',
+                      maxWidth: '100%',
+                    }}
+                  />
+                )}
+              </div>
+            )}
             <ChatInputBox />
           </div>
         </div>

--- a/packages/research-agent-ui/src/settings/search.json
+++ b/packages/research-agent-ui/src/settings/search.json
@@ -139,6 +139,15 @@
     "scope": "server"
   },
   {
+    "name": "Show Weather Widget",
+    "key": "showWeatherWidget",
+    "type": "switch",
+    "required": false,
+    "description": "Show the weather widget on the chat homepage.",
+    "default": true,
+    "scope": "client"
+  },
+  {
     "name": "Weather Locations",
     "key": "weatherLocations",
     "type": "textarea",
@@ -149,13 +158,88 @@
     "default": ""
   },
   {
+    "name": "Weather Forecast Days",
+    "key": "weatherForecastDays",
+    "type": "select",
+    "required": false,
+    "description": "Number of upcoming days to show in the weather widget.",
+    "default": "5",
+    "scope": "client",
+    "options": [
+      { "name": "3 days", "value": "3" },
+      { "name": "5 days (default)", "value": "5" },
+      { "name": "7 days", "value": "7" }
+    ]
+  },
+  {
+    "name": "Weather Forecast Hours",
+    "key": "weatherForecastHours",
+    "type": "select",
+    "required": false,
+    "description": "Number of upcoming hours to show in the weather widget.",
+    "default": "12",
+    "scope": "client",
+    "options": [
+      { "name": "6 hours", "value": "6" },
+      { "name": "12 hours (default)", "value": "12" },
+      { "name": "24 hours", "value": "24" }
+    ]
+  },
+  {
+    "name": "Weather Temperature Unit",
+    "key": "weatherTemperatureUnit",
+    "type": "select",
+    "required": false,
+    "description": "Default temperature unit for the weather widget. You can still toggle it directly on the widget.",
+    "default": "fahrenheit",
+    "scope": "client",
+    "options": [
+      { "name": "Fahrenheit (default)", "value": "fahrenheit" },
+      { "name": "Celsius", "value": "celsius" }
+    ]
+  },
+  {
+    "name": "Show Trending News Widget",
+    "key": "showTrendingNewsWidget",
+    "type": "switch",
+    "required": false,
+    "description": "Show the trending news widget on the chat homepage.",
+    "default": true,
+    "scope": "client"
+  },
+  {
     "name": "Trending News API URL",
     "key": "trendingNewsApiUrl",
     "type": "string",
     "required": false,
-    "description": "Show the homepage trending news widget. Enter the URL of your deployed trending-news-api Cloudflare Worker. Leave blank to hide the widget.",
+    "description": "Enter the URL of your deployed trending-news-api Cloudflare Worker. Leave blank to hide the widget.",
     "placeholder": "https://trending-news-api.your-subdomain.workers.dev",
     "scope": "client",
     "default": ""
+  },
+  {
+    "name": "Trending News Topics",
+    "key": "trendingNewsMaxTopics",
+    "type": "select",
+    "required": false,
+    "description": "Number of trending topics to show in the trending news widget.",
+    "default": "6",
+    "scope": "client",
+    "options": [
+      { "name": "4 topics", "value": "4" },
+      { "name": "6 topics (default)", "value": "6" },
+      { "name": "8 topics", "value": "8" },
+      { "name": "10 topics", "value": "10" },
+      { "name": "12 topics", "value": "12" }
+    ]
+  },
+  {
+    "name": "Trending News Images",
+    "key": "trendingNewsShowImages",
+    "type": "switch",
+    "required": false,
+    "description": "Show article thumbnail images in the trending news widget.",
+    "default": true,
+    "scope": "client"
   }
 ]

--- a/packages/trending-news-api/README.md
+++ b/packages/trending-news-api/README.md
@@ -8,6 +8,7 @@ Cloudflare Worker so the News API key never reaches the browser.
 
 - Daily trending topics, ranked by Wikipedia pageviews.
 - Matching headlines per topic from The News API.
+- Article thumbnail images, shown alongside headlines (toggle off with `showImages={false}`).
 - Single-topic headline lookup.
 - Compact card row or full article-list layouts.
 - `localStorage` response caching (10 minutes).

--- a/packages/trending-news-api/src/api/trending.ts
+++ b/packages/trending-news-api/src/api/trending.ts
@@ -6,6 +6,7 @@ type WorkerArticle = {
   url?: string;
   source?: string;
   published_at?: string;
+  image_url?: string;
 };
 
 type WorkerTopic = {
@@ -35,6 +36,7 @@ function mapArticles(articles: WorkerArticle[] = []): NewsArticle[] {
     url: a.url,
     source: a.source,
     publishedAt: a.published_at,
+    imageUrl: a.image_url,
   }));
 }
 

--- a/packages/trending-news-api/src/components/TrendingNews.tsx
+++ b/packages/trending-news-api/src/components/TrendingNews.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useTrendingNews } from '../hooks/useTrendingNews';
-import type { TrendingNewsOptions } from '../types';
+import type { TrendingNewsOptions, TrendingTopic } from '../types';
 
 type Props = TrendingNewsOptions & {
   className?: string;
@@ -17,6 +17,8 @@ type Props = TrendingNewsOptions & {
   expandable?: boolean;
   /** Max topics to render once expanded (default 15). */
   expandedMaxTopics?: number;
+  /** Show each topic's lead article thumbnail image, when available (default true). */
+  showImages?: boolean;
 };
 
 function ChevronIcon({ up }: { up?: boolean }) {
@@ -80,7 +82,6 @@ const styles = {
   topicCard: {
     minWidth: 160,
     maxWidth: 200,
-    padding: '8px 10px',
     borderRadius: 8,
     background: 'rgba(255,255,255,0.06)',
     display: 'flex',
@@ -88,7 +89,23 @@ const styles = {
     gap: 4,
     textDecoration: 'none',
     color: 'inherit',
+    overflow: 'hidden',
   } as React.CSSProperties,
+  topicCardBody: { padding: '8px 10px', display: 'flex', flexDirection: 'column', gap: 4 } as React.CSSProperties,
+  topicThumb: {
+    width: '100%',
+    height: 84,
+    objectFit: 'cover',
+    display: 'block',
+  } as React.CSSProperties,
+  articleThumb: {
+    width: 48,
+    height: 48,
+    objectFit: 'cover',
+    borderRadius: 6,
+    flexShrink: 0,
+  } as React.CSSProperties,
+  fullTopicWithThumb: { display: 'flex', gap: 10, alignItems: 'flex-start' } as React.CSSProperties,
   topicName: {
     fontSize: 12,
     fontWeight: 600,
@@ -112,6 +129,40 @@ const styles = {
   articleLink: { color: 'inherit', textDecoration: 'none' } as React.CSSProperties,
 };
 
+function ArticleLine({ article, showImage }: { article: TrendingTopic['articles'][number]; showImage?: boolean }) {
+  return (
+    <div style={{ ...styles.article, ...(showImage && article.imageUrl ? styles.fullTopicWithThumb : {}) }}>
+      {showImage && article.imageUrl && <img src={article.imageUrl} alt="" style={styles.articleThumb} />}
+      <div>
+        {article.url ? (
+          <a href={article.url} target="_blank" rel="noreferrer" style={styles.articleLink}>
+            {article.title}
+          </a>
+        ) : (
+          article.title
+        )}
+        {article.source && <span style={{ opacity: 0.6 }}> &middot; {article.source}</span>}
+      </div>
+    </div>
+  );
+}
+
+function TopicArticleList({ topic, showImages }: { topic: TrendingTopic; showImages: boolean }) {
+  return (
+    <div style={styles.fullTopic}>
+      <div style={styles.fullTopicHeader}>
+        <strong>{topic.topic}</strong>
+        <span style={styles.count}>
+          {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
+        </span>
+      </div>
+      {topic.articles.slice(0, 5).map((article, i) => (
+        <ArticleLine key={article.url ?? i} article={article} showImage={showImages} />
+      ))}
+    </div>
+  );
+}
+
 /**
  * Trending news widget. Requires `apiEndpoint` pointing at a deployed
  * instance of the bundled Cloudflare Worker (`worker/index.ts`) — renders
@@ -119,7 +170,16 @@ const styles = {
  * disrupts the layout it's dropped into.
  */
 export function TrendingNews(props: Props) {
-  const { className, style, compact, maxTopics = 8, expandable, expandedMaxTopics = 15, ...options } = props;
+  const {
+    className,
+    style,
+    compact,
+    maxTopics = 8,
+    expandable,
+    expandedMaxTopics = 15,
+    showImages = true,
+    ...options
+  } = props;
   const { data, loading, error } = useTrendingNews(options);
   const [expanded, setExpanded] = useState(false);
 
@@ -154,45 +214,32 @@ export function TrendingNews(props: Props) {
         {showExpanded ? (
           <div style={styles.expandedList}>
             {expandedTopics.map((topic) => (
-              <div key={topic.topic} style={styles.fullTopic}>
-                <div style={styles.fullTopicHeader}>
-                  <strong>{topic.topic}</strong>
-                  <span style={styles.count}>
-                    {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
-                  </span>
-                </div>
-                {topic.articles.slice(0, 5).map((article, i) => (
-                  <div key={article.url ?? i} style={styles.article}>
-                    {article.url ? (
-                      <a href={article.url} target="_blank" rel="noreferrer" style={styles.articleLink}>
-                        {article.title}
-                      </a>
-                    ) : (
-                      article.title
-                    )}
-                    {article.source && <span style={{ opacity: 0.6 }}> &middot; {article.source}</span>}
-                  </div>
-                ))}
-              </div>
+              <TopicArticleList key={topic.topic} topic={topic} showImages={showImages} />
             ))}
           </div>
         ) : (
           <div style={styles.topicRow}>
-            {topics.map((topic) => (
-              <a
-                key={topic.topic}
-                href={topic.articles[0]?.url}
-                target="_blank"
-                rel="noreferrer"
-                style={styles.topicCard}
-              >
-                <div style={styles.topicName}>{topic.topic}</div>
-                {topic.articles[0] && <div style={styles.headline}>{topic.articles[0].title}</div>}
-                <div style={styles.count}>
-                  {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
-                </div>
-              </a>
-            ))}
+            {topics.map((topic) => {
+              const thumb = showImages ? topic.articles[0]?.imageUrl : undefined;
+              return (
+                <a
+                  key={topic.topic}
+                  href={topic.articles[0]?.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={styles.topicCard}
+                >
+                  {thumb && <img src={thumb} alt="" style={styles.topicThumb} />}
+                  <div style={styles.topicCardBody}>
+                    <div style={styles.topicName}>{topic.topic}</div>
+                    {topic.articles[0] && <div style={styles.headline}>{topic.articles[0].title}</div>}
+                    <div style={styles.count}>
+                      {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
+                    </div>
+                  </div>
+                </a>
+              );
+            })}
           </div>
         )}
       </div>
@@ -202,26 +249,7 @@ export function TrendingNews(props: Props) {
   return (
     <div className={className} style={{ ...styles.root, ...styles.list, ...style }}>
       {topics.map((topic) => (
-        <div key={topic.topic} style={styles.fullTopic}>
-          <div style={styles.fullTopicHeader}>
-            <strong>{topic.topic}</strong>
-            <span style={styles.count}>
-              {topic.newsCount} article{topic.newsCount === 1 ? '' : 's'}
-            </span>
-          </div>
-          {topic.articles.slice(0, 5).map((article, i) => (
-            <div key={article.url ?? i} style={styles.article}>
-              {article.url ? (
-                <a href={article.url} target="_blank" rel="noreferrer" style={styles.articleLink}>
-                  {article.title}
-                </a>
-              ) : (
-                article.title
-              )}
-              {article.source && <span style={{ opacity: 0.6 }}> &middot; {article.source}</span>}
-            </div>
-          ))}
-        </div>
+        <TopicArticleList key={topic.topic} topic={topic} showImages={showImages} />
       ))}
     </div>
   );

--- a/packages/trending-news-api/src/types.ts
+++ b/packages/trending-news-api/src/types.ts
@@ -3,6 +3,7 @@ export type NewsArticle = {
   url?: string;
   source?: string;
   publishedAt?: string;
+  imageUrl?: string;
 };
 
 export type TrendingTopic = {

--- a/packages/trending-news-api/test/TrendingNews.test.tsx
+++ b/packages/trending-news-api/test/TrendingNews.test.tsx
@@ -14,7 +14,12 @@ function data(overrides: Partial<TrendingNewsData> = {}): TrendingNewsData {
         topic: 'Eclipse',
         newsCount: 2,
         articles: [
-          { title: 'Total eclipse crosses North America', url: 'https://example.com/a', source: 'example.com' },
+          {
+          title: 'Total eclipse crosses North America',
+          url: 'https://example.com/a',
+          source: 'example.com',
+          imageUrl: 'https://example.com/a.jpg',
+        },
           { title: 'Where to watch' },
         ],
       },
@@ -147,6 +152,24 @@ describe('<TrendingNews />', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Collapse trending news' }));
 
     expect(screen.getByRole('button', { name: 'Expand trending news' }).getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('renders the lead article thumbnail in a compact card by default', async () => {
+    vi.spyOn(trendingApi, 'getTrendingNews').mockResolvedValue(data());
+
+    render(<TrendingNews apiEndpoint={ENDPOINT} compact />);
+
+    const img = (await screen.findByText('Eclipse')).closest('a')?.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('https://example.com/a.jpg');
+  });
+
+  it('omits thumbnails when showImages is false', async () => {
+    vi.spyOn(trendingApi, 'getTrendingNews').mockResolvedValue(data());
+
+    render(<TrendingNews apiEndpoint={ENDPOINT} compact showImages={false} />);
+
+    const card = (await screen.findByText('Eclipse')).closest('a');
+    expect(card?.querySelector('img')).toBeNull();
   });
 
   it('applies the className and style props', async () => {

--- a/packages/trending-news-api/test/trending.test.ts
+++ b/packages/trending-news-api/test/trending.test.ts
@@ -19,6 +19,7 @@ function workerTopics(overrides: Record<string, unknown> = {}) {
             url: 'https://example.com/a',
             source: 'example.com',
             published_at: '2024-01-01T09:00:00Z',
+            image_url: 'https://example.com/a.jpg',
           },
           { title: 'Where to watch' },
         ],
@@ -77,8 +78,15 @@ describe('getTrendingNews', () => {
           url: 'https://example.com/a',
           source: 'example.com',
           publishedAt: '2024-01-01T09:00:00Z',
+          imageUrl: 'https://example.com/a.jpg',
         },
-        { title: 'Where to watch', url: undefined, source: undefined, publishedAt: undefined },
+        {
+          title: 'Where to watch',
+          url: undefined,
+          source: undefined,
+          publishedAt: undefined,
+          imageUrl: undefined,
+        },
       ],
     });
   });

--- a/packages/trending-news-api/worker/index.ts
+++ b/packages/trending-news-api/worker/index.ts
@@ -8,6 +8,7 @@ type NewsApiArticle = {
   source?: string;
   url?: string;
   published_at?: string;
+  image_url?: string;
 };
 
 type WikiTopPage = {
@@ -26,6 +27,7 @@ type TopicPayload = {
     url?: string;
     source?: string;
     published_at?: string;
+    image_url?: string;
   }>;
 };
 
@@ -103,6 +105,7 @@ function toArticlePayload(articles: NewsApiArticle[]) {
     url: a.url,
     source: a.source,
     published_at: a.published_at,
+    image_url: a.image_url,
   }));
 }
 


### PR DESCRIPTION
## Summary
- Trending news topic cards now show the lead article's thumbnail image (sourced from The News API via the bundled Cloudflare Worker), with a new `showImages` prop to opt out; the compact/expanded/full layouts share a `TopicArticleList`/`ArticleLine` renderer instead of duplicating the topic block.
- Added Settings controls (Search Settings section) to customize and toggle the homepage weather and trending news widgets independently of their existing location/API-URL fields:
  - **Show Weather Widget** switch, **Weather Forecast Days** (3/5/7), **Weather Forecast Hours** (6/12/24), **Weather Temperature Unit** (°F/°C default)
  - **Show Trending News Widget** switch, **Trending News Topics** (4/6/8/10/12), **Trending News Images** switch
- `ChatHomepage` reads these from `localStorage` (same pattern as the existing background-art/orb-glow settings) and only renders the weather/trending row when at least one widget is enabled.

## Test plan
- [x] `cd packages/trending-news-api && bun run test` — 48 passed, including new thumbnail-rendering and `showImages={false}` tests
- [x] `cd packages/trending-news-api && bun run build` — tsup build succeeds
- [x] `cd packages/research-agent-ui && bun run test` — 88 passed
- [x] `bunx tsc --noEmit -p tsconfig.build.json` in `research-agent-ui` — no new errors introduced (pre-existing unrelated module-resolution errors for unbuilt sibling packages remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGdUvtib7mMakuS4dHNkEK


---
_Generated by [Claude Code](https://claude.ai/code/session_01FGdUvtib7mMakuS4dHNkEK)_