### PR TITLE
Allow scoped CORS on public agent routes for debate-ai.com's embed

### DIFF
--- a/apps/qwksearch-web/app/api/agent/autocomplete/route.ts
+++ b/apps/qwksearch-web/app/api/agent/autocomplete/route.ts
@@ -1,4 +1,6 @@
 import { createAutocompleteHandler } from "research-agent-ui/api";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 const handler = createAutocompleteHandler();
-export const { GET } = handler;
+export const GET = withCors(handler.GET);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/agent/chat/route.ts
+++ b/apps/qwksearch-web/app/api/agent/chat/route.ts
@@ -4,8 +4,10 @@
  * LLM-powered response generation with streaming output.
  */
 import { handleChatRequest } from "@/lib/chat";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-export const POST = handleChatRequest;
+export const POST = withCors(handleChatRequest);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/agent/discover/route.ts
+++ b/apps/qwksearch-web/app/api/agent/discover/route.ts
@@ -1,4 +1,6 @@
 import { createDiscoverHandler } from "research-agent-ui/api";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 const handler = createDiscoverHandler();
-export const { GET } = handler;
+export const GET = withCors(handler.GET);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/agent/providers/route.ts
+++ b/apps/qwksearch-web/app/api/agent/providers/route.ts
@@ -1,5 +1,8 @@
 import { createProvidersHandler } from "research-agent-ui/api";
 import { getSession } from "@/lib/auth/session";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 const handler = createProvidersHandler({ getSession });
-export const { GET, POST } = handler;
+export const GET = withCors(handler.GET);
+export const POST = withCors(handler.POST);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/agent/search/route.ts
+++ b/apps/qwksearch-web/app/api/agent/search/route.ts
@@ -1,4 +1,6 @@
 import { createSearchHandler } from "research-agent-ui/api";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 const handler = createSearchHandler({ searxngDomain: "https://search.qwksearch.com" });
-export const { GET } = handler;
+export const GET = withCors(handler.GET);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/agent/suggestions/route.ts
+++ b/apps/qwksearch-web/app/api/agent/suggestions/route.ts
@@ -1,4 +1,6 @@
 import { createSuggestionsHandler } from "research-agent-ui/api";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 const handler = createSuggestionsHandler();
-export const { POST } = handler;
+export const POST = withCors(handler.POST);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/agent/test-models/route.ts
+++ b/apps/qwksearch-web/app/api/agent/test-models/route.ts
@@ -1,7 +1,9 @@
 import { createTestModelsHandler } from "research-agent-ui/api";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 export const runtime = "nodejs";
 export const maxDuration = 300;
 
 const handler = createTestModelsHandler();
-export const { POST } = handler;
+export const POST = withCors(handler.POST);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/app/api/doc/article/route.ts
+++ b/apps/qwksearch-web/app/api/doc/article/route.ts
@@ -12,6 +12,7 @@ import { eq, sql } from "drizzle-orm";
 import { extractContent } from "extract-webpage/url-to-content/url-to-content";
 import { extractArticleViaScraper, extractViaTavily } from "@/lib/scraper";
 import { getTavilyApiKey } from "@/lib/config/serverRegistry";
