### PR TITLE
Add Vast.ai GPU rental backend for training jobs

### DIFF
--- a/packages/language-model-training/README.md
+++ b/packages/language-model-training/README.md
@@ -64,6 +64,26 @@ npm install
 npm run dev   # http://localhost:3000
 ```
 
+The dashboard's **Train transformer** button provisions a GPU on [Vast.ai](https://vast.ai) rather than training inside the control API's own container - see `src/services/vast_job.py`/`src/cloud/vast_utils.py` and **Vast.ai training backend** below before using it.
+
+### 5. Vast.ai training backend
+
+The "Train transformer" job in the web UI rents a GPU on Vast.ai's marketplace, uploads this package to it over SSH, runs the pipeline there, and destroys the instance when it finishes (so you're only billed for the run). Set on the `api` container/service:
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `VAST_API_KEY` | *(required)* | From your [Vast.ai account](https://cloud.vast.ai/manage-keys/) |
+| `VAST_SSH_KEY_PATH` | `~/.ssh/id_rsa` | Private key whose **public** half is already added to your Vast.ai account under Settings -> SSH Keys (Vast has no API to push a one-off key at instance creation) |
+| `VAST_GPU_NAME` | `RTX_4090` | GPU model to search for |
+| `VAST_NUM_GPUS` | `1` | GPUs per instance |
+| `VAST_MAX_HOURLY` | `1.5` | Price cap in $/hr; the cheapest-performance-per-dollar offer under this cap is picked |
+| `VAST_IMAGE` | `pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime` | Docker image Vast boots on the instance |
+| `VAST_DISK_GB` | `64` | Instance disk size |
+| `VAST_TRAIN_CMD` | `pip install -r requirements.txt && python src/training/wikipedia_transformer.py` | Command run on the instance after upload |
+| `VAST_DESTROY_ON_FINISH` | `true` | Destroy (vs. just stop) the instance once the run ends |
+
+`gpu_name`/`num_gpus`/`max_hourly`/`image`/`disk_gb`/`train_cmd` can also be overridden per-run in the `POST /api/jobs/train/start` body (the web UI's GPU/price fields do this). Job status (`GET /api/jobs/train`) includes `instance_id`, `ssh_host`, `gpu_name`, and `cost_per_hour` while the instance is up, and the log stream tails the remote training log over SSH exactly like the local-subprocess jobs.
+
 ## What You'll Learn
 
 - **How language models work**: converting words into high-dimensional vectors and using transformer architecture to capture relationships like "king/queen" and "Paris/France ↔ Tokyo/Japan"

--- a/packages/language-model-training/docker/compose/compose.yml
+++ b/packages/language-model-training/docker/compose/compose.yml
@@ -23,9 +23,18 @@ services:
     volumes:
       - ./output:/app/logs
       - ./data:/app/data
+      # Private half of an SSH keypair whose public half is already added to
+      # your Vast.ai account (Settings -> SSH Keys) - see src/services/vast_job.py.
+      - ${VAST_SSH_KEY_PATH:-~/.ssh/id_rsa}:/home/transformer/.ssh/id_rsa:ro
     environment:
       - PYTHONUNBUFFERED=1
       - CORS_ORIGINS=http://localhost:3000
+      # Vast.ai training backend - the "Train transformer" button in webui/
+      # provisions a GPU there instead of training in this container.
+      - VAST_API_KEY=${VAST_API_KEY}
+      - VAST_SSH_KEY_PATH=/home/transformer/.ssh/id_rsa
+      - VAST_GPU_NAME=${VAST_GPU_NAME:-RTX_4090}
+      - VAST_MAX_HOURLY=${VAST_MAX_HOURLY:-1.5}
 
   # 🖥️ Next.js control dashboard (webui/) - talks to the `api` service from
   # the browser at NEXT_PUBLIC_API_URL. Dev-mode only; for a production

--- a/packages/language-model-training/docker/images/Dockerfile
+++ b/packages/language-model-training/docker/images/Dockerfile
@@ -40,6 +40,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     htop \
     vim \
     ocl-icd-opencl-dev \
+    # ssh/scp: the training job runs on a rented Vast.ai GPU, not in this
+    # container - see src/services/vast_job.py
+    openssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/packages/language-model-training/requirements.txt
+++ b/packages/language-model-training/requirements.txt
@@ -8,6 +8,9 @@ fastapi>=0.110.0
 uvicorn[standard]>=0.29.0
 pydantic>=2.0.0
 
+# Vast.ai training backend (src/cloud/vast_utils.py, src/services/vast_job.py)
+requests>=2.31.0
+
 # Wikipedia-scale pipeline: MongoDB client for dumpster-dive article storage
 pymongo>=4.6.0
 

--- a/packages/language-model-training/src/cloud/vast_utils.py
+++ b/packages/language-model-training/src/cloud/vast_utils.py
@@ -1,0 +1,133 @@
+"""
+Vast.ai REST client and offer-selection helpers.
+
+Vast.ai rents spare GPUs on a marketplace: you search available offers via
+GET /bundles/, then accept one by PUT to /asks/{id}/, which creates a running
+instance. Auth is a bearer token (the account's API key) on every request.
+See https://docs.vast.ai/api-reference for the underlying HTTP API.
+
+This module only wraps that HTTP API - it knows nothing about SSH or the
+training container's job lifecycle. See src/services/vast_job.py for the
+piece that turns a launched instance into a Job the control API can track.
+"""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+VAST_API_BASE = os.getenv("VAST_API_BASE", "https://console.vast.ai/api/v0")
+
+
+class VastAPIError(RuntimeError):
+    """Raised when the Vast.ai API returns a non-2xx response."""
+
+
+class VastClient:
+    """Thin wrapper over the Vast.ai REST API."""
+
+    def __init__(self, api_key: Optional[str] = None, base_url: str = VAST_API_BASE):
+        self.api_key = api_key or os.getenv("VAST_API_KEY", "")
+        if not self.api_key:
+            raise VastAPIError("VAST_API_KEY is not set")
+        self.base_url = base_url.rstrip("/")
+
+    def _request(self, method: str, path: str, *, params: Optional[dict] = None, json: Optional[dict] = None) -> Any:
+        url = f"{self.base_url}{path}"
+        resp = requests.request(
+            method,
+            url,
+            params={k: v for k, v in (params or {}).items() if v is not None},
+            json=json,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            timeout=30,
+        )
+        if not resp.ok:
+            raise VastAPIError(f"Vast API {method} {path} failed: {resp.status_code} {resp.text}")
+        if not resp.content:
+            return {}
+        return resp.json()
+
+    def search_offers(
+        self,
+        gpu_name: Optional[str] = None,
+        num_gpus: int = 1,
+        max_hourly: Optional[float] = None,
+        verified: bool = True,
+        rentable: bool = True,
+        order: str = "dlperf_usd-",
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """GET /bundles/ - the set of GPU offers currently for rent."""
+        query: Dict[str, Any] = {"num_gpus": num_gpus, "order": order, "limit": limit}
+        if gpu_name:
+            query["gpu_name"] = gpu_name
+        if verified:
+            query["verified"] = "true"
+        if rentable:
+            query["rentable"] = "true"
+        if max_hourly is not None:
+            query["dph_total"] = f"lte={max_hourly}"
+        result = self._request("GET", "/bundles/", params=query)
+        return result.get("offers", result if isinstance(result, list) else [])
+
+    def create_instance(
+        self,
+        ask_id: int,
+        *,
+        image: str,
+        disk: float,
+        onstart: str = "",
+        env: Optional[Dict[str, str]] = None,
+        ssh: bool = True,
+        direct: bool = True,
+        jupyter: bool = False,
+    ) -> Dict[str, Any]:
+        """PUT /asks/{id}/ - accept an offer, creating a running instance."""
+        return self._request(
+            "PUT",
+            f"/asks/{ask_id}/",
+            json={
+                "image": image,
+                "disk": disk,
+                "ssh": ssh,
+                "direct": direct,
+                "env": env or {},
+                "onstart": onstart,
+                "jupyter": jupyter,
+                "runtype": "ssh" if ssh else "args",
+            },
+        )
+
+    def list_instances(self) -> List[Dict[str, Any]]:
+        result = self._request("GET", "/instances/")
+        return result.get("instances", result if isinstance(result, list) else [])
+
+    def show_instance(self, instance_id: int) -> Dict[str, Any]:
+        result = self._request("GET", f"/instances/{instance_id}/")
+        return result.get("instances", result)
+
+    def stop_instance(self, instance_id: int) -> Dict[str, Any]:
+        return self._request("PUT", f"/instances/{instance_id}/", json={"state": "stopped"})
+
+    def destroy_instance(self, instance_id: int) -> Dict[str, Any]:
+        return self._request("DELETE", f"/instances/{instance_id}/")
+
+
+def pick_best_offer(offers: List[Dict[str, Any]], max_hourly: Optional[float] = None) -> Dict[str, Any]:
+    """Cheapest-performance-per-dollar offer, optionally capped at max_hourly."""
+    candidates = [
+        o for o in offers
+        if max_hourly is None or float(o.get("dph_total", o.get("dph_base", float("inf")))) <= max_hourly
+    ]
+    if not candidates:
+        raise VastAPIError("No Vast.ai offers matched the search filters and price cap")
+
+    candidates.sort(
+        key=lambda o: float(o.get("dlperf_per_dphtotal", o.get("dlperf_usd", 0.0))),
+        reverse=True,
+    )
+    return candidates[0]

--- a/packages/language-model-training/src/services/server.py
+++ b/packages/language-model-training/src/services/server.py
@@ -12,6 +12,7 @@ Run directly:
 """
 
 import asyncio
+import dataclasses
 import json
 import os
 import signal
@@ -27,8 +28,12 @@ from pydantic import BaseModel
 
 try:  # `uvicorn src.services.server:app` imports this as part of the `src` package
     from ..training.improve import PROVIDERS, SAMPLE_QA, ImproveError, call_professional_model
+    from ..cloud.vast_utils import VastAPIError
+    from .vast_job import VastJob, VastTrainConfig
 except ImportError:  # `python src/services/server.py` runs it as a standalone script
     from training.improve import PROVIDERS, SAMPLE_QA, ImproveError, call_professional_model
+    from cloud.vast_utils import VastAPIError
+    from services.vast_job import VastJob, VastTrainConfig
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 LOG_DIR = os.environ.get("LOG_DIR", os.path.join(ROOT_DIR, "logs"))
@@ -121,7 +126,7 @@ class Job:
         }
 
 
-_jobs: dict[str, Job] = {}
+_jobs: dict[str, "Job | VastJob"] = {}
 
 
 def _start_job(name: str, cmd: list, env: Optional[dict] = None) -> Job:
@@ -133,7 +138,7 @@ def _start_job(name: str, cmd: list, env: Optional[dict] = None) -> Job:
     return job
 
 
-def _get_job(name: str) -> Job:
+def _get_job(name: str) -> "Job | VastJob":
     job = _jobs.get(name)
     if not job:
         raise HTTPException(404, detail=f"no job named '{name}' has been started")
@@ -155,6 +160,7 @@ def status():
     return {
         "service": "train-next-word-prediction",
         "reference": "https://github.com/tinygrad/tinygrad",
+        "train_backend": "vast.ai",
         "docs": {"scalar": "/scalar", "openapi": "/openapi.json", "swagger": "/docs"},
         "jobs": {name: job.to_dict() for name, job in _jobs.items()},
     }
@@ -229,13 +235,41 @@ def download_status():
 
 
 # --------------------------------------------------------------------------
-# Training job (full pipeline: tokenizer -> dataset -> transformer -> generate)
+# Training job - provisions a GPU on Vast.ai, uploads this package to it, and
+# runs the full pipeline (tokenizer -> dataset -> transformer -> generate)
+# there. See src/services/vast_job.py for the provisioning/upload/log-tail
+# lifecycle and src/cloud/vast_utils.py for the raw Vast.ai REST client.
+# Requires VAST_API_KEY; VAST_GPU_NAME/VAST_MAX_HOURLY/etc set the defaults
+# below and can be overridden per-request.
 # --------------------------------------------------------------------------
 
+class TrainRequest(BaseModel):
+    gpu_name: Optional[str] = None
+    num_gpus: Optional[int] = None
+    max_hourly: Optional[float] = None
+    image: Optional[str] = None
+    disk_gb: Optional[float] = None
+    train_cmd: Optional[str] = None
+
+
 @app.post("/api/jobs/train/start")
-def start_train():
-    script = os.path.join(ROOT_DIR, "src", "training", "wikipedia_transformer.py")
-    job = _start_job("train", [sys.executable, script])
+def start_train(req: TrainRequest = TrainRequest()):
+    if not os.environ.get("VAST_API_KEY"):
+        raise HTTPException(500, detail="VAST_API_KEY is not configured on the control API container")
+
+    existing = _jobs.get("train")
+    if existing and existing.running:
+        raise HTTPException(409, detail="job 'train' is already running")
+
+    config = VastTrainConfig.from_env()
+    overrides = req.model_dump(exclude_none=True)
+    config = dataclasses.replace(config, **overrides)
+
+    try:
+        job = VastJob("train", LOG_DIR, ROOT_DIR, config)
+    except VastAPIError as exc:
+        raise HTTPException(502, detail=str(exc))
+    _jobs["train"] = job
     return job.to_dict()
 
 

--- a/packages/language-model-training/src/services/vast_job.py
+++ b/packages/language-model-training/src/services/vast_job.py
@@ -1,0 +1,309 @@
+"""
+Runs the training job on a rented Vast.ai GPU instead of in-process.
+
+VastJob implements the same interface as the plain subprocess `Job` in
+server.py (`.running`, `.exit_code`, `.stop()`, `.tail()`, `.to_dict()`), so
+the existing /api/jobs/train/* routes and the webui's JobPanel/SSE log
+stream work unmodified - only where "train" actually runs changes.
+
+Lifecycle, run entirely on a background thread:
+  1. Search Vast.ai offers, pick the best one under the price cap, accept it
+     (this creates the instance) and wait for it to report `running`.
+  2. Wait for SSH to come up, then scp the package's src/, scripts/, and
+     requirements.txt onto the instance and drop a generated run.sh that
+     installs deps, runs the training command, and records its exit code.
+  3. Touch a READY sentinel file; the instance's onstart script (a wait
+     loop) picks it up and launches run.sh.
+  4. `ssh ... tail -F` the remote log into this job's local log file, so
+     the existing tail()/SSE-stream code paths need no changes.
+  5. Poll for the exit-code sentinel file; once seen, stop tailing and
+     (optionally) destroy the instance so billing stops.
+
+Requires VAST_API_KEY, and an SSH keypair where the *public* half is
+already added to the Vast.ai account (Settings -> SSH Keys) - Vast has no
+API for pushing a one-off key at instance-creation time. Point
+VAST_SSH_KEY_PATH at the matching private key (default ~/.ssh/id_rsa).
+"""
+
+import dataclasses
+import logging
+import os
+import shlex
+import subprocess
+import threading
+import time
+from typing import Optional
+
+from ..cloud.vast_utils import VastAPIError, VastClient, pick_best_offer
+
+logger = logging.getLogger(__name__)
+
+REMOTE_PROJECT_DIR = "/workspace/project"
+REMOTE_LOG_FILE = "/workspace/train.log"
+REMOTE_EXIT_FILE = "/workspace/train.exit"
+REMOTE_READY_FILE = "/workspace/READY"
+REMOTE_RUN_SCRIPT = "/workspace/run.sh"
+
+
+@dataclasses.dataclass
+class VastTrainConfig:
+    gpu_name: str = "RTX_4090"
+    num_gpus: int = 1
+    max_hourly: float = 1.5
+    image: str = "pytorch/pytorch:2.4.0-cuda12.4-cudnn9-runtime"
+    disk_gb: float = 64
+    train_cmd: str = "pip install -r requirements.txt && python src/training/wikipedia_transformer.py"
+    destroy_on_finish: bool = True
+    ssh_key_path: str = os.path.expanduser(os.getenv("VAST_SSH_KEY_PATH", "~/.ssh/id_rsa"))
+    poll_seconds: float = 15
+    ssh_ready_timeout: float = 300
+    instance_running_timeout: float = 900
+
+    @classmethod
+    def from_env(cls) -> "VastTrainConfig":
+        return cls(
+            gpu_name=os.getenv("VAST_GPU_NAME", cls.gpu_name),
+            num_gpus=int(os.getenv("VAST_NUM_GPUS", cls.num_gpus)),
+            max_hourly=float(os.getenv("VAST_MAX_HOURLY", cls.max_hourly)),
+            image=os.getenv("VAST_IMAGE", cls.image),
+            disk_gb=float(os.getenv("VAST_DISK_GB", cls.disk_gb)),
+            train_cmd=os.getenv("VAST_TRAIN_CMD", cls.train_cmd),
+            destroy_on_finish=os.getenv("VAST_DESTROY_ON_FINISH", "true").lower() != "false",
+        )
+
+
+def _onstart_script() -> str:
+    # Idles until the orchestrator has finished uploading files, then runs them.
+    return (
+        f"mkdir -p {REMOTE_PROJECT_DIR} && touch {REMOTE_LOG_FILE} && "
+        f"while [ ! -f {REMOTE_READY_FILE} ]; do sleep 2; done && "
+        f"bash {REMOTE_RUN_SCRIPT}"
+    )
+
+
+def _run_script(train_cmd: str) -> str:
+    return (
+        "#!/bin/bash\n"
+        "set -uo pipefail\n"
+        f"cd {REMOTE_PROJECT_DIR}\n"
+        f"( {train_cmd} ) >> {REMOTE_LOG_FILE} 2>&1\n"
+        f"echo $? > {REMOTE_EXIT_FILE}\n"
+    )
+
+
+class VastJob:
+    """A training run provisioned on Vast.ai; same surface as the local `Job`."""
+
+    def __init__(self, name: str, log_dir: str, project_dir: str, config: VastTrainConfig):
+        self.name = name
+        self.project_dir = project_dir
+        self.config = config
+        self.log_path = os.path.join(log_dir, f"{name}.log")
+        self.started_at = time.time()
+        self.finished_at: Optional[float] = None
+        self.instance_id: Optional[int] = None
+        self.ssh_host: Optional[str] = None
+        self.ssh_port: Optional[int] = None
+        self.offer: dict = {}
+
+        self._exit_code: Optional[int] = None
+        self._stop_requested = threading.Event()
+        self._tail_proc: Optional[subprocess.Popen] = None
+        self._log_file = open(self.log_path, "w")
+        self._vast = VastClient()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    # -- Job interface expected by server.py --------------------------------
+
+    @property
+    def running(self) -> bool:
+        return self.finished_at is None
+
+    @property
+    def exit_code(self) -> Optional[int]:
+        return self._exit_code
+
+    def stop(self) -> bool:
+        if not self.running:
+            return False
+        self._stop_requested.set()
+        self._teardown(exit_code=self._exit_code if self._exit_code is not None else -1)
+        return True
+
+    def tail(self, max_lines: int = 200) -> str:
+        try:
+            with open(self.log_path, "r", errors="replace") as f:
+                return "".join(f.readlines()[-max_lines:])
+        except FileNotFoundError:
+            return ""
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "running": self.running,
+            "exit_code": self.exit_code,
+            "pid": self.instance_id or 0,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "log_tail": self.tail(),
+            "backend": "vast.ai",
+            "instance_id": self.instance_id,
+            "ssh_host": self.ssh_host,
+            "ssh_port": self.ssh_port,
+            "gpu_name": self.offer.get("gpu_name", self.config.gpu_name),
+            "cost_per_hour": self.offer.get("dph_total"),
+        }
+
+    # -- internals ------------------------------------------------------------
+
+    def _log(self, line: str) -> None:
+        self._log_file.write(line.rstrip("\n") + "\n")
+        self._log_file.flush()
+
+    def _ssh_base(self) -> list:
+        return [
+            "ssh",
+            "-i", self.config.ssh_key_path,
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-p", str(self.ssh_port),
+            f"root@{self.ssh_host}",
+        ]
+
+    def _scp(self, local_path: str, remote_path: str, recursive: bool = False) -> None:
+        cmd = ["scp"] + (["-r"] if recursive else []) + [
+            "-i", self.config.ssh_key_path,
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-P", str(self.ssh_port),
+            local_path,
+            f"root@{self.ssh_host}:{remote_path}",
+        ]
+        subprocess.run(cmd, check=True, capture_output=True, timeout=120)
+
+    def _ssh_exec(self, remote_cmd: str, timeout: float = 30) -> subprocess.CompletedProcess:
+        return subprocess.run(self._ssh_base() + [remote_cmd], capture_output=True, timeout=timeout)
+
+    def _run(self) -> None:
+        try:
+            self._provision()
+            self._wait_for_ssh()
+            self._upload_project()
+            self._start_tail()
+            self._wait_for_completion()
+        except Exception as exc:  # noqa: BLE001 - surface any failure into the job log
+            logger.exception("Vast.ai training job %s failed", self.name)
+            self._log(f"[vast] job failed: {exc}")
+            self._teardown(exit_code=1)
+
+    def _provision(self) -> None:
+        self._log(f"[vast] searching offers for {self.config.num_gpus}x {self.config.gpu_name} "
+                   f"under ${self.config.max_hourly}/hr")
+        offers = self._vast.search_offers(
+            gpu_name=self.config.gpu_name,
+            num_gpus=self.config.num_gpus,
+            max_hourly=self.config.max_hourly,
+        )
+        self.offer = pick_best_offer(offers, max_hourly=self.config.max_hourly)
+        self._log(f"[vast] selected offer {self.offer.get('id')} "
+                   f"(${self.offer.get('dph_total')}/hr, {self.offer.get('gpu_name')})")
+
+        created = self._vast.create_instance(
+            int(self.offer["id"]),
+            image=self.config.image,
+            disk=self.config.disk_gb,
+            onstart=_onstart_script(),
+        )
+        self.instance_id = int(created.get("new_contract") or created.get("id"))
+        self._log(f"[vast] created instance {self.instance_id}, waiting for it to boot")
+
+        deadline = time.time() + self.config.instance_running_timeout
+        while time.time() < deadline:
+            if self._stop_requested.is_set():
+                return
+            info = self._vast.show_instance(self.instance_id)
+            if info.get("actual_status") == "running":
+                self.ssh_host = info.get("ssh_host") or info.get("public_ipaddr")
+                self.ssh_port = int(info.get("ssh_port", 22))
+                self._log(f"[vast] instance running at {self.ssh_host}:{self.ssh_port}")
+                return
+            time.sleep(self.config.poll_seconds)
+        raise VastAPIError(f"Timed out waiting for instance {self.instance_id} to reach 'running'")
+
+    def _wait_for_ssh(self) -> None:
+        self._log("[vast] waiting for SSH to come up")
+        deadline = time.time() + self.config.ssh_ready_timeout
+        while time.time() < deadline:
+            if self._stop_requested.is_set():
+                return
+            result = self._ssh_exec("true", timeout=15)
+            if result.returncode == 0:
+                self._log("[vast] SSH is up")
+                return
+            time.sleep(5)
+        raise VastAPIError(f"Timed out waiting for SSH on instance {self.instance_id}")
+
+    def _upload_project(self) -> None:
+        self._log("[vast] uploading project files")
+        run_sh_path = os.path.join(os.path.dirname(self.log_path), f"{self.name}.run.sh")
+        with open(run_sh_path, "w") as f:
+            f.write(_run_script(self.config.train_cmd))
+
+        for rel in ("src", "scripts", "requirements.txt"):
+            local_path = os.path.join(self.project_dir, rel)
+            if os.path.exists(local_path):
+                self._scp(local_path, REMOTE_PROJECT_DIR + "/", recursive=os.path.isdir(local_path))
+
+        self._scp(run_sh_path, REMOTE_RUN_SCRIPT)
+        self._ssh_exec(f"chmod +x {shlex.quote(REMOTE_RUN_SCRIPT)}")
+        self._ssh_exec(f"touch {shlex.quote(REMOTE_READY_FILE)}")
+        self._log("[vast] upload complete, training started remotely")
+
+    def _start_tail(self) -> None:
+        self._tail_proc = subprocess.Popen(
+            self._ssh_base() + [f"touch {REMOTE_LOG_FILE}; tail -n +1 -F {REMOTE_LOG_FILE}"],
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
+        )
+
+    def _wait_for_completion(self) -> None:
+        while not self._stop_requested.is_set():
+            result = self._ssh_exec(f"cat {shlex.quote(REMOTE_EXIT_FILE)} 2>/dev/null || true", timeout=15)
+            output = result.stdout.decode(errors="replace").strip()
+            if output:
+                try:
+                    self._teardown(exit_code=int(output.splitlines()[-1]))
+                    return
+                except ValueError:
+                    pass
+
+            info = self._vast.show_instance(self.instance_id)
+            if info.get("actual_status") not in ("running", "loading"):
+                self._log(f"[vast] instance left running state ({info.get('actual_status')})")
+                self._teardown(exit_code=1)
+                return
+
+            time.sleep(self.config.poll_seconds)
+
+    def _teardown(self, exit_code: int) -> None:
+        if self.finished_at is not None:
+            return
+        self._exit_code = exit_code
+        self.finished_at = time.time()
+
+        if self._tail_proc and self._tail_proc.poll() is None:
+            self._tail_proc.terminate()
+
+        if self.instance_id is not None:
+            try:
+                if self.config.destroy_on_finish:
+                    self._vast.destroy_instance(self.instance_id)
+                    self._log(f"[vast] destroyed instance {self.instance_id}")
+                else:
+                    self._vast.stop_instance(self.instance_id)
+                    self._log(f"[vast] stopped instance {self.instance_id}")
+            except VastAPIError as exc:
+                self._log(f"[vast] failed to tear down instance {self.instance_id}: {exc}")
+
+        self._log(f"[vast] job finished with exit code {exit_code}")

--- a/packages/language-model-training/webui/components/dashboard/job-panel.tsx
+++ b/packages/language-model-training/webui/components/dashboard/job-panel.tsx
@@ -106,6 +106,14 @@ export function JobPanel({ title, description, jobName, fetchStatus, start, stop
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         {children}
+        {job?.instance_id && (
+          <p className="text-xs text-muted-foreground">
+            Vast.ai instance {job.instance_id}
+            {job.gpu_name ? ` · ${job.gpu_name}` : ""}
+            {job.cost_per_hour != null ? ` · $${job.cost_per_hour}/hr` : ""}
+            {job.ssh_host ? ` · ${job.ssh_host}:${job.ssh_port}` : ""}
+          </p>
+        )}
         <pre
           ref={logRef}
           className="h-48 overflow-y-auto rounded-md bg-muted p-3 text-xs leading-relaxed text-muted-foreground"

--- a/packages/language-model-training/webui/components/dashboard/train-panel.tsx
+++ b/packages/language-model-training/webui/components/dashboard/train-panel.tsx
@@ -1,17 +1,44 @@
 "use client";
 
+import * as React from "react";
+
 import { JobPanel } from "@/components/dashboard/job-panel";
 import { api } from "@/lib/api";
 
 export function TrainPanel() {
+  const [gpuName, setGpuName] = React.useState("RTX_4090");
+  const [maxHourly, setMaxHourly] = React.useState("1.50");
+
   return (
     <JobPanel
-      title="Train transformer"
-      description="Full pipeline: tokenizer -> dataset -> GPT-style transformer -> sample generation (src/training/wikipedia_transformer.py). Set USE_DEMO_MODE=false on the API container for the real Wikipedia corpus."
+      title="Train transformer on Vast.ai"
+      description="Rents a GPU on Vast.ai, uploads this package to it, and runs the full pipeline there (tokenizer -> dataset -> GPT-style transformer -> sample generation, src/training/wikipedia_transformer.py). The instance is destroyed automatically when the run finishes or is stopped. Requires VAST_API_KEY on the API container."
       jobName="train"
       fetchStatus={api.trainStatus}
-      start={api.startTrain}
+      start={() => api.startTrain({ gpu_name: gpuName, max_hourly: Number(maxHourly) || undefined })}
       stop={api.stopTrain}
-    />
+    >
+      <div className="flex flex-wrap items-center gap-4">
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          GPU
+          <input
+            value={gpuName}
+            onChange={(e) => setGpuName(e.target.value)}
+            placeholder="RTX_4090"
+            className="w-32 rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+          />
+        </label>
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          Max $/hr
+          <input
+            value={maxHourly}
+            onChange={(e) => setMaxHourly(e.target.value)}
+            placeholder="1.50"
+            inputMode="decimal"
+            className="w-20 rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+          />
+        </label>
+      </div>
+    </JobPanel>
   );
 }

--- a/packages/language-model-training/webui/lib/api.ts
+++ b/packages/language-model-training/webui/lib/api.ts
@@ -5,6 +5,10 @@
  * Dockerfile/wrangler.jsonc container exposes). Every job (download,
  * train) follows the same shape: POST .../start, POST .../stop,
  * GET ... for status, GET .../stream for an SSE log tail.
+ *
+ * The train job runs on a rented Vast.ai GPU rather than in-container - see
+ * src/services/vast_job.py. Its JobInfo carries extra instance fields
+ * (instance_id, ssh_host, gpu_name, cost_per_hour) alongside the normal ones.
  */
 
 export const API_URL =
@@ -18,6 +22,22 @@ export interface JobInfo {
   started_at: number;
   finished_at: number | null;
   log_tail: string;
+  /** Present on jobs provisioned on Vast.ai (currently just "train"). */
+  backend?: "vast.ai";
+  instance_id?: number | null;
+  ssh_host?: string | null;
+  ssh_port?: number | null;
+  gpu_name?: string | null;
+  cost_per_hour?: number | null;
+}
+
+export interface StartTrainRequest {
+  gpu_name?: string;
+  num_gpus?: number;
+  max_hourly?: number;
+  image?: string;
+  disk_gb?: number;
+  train_cmd?: string;
 }
 
 export interface StatusResponse {
@@ -80,7 +100,11 @@ export const api = {
     request<{ stopped: boolean }>("/api/jobs/download-wikipedia/stop", { method: "POST" }),
   downloadStatus: () => request<JobInfo>("/api/jobs/download-wikipedia"),
 
-  startTrain: () => request<JobInfo>("/api/jobs/train/start", { method: "POST" }),
+  startTrain: (body?: StartTrainRequest) =>
+    request<JobInfo>("/api/jobs/train/start", {
+      method: "POST",
+      body: JSON.stringify(body ?? {}),
+    }),
   stopTrain: () => request<{ stopped: boolean }>("/api/jobs/train/stop", { method: "POST" }),
   trainStatus: () => request<JobInfo>("/api/jobs/train"),
 };


### PR DESCRIPTION
## Summary
This PR adds support for running training jobs on rented GPUs from Vast.ai's marketplace instead of in-process. The training pipeline now provisions a GPU instance, uploads the project files via SSH, executes the training remotely, and streams logs back to the control API—all while maintaining the same job interface for the web UI.

## Key Changes

- **New Vast.ai client module** (`src/cloud/vast_utils.py`): Thin REST API wrapper for Vast.ai's offer search, instance creation, and lifecycle management (stop/destroy). Includes offer selection logic to pick the best performance-per-dollar option under a price cap.

- **New VastJob service** (`src/services/vast_job.py`): Implements the same job interface as the local `Job` class (`.running`, `.exit_code`, `.stop()`, `.tail()`, `.to_dict()`), but orchestrates the full Vast.ai lifecycle on a background thread:
  - Searches and accepts GPU offers
  - Waits for instance to boot and SSH to come up
  - Uploads project files (src/, scripts/, requirements.txt) and a generated run script
  - Tails remote logs back to the local log file via SSH
  - Polls for completion and cleans up the instance

- **Updated training API** (`src/services/server.py`): Modified `/api/jobs/train/start` to accept optional GPU configuration parameters (gpu_name, max_hourly, image, disk_gb, train_cmd) and provision a `VastJob` instead of a local subprocess. Requires `VAST_API_KEY` environment variable.

- **Web UI enhancements** (`webui/components/dashboard/train-panel.tsx`): Added input fields for GPU selection and hourly price cap, displays Vast.ai instance details (ID, GPU model, cost/hr, SSH address) in the job panel.

- **Configuration & documentation**: 
  - Added environment variables for Vast.ai backend configuration (API key, SSH key path, GPU preferences, pricing, image, disk size, training command)
  - Updated Docker Compose to mount SSH private key and pass Vast.ai credentials
  - Added Dockerfile dependencies (ssh, scp)
  - Updated README with Vast.ai backend setup instructions
  - Updated API client types to include Vast.ai-specific job fields

## Implementation Details

- The VastJob lifecycle runs entirely on a daemon thread, allowing the API to return immediately while provisioning happens asynchronously
- SSH key management: the public key must be pre-added to the Vast.ai account; the private key path is configurable
- Instance cleanup is automatic (destroy by default, or stop if `destroy_on_finish=false`)
- Log streaming uses `ssh ... tail -F` to avoid polling the remote log file
- Exit code detection polls for a sentinel file written by the remote run script
- All Vast.ai-specific errors are surfaced into the job log for visibility

https://claude.ai/code/session_012ijcuv474GmLXQLtfUyRGt