### PR TITLE
Fix sidebar bottom whitespace and font-size dropdown duplicate entries

### DIFF
--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -14,6 +14,7 @@ import { FileManagerModal } from './dialogs/FileManagerModal';
 import { cn } from './app-utils/utils';
 import { SidebarToolbar } from './SidebarToolbar';
 import { SidebarContent } from './SidebarContent';
+import { SidebarFooter } from './SidebarFooter';
 
 /** Translucent, blurred glass background — matches the app dock and weather widget. */
 const SIDEBAR_GLASS_CLASSES =
@@ -253,6 +254,21 @@ export const Sidebar = ({
     onNewChat,
   };
 
+  const footerProps = {
+    leftPanels,
+    leftSplit,
+    onLeftPanelsChange,
+    onLeftSplitChange,
+    rightPanels,
+    rightSplit,
+    onRightPanelsChange,
+    onRightSplitChange,
+    isMobile,
+    deletedDocs,
+    onRestore,
+    onSettingsClick,
+  };
+
   // Mobile: render in a drawer
   if (isMobile) {
     return (
@@ -263,6 +279,7 @@ export const Sidebar = ({
             <div className="flex-1 min-h-0 overflow-hidden">
               <SidebarContent {...contentProps} />
             </div>
+            <SidebarFooter {...footerProps} />
             <FileManagerModal open={isFileManagerOpen} onOpenChange={setIsFileManagerOpen} documents={activeDocuments} onSelectDocument={onSelect} />
           </aside>
         </SheetContent>
@@ -277,6 +294,7 @@ export const Sidebar = ({
       <div className="flex-1 min-h-0 overflow-hidden">
         <SidebarContent {...contentProps} />
       </div>
+      <SidebarFooter {...footerProps} />
       <FileManagerModal open={isFileManagerOpen} onOpenChange={setIsFileManagerOpen} documents={activeDocuments} onSelectDocument={onSelect} />
     </aside>
   );

--- a/packages/reason-editor/src/extensions/FontSize/FontSize.ts
+++ b/packages/reason-editor/src/extensions/FontSize/FontSize.ts
@@ -53,7 +53,7 @@ export const FontSize =  Extension.create<FontSizeOptions>({
         const fontSizes = ensureNameValueOptions(extension.options?.fontSizes);
 
         const items = fontSizes.map((k) => ({
-          title: k.value === 'Default' ? '16px' : String(k.name),
+          title: String(k.name),
           isActive: () => {
             const { fontSize } = editor.getAttributes('textStyle');
             const isDefault = k.value === 'Default';


### PR DESCRIPTION
## Summary
- **Sidebar bottom whitespace**: The REASON editor's `Sidebar` component always fills the full viewport height, and with a short document list that left a large empty gap at the bottom. Found that `SidebarFooter` — a fully-built bottom bar with trash/settings/split-view controls — existed in `packages/reason-editor-sidebar/src/SidebarFooter.tsx` but was never actually rendered anywhere. Wired it into `Sidebar.tsx` (desktop and mobile layouts) so it fills that space with useful controls, and restores access to Settings from the sidebar (previously unreachable there).
- **Font-size dropdown duplicate "16" entries**: In the toolbar's font-size dropdown (`FontSize.ts`), the "Default" list entry's title was hardcoded to `"16px"` — the same title as the actual 16px entry. Both rows displayed as "16" with a checkmark, producing a cramped, duplicated-looking list right under the custom-size input/increment controls. This also caused a functional bug: incrementing/decrementing to reach 16 could silently call `unsetFontSize()` instead of `setFontSize('16px')`, since `items.find()` matched the "Default" entry first. Fixed by giving the Default entry its own distinct title ("Default") so only the actually-matching size shows a checkmark.

## Test plan
- [x] Reviewed both diffs for correct prop/logic wiring.
- [ ] Could not spin up the app locally in this sandboxed session (no `node_modules` installed and installing the full monorepo wasn't feasible here) — please verify visually:
  - Sidebar footer (trash/settings/split-view icons) renders correctly at the bottom in both light/dark themes and on mobile.
  - Font-size dropdown shows a single "Default" row (unchecked) followed by a separator, then the numeric list with exactly one size checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGEUh6tTCLZJtyom9UQKCZ


---
_Generated by [Claude Code](https://claude.ai/code/session_01PGEUh6tTCLZJtyom9UQKCZ)_