### PR TITLE
Add Markdown detection and conversion for JINA reader output

### DIFF
--- a/packages/extract-webpage/src/html-to-content/__tests__/html-utils.test.ts
+++ b/packages/extract-webpage/src/html-to-content/__tests__/html-utils.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @fileoverview Tests for regexp-based Markdown detection, navigation/noise
+ * removal, and Markdown-to-HTML conversion used on JINA-style extractions.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  convertMarkdownToFormattedHTML,
+  detectMarkdown,
+  removeMarkdownNavigation,
+} from "../html-utils";
+
+describe("detectMarkdown", () => {
+  it("detects typical markdown documents", () => {
+    expect(
+      detectMarkdown("# Title\n\nSome **bold** text.\n\n- item 1\n- item 2")
+    ).toBe(true);
+  });
+
+  it("detects JINA reader output", () => {
+    const jina = [
+      "Markdown Content:",
+      "Michael Jackson",
+      "===============",
+      "",
+      "[![Image 1](https://i.scdn.co/image/abc)](/album/1)",
+      "[Thriller](/album/1C2h7mLntPSeVYciMRTF4a)",
+      "[Bad 25th Anniversary](/album/24TAupSNVWSAHL0R7n71vm)",
+    ].join("\n");
+    expect(detectMarkdown(jina)).toBe(true);
+  });
+
+  it("detects link-heavy markdown with a single syntax signal", () => {
+    const links = [
+      "[Dangerous](/album/0oX4SealMgNXrvRDhqqOKg) some text",
+      "more [Invincible](/album/52E4RP7XDzalpIrOgSTgiQ) text",
+      "and [HIStory](/album/3OBhnTLrvkoEEETjFA3Qfk) too",
+    ].join("\n");
+    expect(detectMarkdown(links)).toBe(true);
+  });
+
+  it("does not flag HTML documents", () => {
+    expect(
+      detectMarkdown(
+        "<html><body><h1>Title</h1><p>Some **bold** text</p><ul><li>a</li></ul></body></html>"
+      )
+    ).toBe(false);
+  });
+
+  it("does not flag HTML fragments with several closing tags", () => {
+    expect(
+      detectMarkdown(
+        "<div><p>One - two</p><p>Three</p><p>- looks like a list</p></div>"
+      )
+    ).toBe(false);
+  });
+
+  it("does not flag plain text", () => {
+    expect(
+      detectMarkdown("Just a plain sentence.\nAnother plain sentence here.")
+    ).toBe(false);
+  });
+
+  it("handles empty and non-string input", () => {
+    expect(detectMarkdown("")).toBe(false);
+    expect(detectMarkdown(null as any)).toBe(false);
+    expect(detectMarkdown(undefined as any)).toBe(false);
+  });
+});
+
+describe("removeMarkdownNavigation", () => {
+  it("removes JINA reader metadata lines", () => {
+    const input = [
+      "Title: Some Page",
+      "URL Source: https://example.com",
+      "Published Time: 2024-01-01",
+      "Markdown Content:",
+      "",
+      "Real article text here.",
+    ].join("\n");
+    const output = removeMarkdownNavigation(input);
+    expect(output).toBe("Real article text here.");
+  });
+
+  it("removes navigation phrase lines", () => {
+    const input = [
+      "[Skip to content](#main)",
+      "[Sign in](/login)",
+      "Real paragraph of the article.",
+      "[Back to top](#top)",
+    ].join("\n");
+    const output = removeMarkdownNavigation(input);
+    expect(output).toBe("Real paragraph of the article.");
+  });
+
+  it("removes runs of 3+ link-only lines pointing at relative URLs", () => {
+    const input = [
+      "Intro paragraph.",
+      "",
+      "[![Image 1](https://i.scdn.co/a)](/album/1)",
+      "[Thriller](/album/1)",
+      "[Bad](/album/2)",
+      "[Dangerous](/album/3)",
+      "",
+      "Closing paragraph.",
+    ].join("\n");
+    const output = removeMarkdownNavigation(input);
+    expect(output).toContain("Intro paragraph.");
+    expect(output).toContain("Closing paragraph.");
+    expect(output).not.toContain("/album/");
+  });
+
+  it("keeps short link-only runs and external citation links", () => {
+    const input = [
+      "See sources:",
+      "[Source A](https://a.example.com)",
+      "[Source B](https://b.example.com)",
+      "[Source C](https://c.example.com)",
+    ].join("\n");
+    const output = removeMarkdownNavigation(input);
+    expect(output).toContain("Source A");
+    expect(output).toContain("Source C");
+  });
+
+  it("keeps links inside prose", () => {
+    const input = "This mentions [a page](/internal/path) inside a sentence.";
+    expect(removeMarkdownNavigation(input)).toBe(input);
+  });
+
+  it("leaves fenced code blocks untouched", () => {
+    const input = [
+      "```",
+      "Title: not metadata, just code",
+      "[a](/x)",
+      "[b](/y)",
+      "[c](/z)",
+      "```",
+    ].join("\n");
+    const output = removeMarkdownNavigation(input);
+    expect(output).toContain("Title: not metadata, just code");
+    expect(output).toContain("[b](/y)");
+  });
+
+  it("handles empty and non-string input", () => {
+    expect(removeMarkdownNavigation("")).toBe("");
+    expect(removeMarkdownNavigation(null as any)).toBe("");
+  });
+});
+
+describe("convertMarkdownToFormattedHTML", () => {
+  it("converts linked images [![alt](src)](href)", () => {
+    const html = convertMarkdownToFormattedHTML(
+      "[![Cover](https://i.scdn.co/image/abc)](https://example.com/album/1)"
+    );
+    expect(html).toContain(
+      '<a href="https://example.com/album/1"><img src="https://i.scdn.co/image/abc" alt="Cover" /></a>'
+    );
+  });
+
+  it("converts images with empty alt text", () => {
+    const html = convertMarkdownToFormattedHTML(
+      "![](https://i.scdn.co/image/abc)"
+    );
+    expect(html).toContain('<img src="https://i.scdn.co/image/abc" alt="" />');
+  });
+
+  it("converts setext headers", () => {
+    const html = convertMarkdownToFormattedHTML(
+      "Page Title\n===============\n\nSection\n-------\n\nBody text."
+    );
+    expect(html).toContain("<h1>Page Title</h1>");
+    expect(html).toContain("<h2>Section</h2>");
+    expect(html).toContain("<p>Body text.</p>");
+  });
+
+  it("still treats --- after a blank line as a horizontal rule", () => {
+    const html = convertMarkdownToFormattedHTML("Some text.\n\n---\n\nMore.");
+    expect(html).toContain("<hr>");
+  });
+
+  it("converts autolinks", () => {
+    const html = convertMarkdownToFormattedHTML("Visit <https://example.com> now.");
+    expect(html).toContain('<a href="https://example.com">https://example.com</a>');
+  });
+
+  it("converts pipe tables", () => {
+    const html = convertMarkdownToFormattedHTML(
+      "| Name | Year |\n| --- | --- |\n| Thriller | 1982 |\n| Bad | 1987 |"
+    );
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>Name</th>");
+    expect(html).toContain("<td>Thriller</td>");
+    expect(html).toContain("<td>1987</td>");
+    expect(html).toContain("</table>");
+  });
+
+  it("applies inline markdown inside table cells", () => {
+    const html = convertMarkdownToFormattedHTML(
+      "| Album | Link |\n| --- | --- |\n| **Bad** | [play](/album/2) |"
+    );
+    expect(html).toContain("<strong>Bad</strong>");
+    expect(html).toContain('<a href="/album/2">play</a>');
+  });
+
+  it("converts a JINA-style extraction end to end", () => {
+    const jina = [
+      "Michael Jackson",
+      "===============",
+      "",
+      "The **King of Pop** released many albums.",
+      "",
+      "- [Thriller](https://open.spotify.com/album/1)",
+      "- [Bad](https://open.spotify.com/album/2)",
+    ].join("\n");
+    const html = convertMarkdownToFormattedHTML(jina);
+    expect(html).toContain("<h1>Michael Jackson</h1>");
+    expect(html).toContain("<strong>King of Pop</strong>");
+    expect(html).toContain('<li><a href="https://open.spotify.com/album/1">Thriller</a></li>');
+    expect(html).not.toContain("](");
+  });
+});

