### PR TITLE
Restore sidebar's dock offset and default Open Tabs panel

### DIFF
--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -9,6 +9,7 @@
 @import "tw-animate-css";
 @import "react-native-app-buttons/styles" layer(vendor);
 @import "react-reason-editor/style.css" layer(vendor);
+@import "react-reason-editor-sidebar/style.css" layer(vendor);
 /* Workspace packages aren't covered by Tailwind's automatic source detection,
    so their responsive utilities (e.g. md:hidden on the mobile dock) must be
    registered explicitly. */
@@ -17,6 +18,7 @@
 @source "../../../packages/research-agent-ui/src";
 @source "../../../packages/shadcn-settings/src";
 @source "../../../packages/reason-editor/src";
+@source "../../../packages/reason-editor-sidebar/src";
 
 @custom-variant dark (&:is(.dark *));
 /* @plugin "@tailwindcss/typography"; */

--- a/packages/reason-editor/demo/src/styles.css
+++ b/packages/reason-editor/demo/src/styles.css
@@ -12,6 +12,10 @@
    and portaled dropdowns/modals render transparent (so the content behind
    them bleeds through) or fall into static flow. */
 @source "../../src";
+/* The sidebar lives in its own workspace package since the #305/#308
+   extraction; its unprefixed utilities (e.g. the `pt-14` dock offset on the
+   desktop <aside>) must be scanned from there too. */
+@source "../../../reason-editor-sidebar/src";
 
 /* next-themes toggles a `dark` class on <html>, so the dark: variant must
    be class-based rather than the v4 default media-query strategy. */

--- a/packages/reason-editor/demo/vite.config.ts
+++ b/packages/reason-editor/demo/vite.config.ts
@@ -151,7 +151,7 @@ export default defineConfig({
     },
   },
   optimizeDeps: {
-    include: ['react', 'react-dom', 'react/jsx-runtime'],
+    include: ['react', 'react-dom', 'react/jsx-runtime', 'use-sync-external-store/shim/with-selector.js'],
     // Novel is pre-bundled ESM with `sideEffects: false`; letting esbuild/
     // rolldown prebundle it in dev would bypass the `novel-tiptap-v3-compat`
     // transform above (same reasoning as the library's own vite.config.ts).

--- a/packages/reason-editor/src/editor/useReasonDocsState.ts
+++ b/packages/reason-editor/src/editor/useReasonDocsState.ts
@@ -446,12 +446,38 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
   }, []);
 
   // Opens the files sidebar in response to an external trigger (e.g. an app
-  // dock icon mounted outside this component tree).
+  // dock icon mounted outside this component tree). Adds the files panel
+  // without dropping whatever else is showing — replacing the whole list
+  // here used to persist a files-only layout, permanently hiding the
+  // Open Tabs panel that is on by default.
   useEffect(() => {
     if (!openFilesSidebarSignal) return;
-    setLeftPanels(["files"]);
+    setLeftPanels((prev) =>
+      prev.includes("files") ? prev : ["files", ...prev],
+    );
     setIsSidebarOpen(true);
   }, [openFilesSidebarSignal]);
+
+  // One-time repair for layouts saved by older builds, where the effect
+  // above overwrote the persisted panel list down to just "files": restore
+  // the default Open Tabs panel unless the user has since chosen a
+  // files-only or outline-only default view themselves.
+  useEffect(() => {
+    const RESTORE_FLAG = "REASON-open-tabs-default-restored";
+    try {
+      if (window.localStorage.getItem(RESTORE_FLAG)) return;
+      window.localStorage.setItem(RESTORE_FLAG, "1");
+    } catch {
+      return;
+    }
+    if (defaultSidebarView === "tree" || defaultSidebarView === "outline") return;
+    setLeftPanels((prev) =>
+      prev.includes("openTabs") ? prev : [...prev, "openTabs"],
+    );
+    setLeftSplit(true);
+    // Runs once on mount only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Apply default sidebar view on mount
   useEffect(() => {


### PR DESCRIPTION
The #305/#308 extraction moved the sidebar's source out of packages/reason-editor/src into packages/reason-editor-sidebar, but the Tailwind v4 @source lists in qwksearch-web's globals.css and the reason-editor demo still only scanned the old location. Utilities used only by the sidebar stopped being generated — most visibly pt-14, the top padding that offsets the fixed app dock, and the glass background classes — so the dock overlapped the sidebar toolbar. Register the new package's src with @source in both consumers, and import the package's bundled vendor stylesheet (file-manager/split-pane CSS that no longer ships inside react-reason-editor/style.css). The sidebar is back to a 56px top offset with no bottom padding.

The Open Tabs panel is meant to be on by default (left panels default to ["files", "openTabs"]), but the app-dock Files shortcut replaced the whole persisted panel list with ["files"], permanently hiding Open Tabs for anyone who ever clicked it. The shortcut now only adds the files panel, and a one-time localStorage repair restores the Open Tabs default for layouts the old behavior clobbered (skipped when the user explicitly chose a tree- or outline-only default view).

Also pre-bundle use-sync-external-store's with-selector shim in the demo Vite config — its CJS default-export interop otherwise breaks `bun run dev` in packages/reason-editor.


Claude-Session: https://claude.ai/code/session_01MDrT4MdVzECEW1XCYtKdUC