### PR TITLE
Sidebar: Open Tabs above Files, inferred split view, expand-all fix; full-width weather widget

### DIFF
--- a/packages/react-weather-forecast/src/components/WeatherForecast.tsx
+++ b/packages/react-weather-forecast/src/components/WeatherForecast.tsx
@@ -77,9 +77,8 @@ function parseCalendarDate(date: string): Date {
   return new Date(year, month - 1, day);
 }
 
-// The upcoming days sit in narrow columns along the bottom of the card, so
-// they are labelled with the abbreviated weekday ("Fri") rather than a full
-// name or "Tomorrow".
+// The upcoming days sit in narrow columns in the card, so they are labelled
+// with the abbreviated weekday ("Fri") rather than a full name or "Tomorrow".
 function upcomingDayLabel(date: string): string {
   return parseCalendarDate(date).toLocaleDateString([], { weekday: 'short' });
 }
@@ -107,22 +106,24 @@ const styles = {
   hours: { display: 'flex', gap: 12, overflowX: 'auto', paddingBottom: 4 } as React.CSSProperties,
   hourCard: { minWidth: 72, textAlign: 'center' as const, padding: 8, borderRadius: 8, background: '#f9fafb' },
   dayRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '8px 0', borderBottom: '1px solid #f3f4f6' } as React.CSSProperties,
-  // Card-sized: a fixed maximum width with generous, even padding, so the
-  // widget reads as a self-contained tile wherever it is dropped in.
+  // Fluid: fills whatever container it is dropped into (e.g. the full
+  // sidebar/column width on desktop), with generous, even padding. Current
+  // conditions sit on the left and the upcoming days on the right; the two
+  // halves wrap into a stack when the container gets narrow.
   compactRoot: {
     fontFamily: 'system-ui, sans-serif',
     display: 'flex',
-    flexDirection: 'column',
-    gap: 14,
-    padding: 18,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'stretch',
+    gap: 18,
+    padding: '16px 20px',
     borderRadius: 16,
     width: '100%',
-    maxWidth: 340,
     boxSizing: 'border-box',
   } as React.CSSProperties,
-  // Current conditions stack down the card; the upcoming days sit in a row
-  // along the bottom.
-  compactBody: { display: 'flex', flexDirection: 'column', gap: 10 } as React.CSSProperties,
+  // Current conditions stack down the left side of the card.
+  compactBody: { display: 'flex', flexDirection: 'column', gap: 10, flex: '1 1 200px', minWidth: 0 } as React.CSSProperties,
   compactCity: { fontSize: 15, fontWeight: 700, lineHeight: 1.2 } as React.CSSProperties,
   compactHeader: { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8 } as React.CSSProperties,
   compactTemp: { fontSize: 32, fontWeight: 600, lineHeight: 1 } as React.CSSProperties,
