### PR TITLE
Add chat diagnostics tool and improve error visibility

### DIFF
--- a/apps/qwksearch-web/.env.example
+++ b/apps/qwksearch-web/.env.example
@@ -89,9 +89,10 @@ AUTH_RESEND_KEY=your_resend_api_key
 # ============================================================================
 
 # Comma-separated list of email addresses allowed to access /admin.
-# If unset, the first registered user (by signup date) is treated as admin.
-# Both ADMIN_EMAIL and ADMIN_EMAILS are supported (values are merged).
-# ADMIN_EMAIL=you@example.com,cofounder@example.com
+# The admin panel (and admin API routes) are ONLY accessible to these
+# emails — if unset, nobody has admin access.
+# Both ADMIN_EMAILS and legacy ADMIN_EMAIL are supported (values are merged).
+# ADMIN_EMAILS=you@example.com,cofounder@example.com
 
 # ============================================================================
 # LLM / AI Providers

--- a/apps/qwksearch-web/app/admin/AdminNav.tsx
+++ b/apps/qwksearch-web/app/admin/AdminNav.tsx
@@ -7,6 +7,7 @@ const NAV = [
   { href: "/admin/users", label: "Users" },
   { href: "/admin/config", label: "Site Config" },
   { href: "/admin/freekeys", label: "API Keys" },
+  { href: "/admin/chat-test", label: "Chat Test" },
 ];
 
 export default function AdminNav({ children }: { children: React.ReactNode }) {

--- a/apps/qwksearch-web/app/admin/chat-test/page.tsx
+++ b/apps/qwksearch-web/app/admin/chat-test/page.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+/**
+ * Admin diagnostic for the chat output pipeline.
+ *
+ * Runs the exact request the chat UI sends (POST /api/agent/chat, SSE
+ * response) and reports per-stage results: provider discovery, HTTP status,
+ * streamed frame counts, the assembled answer, and any error frames. Use it
+ * to answer "why is the chat not showing output?" — the verdict names the
+ * first stage that failed instead of the UI's silent toast.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface MinimalModel {
+  key: string;
+  name: string;
+}
+
+interface MinimalProvider {
+  id: string;
+  name: string;
+  type?: string;
+  chatModels: MinimalModel[];
+}
+
+interface FrameLogEntry {
+  at: number;
+  type: string;
+  detail: string;
+}
+
+interface RunResult {
+  verdict: "pass" | "fail";
+  reason: string;
+  httpStatus?: number;
+  counts: Record<string, number>;
+  answer: string;
+  errors: string[];
+  durationMs: number;
+}
+
+const TEST_PROMPT = "Reply with the single word: OK";
+
+export default function ChatTestPage() {
+  const [providers, setProviders] = useState<MinimalProvider[] | null>(null);
+  const [providersError, setProvidersError] = useState<string | null>(null);
+  const [providerId, setProviderId] = useState("");
+  const [modelKey, setModelKey] = useState("");
+  const [focusMode, setFocusMode] = useState("webSearch");
+  const [prompt, setPrompt] = useState(TEST_PROMPT);
+  const [running, setRunning] = useState(false);
+  const [frames, setFrames] = useState<FrameLogEntry[]>([]);
+  const [result, setResult] = useState<RunResult | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Stage 1: provider discovery — the same call the chat UI's checkConfig makes.
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/agent/providers");
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          setProvidersError(`HTTP ${res.status}: ${data?.error ?? data?.message ?? "request failed"}`);
+          setProviders([]);
+          return;
+        }
+        const list: MinimalProvider[] = data?.providers ?? [];
+        setProviders(list);
+        if (data?.error) setProvidersError(String(data.error));
+        const first = list.find((p) => (p.chatModels?.length ?? 0) > 0);
+        if (first) {
+          setProviderId(first.id);
+          setModelKey(first.chatModels[0].key);
+        }
+      } catch (err) {
+        setProvidersError(err instanceof Error ? err.message : String(err));
+        setProviders([]);
+      }
+    })();
+  }, []);
+
+  const selectedProvider = providers?.find((p) => p.id === providerId);
+
+  const runTest = useCallback(async () => {
+    setRunning(true);
+    setFrames([]);
+    setResult(null);
+    const t0 = Date.now();
+    const log: FrameLogEntry[] = [];
+    const counts: Record<string, number> = {};
+    const errors: string[] = [];
+    let answer = "";
+
+    const pushFrame = (type: string, detail: string) => {
+      counts[type] = (counts[type] ?? 0) + 1;
+      log.push({ at: Date.now() - t0, type, detail });
+      setFrames([...log]);
+    };
+
+    const finish = (verdict: "pass" | "fail", reason: string, httpStatus?: number) => {
+      setResult({
+        verdict,
+        reason,
+        httpStatus,
+        counts: { ...counts },
+        answer,
+        errors: [...errors],
+        durationMs: Date.now() - t0,
+      });
+      setRunning(false);
+    };
+
+    const abort = new AbortController();
+    abortRef.current = abort;
+
+    try {
+      // Stage 2: the exact chat request the UI sends.
+      const res = await fetch("/api/agent/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: abort.signal,
+        body: JSON.stringify({
+          message: {
+            messageId: crypto.randomUUID().replace(/-/g, "").slice(0, 14),
+            chatId: `admin-chat-test-${Date.now()}`,
+            content: prompt,
+          },
+          optimizationMode: "speed",
+          focusMode,
+          category: "general",
+          history: [],
+          files: [],
+          chatModel: { key: modelKey, providerId },
+          sourceExtractionEnabled: false,
+          thinkingTimeLimit: 0,
+        }),
+      });
+
+      if (!res.ok) {
+        const body = await res.text();
+        let detail = body;
+        try {
+          detail = JSON.parse(body)?.message ?? body;
+        } catch {
+          /* keep raw body */
+        }
+        finish("fail", `The server rejected the chat request: ${detail}`, res.status);
+        return;
+      }
+      if (!res.body) {
+        finish("fail", "The server returned no response body to stream.", res.status);
+        return;
+      }
+
+      // Stage 3: consume the SSE stream, frame by frame.
+      const reader = res.body.pipeThrough(new TextDecoderStream()).getReader();
+      let buffer = "";
+      let sawMessageEnd = false;
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += value;
+        const chunks = buffer.split("\n\n");
+        buffer = chunks.pop() ?? "";
+        for (const chunk of chunks) {
+          const dataLine = chunk
+            .split("\n")
+            .find((line) => line.startsWith("data:"));
+          if (!dataLine) continue;
+          let event: { type?: string; data?: unknown } = {};
+          try {
+            event = JSON.parse(dataLine.replace(/^data:\s*/, ""));
+          } catch {
+            pushFrame("unparseable", dataLine.slice(0, 200));
+            continue;
+          }
+          const type = event.type ?? "unknown";
+          if (type === "message") {
+            answer += String(event.data ?? "");
+            pushFrame("message", String(event.data ?? ""));
+          } else if (type === "error") {
+            errors.push(String(event.data ?? ""));
+            pushFrame("error", String(event.data ?? ""));
+          } else if (type === "sources") {
+            const sources = Array.isArray(event.data) ? event.data : [];
+            pushFrame("sources", `${sources.length} source(s)`);
+          } else if (type === "messageEnd") {
+            sawMessageEnd = true;
+            pushFrame("messageEnd", "stream completed");
+          } else {
+            pushFrame(type, JSON.stringify(event.data)?.slice(0, 200) ?? "");
+          }
+        }
+      }
+
+      if (errors.length > 0) {
+        finish(
+          "fail",
+          `The model/provider returned an error instead of output: ${errors.join("; ")}`,
+          res.status,
+        );
+      } else if ((counts["message"] ?? 0) === 0) {
+        finish(
+          "fail",
+          sawMessageEnd
+            ? "The stream completed but contained zero output frames — the model produced no text."
+            : "The stream ended without any output frames or a completion frame — it was cut off.",
+          res.status,
+        );
+      } else if (!sawMessageEnd) {
+        finish(
+          "fail",
+          "Output arrived but the stream was cut off before completing (no messageEnd frame).",
+          res.status,
+        );
+      } else {
+        finish("pass", "Chat output streamed and completed normally.", res.status);
+      }
+    } catch (err) {
+      finish(
+        "fail",
+        `The request failed before any response streamed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }, [prompt, focusMode, modelKey, providerId]);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  const badge = (ok: boolean, label: string) => (
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold ${
+        ok
+          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+          : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
+      }`}
+    >
+      {label}
+    </span>
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Chat Output Test</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Sends a real request through the chat pipeline (providers → /api/agent/chat →
+          SSE stream) and reports the first stage that fails.
+        </p>
+      </div>
+
+      {/* Stage 1: providers */}
+      <section className="rounded-lg border border-gray-200 dark:border-gray-800 p-4 space-y-2">
+        <h2 className="text-sm font-semibold">1. Provider discovery</h2>
+        {providers === null ? (
+          <p className="text-sm text-gray-500">Loading /api/agent/providers…</p>
+        ) : (
+          <>
+            <p className="text-sm">
+              {badge(providers.length > 0, providers.length > 0 ? `${providers.length} provider(s)` : "No providers")}{" "}
+              {providersError && (
+                <span className="text-red-600 dark:text-red-400">{providersError}</span>
+              )}
+            </p>
+            {providers.length === 0 && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                With no providers, the chat UI still loads but every send fails —
+                this is the most common cause of &quot;no chat output&quot;. Check the
+                provider API keys under{" "}
+                <a href="/admin/freekeys" className="text-blue-600 dark:text-blue-400 underline">
+                  API Keys
+                </a>
+                .
+              </p>
+            )}
+          </>
+        )}
+      </section>
+
+      {/* Stage 2: run config */}
+      <section className="rounded-lg border border-gray-200 dark:border-gray-800 p-4 space-y-3">
+        <h2 className="text-sm font-semibold">2. Streaming chat request</h2>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="text-sm">
+            <span className="block text-xs text-gray-500 mb-1">Provider</span>
+            <select
+              className="rounded border border-gray-300 dark:border-gray-700 bg-transparent px-2 py-1 text-sm"
+              value={providerId}
+              onChange={(e) => {
+                setProviderId(e.target.value);
+                const p = providers?.find((pr) => pr.id === e.target.value);
+                setModelKey(p?.chatModels?.[0]?.key ?? "");
+              }}
+            >
+              <option value="">(auto / server default)</option>
+              {providers?.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs text-gray-500 mb-1">Model</span>
+            <select
+              className="rounded border border-gray-300 dark:border-gray-700 bg-transparent px-2 py-1 text-sm"
+              value={modelKey}
+              onChange={(e) => setModelKey(e.target.value)}
+            >
+              <option value="">(auto)</option>
+              {selectedProvider?.chatModels?.map((m) => (
+                <option key={m.key} value={m.key}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-sm">
+            <span className="block text-xs text-gray-500 mb-1">Focus mode</span>
+            <select
+              className="rounded border border-gray-300 dark:border-gray-700 bg-transparent px-2 py-1 text-sm"
+              value={focusMode}
+              onChange={(e) => setFocusMode(e.target.value)}
+            >
+              <option value="webSearch">webSearch</option>
+              <option value="writingAssistant">writingAssistant</option>
+            </select>
+          </label>
+          <label className="grow text-sm min-w-64">
+            <span className="block text-xs text-gray-500 mb-1">Test prompt</span>
+            <input
+              className="w-full rounded border border-gray-300 dark:border-gray-700 bg-transparent px-2 py-1 text-sm"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+            />
+          </label>
+          <button
+            onClick={runTest}
+            disabled={running}
+            className="rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {running ? "Running…" : "Run test"}
+          </button>
+        </div>
+      </section>
+
+      {/* Stage 3: results */}
+      {(result || frames.length > 0) && (
+        <section className="rounded-lg border border-gray-200 dark:border-gray-800 p-4 space-y-3">
+          <h2 className="text-sm font-semibold">3. Result</h2>
+          {result && (
+            <div className="space-y-2">
+              <p className="text-sm">
+                {badge(result.verdict === "pass", result.verdict.toUpperCase())}{" "}
+                <span className={result.verdict === "pass" ? "" : "text-red-600 dark:text-red-400"}>
+                  {result.reason}
+                </span>
+              </p>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                {result.httpStatus !== undefined && <>HTTP {result.httpStatus} · </>}
+                {Object.entries(result.counts)
+                  .map(([k, v]) => `${k}: ${v}`)
+                  .join(" · ") || "no frames"}{" "}
+                · {result.durationMs}ms
+              </p>
+              {result.answer && (
+                <div>
+                  <p className="text-xs font-semibold text-gray-500 mb-1">Assembled answer</p>
+                  <pre className="max-h-48 overflow-auto rounded bg-gray-50 dark:bg-gray-900 p-3 text-xs whitespace-pre-wrap">
+                    {result.answer}
+                  </pre>
+                </div>
+              )}
+            </div>
+          )}
+          {frames.length > 0 && (
+            <details open={!result || result.verdict === "fail"}>
+              <summary className="cursor-pointer text-xs font-semibold text-gray-500">
+                Frame log ({frames.length})
+              </summary>
+              <div className="mt-2 max-h-64 overflow-auto rounded bg-gray-50 dark:bg-gray-900 p-3 font-mono text-xs">
+                {frames.map((f, i) => (
+                  <div key={i} className={f.type === "error" ? "text-red-600 dark:text-red-400" : ""}>
+                    +{f.at}ms [{f.type}] {f.detail}
+                  </div>
+                ))}
+              </div>
+            </details>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/apps/qwksearch-web/app/api/config/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/config/__tests__/route.test.ts
@@ -33,6 +33,14 @@ vi.mock('@/lib/config/env', () => ({
   getEnv: vi.fn(),
 }))
 
+// POST is admin-only; default to an authorized admin so the existing
+// behavior tests exercise the handler body. The guard itself is covered in
+// the dedicated tests below and in lib/auth/__tests__/admin.test.ts.
+vi.mock('@/lib/auth/admin', () => ({
+  assertAdmin: vi.fn(),
+}))
+
+import { assertAdmin } from '@/lib/auth/admin'
 import configManager from '@/lib/config'
 import { getEnv } from '@/lib/config/env'
 import ModelRegistry from 'chat-agent-toolkit/models/registry'
@@ -59,6 +67,8 @@ beforeEach(() => {
   mockModelRegistry.mockImplementation(() => ({
     getActiveProviders: vi.fn().mockResolvedValue([]),
   }))
+  // null = authorized; tests for the guard override this per-case.
+  ;(assertAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(null)
 })
 
 function makeRequest(method = 'GET', body?: unknown) {
@@ -126,6 +136,15 @@ describe('GET /api/config', () => {
 })
 
 describe('POST /api/config', () => {
+  it('rejects non-admin callers without touching the config', async () => {
+    ;(assertAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 }),
+    )
+    const res = await POST(makeRequest('POST', { key: 'theme', value: 'dark' }))
+    expect(res.status).toBe(403)
+    expect(mockUpdateConfig).not.toHaveBeenCalled()
+  })
+
   it('calls updateConfig and returns 200', async () => {
     const res = await POST(makeRequest('POST', { key: 'theme', value: 'dark' }))
     expect(res.status).toBe(200)

--- a/apps/qwksearch-web/app/api/config/route.ts
+++ b/apps/qwksearch-web/app/api/config/route.ts
@@ -8,6 +8,7 @@ import ModelRegistry from "chat-agent-toolkit/models/registry";
 import { NextRequest, NextResponse } from "next/server";
 import { ConfigModelProvider } from "@/lib/config/types";
 import { getEnv } from "@/lib/config/env";
+import { assertAdmin } from "@/lib/auth/admin";
 
 type SaveConfigBody = {
   key: string;
@@ -54,6 +55,11 @@ export const GET = async (req: NextRequest) => {
 
 export const POST = async (req: NextRequest) => {
   try {
+    // Site-wide config writes are admin-only (the read side stays public —
+    // the regular Settings UI needs it).
+    const guard = await assertAdmin();
+    if (guard) return guard;
+
     const body: SaveConfigBody = await req.json();
 
     if (!body.key || !body.value) {

--- a/apps/qwksearch-web/app/api/search/engines/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/search/engines/__tests__/route.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-vi.mock('search-web-api/search/search-engines-registry-list.js', () => ({
+vi.mock('search-web-api/search/search-engines-registry-list', () => ({
   ALL_ENGINES: [
     { name: 'google', categories: ['general'] },
     { name: 'brave', categories: ['general', 'news'] },

--- a/apps/qwksearch-web/app/api/search/engines/route.ts
+++ b/apps/qwksearch-web/app/api/search/engines/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { ALL_ENGINES, engineDescriptions } from "search-web-api/search/search-engines-registry-list.js";
+import { ALL_ENGINES, engineDescriptions } from "search-web-api/search/search-engines-registry-list";
 import { CATEGORIES } from "search-web-api/registry/search-engine-category-registry.js";
 
 /** Map engine name to a best-guess domain for favicon lookup. */

--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -15,8 +15,8 @@
 @source "../../../packages/shadcn-app-dock/src";
 @source "../../../packages/shadcn-settings/src";
 @source "../../../packages/research-agent-ui/src";
-@source "../../../packages/shadcn-settings/src";
 @source "../../../packages/reason-editor/src";
+@source "../../../packages/reason-editor-sidebar/src";
 
 @custom-variant dark (&:is(.dark *));
 /* @plugin "@tailwindcss/typography"; */

--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -28,7 +28,6 @@ import {
 import {
   ENGINE_NAMES,
   FEATURE_TABS,
-  PACKAGES,
   PIPELINE,
   PLATFORMS,
   PROVIDERS,
@@ -460,37 +459,6 @@ function Platforms() {
   );
 }
 
-function OpenSource() {
-  return (
-    <section className="relative px-4 py-20 sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-6xl">
-        <SectionHeading
-          eyebrow="Open source"
-          title="Built from packages you can use yourself"
-          blurb="The product is a thin shell over a monorepo of standalone, independently published libraries."
-        />
-
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {PACKAGES.map((pkg, index) => (
-            <Reveal key={pkg.name} delay={(index % 3) * 60}>
-              <SpotlightCard beam={false} spotlightSize={280} className="h-full">
-                <div className="p-5">
-                  <code className="qs-accent-text text-sm font-semibold">
-                    {pkg.name}
-                  </code>
-                  <p className="text-muted-foreground mt-1.5 text-sm leading-relaxed">
-                    {pkg.blurb}
-                  </p>
-                </div>
-              </SpotlightCard>
-            </Reveal>
-          ))}
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function ClosingCta() {
   return (
     <section className="relative px-4 pt-10 pb-28 sm:px-6 lg:px-8">
@@ -545,7 +513,6 @@ export function FeaturesView() {
       <Pipeline />
       <FeatureExplorer />
       <Platforms />
-      <OpenSource />
       <ClosingCta />
     </div>
   );

--- a/apps/qwksearch-web/lib/auth/__tests__/admin.test.ts
+++ b/apps/qwksearch-web/lib/auth/__tests__/admin.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSessionMock = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  getSession: getSessionMock,
+}));
+
+/**
+ * getAdminEmails is wrapped in React's cache(), so each scenario re-imports
+ * a fresh module to avoid memoized results leaking between env setups.
+ */
+const loadAdmin = async () => {
+  vi.resetModules();
+  return import("../admin");
+};
+
+describe("admin access control", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    getSessionMock.mockReset();
+  });
+
+  it("grants access only to emails listed in ADMIN_EMAILS", async () => {
+    vi.stubEnv("ADMIN_EMAILS", "root@example.com, other@example.com");
+    vi.stubEnv("ADMIN_EMAIL", "");
+    const { isAdmin, getAdminEmails } = await loadAdmin();
+
+    expect(await getAdminEmails()).toEqual([
+      "root@example.com",
+      "other@example.com",
+    ]);
+    expect(await isAdmin("root@example.com")).toBe(true);
+    expect(await isAdmin("Root@Example.com")).toBe(true);
+    expect(await isAdmin("intruder@example.com")).toBe(false);
+  });
+
+  it("merges legacy ADMIN_EMAIL with ADMIN_EMAILS", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "legacy@example.com");
+    vi.stubEnv("ADMIN_EMAILS", "new@example.com");
+    const { getAdminEmails } = await loadAdmin();
+
+    expect(await getAdminEmails()).toEqual([
+      "legacy@example.com",
+      "new@example.com",
+    ]);
+  });
+
+  it("grants access to nobody when no admin env var is set", async () => {
+    vi.stubEnv("ADMIN_EMAIL", "");
+    vi.stubEnv("ADMIN_EMAILS", "");
+    const { isAdmin, getAdminEmails } = await loadAdmin();
+
+    expect(await getAdminEmails()).toEqual([]);
+    // Even a real signed-in user is not an admin without the env var —
+    // there is no first-registered-user fallback.
+    expect(await isAdmin("anyone@example.com")).toBe(false);
+  });
+
+  it("assertAdmin returns 401 without a session and 403 for non-admins", async () => {
+    vi.stubEnv("ADMIN_EMAILS", "root@example.com");
+    const { assertAdmin } = await loadAdmin();
+
+    getSessionMock.mockResolvedValueOnce(null);
+    const unauthorized = await assertAdmin();
+    expect(unauthorized?.status).toBe(401);
+
+    getSessionMock.mockResolvedValueOnce({
+      user: { email: "intruder@example.com" },
+    });
+    const forbidden = await assertAdmin();
+    expect(forbidden?.status).toBe(403);
+
+    getSessionMock.mockResolvedValueOnce({
+      user: { email: "root@example.com" },
+    });
+    const allowed = await assertAdmin();
+    expect(allowed).toBeNull();
+  });
+});

--- a/apps/qwksearch-web/lib/auth/admin.ts
+++ b/apps/qwksearch-web/lib/auth/admin.ts
@@ -1,35 +1,24 @@
 import { cache } from "react";
 import { NextResponse } from "next/server";
-import { getSession, type AuthSession } from "@/lib/auth";
-import { getDB } from "@/lib/database";
-import { user } from "@/lib/database/schema";
-import { asc } from "drizzle-orm";
+import { getSession } from "@/lib/auth";
 
+/**
+ * Admin access comes exclusively from the ADMIN_EMAILS (or legacy
+ * ADMIN_EMAIL) env var — a comma-separated list of addresses; the two vars
+ * are merged. With neither set, nobody is an admin: there is deliberately
+ * no fallback (an earlier version promoted the first registered user, which
+ * silently granted admin on deployments that forgot to set the var).
+ */
 export const getAdminEmails = cache(async (): Promise<string[]> => {
   const raw = [
     process.env.ADMIN_EMAIL ?? "",
     process.env.ADMIN_EMAILS ?? "",
   ].join(",");
 
-  const fromEnv = raw
+  return raw
     .split(",")
     .map((e) => e.trim().toLowerCase())
     .filter(Boolean);
-
-  if (fromEnv.length > 0) return fromEnv;
-
-  const db = getDB();
-  const [firstUser] = await db
-    .select({ email: user.email })
-    .from(user)
-    .orderBy(asc(user.createdAt))
-    .limit(1);
-
-  if (firstUser?.email) {
-    return [firstUser.email.toLowerCase()];
-  }
-
-  return [];
 });
 
 export async function isAdmin(email: string): Promise<boolean> {

--- a/apps/qwksearch-web/lib/config/index.ts
+++ b/apps/qwksearch-web/lib/config/index.ts
@@ -7,7 +7,7 @@ import {
 import { getModelProvidersUIConfigSection } from "chat-agent-toolkit/models/providers";
 import { getMCPServersUIConfigSection } from "../mcp-servers";
 import { getEnv } from "./env";
-import { ALL_ENGINES } from "search-web-api/search/search-engines-registry-list.js";
+import { ALL_ENGINES } from "search-web-api/search/search-engines-registry-list";
 // App-specific settings schema now lives as data in research-agent-ui; the
 // config manager "requests" it here instead of declaring the fields inline.
 import { searchSettingsFields } from "research-agent-ui/settings";

--- a/apps/qwksearch-web/next.config.mjs
+++ b/apps/qwksearch-web/next.config.mjs
@@ -26,7 +26,7 @@ const nextConfig = {
     "@huggingface/transformers",
     "onnxruntime-web",
   ],
-  transpilePackages: ["quantum-sphere-loading-icon", "shadcn-theme-menu", "chat-agent-toolkit", "extract-webpage"],
+  transpilePackages: ["quantum-sphere-loading-icon", "shadcn-theme-menu", "chat-agent-toolkit", "extract-webpage", "search-web-api"],
 
   turbopack: {},
   async headers() {

--- a/packages/reason-editor/src/editor/useReasonDocsState.ts
+++ b/packages/reason-editor/src/editor/useReasonDocsState.ts
@@ -44,8 +44,12 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
   const [defaultSidebarView, setDefaultSidebarView] = useLocalStorage<
     "tree" | "outline" | "split" | "last-used"
   >("REASON-default-sidebar-view", "last-used");
+  // Versioned key (v2): earlier builds persisted panel sets without
+  // "openTabs" (e.g. via the files-dock shortcut), which permanently hid the
+  // Open Tabs panel. Bumping the key restores the files + openTabs default
+  // for everyone once.
   const [leftPanels, setLeftPanels] = useLocalStorage<SidebarPanelType[]>(
-    "REASON-left-panels",
+    "REASON-left-panels-v2",
     ["files", "openTabs"],
   );
   const [leftSplit, setLeftSplit] = useLocalStorage<boolean>(
@@ -446,10 +450,12 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
   }, []);
 
   // Opens the files sidebar in response to an external trigger (e.g. an app
-  // dock icon mounted outside this component tree).
+  // dock icon mounted outside this component tree). Keeps the Open Tabs panel
+  // alongside Files — this setter persists to localStorage, so dropping
+  // openTabs here would permanently strip it from the user's default layout.
   useEffect(() => {
     if (!openFilesSidebarSignal) return;
-    setLeftPanels(["files"]);
+    setLeftPanels(["files", "openTabs"]);
     setIsSidebarOpen(true);
   }, [openFilesSidebarSignal]);
 

--- a/packages/research-agent-ui/src/hooks/useChat/chatConfig.ts
+++ b/packages/research-agent-ui/src/hooks/useChat/chatConfig.ts
@@ -38,7 +38,7 @@ export const checkConfig = async (
   setIsConfigReady: (ready: boolean) => void,
   setHasError: (hasError: boolean) => void,
 ): Promise<void> => {
-  // try {
+  try {
     // Load user preferences from localStorage
     let chatModelKey = localStorage.getItem("chatModelKey");
     let chatModelProviderId = localStorage.getItem("chatModelProviderId");
@@ -179,10 +179,16 @@ export const checkConfig = async (
     });
 
     setIsConfigReady(true);
-  // } catch (err: any) {
-  //   console.error("An error occurred while checking the configuration:", err);
-  //   toast.error(err.message);
-  //   setIsConfigReady(false);
-  //   setHasError(true);
-  // }
+  } catch (err: any) {
+    // A failed providers fetch must not leave the app on an infinite loader:
+    // without this catch the promise rejected with neither isConfigReady nor
+    // hasError set, so ChatWindow never left its Loader state. Mark the app
+    // ready so the UI is usable and the user can configure a provider in
+    // Settings; surface the failure via toast.
+    console.error("An error occurred while checking the configuration:", err);
+    toast.error(
+      `Could not load AI providers: ${err?.message ?? String(err)}`,
+    );
+    setIsConfigReady(true);
+  }
 };

--- a/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
+++ b/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
@@ -225,6 +225,26 @@ export async function sendMessage(
    * Handles individual streaming events from the chat API.
    * @param data - Parsed JSON event from the stream
    */
+  /**
+   * Appends a persistent error bubble to the conversation so failures stay
+   * visible after the toast disappears. Without this, a failed response left
+   * the user's message with no reply at all — the only signal was a transient
+   * toast, which reads as "the chat produced no output".
+   */
+  const showErrorInChat = (errorMsg: string) => {
+    setMessages((prevMessages) => [
+      ...prevMessages,
+      {
+        content: `⚠️ **The response failed:** ${errorMsg}`,
+        messageId: generateMessageId(),
+        chatId: chatId,
+        role: "assistant",
+        createdAt: new Date(),
+      },
+    ]);
+    setMessageAppeared(true);
+  };
+
   const messageHandler = async (data: any) => {
     // Handle error events
     if (data.type === "error") {
@@ -244,6 +264,7 @@ export async function sendMessage(
         setChatModelProvider?.({ key: "", providerId: "" });
       }
       toast.error(errorMsg);
+      showErrorInChat(errorMsg);
       setLoading(false);
       return;
     }
@@ -455,6 +476,9 @@ export async function sendMessage(
         thinkingTimeLimit,
         systemInstructions: localStorage.getItem("systemInstructions") ?? undefined,
       },
+      // A chat POST is not idempotent — retrying re-sends the message and
+      // hammers the backend while the user sees nothing. Fail fast instead.
+      sseMaxRetryAttempts: 1,
       onSseError: (error: unknown) => {
         const errMsg =
           error instanceof Error ? error.message : String(error);
@@ -466,6 +490,7 @@ export async function sendMessage(
           return;
         }
         toast.error("Failed to send message. Please try again.");
+        showErrorInChat(`${errMsg}. Please try again.`);
         setLoading(false);
       },
     });

--- a/packages/search-web-api/src/category-registry.ts
+++ b/packages/search-web-api/src/category-registry.ts
@@ -3,4 +3,4 @@
  * config map (with per-category scoring weights), and the global
  * `categoryRegistry` singleton from the canonical registry module.
  */
-export * from "./registry/search-engine-category-registry.js";
+export * from "./registry/search-engine-category-registry";

--- a/packages/search-web-api/src/constants.ts
+++ b/packages/search-web-api/src/constants.ts
@@ -3,4 +3,4 @@
  * config module: CATEGORY_LIST, RECENCY_ALLOWED_LIST, SEARX_DOMAINS, and the
  * per-category engine directory used for documentation and UI rendering.
  */
-export * from "./config/search-engine-constants.js";
+export * from "./config/search-engine-constants";

--- a/packages/search-web-api/src/engine-descriptions.ts
+++ b/packages/search-web-api/src/engine-descriptions.ts
@@ -4,4 +4,4 @@
  * canonical registry module. Descriptions are sourced from SearXNG's
  * engine_descriptions.json and cover all 75+ supported engines.
  */
-export * from "./registry/search-engine-descriptions.js";
+export * from "./registry/search-engine-descriptions";

--- a/packages/search-web-api/src/engine-status.ts
+++ b/packages/search-web-api/src/engine-status.ts
@@ -4,4 +4,4 @@
  * The tracker records per-engine success/failure counts, response times,
  * and health status, and gates which engines are eligible to run.
  */
-export * from "./registry/search-engine-status-tracker.js";
+export * from "./registry/search-engine-status-tracker";

--- a/packages/search-web-api/src/engine.ts
+++ b/packages/search-web-api/src/engine.ts
@@ -3,4 +3,4 @@
  * and the `extractResponseData` helper from the canonical types module. All
  * engine source adapters import from `types/search-engine-interface` directly.
  */
-export * from "./types/search-engine-interface.js";
+export * from "./types/search-engine-interface";

--- a/packages/search-web-api/src/registry/search-engine-category-registry.ts
+++ b/packages/search-web-api/src/registry/search-engine-category-registry.ts
@@ -5,8 +5,8 @@
  * system, it supports multi-category searches and weighted result combination.
  */
 
-import { Engine } from "../types/search-engine-interface.js";
-import { CategoryConfig } from "../types/search-result-types.js";
+import { Engine } from "../types/search-engine-interface";
+import { CategoryConfig } from "../types/search-result-types";
 
 export const CATEGORIES: { [key: string]: CategoryConfig } = {
   general: {

--- a/packages/search-web-api/src/registry/search-engine-status-tracker.ts
+++ b/packages/search-web-api/src/registry/search-engine-status-tracker.ts
@@ -6,7 +6,7 @@
  * their success rate exceeds twice their failure count.
  */
 
-import { EngineStatus, EngineLog } from "../types/search-result-types.js";
+import { EngineStatus, EngineLog } from "../types/search-result-types";
 
 export class EngineStatusTracker {
   private statusMap: Map<string, EngineStatus> = new Map();

--- a/packages/search-web-api/src/result-container.ts
+++ b/packages/search-web-api/src/result-container.ts
@@ -5,4 +5,4 @@
  * using position-weighted per-engine and per-category multipliers, and groups
  * the final list by result category.
  */
-export * from "./search/search-result-container.js";
+export * from "./search/search-result-container";

--- a/packages/search-web-api/src/search-web-types.ts
+++ b/packages/search-web-api/src/search-web-types.ts
@@ -4,4 +4,4 @@
  * CategoryConfig, EngineMetadata, EngineStatus, EngineLog, and all supporting
  * weight and tracking interfaces used across the search API.
  */
-export * from "./types/search-result-types.js";
+export * from "./types/search-result-types";

--- a/packages/search-web-api/src/search.ts
+++ b/packages/search-web-api/src/search.ts
@@ -6,5 +6,5 @@
  * - `search/search-engines-registry-list` — the static catalogue of all 75+
  *   engine adapters organised by category.
  */
-export { Search } from "./search/search-query-executor.js";
-export { ALL_ENGINES } from "./search/search-engines-registry-list.js";
+export { Search } from "./search/search-query-executor";
+export { ALL_ENGINES } from "./search/search-engines-registry-list";

--- a/packages/search-web-api/src/search/search-engines-registry-list.ts
+++ b/packages/search-web-api/src/search/search-engines-registry-list.ts
@@ -9,9 +9,9 @@
  * data separate from the query-execution logic.
  */
 
-import { EngineFunction } from "../types/search-engine-interface.js";
-import { EngineMetadata } from "../types/search-result-types.js";
-import { engineDescriptions } from "../registry/search-engine-descriptions.js";
+import { EngineFunction } from "../types/search-engine-interface";
+import { EngineMetadata } from "../types/search-result-types";
+import { engineDescriptions } from "../registry/search-engine-descriptions";
 import grab from "grab-url";
 
 // Set default browser User-Agent for all outgoing requests
@@ -24,97 +24,97 @@ grab("", {
 });
 
 // General search engines
-import { google } from "../sources/general/google.js";
-import { bing } from "../sources/general/bing.js";
-import { duckduckgo } from "../sources/general/duckduckgo.js";
-import { yahoo } from "../sources/general/yahoo.js";
-import { qwant } from "../sources/general/qwant.js";
-import { startpage } from "../sources/general/startpage.js";
-import { brave } from "../sources/general/brave.js";
-import { yandex } from "../sources/general/yandex.js";
-import { baidu } from "../sources/general/baidu.js";
-import { mojeek } from "../sources/general/mojeek.js";
+import { google } from "../sources/general/google";
+import { bing } from "../sources/general/bing";
+import { duckduckgo } from "../sources/general/duckduckgo";
+import { yahoo } from "../sources/general/yahoo";
+import { qwant } from "../sources/general/qwant";
+import { startpage } from "../sources/general/startpage";
+import { brave } from "../sources/general/brave";
+import { yandex } from "../sources/general/yandex";
+import { baidu } from "../sources/general/baidu";
+import { mojeek } from "../sources/general/mojeek";
 
 // IT / Developer engines
-import { github } from "../sources/it/github.js";
-import { stackoverflow } from "../sources/it/stackoverflow.js";
-import { npm } from "../sources/it/npm.js";
-import { crates } from "../sources/it/crates.js";
-import { dockerhub } from "../sources/it/dockerhub.js";
-import { pypi } from "../sources/it/pypi.js";
-import { packagist } from "../sources/it/packagist.js";
-import { rubygems } from "../sources/it/rubygems.js";
-import { gitlab } from "../sources/it/gitlab.js";
+import { github } from "../sources/it/github";
+import { stackoverflow } from "../sources/it/stackoverflow";
+import { npm } from "../sources/it/npm";
+import { crates } from "../sources/it/crates";
+import { dockerhub } from "../sources/it/dockerhub";
+import { pypi } from "../sources/it/pypi";
+import { packagist } from "../sources/it/packagist";
+import { rubygems } from "../sources/it/rubygems";
+import { gitlab } from "../sources/it/gitlab";
 
 // Image engines
-import { unsplash } from "../sources/images/unsplash.js";
-import { bing_images } from "../sources/images/bing_images.js";
-import { google_images } from "../sources/images/google_images.js";
-import { flickr } from "../sources/images/flickr.js";
-import { imgur } from "../sources/images/imgur.js";
-import { pixabay } from "../sources/images/pixabay.js";
-import { wallhaven } from "../sources/images/wallhaven.js";
-import { deviantart } from "../sources/images/deviantart.js";
-import { openclipart } from "../sources/images/openclipart.js";
+import { unsplash } from "../sources/images/unsplash";
+import { bing_images } from "../sources/images/bing_images";
+import { google_images } from "../sources/images/google_images";
+import { flickr } from "../sources/images/flickr";
+import { imgur } from "../sources/images/imgur";
+import { pixabay } from "../sources/images/pixabay";
+import { wallhaven } from "../sources/images/wallhaven";
+import { deviantart } from "../sources/images/deviantart";
+import { openclipart } from "../sources/images/openclipart";
 
 // Video engines
-import { youtube } from "../sources/videos/youtube.js";
-import { vimeo } from "../sources/videos/vimeo.js";
-import { dailymotion } from "../sources/videos/dailymotion.js";
-import { invidious } from "../sources/videos/invidious.js";
-import { peertube } from "../sources/videos/peertube.js";
-import { bing_videos } from "../sources/videos/bing_videos.js";
+import { youtube } from "../sources/videos/youtube";
+import { vimeo } from "../sources/videos/vimeo";
+import { dailymotion } from "../sources/videos/dailymotion";
+import { invidious } from "../sources/videos/invidious";
+import { peertube } from "../sources/videos/peertube";
+import { bing_videos } from "../sources/videos/bing_videos";
 
 // News engines
-import { hackernews } from "../sources/news/hackernews.js";
-import { yahoo_news } from "../sources/news/yahoo_news.js";
-import { bing_news } from "../sources/news/bing_news.js";
-import { google_news } from "../sources/news/google_news.js";
+import { hackernews } from "../sources/news/hackernews";
+import { yahoo_news } from "../sources/news/yahoo_news";
+import { bing_news } from "../sources/news/bing_news";
+import { google_news } from "../sources/news/google_news";
 
 // Academic engines
-import { google_scholar } from "../sources/academic/google_scholar.js";
-import { arxiv } from "../sources/academic/arxiv.js";
-import { wikidata } from "../sources/academic/wikidata.js";
-import { semantic_scholar } from "../sources/academic/semantic_scholar.js";
-import { crossref } from "../sources/academic/crossref.js";
-import { pubmed } from "../sources/academic/pubmed.js";
-import { openalex } from "../sources/academic/openalex.js";
-import { doaj } from "../sources/academic/doaj.js";
-import { core } from "../sources/academic/core.js";
+import { google_scholar } from "../sources/academic/google_scholar";
+import { arxiv } from "../sources/academic/arxiv";
+import { wikidata } from "../sources/academic/wikidata";
+import { semantic_scholar } from "../sources/academic/semantic_scholar";
+import { crossref } from "../sources/academic/crossref";
+import { pubmed } from "../sources/academic/pubmed";
+import { openalex } from "../sources/academic/openalex";
+import { doaj } from "../sources/academic/doaj";
+import { core } from "../sources/academic/core";
 
 // Torrent engines
-import { torrent_1337x } from "../sources/torrents/1337x.js";
-import { thepiratebay } from "../sources/torrents/thepiratebay.js";
-import { nyaa } from "../sources/torrents/nyaa.js";
-import { yts } from "../sources/torrents/yts.js";
-import { eztv } from "../sources/torrents/eztv.js";
-import { solidtorrents } from "../sources/torrents/solidtorrents.js";
-import { kickass } from "../sources/torrents/kickass.js";
+import { torrent_1337x } from "../sources/torrents/1337x";
+import { thepiratebay } from "../sources/torrents/thepiratebay";
+import { nyaa } from "../sources/torrents/nyaa";
+import { yts } from "../sources/torrents/yts";
+import { eztv } from "../sources/torrents/eztv";
+import { solidtorrents } from "../sources/torrents/solidtorrents";
+import { kickass } from "../sources/torrents/kickass";
 
 // Social media engines
-import { twitter } from "../sources/social/twitter.js";
-import { reddit } from "../sources/social/reddit.js";
-import { medium } from "../sources/social/medium.js";
-import { soundcloud } from "../sources/social/soundcloud.js";
-import { mastodon } from "../sources/social/mastodon.js";
+import { twitter } from "../sources/social/twitter";
+import { reddit } from "../sources/social/reddit";
+import { medium } from "../sources/social/medium";
+import { soundcloud } from "../sources/social/soundcloud";
+import { mastodon } from "../sources/social/mastodon";
 
 // Map engines
-import { openstreetmap } from "../sources/maps/openstreetmap.js";
-import { photon } from "../sources/maps/photon.js";
-import { apple_maps } from "../sources/maps/apple_maps.js";
+import { openstreetmap } from "../sources/maps/openstreetmap";
+import { photon } from "../sources/maps/photon";
+import { apple_maps } from "../sources/maps/apple_maps";
 
 // Shopping engines
-import { ebay } from "../sources/shopping/ebay.js";
+import { ebay } from "../sources/shopping/ebay";
 
 // Specialised engines
-import { wikipedia } from "../sources/specialized/wikipedia.js";
-import { imdb } from "../sources/specialized/imdb.js";
-import { genius } from "../sources/specialized/genius.js";
-import { archive } from "../sources/specialized/archive.js";
-import { openlibrary } from "../sources/specialized/openlibrary.js";
-import { wttr } from "../sources/specialized/wttr.js";
-import { annas_archive } from "../sources/specialized/annas_archive.js";
-import { goodreads } from "../sources/specialized/goodreads.js";
+import { wikipedia } from "../sources/specialized/wikipedia";
+import { imdb } from "../sources/specialized/imdb";
+import { genius } from "../sources/specialized/genius";
+import { archive } from "../sources/specialized/archive";
+import { openlibrary } from "../sources/specialized/openlibrary";
+import { wttr } from "../sources/specialized/wttr";
+import { annas_archive } from "../sources/specialized/annas_archive";
+import { goodreads } from "../sources/specialized/goodreads";
 
 export { engineDescriptions };
 

--- a/packages/search-web-api/src/search/search-query-executor.ts
+++ b/packages/search-web-api/src/search/search-query-executor.ts
@@ -7,11 +7,11 @@
  * deduplicated, ranked list of `MergedResult` objects.
  */
 
-import { engineStatusTracker } from "../registry/search-engine-status-tracker.js";
-import { categoryRegistry, CATEGORIES } from "../registry/search-engine-category-registry.js";
-import { ResultContainer } from "./search-result-container.js";
-import { ALL_ENGINES } from "./search-engines-registry-list.js";
-import { MergedResult, CategoryWeight, EngineMetadata } from "../types/search-result-types.js";
+import { engineStatusTracker } from "../registry/search-engine-status-tracker";
+import { categoryRegistry, CATEGORIES } from "../registry/search-engine-category-registry";
+import { ResultContainer } from "./search-result-container";
+import { ALL_ENGINES } from "./search-engines-registry-list";
+import { MergedResult, CategoryWeight, EngineMetadata } from "../types/search-result-types";
 
 export class Search {
   private engines: EngineMetadata[] = ALL_ENGINES;

--- a/packages/search-web-api/src/search/search-result-container.ts
+++ b/packages/search-web-api/src/search/search-result-container.ts
@@ -8,7 +8,7 @@
  * unresponsive engines, and per-engine timing metrics.
  */
 
-import { EngineResult } from "../types/search-engine-interface.js";
+import { EngineResult } from "../types/search-engine-interface";
 import {
   PriorityType,
   MergedResult,
@@ -18,7 +18,7 @@ import {
   UnresponsiveEngine,
   Timing,
   EngineData,
-} from "../types/search-result-types.js";
+} from "../types/search-result-types";
 
 export class ResultContainer {
   private mainResultsMap: Map<string, MergedResult> = new Map();

--- a/packages/search-web-api/src/sources/academic/arxiv.ts
+++ b/packages/search-web-api/src/sources/academic/arxiv.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that queries the arXiv API for academic paper search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const arxiv: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/core.ts
+++ b/packages/search-web-api/src/sources/academic/core.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the CORE API for open-access academic papers (requires CORE_API_KEY).
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const core: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/crossref.ts
+++ b/packages/search-web-api/src/sources/academic/crossref.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Crossref API for scholarly work metadata.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const crossref: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/doaj.ts
+++ b/packages/search-web-api/src/sources/academic/doaj.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Directory of Open Access Journals (DOAJ) API.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const doaj: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/google_scholar.ts
+++ b/packages/search-web-api/src/sources/academic/google_scholar.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Google Scholar search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const google_scholar: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/openalex.ts
+++ b/packages/search-web-api/src/sources/academic/openalex.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the OpenAlex API for scholarly works, reconstructing abstracts from their inverted index.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 function reconstructAbstract(
   invertedIndex: Record<string, number[]>

--- a/packages/search-web-api/src/sources/academic/pubmed.ts
+++ b/packages/search-web-api/src/sources/academic/pubmed.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes PubMed search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const pubmed: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/semantic_scholar.ts
+++ b/packages/search-web-api/src/sources/academic/semantic_scholar.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Semantic Scholar API for academic papers.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const semantic_scholar: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/academic/wikidata.ts
+++ b/packages/search-web-api/src/sources/academic/wikidata.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Wikidata API for entity search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const wikidata: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/baidu.ts
+++ b/packages/search-web-api/src/sources/general/baidu.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Baidu web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const baidu: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/bing.ts
+++ b/packages/search-web-api/src/sources/general/bing.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Bing web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const bing: EngineFunction = async (q: string, page?: number) => {
   const params = new URLSearchParams({

--- a/packages/search-web-api/src/sources/general/brave.ts
+++ b/packages/search-web-api/src/sources/general/brave.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Brave web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const brave: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/duckduckgo.ts
+++ b/packages/search-web-api/src/sources/general/duckduckgo.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes DuckDuckGo HTML search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const duckduckgo: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/google.ts
+++ b/packages/search-web-api/src/sources/general/google.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Google web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const google: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/mojeek.ts
+++ b/packages/search-web-api/src/sources/general/mojeek.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Mojeek web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const mojeek: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/qwant.ts
+++ b/packages/search-web-api/src/sources/general/qwant.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Qwant search API.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const qwant: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/startpage.ts
+++ b/packages/search-web-api/src/sources/general/startpage.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Startpage web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const startpage: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/yahoo.ts
+++ b/packages/search-web-api/src/sources/general/yahoo.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Yahoo web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const yahoo: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/general/yandex.ts
+++ b/packages/search-web-api/src/sources/general/yandex.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Yandex web search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const yandex: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/bing_images.ts
+++ b/packages/search-web-api/src/sources/images/bing_images.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Bing Images search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const bing_images: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/deviantart.ts
+++ b/packages/search-web-api/src/sources/images/deviantart.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes DeviantArt search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const deviantart: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/flickr.ts
+++ b/packages/search-web-api/src/sources/images/flickr.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Flickr API for photo search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const flickr: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/google_images.ts
+++ b/packages/search-web-api/src/sources/images/google_images.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that scrapes Google Images search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const google_images: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/imgur.ts
+++ b/packages/search-web-api/src/sources/images/imgur.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Imgur search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const imgur: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/openclipart.ts
+++ b/packages/search-web-api/src/sources/images/openclipart.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Openclipart search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const openclipart: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/pixabay.ts
+++ b/packages/search-web-api/src/sources/images/pixabay.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Pixabay API for image search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const pixabay: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/unsplash.ts
+++ b/packages/search-web-api/src/sources/images/unsplash.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Unsplash API for photo search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const unsplash: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/images/wallhaven.ts
+++ b/packages/search-web-api/src/sources/images/wallhaven.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Wallhaven API for wallpaper search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const wallhaven: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/crates.ts
+++ b/packages/search-web-api/src/sources/it/crates.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the crates.io API for Rust package search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const crates: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/dockerhub.ts
+++ b/packages/search-web-api/src/sources/it/dockerhub.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Docker Hub API for container image search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const dockerhub: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/github.ts
+++ b/packages/search-web-api/src/sources/it/github.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the GitHub API for repository search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const github: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/gitlab.ts
+++ b/packages/search-web-api/src/sources/it/gitlab.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the GitLab API for project search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const gitlab: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/npm.ts
+++ b/packages/search-web-api/src/sources/it/npm.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the npm registry search API.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const npm: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/packagist.ts
+++ b/packages/search-web-api/src/sources/it/packagist.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Packagist API for PHP package search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const packagist: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/pypi.ts
+++ b/packages/search-web-api/src/sources/it/pypi.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that scrapes PyPI search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const pypi: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/rubygems.ts
+++ b/packages/search-web-api/src/sources/it/rubygems.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the RubyGems API for gem search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const rubygems: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/it/stackoverflow.ts
+++ b/packages/search-web-api/src/sources/it/stackoverflow.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Stack Exchange API for Stack Overflow question results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const stackoverflow: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/maps/apple_maps.ts
+++ b/packages/search-web-api/src/sources/maps/apple_maps.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Apple Maps API for place search results, with automatic access-token caching/renewal.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 // Token management for Apple Maps API
 let tokenCache = {

--- a/packages/search-web-api/src/sources/maps/openstreetmap.ts
+++ b/packages/search-web-api/src/sources/maps/openstreetmap.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the OpenStreetMap Nominatim API for place search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const openstreetmap: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/maps/photon.ts
+++ b/packages/search-web-api/src/sources/maps/photon.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Photon (Komoot) geocoding API for place search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const photon: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/news/bing_news.ts
+++ b/packages/search-web-api/src/sources/news/bing_news.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Bing News search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const bing_news: EngineFunction = async (
   q: string,

--- a/packages/search-web-api/src/sources/news/google_news.ts
+++ b/packages/search-web-api/src/sources/news/google_news.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Google News search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const google_news: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/news/hackernews.ts
+++ b/packages/search-web-api/src/sources/news/hackernews.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Hacker News (Algolia) API for story search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const hackernews: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/news/yahoo_news.ts
+++ b/packages/search-web-api/src/sources/news/yahoo_news.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Yahoo News search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const yahoo_news: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/shopping/ebay.ts
+++ b/packages/search-web-api/src/sources/shopping/ebay.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes eBay marketplace search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 /**
  * eBay Shopping Search Engine

--- a/packages/search-web-api/src/sources/social/mastodon.ts
+++ b/packages/search-web-api/src/sources/social/mastodon.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Mastodon public API for post search results.
  */
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const mastodon: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/social/medium.ts
+++ b/packages/search-web-api/src/sources/social/medium.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Medium search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const medium: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/social/reddit.ts
+++ b/packages/search-web-api/src/sources/social/reddit.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Reddit search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const reddit: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/social/soundcloud.ts
+++ b/packages/search-web-api/src/sources/social/soundcloud.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes SoundCloud search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const soundcloud: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/social/twitter.ts
+++ b/packages/search-web-api/src/sources/social/twitter.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Twitter/X search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const twitter: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/annas_archive.ts
+++ b/packages/search-web-api/src/sources/specialized/annas_archive.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Anna's Archive search results, trying multiple mirror domains.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 const baseDomains = [
   "annas-archive.gl",

--- a/packages/search-web-api/src/sources/specialized/archive.ts
+++ b/packages/search-web-api/src/sources/specialized/archive.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Internet Archive API for search results.
  */
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const archive: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/genius.ts
+++ b/packages/search-web-api/src/sources/specialized/genius.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Genius API for song/lyrics search results.
  */
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const genius: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/goodreads.ts
+++ b/packages/search-web-api/src/sources/specialized/goodreads.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Goodreads search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const goodreads: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/imdb.ts
+++ b/packages/search-web-api/src/sources/specialized/imdb.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes IMDb search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const imdb: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/openlibrary.ts
+++ b/packages/search-web-api/src/sources/specialized/openlibrary.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Open Library API for book search results.
  */
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const openlibrary: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/wikipedia.ts
+++ b/packages/search-web-api/src/sources/specialized/wikipedia.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Wikipedia API for article search results.
  */
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 export const wikipedia: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/specialized/wttr.ts
+++ b/packages/search-web-api/src/sources/specialized/wttr.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries wttr.in for weather data, mapping WWO condition codes to human-readable descriptions.
  */
-import { EngineFunction, EngineResult } from "../../types/search-engine-interface.js";
+import { EngineFunction, EngineResult } from "../../types/search-engine-interface";
 
 // Weather condition mapping
 const WWO_TO_CONDITION: Record<string, string> = {

--- a/packages/search-web-api/src/sources/torrents/1337x.ts
+++ b/packages/search-web-api/src/sources/torrents/1337x.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes 1337x torrent search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const torrent_1337x: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/torrents/eztv.ts
+++ b/packages/search-web-api/src/sources/torrents/eztv.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes EZTV torrent search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const eztv: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/torrents/kickass.ts
+++ b/packages/search-web-api/src/sources/torrents/kickass.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes KickassTorrents search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const kickass: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/torrents/nyaa.ts
+++ b/packages/search-web-api/src/sources/torrents/nyaa.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Nyaa torrent search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const nyaa: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/torrents/solidtorrents.ts
+++ b/packages/search-web-api/src/sources/torrents/solidtorrents.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes SolidTorrents search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const solidtorrents: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/torrents/thepiratebay.ts
+++ b/packages/search-web-api/src/sources/torrents/thepiratebay.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes The Pirate Bay search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const thepiratebay: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/torrents/yts.ts
+++ b/packages/search-web-api/src/sources/torrents/yts.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the YTS API for movie torrent search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const yts: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/videos/bing_videos.ts
+++ b/packages/search-web-api/src/sources/videos/bing_videos.ts
@@ -2,7 +2,7 @@
  * @fileoverview Engine adapter that scrapes Bing Videos search results.
  */
 import { parseHTML } from "linkedom";
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 /**
  * Bing Videos Search Engine

--- a/packages/search-web-api/src/sources/videos/dailymotion.ts
+++ b/packages/search-web-api/src/sources/videos/dailymotion.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Dailymotion API for video search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const dailymotion: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/videos/invidious.ts
+++ b/packages/search-web-api/src/sources/videos/invidious.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries public Invidious instances for YouTube video search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 // Public Invidious instances - user can configure their own
 const DEFAULT_INSTANCES = [

--- a/packages/search-web-api/src/sources/videos/peertube.ts
+++ b/packages/search-web-api/src/sources/videos/peertube.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the PeerTube API for video search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const peertube: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/videos/vimeo.ts
+++ b/packages/search-web-api/src/sources/videos/vimeo.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries the Vimeo API for video search results.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 export const vimeo: EngineFunction = async (
   query: string,

--- a/packages/search-web-api/src/sources/videos/youtube.ts
+++ b/packages/search-web-api/src/sources/videos/youtube.ts
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Engine adapter that queries YouTube video search via public Invidious instances, with fallback across multiple instances.
  */
-import { EngineFunction } from "../../types/search-engine-interface.js";
+import { EngineFunction } from "../../types/search-engine-interface";
 
 // Multiple Invidious instances for fallback
 const INVIDIOUS_INSTANCES = [

--- a/packages/search-web-api/src/types/search-engine-interface.ts
+++ b/packages/search-web-api/src/types/search-engine-interface.ts
@@ -5,7 +5,7 @@
  * import `EngineFunction` and `EngineResult` from here.
  */
 
-import type { EngineResult, Engine, EngineFunction } from "./search-result-types.js";
+import type { EngineResult, Engine, EngineFunction } from "./search-result-types";
 
 export type { EngineResult, Engine, EngineFunction };
 


### PR DESCRIPTION
## Summary
This PR adds a comprehensive admin diagnostic tool for debugging chat output failures and improves error visibility in the chat UI. It also removes the "Open Source" section from the features page and simplifies admin access control.

## Key Changes

### New Chat Diagnostics Tool
- **Added `/admin/chat-test` page** (`apps/qwksearch-web/app/admin/chat-test/page.tsx`): A new admin diagnostic tool that runs real chat requests through the complete pipeline (provider discovery → `/api/agent/chat` → SSE stream consumption) and reports which stage fails first. Includes:
  - Provider discovery validation
  - Configurable test parameters (provider, model, focus mode, prompt)
  - Real-time frame logging showing each SSE event with timing
  - Detailed result reporting with HTTP status, frame counts, assembled answer, and error messages
  - Helps answer "why is the chat not showing output?" with specific stage-level diagnostics

### Error Visibility Improvements
- **Enhanced chat error handling** (`packages/research-agent-ui/src/hooks/useChat/sendMessage.ts`): Added `showErrorInChat()` function that appends persistent error bubbles to the conversation, so failures remain visible after transient toasts disappear
- **Re-enabled error handling** (`packages/research-agent-ui/src/hooks/useChat/chatConfig.ts`): Uncommented try-catch block in `checkConfig()` to properly surface configuration errors

### Admin Access Control Simplification
- **Refactored admin authorization** (`apps/qwksearch-web/lib/auth/admin.ts`): 
  - Removed database-backed first-user fallback (which silently granted admin on deployments that forgot to set env vars)
  - Admin access now comes exclusively from `ADMIN_EMAILS` (or legacy `ADMIN_EMAIL`) environment variables
  - Merged both env vars into a single comma-separated list
  - Added comprehensive test suite (`apps/qwksearch-web/lib/auth/__tests__/admin.test.ts`) covering access control scenarios
- **Updated config route tests** (`apps/qwksearch-web/app/api/config/__tests__/route.test.ts`): Mocked `assertAdmin` to isolate handler logic from auth guard testing

### UI Updates
- **Removed "Open Source" section** from features page (`apps/qwksearch-web/components/features/FeaturesView.tsx`): Deleted the `OpenSource()` component and removed `PACKAGES` import
- **Updated admin navigation** (`apps/qwksearch-web/app/admin/AdminNav.tsx`): Added link to new chat-test diagnostic tool
- **Updated environment documentation** (`.env.example`): Clarified `ADMIN_EMAILS` behavior and removed references to first-user fallback

### Build Configuration
- **Fixed import paths**: Converted `.js` extensions to bare imports across ~80 files in `search-web-api` package for consistency with module resolution

## Notable Implementation Details
- The chat test tool uses the exact same request format and SSE parsing logic as the production chat UI, ensuring diagnostics match real behavior
- Error frames are now persisted in the chat history with a warning emoji, making failures discoverable without relying on toast notifications
- Admin access control is now explicit and auditable via environment variables only—no implicit fallbacks

https://claude.ai/code/session_019SmrojuzJ3sgCi7sk3pxQy