+import { withCors, corsPreflight } from "@/lib/cors";
 
 interface Article {
   html?: string;
@@ -33,7 +34,7 @@ interface CachedArticle extends Article {
 }
 
 // GET /api/article?url=... - Get article with cache
-export async function GET(req: NextRequest) {
+async function articleGet(req: NextRequest) {
   console.log("[article] GET start", { url: req.nextUrl.searchParams.get("url") });
   try {
     const db = getDB();
@@ -320,7 +321,7 @@ export async function GET(req: NextRequest) {
 }
 
 // POST /api/article - Store Q&A or update follow-up questions
-export async function POST(req: NextRequest) {
+async function articlePost(req: NextRequest) {
   try {
     const db = getDB();
     const body = await req.json();
@@ -363,3 +364,7 @@ export async function POST(req: NextRequest) {
     );
   }
 }
+
+export const GET = withCors(articleGet);
+export const POST = withCors(articlePost);
+export const OPTIONS = corsPreflight;

--- a/apps/qwksearch-web/lib/cors.ts
+++ b/apps/qwksearch-web/lib/cors.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview CORS helpers for the small set of public, unauthenticated
+ * agent API routes (search, chat, discover, autocomplete, suggestions,
+ * providers, test-models) that external sites embed research-agent-ui
+ * against directly from the browser instead of iframing qwksearch.com.
+ * Everything else (chats, messages, uploads, auth, admin) stays same-origin
+ * only, so this allowlist deliberately isn't wired into research-agent-ui's
+ * shared handler factories — it's a deployment-specific policy for this app.
+ */
+
+const ALLOWED_ORIGINS = new Set([
+  "https://debate-ai.com",
+  "https://www.debate-ai.com",
+  ...(process.env.NODE_ENV !== "production"
+    ? ["http://localhost:3000", "http://localhost:3001"]
+    : []),
+]);
+
+function resolveAllowOrigin(request: Request): string | null {
+  const origin = request.headers.get("origin");
+  return origin && ALLOWED_ORIGINS.has(origin) ? origin : null;
+}
+
+/**
+ * Wraps a route handler, adding `Access-Control-Allow-Origin` to its
+ * response when the caller's origin is allowlisted. Same-origin requests
+ * (no `Origin` header) pass through unchanged. Streams the original
+ * response body through untouched, so this is safe to use on the streaming
+ * `/api/agent/chat` route as well as plain JSON handlers.
+ */
+export function withCors<Args extends unknown[]>(
+  handler: (request: Request, ...args: Args) => Promise<Response> | Response,
+) {
+  return async (request: Request, ...args: Args): Promise<Response> => {
+    const response = await handler(request, ...args);
+    const allowOrigin = resolveAllowOrigin(request);
+    if (!allowOrigin) return response;
+
+    const headers = new Headers(response.headers);
+    headers.set("Access-Control-Allow-Origin", allowOrigin);
+    headers.append("Vary", "Origin");
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    });
+  };
+}
+
+/** OPTIONS handler for CORS preflight on routes wrapped with `withCors`. */
+export function corsPreflight(request: Request): Response {
+  const allowOrigin = resolveAllowOrigin(request);
+  if (!allowOrigin) return new Response(null, { status: 204 });
+
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": allowOrigin,
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      Vary: "Origin",
+    },
+  });
+}

--- a/apps/qwksearch-web/lib/cors.ts
+++ b/apps/qwksearch-web/lib/cors.ts
@@ -17,7 +17,10 @@ const ALLOWED_ORIGINS = new Set([
 ]);
 
 function resolveAllowOrigin(request: Request): string | null {
-  const origin = request.headers.get("origin");
+  // Optional chaining: some route tests call handlers with a minimal
+  // `{ nextUrl, url }` mock (no `.headers`) since the handler itself never
+  // read headers before. Treat that the same as a same-origin request.
+  const origin = request.headers?.get("origin");
   return origin && ALLOWED_ORIGINS.has(origin) ? origin : null;
 }
 


### PR DESCRIPTION
## Summary

- debate-ai.com's `/doc` page used to iframe `qwksearch.com/docs`. It now renders `research-agent-ui`'s `ChatWindow` directly and calls this app's API from the browser instead, cross-origin.
- Adds a small allowlist-based CORS helper (`apps/qwksearch-web/lib/cors.ts`) and applies it only to routes that were already unauthenticated/guest-usable: `/api/agent/providers`, `/api/agent/chat`, `/api/agent/discover`, `/api/agent/autocomplete`, `/api/agent/suggestions`, `/api/agent/search`, `/api/agent/test-models`, and `/api/doc/article`.
- Everything else — chats, messages, uploads, voice, transcript, MCP servers, rewrite, auth, admin — is left same-origin only. No `Access-Control-Allow-Credentials` is set, so cookies are never sent cross-origin; the allowed origins are `https://debate-ai.com` / `https://www.debate-ai.com` in production plus `localhost` in dev.

## Changes

- `apps/qwksearch-web/lib/cors.ts` (new): `withCors(handler)` wraps a route handler to add `Access-Control-Allow-Origin` (only for allowlisted origins) to its response — it streams the original response body through untouched, so it's safe on the streaming `/api/agent/chat` route too. `corsPreflight` handles `OPTIONS` preflight requests.
- Eight route files updated to wrap their exported `GET`/`POST` with `withCors` and add an `OPTIONS` export: `agent/providers`, `agent/discover`, `agent/autocomplete`, `agent/suggestions`, `agent/search`, `agent/test-models`, `agent/chat`, `doc/article`.

## Test plan

- [x] Reviewed each wrapped handler's signature (`(req: Request) => Promise<Response>` or `NextRequest` which is compatible) to confirm `withCors` composes cleanly.
- [ ] Couldn't install/build this monorepo in this environment (large workspace, no network-installed `node_modules` here) — this repo's Next config already sets `typescript.ignoreBuildErrors: true`, but a real build/lint pass before merge is recommended.
- [ ] Manual cross-origin smoke test from debate-ai.com's `/doc` page once both PRs are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6oaFSd4Ug9THo4sXtTkgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6oaFSd4Ug9THo4sXtTkgz)_