@@ -130,18 +131,23 @@ const styles = {
   compactSeconds: { fontSize: 13, fontWeight: 500, opacity: 0.6 } as React.CSSProperties,
   compactDate: { fontSize: 11, opacity: 0.7, marginTop: 2 } as React.CSSProperties,
   compactStats: { display: 'flex', flexWrap: 'wrap', gap: 14, fontSize: 12, opacity: 0.9 } as React.CSSProperties,
-  // Three equal columns along the bottom edge, each stacking weekday / icon /
-  // high-low so the row stays readable at card width.
+  // Three equal columns on the right side of the card, each stacking
+  // weekday / icon / high-low, vertically centered against the current
+  // conditions and nudged over behind a divider so the two halves read as
+  // separate sections.
   upcoming: {
     display: 'grid',
     gridTemplateColumns: 'repeat(3, 1fr)',
-    gap: 4,
-    paddingTop: 8,
-    borderTop: '1px solid currentColor',
-    borderTopColor: 'rgba(128,128,128,0.25)',
+    alignContent: 'center',
+    gap: 10,
+    flex: '1 1 220px',
+    minWidth: 0,
+    paddingLeft: 18,
+    borderLeft: '1px solid currentColor',
+    borderLeftColor: 'rgba(128,128,128,0.25)',
     fontSize: 11,
   } as React.CSSProperties,
-  upcomingDay: { display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, textAlign: 'center' } as React.CSSProperties,
+  upcomingDay: { display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 3, textAlign: 'center' } as React.CSSProperties,
   upcomingDayName: { opacity: 0.7, whiteSpace: 'nowrap' } as React.CSSProperties,
   upcomingTemps: { whiteSpace: 'nowrap' } as React.CSSProperties,
   compactStat: { display: 'flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' } as React.CSSProperties,
@@ -224,8 +230,8 @@ function SingleWeatherForecast(props: Props) {
   if (props.compact) {
     const today = data.daily[0];
     const windSpeedUnitLabel = WIND_SPEED_UNIT_LABELS[props.windSpeedUnit ?? 'mph'];
-    // Today is already summarised in the card's own stats line, so the bottom
-    // row starts at tomorrow and shows the next three days.
+    // Today is already summarised in the card's own stats line, so the
+    // upcoming-days section starts at tomorrow and shows the next three days.
     const upcomingDays = data.daily.slice(1, 4);
 
     return (

--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -36,12 +36,8 @@ export const Sidebar = ({
   isMobile,
   leftPanels,
   onLeftPanelsChange,
-  leftSplit,
-  onLeftSplitChange,
   rightPanels,
   onRightPanelsChange,
-  rightSplit,
-  onRightSplitChange,
   onSettingsClick,
   onRestore,
   newDocumentId,
@@ -66,20 +62,31 @@ export const Sidebar = ({
   tabItems,
   onNewChat,
 }: SidebarProps) => {
-  const deletedDocs = documents.filter(doc => doc.isDeleted);
+  // Memoized so child components (FileTree) don't see a new array identity
+  // on every render, which would reset their internal expansion state.
+  const deletedDocs = useMemo(() => documents.filter(doc => doc.isDeleted), [documents]);
 
-  const activeDocuments = documents.filter(doc => !doc.isDeleted);
+  const activeDocuments = useMemo(() => documents.filter(doc => !doc.isDeleted), [documents]);
 
-  // Cycle depth for the file tree's expand-all button: 0 = collapsed, then
+  // Display level for the expand-all button's tooltip: 0 = collapsed, then
   // 1, 2, 3... one folder level at a time, up to the deepest nesting level,
-  // before wrapping back to collapsed.
+  // before wrapping back to collapsed. The authoritative current level is
+  // inferred from the tree's actual expansion state on each click.
   const [expandLevel, setExpandLevel] = useState(0);
-  // Deepest folder nesting level currently in the tree (1 = only top-level folders).
+  // Deepest folder nesting level currently in the tree (1 = only top-level
+  // folders). A document counts as a folder when flagged as one OR when it
+  // has children — the tree itself promotes any document with children to a
+  // folder, so the button must count them the same way.
   const maxExpandLevel = useMemo(() => {
     const byId = new Map(activeDocuments.map((doc) => [doc.id, doc]));
+    const parentIds = new Set(
+      activeDocuments.map((doc) => doc.parentId).filter((id): id is string => !!id),
+    );
+    const isFolderLike = (doc: (typeof activeDocuments)[number]) =>
+      !!doc.isFolder || parentIds.has(doc.id);
     let max = 0;
     for (const doc of activeDocuments) {
-      if (!doc.isFolder) continue;
+      if (!isFolderLike(doc)) continue;
       let depth = 1;
       let parentId = doc.parentId;
       const seen = new Set<string>();
@@ -131,7 +138,11 @@ export const Sidebar = ({
 
   const handleToggleAllExpanded = () => {
     if (maxExpandLevel === 0) return;
-    const nextLevel = expandLevel >= maxExpandLevel ? 0 : expandLevel + 1;
+    // Cycle from the level the tree is actually at (folders may have been
+    // expanded/collapsed by hand since the last click), not from a stale
+    // local counter.
+    const currentLevel = treeRef.current?.getExpandLevel?.() ?? expandLevel;
+    const nextLevel = currentLevel >= maxExpandLevel ? 0 : currentLevel + 1;
     setExpandLevel(nextLevel);
     if (treeRef.current) {
       if (nextLevel === 0) {
@@ -180,13 +191,9 @@ export const Sidebar = ({
 
   const toolbarProps = {
     leftPanels,
-    leftSplit,
     onLeftPanelsChange,
-    onLeftSplitChange,
     rightPanels,
-    rightSplit,
     onRightPanelsChange,
-    onRightSplitChange,
     activeId,
     onAdd,
     onSearchFocus,
@@ -219,7 +226,6 @@ export const Sidebar = ({
 
   const contentProps = {
     panels: leftPanels,
-    split: leftSplit,
     persistenceKey: 'left',
     activeDocuments,
     activeId,

--- a/packages/reason-editor-sidebar/src/SidebarContent.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarContent.tsx
@@ -1,10 +1,10 @@
 /**
  * @module SidebarContent
  * @description Renders the panel body of a sidebar (left or right). Stacks
- * any combination of the "files", "openTabs", "outline", and "ai" panels
- * vertically in a resizable split when more than one is active, matching
- * whatever `panels` list the {@link SidebarViewMenu} has configured for
- * that side.
+ * any combination of the "openTabs", "files", "outline", and "ai" panels
+ * vertically — Open Tabs always above the Files tree — in a resizable split
+ * inferred whenever two or more panels are active, matching whatever
+ * `panels` list the {@link SidebarViewMenu} has configured for that side.
  */
 import { RefObject, useState, useCallback, useMemo, useRef } from 'react';
 import type { OutlineViewHandle } from './search/OutlineView';
@@ -12,6 +12,7 @@ import type { RelatedDocumentResult } from './search/relatedDocuments';
 import type { SidebarPanelType, SidebarContentProps, OpenTabItem } from './layout/sidebar/types';
 import type { TocEntry } from './app-types/toc';
 import { FileTree } from './file-tree';
+import { sortPanels } from './layout/sidebar/panelOptions';
 import { OutlineView } from './search/OutlineView';
 import { findRelatedDocuments, splitTopSuggestion } from './search/relatedDocuments';
 import { AIRewriteSuggestion } from './features/ai-rewrite/AIRewriteSuggestion';
@@ -31,7 +32,7 @@ import { usePersistence } from 'react-split-pane/persistence';
 import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
 import './split-pane.css';
 
-type DocumentTreeHandle = { collapseAll: () => void; edit: (nodeId: string) => void; expandAll: () => void; expandToLevel: (level: number) => void; cancelExpand: () => void };
+import type { DocumentTreeHandle } from './file-tree/filetree';
 
 /** Human-readable panel titles used in headers/empty states. */
 const PANEL_TITLES: Record<SidebarPanelType, string> = {
@@ -48,7 +49,6 @@ const PANEL_TITLES: Record<SidebarPanelType, string> = {
  */
 export const SidebarContent = ({
   panels,
-  split,
   persistenceKey,
   activeDocuments,
   activeId,
@@ -504,7 +504,11 @@ export const SidebarContent = ({
     }
   };
 
-  if (panels.length === 0) {
+  // Panels always stack in the canonical order (Open Tabs above Files),
+  // regardless of the order they were toggled on in.
+  const orderedPanels = sortPanels(panels);
+
+  if (orderedPanels.length === 0) {
     return (
       <div className="h-full flex items-center justify-center p-6 text-center">
         <p className="text-sm text-muted-foreground">No panels enabled</p>
@@ -512,15 +516,16 @@ export const SidebarContent = ({
     );
   }
 
-  if (panels.length === 1 || !split) {
-    return <div className="h-full">{renderPanel(panels[0])}</div>;
+  // Split view is inferred: two or more selected panels stack in a split.
+  if (orderedPanels.length === 1) {
+    return <div className="h-full">{renderPanel(orderedPanels[0])}</div>;
   }
 
   return (
     <div className="h-full">
       <SplitPane direction="vertical" onResize={setPanelSizes}>
-        {panels.map((type, i) => (
-          <Pane key={type} size={panelSizes?.[i] || `${Math.round(100 / panels.length)}%`} minSize="0px">
+        {orderedPanels.map((type, i) => (
+          <Pane key={type} size={panelSizes?.[i] || `${Math.round(100 / orderedPanels.length)}%`} minSize="0px">
             {renderPanel(type)}
           </Pane>
         ))}

--- a/packages/reason-editor-sidebar/src/SidebarFooter.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarFooter.tsx
@@ -1,7 +1,7 @@
 /**
  * @module SidebarFooter
  * @description Bottom icon bar of the sidebar. Renders trash, settings,
- * and split-view controls.
+ * and panel view controls.
  */
 import { Button } from './app-ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './app-ui/tooltip';
@@ -29,20 +29,12 @@ import { SidebarViewMenu } from './SidebarViewMenu';
 interface SidebarFooterProps {
   /** Panels currently visible in the left sidebar. */
   leftPanels: SidebarPanelType[];
-  /** Whether the left sidebar allows multiple stacked panels. */
-  leftSplit: boolean;
   /** Changes which panels are visible in the left sidebar. */
   onLeftPanelsChange: (panels: SidebarPanelType[]) => void;
-  /** Changes whether the left sidebar allows multiple stacked panels. */
-  onLeftSplitChange: (split: boolean) => void;
   /** Panels currently visible in the right sidebar. */
   rightPanels: SidebarPanelType[];
-  /** Whether the right sidebar allows multiple stacked panels. */
-  rightSplit: boolean;
   /** Changes which panels are visible in the right sidebar. */
   onRightPanelsChange: (panels: SidebarPanelType[]) => void;
-  /** Changes whether the right sidebar allows multiple stacked panels. */
-  onRightSplitChange: (split: boolean) => void;
   /** Suppresses the settings button when `true` (mobile layout). */
   isMobile?: boolean;
   /** Soft-deleted documents shown in the trash dropdown. */
@@ -61,18 +53,14 @@ interface SidebarFooterProps {
 
 /**
  * Compact icon row pinned to the bottom of the sidebar. Includes a trash
- * dropdown (restore deleted docs), settings button, and a split-view mode
+ * dropdown (restore deleted docs), settings button, and a panel view
  * dropdown.
  */
 export const SidebarFooter = ({
   leftPanels,
-  leftSplit,
   onLeftPanelsChange,
-  onLeftSplitChange,
   rightPanels,
-  rightSplit,
   onRightPanelsChange,
-  onRightSplitChange,
   isMobile,
   deletedDocs,
   onRestore,
@@ -183,16 +171,12 @@ export const SidebarFooter = ({
             </DropdownMenu>
           )}
 
-          {/* Split View Menu */}
+          {/* View Options Menu */}
           <SidebarViewMenu
             leftPanels={leftPanels}
             onLeftPanelsChange={onLeftPanelsChange}
-            leftSplit={leftSplit}
-            onLeftSplitChange={onLeftSplitChange}
             rightPanels={rightPanels}
             onRightPanelsChange={onRightPanelsChange}
-            rightSplit={rightSplit}
-            onRightSplitChange={onRightSplitChange}
             triggerClassName="h-9 w-9 p-0 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
             tooltipSide="top"
           />

--- a/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
@@ -29,20 +29,12 @@ import { SidebarViewMenu } from './SidebarViewMenu';
 interface SidebarToolbarProps {
   /** Panels currently visible in the left sidebar — controls which toolbar buttons are shown. */
   leftPanels: SidebarPanelType[];
-  /** Whether the left sidebar allows multiple stacked panels. */
-  leftSplit: boolean;
   /** Changes which panels are visible in the left sidebar. */
   onLeftPanelsChange: (panels: SidebarPanelType[]) => void;
-  /** Changes whether the left sidebar allows multiple stacked panels. */
-  onLeftSplitChange: (split: boolean) => void;
   /** Panels currently visible in the right sidebar. */
   rightPanels: SidebarPanelType[];
-  /** Whether the right sidebar allows multiple stacked panels. */
-  rightSplit: boolean;
   /** Changes which panels are visible in the right sidebar. */
   onRightPanelsChange: (panels: SidebarPanelType[]) => void;
-  /** Changes whether the right sidebar allows multiple stacked panels. */
-  onRightSplitChange: (split: boolean) => void;
   /** ID of the currently selected document (used when creating a new sibling). */
   activeId: string | null;
   /** Creates a new note (`isFolder=false`) or folder (`isFolder=true`) under `parentId`. */
@@ -109,13 +101,9 @@ interface SidebarToolbarProps {
  */
 export const SidebarToolbar = ({
   leftPanels,
-  leftSplit,
   onLeftPanelsChange,
-  onLeftSplitChange,
   rightPanels,
-  rightSplit,
   onRightPanelsChange,
-  onRightSplitChange,
   activeId,
   onAdd,
   onSearchFocus,
@@ -401,16 +389,12 @@ export const SidebarToolbar = ({
             </>
           )}
 
-          {/* Split View Menu */}
+          {/* View Options Menu */}
           <SidebarViewMenu
             leftPanels={leftPanels}
             onLeftPanelsChange={onLeftPanelsChange}
-            leftSplit={leftSplit}
-            onLeftSplitChange={onLeftSplitChange}
             rightPanels={rightPanels}
             onRightPanelsChange={onRightPanelsChange}
-            rightSplit={rightSplit}
-            onRightSplitChange={onRightSplitChange}
             showDynamicIsland={showDynamicIsland}
             onToggleDynamicIsland={onToggleDynamicIsland}
             triggerClassName="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"

--- a/packages/reason-editor-sidebar/src/SidebarViewMenu.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarViewMenu.tsx
@@ -1,9 +1,11 @@
 /**
  * @module SidebarViewMenu
- * @description Shared "Split View Options" dropdown, rendered by both
+ * @description Shared "View Options" dropdown, rendered by both
  * SidebarToolbar and SidebarFooter. Presents two sections — Left Sidebar and
- * Right Sidebar — each with a Split View toggle and checkboxes for which
- * panels (AI, Files, Outline, Open Tabs) are visible on that side.
+ * Right Sidebar — each with checkboxes for which panels (Open Tabs, Files,
+ * Outline, Related, AI) are visible on that side. Selecting two or more
+ * panels on a side implicitly stacks them in a split view; there is no
+ * separate split toggle.
  */
 import { Button } from './app-ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './app-ui/tooltip';
@@ -16,7 +18,7 @@ import {
   DropdownMenuTrigger,
 } from './app-ui/dropdown-menu';
 import { cn } from './app-utils/utils';
-import { PANEL_OPTIONS, togglePanel, applySplitToggle } from './layout/sidebar/panelOptions';
+import { PANEL_OPTIONS, togglePanel } from './layout/sidebar/panelOptions';
 import type { SidebarPanelType } from './layout/sidebar/types';
 import { Columns2 } from 'lucide-react';
 
@@ -24,12 +26,8 @@ import { Columns2 } from 'lucide-react';
 interface SidebarViewMenuProps {
   leftPanels: SidebarPanelType[];
   onLeftPanelsChange: (panels: SidebarPanelType[]) => void;
-  leftSplit: boolean;
-  onLeftSplitChange: (split: boolean) => void;
   rightPanels: SidebarPanelType[];
   onRightPanelsChange: (panels: SidebarPanelType[]) => void;
-  rightSplit: boolean;
-  onRightSplitChange: (split: boolean) => void;
   /** Whether the floating reading-progress island is currently visible. */
   showDynamicIsland?: boolean;
   /** Toggles the floating reading-progress island. */
@@ -45,19 +43,15 @@ interface SidebarViewMenuProps {
 export const SidebarViewMenu = ({
   leftPanels,
   onLeftPanelsChange,
-  leftSplit,
-  onLeftSplitChange,
   rightPanels,
   onRightPanelsChange,
-  rightSplit,
-  onRightSplitChange,
   showDynamicIsland,
   onToggleDynamicIsland,
   triggerClassName,
   tooltipSide = 'bottom',
   align = 'end',
 }: SidebarViewMenuProps) => {
-  const isActive = leftSplit || rightSplit || rightPanels.length > 0;
+  const isActive = leftPanels.length > 1 || rightPanels.length > 0;
 
   return (
     <DropdownMenu>
@@ -74,29 +68,19 @@ export const SidebarViewMenu = ({
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent side={tooltipSide}>
-          <p>Split View Options</p>
+          <p>View Options</p>
         </TooltipContent>
       </Tooltip>
       <DropdownMenuContent align={align} className="w-64">
         <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground">
           Left Sidebar
         </DropdownMenuLabel>
-        <DropdownMenuCheckboxItem
-          checked={leftSplit}
-          onSelect={(e) => e.preventDefault()}
-          onCheckedChange={(checked) => {
-            onLeftSplitChange(checked);
-            onLeftPanelsChange(applySplitToggle(leftPanels, checked));
-          }}
-        >
-          Split View
-        </DropdownMenuCheckboxItem>
         {PANEL_OPTIONS.map(({ type, label, icon: Icon }) => (
           <DropdownMenuCheckboxItem
             key={`left-${type}`}
             checked={leftPanels.includes(type)}
             onSelect={(e) => e.preventDefault()}
-            onCheckedChange={() => onLeftPanelsChange(togglePanel(leftPanels, leftSplit, type, false))}
+            onCheckedChange={() => onLeftPanelsChange(togglePanel(leftPanels, type, false))}
           >
             <Icon className="h-4 w-4" />
             <span>{label}</span>
@@ -108,22 +92,12 @@ export const SidebarViewMenu = ({
         <DropdownMenuLabel className="text-xs font-semibold text-muted-foreground">
           Right Sidebar
         </DropdownMenuLabel>
-        <DropdownMenuCheckboxItem
-          checked={rightSplit}
-          onSelect={(e) => e.preventDefault()}
-          onCheckedChange={(checked) => {
-            onRightSplitChange(checked);
-            onRightPanelsChange(applySplitToggle(rightPanels, checked));
-          }}
-        >
-          Split View
-        </DropdownMenuCheckboxItem>
         {PANEL_OPTIONS.map(({ type, label, icon: Icon }) => (
           <DropdownMenuCheckboxItem
             key={`right-${type}`}
             checked={rightPanels.includes(type)}
             onSelect={(e) => e.preventDefault()}
-            onCheckedChange={() => onRightPanelsChange(togglePanel(rightPanels, rightSplit, type, true))}
+            onCheckedChange={() => onRightPanelsChange(togglePanel(rightPanels, type, true))}
           >
             <Icon className="h-4 w-4" />
             <span>{label}</span>

--- a/packages/reason-editor-sidebar/src/file-tree/filetree.tsx
+++ b/packages/reason-editor-sidebar/src/file-tree/filetree.tsx
@@ -18,7 +18,7 @@ import {
 import { AssistiveTreeDescription, useTree } from "@headless-tree/react";
 import { FolderIcon, FolderOpenIcon } from "lucide-react";
 import { FileTypeIcon } from "../app-ui/FileTypeIcon";
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 
 import type { Document } from "../documents/DocumentTree";
 
@@ -28,6 +28,8 @@ export type DocumentTreeHandle = {
   expandAll: () => void;
   expandToLevel: (level: number) => void;
   cancelExpand: () => void;
+  /** Deepest folder level currently fully expanded (0 = fully collapsed). */
+  getExpandLevel: () => number;
 };
 import { Tree, TreeDragLine, TreeItem, TreeItemLabel } from "../app-ui/tree";
 import {
@@ -76,32 +78,45 @@ interface FileTreeProps {
 const ROOT_ID = "__root__";
 const INDENT = 20;
 
+/** Folder ids grouped by nesting depth (index 0 = top-level folders). */
+function getFolderIdsByLevel(items: Record<string, FileTreeItem>): string[][] {
+  const levels: string[][] = [];
+  let frontier = [ROOT_ID];
+
+  while (frontier.length > 0) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const childId of items[id]?.children ?? []) {
+        if (items[childId]?.isFolder) next.push(childId);
+      }
+    }
+    if (next.length === 0) break;
+    levels.push(next);
+    frontier = next;
+  }
+
+  return levels;
+}
+
 /** Folder ids reachable within `level` levels of nesting (1 = top-level folders). */
 function getFolderIdsUpToLevel(items: Record<string, FileTreeItem>, level: number): string[] {
   if (level <= 0) return [];
+  return getFolderIdsByLevel(items).slice(0, level).flat();
+}
 
-  const result: string[] = [];
-  const queue: Array<{ depth: number; id: string }> = [{ depth: 0, id: ROOT_ID }];
-
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current) break;
-    const item = items[current.id];
-    if (!item) continue;
-
-    for (const childId of item.children ?? []) {
-      const child = items[childId];
-      if (!child?.isFolder) continue;
-
-      const childDepth = current.depth + 1;
-      if (childDepth > level) continue;
-
-      result.push(childId);
-      queue.push({ depth: childDepth, id: childId });
-    }
+/**
+ * Infers the deepest folder level that is currently fully expanded: the
+ * largest depth `L` such that every folder at depth <= L is expanded.
+ * Returns 0 when any top-level folder is collapsed.
+ */
+function getExpandedLevel(items: Record<string, FileTreeItem>, expandedItems: string[]): number {
+  const expanded = new Set(expandedItems);
+  let level = 0;
+  for (const idsAtDepth of getFolderIdsByLevel(items)) {
+    if (!idsAtDepth.every((id) => expanded.has(id))) break;
+    level++;
   }
-
-  return result;
+  return level;
 }
 
 function buildItems(documents: Document[]): Record<string, FileTreeItem> {
@@ -155,7 +170,8 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
     });
     const [copiedNodeId, setCopiedNodeId] = useState<string | null>(null);
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
-    const expandCancelToken = { current: false };
+    // Must survive re-renders so a queued expandAll can actually be cancelled.
+    const expandCancelToken = useRef(false);
 
     const tree = useTree<FileTreeItem>({
       canReorder: true,
@@ -244,13 +260,24 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
       state,
     });
 
+    // Selection follows the active document. Kept separate from expansion
+    // sync so switching documents doesn't clobber the current expansion.
     useEffect(() => {
       setState((prev) => ({
         ...prev,
-        expandedItems,
         selectedItems: activeId && items[activeId] ? [activeId] : [],
       }));
-    }, [activeId, expandedItems, items]);
+    }, [activeId, items]);
+
+    // Re-sync expansion from the documents' persisted `isExpanded` flags only
+    // when that derived list actually changes by value. Comparing by content
+    // (not array identity, which churns on every parent re-render) is what
+    // lets imperative expandToLevel/collapseAll changes stick.
+    const expandedItemsKey = expandedItems.join('\n');
+    useEffect(() => {
+      setState((prev) => ({ ...prev, expandedItems }));
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [expandedItemsKey]);
 
     useImperativeHandle(ref, () => ({
       collapseAll: () => {
@@ -274,6 +301,7 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
       cancelExpand: () => {
         expandCancelToken.current = true;
       },
+      getExpandLevel: () => getExpandedLevel(items, state.expandedItems ?? []),
     }));
 
     const handleDeleteConfirm = () => {

--- a/packages/reason-editor-sidebar/src/index.ts
+++ b/packages/reason-editor-sidebar/src/index.ts
@@ -28,7 +28,7 @@ export type {
   SidebarTipsProps,
   SidebarTopicsProps,
 } from './layout/sidebar/types';
-export { PANEL_OPTIONS, togglePanel, applySplitToggle } from './layout/sidebar/panelOptions';
+export { PANEL_OPTIONS, togglePanel, sortPanels } from './layout/sidebar/panelOptions';
 
 // Folders and files review: the headless-tree-powered folder/file browser
 // and its supporting hooks/utilities.

--- a/packages/reason-editor-sidebar/src/layout/sidebar/panelOptions.ts
+++ b/packages/reason-editor-sidebar/src/layout/sidebar/panelOptions.ts
@@ -1,67 +1,57 @@
 /**
  * @module sidebar/panelOptions
  * @description Shared metadata and pure helpers for the per-side panel
- * toggle system (AI / Files / Outline / Open Tabs) used by both the left
- * sidebar and the right panel, and by the {@link SidebarViewMenu} dropdown
- * that controls them.
+ * toggle system (Open Tabs / Files / Outline / Related / AI) used by both
+ * the left sidebar and the right panel, and by the {@link SidebarViewMenu}
+ * dropdown that controls them.
  */
 import { Sparkles, FileText, AlignLeft, Layers, Link2, type LucideIcon } from 'lucide-react';
 import type { SidebarPanelType } from './types';
 
-/** Ordered list of togglable panel kinds shown in the view menu, with display metadata. */
+/**
+ * Ordered list of togglable panel kinds shown in the view menu, with display
+ * metadata. This order is also the canonical stacking order for the panels
+ * within a sidebar (Open Tabs always stacks above the Files tree).
+ */
 export const PANEL_OPTIONS: { type: SidebarPanelType; label: string; icon: LucideIcon }[] = [
-  { type: 'ai', label: 'AI', icon: Sparkles },
+  { type: 'openTabs', label: 'Open Tabs', icon: Layers },
   { type: 'files', label: 'Files', icon: FileText },
   { type: 'outline', label: 'Outline', icon: AlignLeft },
-  { type: 'openTabs', label: 'Open Tabs', icon: Layers },
   { type: 'related', label: 'Related', icon: Link2 },
+  { type: 'ai', label: 'AI', icon: Sparkles },
 ];
+
+/**
+ * Sorts a panel list into the canonical stacking order defined by
+ * {@link PANEL_OPTIONS} (e.g. Open Tabs above Files), regardless of the
+ * order the panels were toggled on in.
+ */
+export function sortPanels(panels: SidebarPanelType[]): SidebarPanelType[] {
+  const order = PANEL_OPTIONS.map((option) => option.type);
+  return [...panels].sort((a, b) => order.indexOf(a) - order.indexOf(b));
+}
 
 /**
  * Computes the next panel list when a single panel checkbox is toggled.
  *
- * In split mode, panels are independently added/removed and may stack.
- * Outside of split mode, selecting a panel replaces the whole list
- * (single active panel), like a radio group rendered as checkboxes.
+ * Panels are independently added/removed and may stack; whether a side is
+ * "split" is inferred from the result (2 or more panels selected) rather
+ * than being a separate mode.
  *
  * @param panels - Current panels visible on this side.
- * @param split - Whether this side currently allows multiple stacked panels.
  * @param type - The panel being toggled.
  * @param allowEmpty - Whether the resulting list may become empty (hides the side entirely).
  */
 export function togglePanel(
   panels: SidebarPanelType[],
-  split: boolean,
   type: SidebarPanelType,
   allowEmpty: boolean,
 ): SidebarPanelType[] {
   const isActive = panels.includes(type);
 
-  if (split) {
-    if (isActive) {
-      const next = panels.filter((p) => p !== type);
-      return next.length === 0 && !allowEmpty ? panels : next;
-    }
-    return [...panels, type];
-  }
-
   if (isActive) {
-    return allowEmpty ? [] : panels;
+    const next = panels.filter((p) => p !== type);
+    return next.length === 0 && !allowEmpty ? panels : next;
   }
-  return [type];
-}
-
-/**
- * Computes the next panel list when split mode is toggled on/off for a side.
- * Turning split off collapses multiple visible panels down to just the first.
- *
- * @param panels - Current panels visible on this side.
- * @param nextSplit - The new split state being applied.
- */
-export function applySplitToggle(
-  panels: SidebarPanelType[],
-  nextSplit: boolean,
-): SidebarPanelType[] {
-  if (nextSplit || panels.length <= 1) return panels;
-  return [panels[0]];
+  return sortPanels([...panels, type]);
 }

--- a/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
+++ b/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
@@ -101,18 +101,15 @@ export interface SidebarProps {
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   isMobile?: boolean;
-  // Left sidebar panel configuration
+  // Left sidebar panel configuration. Split view is inferred: 2+ selected
+  // panels stack in a resizable split.
   leftPanels: SidebarPanelType[];
   onLeftPanelsChange: (panels: SidebarPanelType[]) => void;
-  leftSplit: boolean;
-  onLeftSplitChange: (split: boolean) => void;
   // Right sidebar panel configuration (controlled here so the same view
   // menu can manage both sides, even though the right panel itself is
   // rendered outside of Sidebar by ReasonDocs)
   rightPanels: SidebarPanelType[];
   onRightPanelsChange: (panels: SidebarPanelType[]) => void;
-  rightSplit: boolean;
-  onRightSplitChange: (split: boolean) => void;
   // Settings
   onSettingsClick?: (section?: string) => void;
   onInviteClick?: () => void;
@@ -159,10 +156,8 @@ export interface SidebarProps {
 
 /** Props for the `SidebarContent` component (the shared panel-body renderer used by both the left sidebar and `RightPanel`). */
 export interface SidebarContentProps {
-  /** Which panels are active on this side, in stacking order. */
+  /** Which panels are active on this side. Two or more panels render stacked in a split (canonical stacking order applies). */
   panels: SidebarPanelType[];
-  /** Whether multiple panels may be shown stacked at once. */
-  split: boolean;
   /** Storage key suffix so left/right panel sizes persist independently. */
   persistenceKey: string;
   /** Filtered/flat document list to pass down to the file tree. */

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -267,12 +267,8 @@ const Index = ({
     isMobile: state.isMobile,
     leftPanels: state.leftPanels,
     onLeftPanelsChange: state.setLeftPanels,
-    leftSplit: state.leftSplit,
-    onLeftSplitChange: state.setLeftSplit,
     rightPanels: state.rightPanels,
     onRightPanelsChange: state.setRightPanels,
-    rightSplit: state.rightSplit,
-    onRightSplitChange: state.setRightSplit,
     onSettingsClick: (section?: string) => { setSettingsInitialSection(section); state.setIsSettingsOpen(true); },
     onInviteClick: () => state.setIsInviteModalOpen(true),
     onRestore: state.handleRestoreDocument,
@@ -329,7 +325,6 @@ const Index = ({
   const rightPanel = state.rightPanels.length > 0 && (
     <RightPanel
       panels={state.rightPanels}
-      split={state.rightSplit}
       documents={state.documents}
       activeId={state.activeDocId}
       activeDocument={state.activeDocument}

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -35,10 +35,8 @@ const SIDEBAR_GLASS_CLASSES =
 interface RightPanelProps {
   /** Renders the panel body. Supply `SidebarContent` from `react-reason-editor-sidebar`. */
   SidebarContentComponent: ComponentType<SidebarContentProps>;
-  /** Panels currently visible in the right sidebar. */
+  /** Panels currently visible in the right sidebar. Two or more panels render stacked in a split. */
   panels: SidebarPanelType[];
-  /** Whether the right sidebar allows multiple stacked panels. */
-  split: boolean;
   documents: Document[];
   activeId: string | null;
   activeDocument?: Document;
@@ -101,7 +99,6 @@ const PANEL_LABELS: Record<SidebarPanelType, string> = Object.fromEntries(
 export function RightPanel({
   SidebarContentComponent,
   panels,
-  split,
   documents,
   activeId,
   activeDocument,
@@ -154,7 +151,6 @@ export function RightPanel({
       <div className="flex-1 min-h-0">
         <SidebarContentComponent
           panels={panels}
-          split={split}
           persistenceKey="right"
           activeDocuments={documents}
           activeId={activeId}

--- a/packages/reason-editor/src/editor/useReasonDocsState.ts
+++ b/packages/reason-editor/src/editor/useReasonDocsState.ts
@@ -44,21 +44,16 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
   const [defaultSidebarView, setDefaultSidebarView] = useLocalStorage<
     "tree" | "outline" | "split" | "last-used"
   >("REASON-default-sidebar-view", "last-used");
+  // Split view is inferred from the panel lists (2+ panels stack in a
+  // split), so there is no separate split flag. Open Tabs stacks above the
+  // Files tree.
   const [leftPanels, setLeftPanels] = useLocalStorage<SidebarPanelType[]>(
     "REASON-left-panels",
-    ["files", "openTabs"],
-  );
-  const [leftSplit, setLeftSplit] = useLocalStorage<boolean>(
-    "REASON-left-split",
-    true,
+    ["openTabs", "files"],
   );
   const [rightPanels, setRightPanels] = useLocalStorage<SidebarPanelType[]>(
     "REASON-right-panels",
     [],
-  );
-  const [rightSplit, setRightSplit] = useLocalStorage<boolean>(
-    "REASON-right-split",
-    false,
   );
   const [showDynamicIsland, setShowDynamicIsland] = useLocalStorage<boolean>(
     "REASON-show-dynamic-island",
@@ -457,13 +452,10 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
   useEffect(() => {
     if (defaultSidebarView === "tree") {
       setLeftPanels(["files"]);
-      setLeftSplit(false);
     } else if (defaultSidebarView === "outline") {
       setLeftPanels(["outline"]);
-      setLeftSplit(false);
     } else if (defaultSidebarView === "split") {
-      setLeftPanels(["files", "openTabs", "outline"]);
-      setLeftSplit(true);
+      setLeftPanels(["openTabs", "files", "outline"]);
     }
   }, []);
 
@@ -767,12 +759,8 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
     setDefaultSidebarView,
     leftPanels,
     setLeftPanels,
-    leftSplit,
-    setLeftSplit,
     rightPanels,
     setRightPanels,
-    rightSplit,
-    setRightSplit,
     showDynamicIsland,
     setShowDynamicIsland,
     sidebarWidth,

--- a/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatHomepage.tsx
@@ -166,10 +166,10 @@ export default function ChatHomepage() {
           <div className="w-full max-w-2xl mt-8 space-y-2">
             <RecentHistoryChips />
             {(showWeatherWidget || showTrendingNewsWidget) && (
-              <div className="flex flex-col md:flex-row gap-2 w-full">
-                {/* The compact weather widget is a fixed-width card, so it sits
-                    beside the trending news column rather than taking its own row
-                    (and stretches to full width once they stack on mobile). */}
+              <div className="flex flex-col gap-2 w-full">
+                {/* The compact weather widget is fluid, so it spans the full
+                    column width on its own row (current conditions on the left,
+                    the next days on the right), with trending news below it. */}
                 {showWeatherWidget && (
                   <WeatherForecast
                     compact
@@ -177,7 +177,7 @@ export default function ChatHomepage() {
                     forecastHours={weatherForecastHours}
                     temperatureUnit={weatherTemperatureUnit}
                     locations={weatherLocations.length > 0 ? weatherLocations : undefined}
-                    className="rounded-2xl"
+                    className="rounded-2xl w-full"
                     style={{
                       background: 'rgba(255,255,255,0.08)',
                       border: '1px solid rgba(255,255,255,0.15)',
@@ -193,7 +193,7 @@ export default function ChatHomepage() {
                     maxTopics={trendingNewsMaxTopics}
                     showImages={trendingNewsShowImages}
                     apiEndpoint={trendingNewsApiUrl || undefined}
-                    className="rounded-2xl md:flex-1"
+                    className="rounded-2xl w-full"
                     style={{
                       background: 'rgba(255,255,255,0.08)',
                       border: '1px solid rgba(255,255,255,0.15)',


### PR DESCRIPTION
## Summary

### Sidebar (reason-editor / reason-editor-sidebar)
- **Open Tabs stacks above the Files tree.** Panels now render in a canonical stacking order (Open Tabs, Files, Outline, Related, AI) regardless of the order they were toggled on or what's persisted; the default left-sidebar layout is Open Tabs + Files.
- **"Split View" menu item removed — split is inferred.** Panel checkboxes toggle independently, and a sidebar renders as a resizable vertical split whenever two or more panels are selected. All `leftSplit`/`rightSplit` state and the `applySplitToggle` helper are removed across `SidebarViewMenu`, `SidebarToolbar`, `SidebarFooter`, `Sidebar`, `SidebarContent`, `RightPanel`, `ReasonDocs`, and `useReasonDocsState`.
- **Expand/collapse-all button fixed.** It was a visual no-op: every parent re-render rebuilt the filtered documents array, and a sync effect in `FileTree` immediately reset the expansion state back to persisted values. Fixes:
  - memoize the filtered document arrays in `Sidebar`;
  - re-sync tree expansion by value instead of array identity, and keep selection sync separate so switching documents doesn't clobber expansion;
  - make the expand-cancel token a `useRef` so it survives re-renders;
  - count documents with children as folders when computing the deepest level (previously trees of nested documents made the button silently return);
  - cycle levels (1 → 2 → … → max → collapsed) from the tree's actual current expansion level via a new `getExpandLevel()` handle, rather than a stale local counter.

### Weather widget (react-weather-forecast / research-agent-ui)
- The compact card no longer caps at 340px: it fills its container, with current conditions on the left and the next-days forecast shifted right behind a divider, vertically centered, paddings evened out (wraps to a stack when narrow).
- On the chat homepage the widget spans the full column width on its own row, with trending news below.

## Testing
- `reason-editor-sidebar`: `tsc --noEmit` clean, 35/35 tests pass
- `react-weather-forecast`: `tsc --noEmit` clean, 84/84 tests pass
- `research-agent-ui`: 88/88 tests pass
- `reason-editor`: 372/372 tests pass (5 suite-load failures are pre-existing unresolved-import issues in unrelated files, also present on master)

## Notes
- The old persisted `REASON-left-split`/`REASON-right-split` localStorage keys are simply ignored now; existing users with multiple panels selected will see them stacked with Open Tabs on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Z3pDuVgtUoz2sy6sfb7pC