### PR TITLE
Update hero tagline to "A game changing first innovation. The Research IDE."

### DIFF
--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -76,12 +76,10 @@ function Hero() {
 
         <Reveal delay={80}>
           <h1 className="text-4xl leading-[1.08] font-bold tracking-tight text-balance sm:text-5xl lg:text-6xl">
-            Search the whole web.
+            A game changing first innovation.
             <br />
             <span className="qs-shimmer-text bg-gradient-to-r from-sky-500 via-violet-500 to-sky-500 bg-clip-text text-transparent">
-              Read every source.
-              <br />
-              Write the answer.
+              The Research IDE.
             </span>
           </h1>
         </Reveal>


### PR DESCRIPTION
## Summary
- Replaced the homepage hero headline ("Search the whole web. Read every source. Write the answer.") with the new tagline "A game changing first innovation. The Research IDE." in `apps/qwksearch-web/components/features/FeaturesView.tsx`.
- Corrected the typo "innoovation" → "innovation" as requested.

## Test plan
- [x] Verified no other occurrences of the old headline text exist elsewhere in the repo.
- [ ] Visually confirm the hero section renders correctly on `/` in a running dev server (not run in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDpCGB8LEZyQop6rCS38tz

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDpCGB8LEZyQop6rCS38tz)_