### PR TITLE
Reorder prebuild dependencies for correct build sequence

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor && bun run build:lib && cd ../reason-editor-sidebar && bun run build",
+    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor-sidebar && bun run build && cd ../reason-editor && bun run build:lib",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",


### PR DESCRIPTION
## Summary
Adjusted the order of package builds in the prebuild script to ensure `reason-editor-sidebar` is built before `reason-editor`, correcting a dependency ordering issue.

## Key Changes
- Moved `reason-editor` build step to the end of the prebuild chain
- Positioned `reason-editor-sidebar` build step before `reason-editor`
- This ensures that `reason-editor-sidebar` dependencies are available when `reason-editor` is built

## Details
The prebuild script chains multiple package builds together. The reordering reflects a dependency relationship where `reason-editor` likely depends on or should be built after `reason-editor-sidebar`. This change prevents potential build failures due to missing dependencies or incorrect initialization order.

https://claude.ai/code/session_01GyB5B1B2d7q189SffXcqMa