### PR TITLE
Add reason-editor-sidebar to prebuild script

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib && cd ../reason-editor-sidebar && bun run build",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",


### PR DESCRIPTION
## Summary
Updated the prebuild script in the qwksearch-web package to include building the `reason-editor-sidebar` package as part of the build pipeline.

## Changes
- Extended the `prebuild` script to build `reason-editor-sidebar` after `reason-editor`
- This ensures the sidebar component is compiled before the main application build runs

## Details
The prebuild script now includes an additional build step that navigates to the `reason-editor-sidebar` package and runs its build command. This maintains consistency with the existing pattern of building all dependent packages in sequence before the main application build.

https://claude.ai/code/session_01XtHrNUXKvNJvkBziBXrC4x