--- a/packages/extract-webpage/src/html-to-content/html-to-content.ts
+++ b/packages/extract-webpage/src/html-to-content/html-to-content.ts
@@ -6,6 +6,11 @@
 import { parseHTML } from "linkedom";
 import { extractCite } from "../html-to-cite/extract-cite";
 import { convertHTMLToBasicHTML } from "./html-to-basic-html";
+import {
+  convertMarkdownToFormattedHTML,
+  detectMarkdown,
+  removeMarkdownNavigation,
+} from "./html-utils";
 import { extractHumanName } from "../html-to-cite/human-names-recognize";
 import { extractMainContentFromHTML } from "./extract-content/extract-content-readability";
 import { extractMainContentFromHTML2 } from "./extract-content/extract-content-mercury";
@@ -47,6 +52,14 @@ export function extractContentAndCite(documentOrHTML, options = {}) {
       : documentOrHTML?.documentElement?.innerHTML;
 
   if (!html) return { error: "No HTML found" };
+
+  // Some scrape paths (the JINA reader, or proxies wrapping it) return the
+  // article as Markdown instead of HTML. Without conversion the sidebar
+  // renders raw `[text](url)` syntax, so use regexp checks to detect
+  // Markdown, strip navigation/reader-metadata noise, and convert it to
+  // formatted HTML before main-content extraction runs.
+  if (detectMarkdown(html))
+    html = convertMarkdownToFormattedHTML(removeMarkdownNavigation(html));
 
   try {
     var content1 = extractMainContentFromHTML(html, options);

--- a/packages/extract-webpage/src/html-to-content/html-utils.ts
+++ b/packages/extract-webpage/src/html-to-content/html-utils.ts
@@ -209,6 +209,159 @@ export function convertMarkdownToHTML(content, toHtml = true) {
 }
 
 /**
+ * Regexp patterns that identify Markdown syntax. Each entry is a signal that
+ * the text is Markdown rather than plain text or HTML — {@link detectMarkdown}
+ * counts how many distinct signals match.
+ * @private
+ */
+const MARKDOWN_SYNTAX_PATTERNS = [
+  /^#{1,6}\s+\S/m, // ATX header: # Title
+  /^[^\n]{1,120}\n(?:={3,}|-{3,})[ \t]*$/m, // setext header underline
+  /!\[[^\]]*\]\([^)]+\)/, // image: ![alt](src)
+  /(?<!!)\[[^\]]+\]\([^)]+\)/, // link: [text](href)
+  /^\s{0,3}[-*+]\s+\S/m, // unordered list item
+  /^\s{0,3}\d+[.)]\s+\S/m, // ordered list item
+  /^```/m, // fenced code block
+  /^\s{0,3}>\s+\S/m, // blockquote
+  /\*\*[^*\n]+\*\*|__[^_\n]+__/, // bold
+  /^\|?[^\n|]*\|[^\n]*\n\|?[\s:]*-{2,}[\s|:-]*$/m, // pipe table header + separator
+  /^Markdown Content:$/m, // JINA reader preamble
+];
+
+/**
+ * Detect whether a string is Markdown (rather than HTML or plain text) using
+ * regexp checks. Content that is dominated by HTML tags is never treated as
+ * Markdown, so real scraped pages pass through untouched; text needs at least
+ * two distinct Markdown syntax signals (or several links/images in Markdown
+ * form) to qualify. Used to catch scraper responses (e.g. the JINA reader or
+ * proxies wrapping it) that return Markdown in place of HTML, so it can be
+ * converted before main-content extraction — otherwise the article panel
+ * renders raw `[text](url)` syntax.
+ *
+ * @param {string} text - The content to test.
+ * @returns {boolean} True when the content should be parsed as Markdown.
+ * @category HTML Utilities
+ * @example
+ * detectMarkdown("# Title\n\nSome **bold** text.") // true
+ * detectMarkdown("<html><body><p>Hi</p></body></html>") // false
+ */
+export function detectMarkdown(text) {
+  if (!text || typeof text !== "string") return false;
+
+  const sample = text.slice(0, 20000);
+
+  // HTML dominance check: a document skeleton or a meaningful density of
+  // closing tags means this is HTML, not Markdown.
+  if (/<!doctype\s+html|<html[\s>]|<body[\s>]/i.test(sample)) return false;
+  const closingTags = sample.match(
+    /<\/(?:p|div|a|span|h[1-6]|li|ul|ol|table|section|article|nav|em|strong|b|i)>/gi
+  );
+  if (closingTags && closingTags.length >= 3) return false;
+
+  let signals = 0;
+  for (const pattern of MARKDOWN_SYNTAX_PATTERNS)
+    if (pattern.test(sample)) signals++;
+
+  if (signals >= 2) return true;
+
+  // A single signal still counts when Markdown links/images repeat — the
+  // signature of JINA reader output for link-heavy pages.
+  const mdLinks = sample.match(/!?\[[^\]]*\]\([^)]+\)/g);
+  return signals >= 1 && !!mdLinks && mdLinks.length >= 3;
+}
+
+/**
+ * Line-level regexps for boilerplate that JINA-style Markdown extractions
+ * carry along with the article: reader-preamble metadata and common
+ * navigation/chrome phrases rendered as standalone links.
+ * @private
+ */
+const MARKDOWN_NOISE_LINE_PATTERNS = [
+  /^(?:Title|URL Source|Published Time|Markdown Content|Warning|Links\/Buttons):.*$/i, // JINA metadata
+  /^\[?\s*(?:skip to (?:main )?content|main menu|jump to (?:content|navigation)|menu|navigation|sign (?:in|up)|log ?in|register|subscribe(?: now)?|share(?: this)?|tweet|print|download app|open app|back to top|show all|see all|see more|view all|load more|read more|previous|next|home)\s*\]?\s*(?:\([^)]*\))?\s*$/i, // nav phrases, bare or as a single link
+  /^(?:\W*\s*)?(?:accept(?: all)?(?: cookies)?|we use cookies.*|cookie (?:policy|settings|preferences)|privacy policy|terms of (?:use|service))\s*(?:\([^)]*\))?\]?\s*$/i, // cookie/legal chrome
+];
+
+/**
+ * Matches a line that carries no prose of its own — only Markdown links,
+ * images, bullets, pipes and punctuation. Runs of these are navigation menus,
+ * breadcrumbs, and tag/related-content lists.
+ * @private
+ */
+const MARKDOWN_LINK_ONLY_LINE =
+  /^\s*(?:[-*+>|]\s*)?(?:(?:\[!\[[^\]]*\]\([^)]*\)\]\([^)]*\)|!?\[[^\]]*\]\([^)]*\))\s*(?:[|•·,/>-]\s*)?)+[.\s]*$/;
+
+/**
+ * Remove extra non-article content from a Markdown extraction using regexp
+ * checks: JINA reader metadata lines, cookie/consent and navigation phrases,
+ * and runs of consecutive link-only lines (menus, breadcrumbs, "related"
+ * link farms) whose targets are mostly relative site navigation. Standalone
+ * links inside prose are kept.
+ *
+ * @param {string} markdown - The Markdown content to clean.
+ * @returns {string} The cleaned Markdown.
+ * @category HTML Utilities
+ * @example
+ * removeMarkdownNavigation("Title: Page\n[Skip to content](#main)\nReal text")
+ * // => "Real text"
+ */
+export function removeMarkdownNavigation(markdown) {
+  if (!markdown || typeof markdown !== "string") return "";
+
+  const lines = markdown.replace(/\r\n?/g, "\n").split("\n");
+  const kept = [];
+
+  // First pass: drop noise lines outside fenced code blocks.
+  let inFence = false;
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      kept.push(line);
+      continue;
+    }
+    if (
+      !inFence &&
+      MARKDOWN_NOISE_LINE_PATTERNS.some((pattern) => pattern.test(line.trim()))
+    )
+      continue;
+    kept.push(line);
+  }
+
+  // Second pass: drop runs of 3+ consecutive link-only lines when the run's
+  // links point mostly at relative URLs (`/path`, `#anchor`) — the signature
+  // of site navigation rather than cited external sources.
+  const out = [];
+  let run = [];
+  inFence = false;
+  const flushRun = () => {
+    if (!run.length) return;
+    const runText = run.join("\n");
+    const hrefs = [...runText.matchAll(/!?\[[^\]]*\]\(([^)\s]*)/g)].map(
+      (m) => m[1]
+    );
+    const relative = hrefs.filter(
+      (href) => href.startsWith("/") || href.startsWith("#")
+    );
+    const isNavRun =
+      run.length >= 3 && hrefs.length > 0 && relative.length / hrefs.length >= 0.5;
+    if (!isNavRun) out.push(...run);
+    run = [];
+  };
+  for (const line of kept) {
+    if (/^\s*```/.test(line)) inFence = !inFence;
+    if (!inFence && MARKDOWN_LINK_ONLY_LINE.test(line)) {
+      run.push(line);
+      continue;
+    }
+    flushRun();
+    out.push(line);
+  }
+  flushRun();
+
+  return out.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+/**
  * Escape the HTML-significant characters in a raw string so it can be
  * safely embedded inside generated HTML (used for code spans/blocks).
  * @param {string} str
@@ -231,6 +384,19 @@ function escapeHTMLChars(str) {
  */
 function applyInlineMarkdown(text) {
   return text
+    // Linked images: [![alt](src "title")](href) -- JINA emits these for
+    // thumbnail links; must run before both the image and link rules or the
+    // outer link's label swallows the inner image syntax.
+    .replace(
+      /\[!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)\]\(([^)\s]+)\)/g,
+      (_m, alt, src, href) =>
+        `<a href="${href}"><img src="${src}" alt="${alt}" /></a>`
+    )
+    // Autolinks: <https://example.com>
+    .replace(
+      /<(https?:\/\/[^>\s]+)>/g,
+      (_m, href) => `<a href="${href}">${href}</a>`
+    )
     // Images: ![alt](src "title") -- must run before links
     .replace(
       /!\[([^\]]*)\]\(([^)\s]+)(?:\s+"([^"]*)")?\)/g,
@@ -260,11 +426,12 @@ function applyInlineMarkdown(text) {
  * intended for post-processing content returned as Markdown (e.g. from the
  * JINA reader fallback in the scraper).
  *
- * Supported block elements: ATX headers (`#`..`######`), fenced code blocks
- * (```lang), blockquotes (`>`), unordered lists (`-`, `*`, `+`), ordered lists
- * (`1.`, `1)`), horizontal rules (`---`, `***`, `___`) and paragraphs.
- * Supported inline elements: bold, italic, strikethrough, inline code, images
- * and links.
+ * Supported block elements: ATX headers (`#`..`######`), setext headers
+ * (`===`/`---` underlines), fenced code blocks (```lang), blockquotes (`>`),
+ * unordered lists (`-`, `*`, `+`), ordered lists (`1.`, `1)`), pipe tables,
+ * horizontal rules (`---`, `***`, `___`) and paragraphs.
+ * Supported inline elements: bold, italic, strikethrough, inline code, images,
+ * links, linked images (`[![alt](src)](href)`) and autolinks (`<https://…>`).
  *
  * @param {string} markdown - The Markdown content to convert.
  * @returns {string} The resulting formatted HTML string.
@@ -298,6 +465,45 @@ export function convertMarkdownToFormattedHTML(markdown) {
     inlineCodes.push(`<code>${escapeHTMLChars(code)}</code>`);
     return `\u0000IC${inlineCodes.length - 1}\u0000`;
   });
+
+  // 3. Setext headers: a text line underlined with === (h1) or --- (h2).
+  // Converted to ATX form so the line loop below handles them; JINA uses
+  // long === underlines for page titles.
+  text = text
+    .replace(/^(?![\s#>])([^\n]{1,120})\n={3,}[ \t]*$/gm, "# $1")
+    .replace(/^(?![\s#>|-])([^\n]{0,119}[^\s|-])\n-{3,}[ \t]*$/gm, "## $1");
+
+  // 4. Pipe tables: header row, |---| separator row, then body rows. Swapped
+  // out for placeholders (like code blocks) so the line loop skips them.
+  const tables = [];
+  text = text.replace(
+    /(?<=^|\n)([^\n]*\|[^\n]*)\n\|?[ \t:]*-{2,}[ \t|:-]*\n((?:[^\n]*\|[^\n]*(?:\n|$))*)/g,
+    (_m, headerRow, bodyRows) => {
+      const splitRow = (row) =>
+        row
+          .trim()
+          .replace(/^\||\|$/g, "")
+          .split("|")
+          .map((cell) => applyInlineMarkdown(cell.trim()));
+      const header = splitRow(headerRow)
+        .map((cell) => `<th>${cell}</th>`)
+        .join("");
+      const body = bodyRows
+        .split("\n")
+        .filter((row) => row.trim())
+        .map(
+          (row) =>
+            `<tr>${splitRow(row)
+              .map((cell) => `<td>${cell}</td>`)
+              .join("")}</tr>`
+        )
+        .join("");
+      tables.push(
+        `<table><thead><tr>${header}</tr></thead><tbody>${body}</tbody></table>`
+      );
+      return `\u0000TB${tables.length - 1}\u0000\n`;
+    }
+  );
 
   const lines = text.split("\n");
   const out = [];
@@ -337,6 +543,16 @@ export function convertMarkdownToFormattedHTML(markdown) {
       closeLists();
       closeBlockquote();
       out.push(codeBlocks[Number(cb[1])]);
+      continue;
+    }
+
+    // Standalone table placeholder line
+    const tb = line.match(/^\u0000TB(\d+)\u0000$/);
+    if (tb) {
+      flushParagraph();
+      closeLists();
+      closeBlockquote();
+      out.push(tables[Number(tb[1])]);
       continue;
     }
 

--- a/packages/extract-webpage/src/url-to-content/url-to-content.ts
+++ b/packages/extract-webpage/src/url-to-content/url-to-content.ts
@@ -3,6 +3,7 @@
  * Supports YouTube transcripts, PDFs, DOCX, and web articles.
  */
 import { extractContentAndCite } from "../html-to-content/html-to-content";
+import { detectMarkdown } from "../html-to-content/html-utils";
 import { getURLYoutubeVideo, convertYoutubeToText } from "./youtube-helpers";
 import { convertDOCXToHTML, isBufferDOCX } from "./docx-to-content";
 import { scrapeURL } from "./url-to-html";
@@ -195,9 +196,12 @@ export async function extractContent(
     }
   } else if (
     typeof urlOrDoc === "string" &&
-    /<\/[^>]+>/.test(urlOrDoc.trim())
+    !urlOrDoc.startsWith("http") &&
+    (/<\/[^>]+>/.test(urlOrDoc.trim()) || detectMarkdown(urlOrDoc))
   ) {
-    console.log("[extractContent] input is raw HTML string");
+    // Raw HTML string, or raw Markdown (detected via regexp checks and
+    // converted to HTML inside extractContentAndCite).
+    console.log("[extractContent] input is raw HTML/Markdown string");
     // If urlOrDoc is an HTML string, treat as HTML content
     options.url = options.url || "";
 

--- a/packages/extract-webpage/src/url-to-content/url-to-html.ts
+++ b/packages/extract-webpage/src/url-to-content/url-to-html.ts
@@ -4,7 +4,10 @@
  * with bot-detection handling and Cloudflare/JINA fallbacks, plus robots.txt checking.
  */
 import { convertHTMLToBasicHTML } from "../html-to-content/html-to-basic-html";
-import { convertMarkdownToFormattedHTML } from "../html-to-content/html-utils";
+import {
+  convertMarkdownToFormattedHTML,
+  removeMarkdownNavigation,
+} from "../html-to-content/html-utils";
 import grab from "../utils/grab";
 
 /**
@@ -312,9 +315,11 @@ export async function scrapeJINA(url) {
   var match = articleExtract.match(/Markdown Content:([\s\S]*)/);
   articleExtract = match ? match[1] : articleExtract;
 
-  // JINA returns the article body as Markdown. Convert it to formatted HTML
-  // using regexp-based Markdown detection so headers, lists, links, emphasis,
+  // JINA returns the article body as Markdown. Strip reader metadata and
+  // navigation-only link blocks first, then convert to formatted HTML using
+  // regexp-based Markdown detection so headers, lists, links, emphasis,
   // and code render correctly downstream.
+  articleExtract = removeMarkdownNavigation(articleExtract);
   articleExtract = convertMarkdownToFormattedHTML(articleExtract);
 
   if (title) articleExtract = "<title>" + title + "</title>" + articleExtract;


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for detecting and converting Markdown content returned by the JINA reader and similar scraping services. Previously, raw Markdown syntax like `[text](url)` would render literally in the article panel. Now the system detects Markdown, strips navigation/metadata noise, and converts it to formatted HTML before content extraction.

## Key Changes

- **Markdown Detection** (`detectMarkdown`): New function that uses regexp patterns to identify Markdown syntax with high confidence. Distinguishes Markdown from HTML (by checking for HTML tags) and plain text (by requiring multiple syntax signals or repeated Markdown links).

- **Navigation Removal** (`removeMarkdownNavigation`): New function that strips JINA reader metadata lines (Title, URL Source, Published Time, etc.), navigation phrases (Skip to content, Sign in, Back to top, etc.), cookie/legal notices, and runs of 3+ consecutive link-only lines pointing to relative URLs (site navigation menus).

- **Enhanced Markdown Conversion** (`convertMarkdownToFormattedHTML`):
  - Added support for setext headers (underlined with `===` or `---`)
  - Added support for pipe tables with proper HTML `<table>` generation
  - Added support for linked images (`[![alt](src)](href)`)
  - Added support for autolinks (`<https://url>`)
  - Inline Markdown (bold, italic, links, images) now applies inside table cells

- **Integration Points**:
  - `html-to-content.ts`: Detects Markdown input and converts it before main-content extraction
  - `url-to-html.ts`: Enhanced JINA scraper to remove navigation noise before conversion
  - `url-to-content.ts`: Updated raw input detection to recognize Markdown in addition to HTML

- **Comprehensive Tests**: Added 220 lines of test coverage for all three new functions, including edge cases like code blocks, external vs. relative links, and end-to-end JINA extraction scenarios.

## Implementation Details

- Markdown detection uses a curated set of 11 regexp patterns (headers, lists, code blocks, tables, links, images, blockquotes, bold/italic, JINA preamble)
- Navigation removal operates in two passes: first removes noise lines, then identifies and removes navigation-only link runs
- Setext header conversion happens before the main line-by-line processing to normalize them to ATX form
- Table and code block content is temporarily replaced with placeholders to prevent interference with line-level processing
- All functions handle edge cases: empty input, non-string input, fenced code blocks (which should not be processed)

https://claude.ai/code/session_01KVKqvKxiLid3MN9sV61bA5