### PR TITLE
Add D1 read replication support with Sessions API

### DIFF
--- a/apps/qwksearch-web/lib/database/__tests__/d1-session.test.ts
+++ b/apps/qwksearch-web/lib/database/__tests__/d1-session.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+import {
+  D1_BOOKMARK_COOKIE,
+  D1_BOOKMARK_HEADER,
+  applyD1Bookmark,
+  getD1Bookmark,
+  getD1ReplicaInfo,
+  runWithD1Session,
+  runWithPrimaryD1Session,
+  sessionedD1,
+} from "../d1-session";
+
+interface FakeResult {
+  results: unknown[];
+  success: boolean;
+  meta: Record<string, unknown>;
+}
+
+interface FakeStatement {
+  bind(...values: unknown[]): FakeStatement;
+  first(colName?: string): Promise<unknown>;
+  run(): Promise<FakeResult>;
+  all(): Promise<FakeResult>;
+  raw(options?: unknown): Promise<unknown[]>;
+}
+
+/**
+ * A stand-in for the D1 binding that records how it was used: the constraint
+ * each session was opened with, and which statements ran where. Calls landing
+ * on `binding` rather than on a session are the un-sessioned path.
+ */
+function fakeD1() {
+  const opened: string[] = [];
+  const ranOnBinding: string[] = [];
+  const ranInSession: string[] = [];
+  let bookmark: string | null = null;
+
+  const statement = (sql: string, sink: string[], meta: Record<string, unknown>): FakeStatement => {
+    const self: FakeStatement = {
+      bind: (...values: unknown[]) => {
+        sink.push(`bind:${sql}:${values.join(",")}`);
+        return self;
+      },
+      run: async () => {
+        sink.push(`run:${sql}`);
+        return { results: [], success: true, meta };
+      },
+      all: async () => {
+        sink.push(`all:${sql}`);
+        return { results: [], success: true, meta };
+      },
+      first: async () => {
+        sink.push(`first:${sql}`);
+        return null;
+      },
+      raw: async () => {
+        sink.push(`raw:${sql}`);
+        return [];
+      },
+    };
+    return self;
+  };
+
+  const binding = {
+    prepare: (sql: string) => statement(sql, ranOnBinding, { served_by_primary: true }),
+    batch: async (statements: FakeStatement[]): Promise<FakeResult[]> => {
+      ranOnBinding.push(`batch:${statements.length}`);
+      return statements.map(() => ({ results: [], success: true, meta: {} }));
+    },
+    exec: async (sql: string) => {
+      ranOnBinding.push(`exec:${sql}`);
+      return { count: 1, duration: 0 };
+    },
+    withSession: (constraint?: string) => {
+      opened.push(constraint ?? "<none>");
+      return {
+        prepare: (sql: string) =>
+          statement(sql, ranInSession, { served_by_region: "WEUR", served_by_primary: false }),
+        batch: async (statements: FakeStatement[]): Promise<FakeResult[]> => {
+          // The runtime only accepts its own statement objects here, so assert
+          // the wrapper unwrapped its tracking layer before forwarding.
+          for (const candidate of statements) {
+            expect(Object.getOwnPropertySymbols(candidate)).toHaveLength(0);
+          }
+          ranInSession.push(`batch:${statements.length}`);
+          return statements.map(() => ({
+            results: [],
+            success: true,
+            meta: { served_by_region: "APAC" },
+          }));
+        },
+        getBookmark: () => bookmark,
+      };
+    },
+  };
+
+  return {
+    binding,
+    opened,
+    ranOnBinding,
+    ranInSession,
+    setBookmark: (value: string | null) => {
+      bookmark = value;
+    },
+  };
+}
+
+const get = (headers?: Record<string, string>) =>
+  new Request("https://example.test/dashboard", { headers });
+const post = (headers?: Record<string, string>) =>
+  new Request("https://example.test/api/items", { method: "POST", headers });
+
+describe("session constraints", () => {
+  it("starts reads on any replica and writes on the primary", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get(), undefined, () => db.prepare("select 1").run());
+    await runWithD1Session(post(), undefined, () => db.prepare("insert 1").run());
+
+    expect(d1.opened).toEqual(["first-unconstrained", "first-primary"]);
+  });
+
+  it("resumes from the client's bookmark, header or cookie", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get({ [D1_BOOKMARK_HEADER]: "0000001-0000002" }), undefined, () =>
+      db.prepare("select 1").run(),
+    );
+    await runWithD1Session(
+      get({ cookie: `other=x; ${D1_BOOKMARK_COOKIE}=0000003-0000004` }),
+      undefined,
+      () => db.prepare("select 1").run(),
+    );
+
+    expect(d1.opened).toEqual(["0000001-0000002", "0000003-0000004"]);
+  });
+
+  it("ignores a bookmark that is not shaped like one", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get({ [D1_BOOKMARK_HEADER]: "'; drop table users --" }), undefined, () =>
+      db.prepare("select 1").run(),
+    );
+
+    expect(d1.opened).toEqual(["first-unconstrained"]);
+  });
+
+  it("honours the D1_SESSION_MODE override", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get(), "primary", () => db.prepare("select 1").run());
+    await runWithD1Session(post(), "unconstrained", () => db.prepare("select 1").run());
+    // An unrecognised value is not an outage: fall back to "auto".
+    await runWithD1Session(get(), "nonsense", () => db.prepare("select 1").run());
+
+    expect(d1.opened).toEqual(["first-primary", "first-unconstrained", "first-unconstrained"]);
+  });
+
+  it("starts background work on the primary", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithPrimaryD1Session(() => db.prepare("delete 1").run());
+
+    expect(d1.opened).toEqual(["first-primary"]);
+  });
+});
+
+describe("sessioned binding", () => {
+  it("routes every query in a request through one session", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get(), undefined, async () => {
+      await db.prepare("select 1").bind(7).all();
+      await db.batch([db.prepare("select 2"), db.prepare("select 3")]);
+    });
+
+    expect(d1.opened).toHaveLength(1);
+    expect(d1.ranInSession).toEqual(["bind:select 1:7", "all:select 1", "batch:2"]);
+    expect(d1.ranOnBinding).toEqual([]);
+  });
+
+  it("falls through to the plain binding outside a session scope", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await db.prepare("select 1").run();
+
+    expect(d1.opened).toEqual([]);
+    expect(d1.ranOnBinding).toEqual(["run:select 1"]);
+  });
+
+  it("bypasses the Sessions API when the mode is off", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get(), "off", () => db.prepare("select 1").run());
+
+    expect(d1.opened).toEqual([]);
+    expect(d1.ranOnBinding).toEqual(["run:select 1"]);
+  });
+
+  it("passes methods it does not intercept through to the binding", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    await runWithD1Session(get(), undefined, () => db.exec("pragma foreign_keys = on"));
+
+    expect(d1.ranOnBinding).toEqual(["exec:pragma foreign_keys = on"]);
+  });
+
+  it("reports which D1 instance answered the last query", async () => {
+    const d1 = fakeD1();
+    const db = sessionedD1(d1.binding);
+
+    const info = await runWithD1Session(get(), undefined, async () => {
+      await db.prepare("select 1").run();
+      return getD1ReplicaInfo();
+    });
+
+    expect(info).toEqual({ region: "WEUR", primary: false });
+  });
+});
+
+describe("bookmark propagation", () => {
+  it("returns the session's closing bookmark on the response", async () => {
+    const d1 = fakeD1();
+    d1.setBookmark("0000005-0000006");
+    const db = sessionedD1(d1.binding);
+
+    const response = await runWithD1Session(get(), undefined, async () => {
+      await db.prepare("select 1").run();
+      return applyD1Bookmark(new Response("ok"));
+    });
+
+    expect(response.headers.get(D1_BOOKMARK_HEADER)).toBe("0000005-0000006");
+    expect(response.headers.get("set-cookie")).toContain(`${D1_BOOKMARK_COOKIE}=0000005-0000006`);
+    expect(response.headers.get("set-cookie")).toContain("HttpOnly");
+  });
+
+  it("keeps the cookie off responses that never touched D1", () => {
+    const d1 = fakeD1();
+    d1.setBookmark("0000005-0000006");
+    sessionedD1(d1.binding);
+
+    const response = runWithD1Session(get(), undefined, () => {
+      expect(getD1Bookmark()).toBeNull();
+      return applyD1Bookmark(new Response("static"));
+    });
+
+    expect(d1.opened).toEqual([]);
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(response.headers.get(D1_BOOKMARK_HEADER)).toBeNull();
+  });
+
+  it("preserves Set-Cookie headers the app already wrote", async () => {
+    const d1 = fakeD1();
+    d1.setBookmark("0000005-0000006");
+    const db = sessionedD1(d1.binding);
+
+    const response = await runWithD1Session(post(), undefined, async () => {
+      await db.prepare("insert 1").run();
+      const original = new Response("ok");
+      original.headers.append("set-cookie", "session=abc; Path=/");
+      return applyD1Bookmark(original);
+    });
+
+    const cookies = response.headers.getSetCookie();
+    expect(cookies).toHaveLength(2);
+    expect(cookies[0]).toContain("session=abc");
+    expect(cookies[1]).toContain(D1_BOOKMARK_COOKIE);
+  });
+
+  it("adds the replica-routing headers only in debug mode", async () => {
+    const d1 = fakeD1();
+    d1.setBookmark("0000005-0000006");
+    const db = sessionedD1(d1.binding);
+
+    const plain = await runWithD1Session(get(), undefined, async () => {
+      await db.prepare("select 1").run();
+      return applyD1Bookmark(new Response("ok"));
+    });
+    const debug = await runWithD1Session(get(), undefined, async () => {
+      await db.prepare("select 1").run();
+      return applyD1Bookmark(new Response("ok"), { debug: true });
+    });
+
+    expect(plain.headers.get("x-d1-served-by-region")).toBeNull();
+    expect(debug.headers.get("x-d1-served-by-region")).toBe("WEUR");
+    expect(debug.headers.get("x-d1-served-by-primary")).toBe("false");
+  });
+
+  it("round-trips a bookmark from one request into the next", async () => {
+    const d1 = fakeD1();
+    d1.setBookmark("0000007-0000008");
+    const db = sessionedD1(d1.binding);
+
+    const first = await runWithD1Session(post(), undefined, async () => {
+      await db.prepare("insert 1").run();
+      return applyD1Bookmark(new Response("ok"));
+    });
+
+    const cookie = first.headers.getSetCookie()[0].split(";")[0];
+    await runWithD1Session(get({ cookie }), undefined, () => db.prepare("select 1").run());
+
+    expect(d1.opened).toEqual(["first-primary", "0000007-0000008"]);
+  });
+});

--- a/apps/qwksearch-web/lib/database/d1-session.ts
+++ b/apps/qwksearch-web/lib/database/d1-session.ts
@@ -1,0 +1,325 @@
+/**
+ * D1 read replication via the Sessions API.
+ *
+ * With read replication enabled, D1 answers reads from a replica in the region
+ * nearest the request instead of from the single primary instance in WNAM —
+ * the win is round trips, not query time. A replica can lag the primary,
+ * though, so reads have to be pinned to a database version or a user can write
+ * a row and then not see it. That is what a *session* is for: every query in a
+ * session carries a bookmark, and D1 only lets the session read a version at
+ * least as new as everything it has already seen (sequential consistency), no
+ * matter which replica answers.
+ *
+ * The lifecycle of one request:
+ *
+ *   1. The Worker entry opens a session scope (`runWithD1Session`), seeded
+ *      with the bookmark the client returned from its previous request.
+ *   2. `sessionedD1()` wraps the raw `DB` binding so every statement
+ *      drizzle prepares runs inside that request's single session.
+ *   3. The Worker entry writes the session's closing bookmark back onto the
+ *      response (`applyD1Bookmark`), so the next request picks up where this
+ *      one left off.
+ *
+ * Requests that never touch D1 never open a session, and outside a session
+ * scope (prerendering, scripts, unit tests) the wrapper is a pass-through to
+ * the plain binding. The Sessions API is also a no-op on databases with read
+ * replication turned off, so this is safe to deploy before — and independently
+ * of — flipping the switch in the D1 dashboard.
+ *
+ * @see https://developers.cloudflare.com/d1/best-practices/read-replication/
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/** Header an API client can use to carry a bookmark across requests. */
+export const D1_BOOKMARK_HEADER = "x-d1-bookmark";
+
+/** Cookie used to carry a bookmark across browser navigations. */
+export const D1_BOOKMARK_COOKIE = "d1_bookmark";
+
+/**
+ * How long a returned bookmark stays useful. A bookmark only pins a *floor* on
+ * the database version, so letting one expire costs a consistency guarantee,
+ * never correctness — 15 minutes comfortably covers a browsing session while
+ * keeping a long-idle tab from pinning its reads to an ancient version.
+ */
+const BOOKMARK_MAX_AGE_SECONDS = 900;
+
+/**
+ * Bookmarks are opaque strings minted by D1 (`<hex>-<hex>-<hex>-<hex>`), but
+ * they reach us from a client-controlled cookie or header, so anything not
+ * shaped like one is dropped rather than handed to the binding.
+ */
+const BOOKMARK_PATTERN = /^[0-9a-zA-Z_-]{1,255}$/;
+
+/** Start the session anywhere — the first query may be served by any replica. */
+export const FIRST_UNCONSTRAINED = "first-unconstrained";
+
+/** Start the session on the primary — the first query sees the latest version. */
+export const FIRST_PRIMARY = "first-primary";
+
+/**
+ * `D1_SESSION_MODE` (a plain Worker variable, so it can be changed in the
+ * dashboard without a redeploy) overrides the per-request choice below:
+ *
+ *   auto (default)  bookmark if the client has one, else the primary for
+ *                   writes and any replica for reads
+ *   primary         always start on the primary — replicas still serve, but
+ *                   only from the latest version
+ *   unconstrained   always start anywhere — lowest latency, weakest freshness
+ *   off             bypass the Sessions API entirely (rollback switch)
+ */
+export type D1SessionMode = "auto" | "primary" | "unconstrained" | "off";
+
+/**
+ * The slice of the D1 surface this module touches, declared structurally so
+ * the module does not depend on which `@cloudflare/workers-types` happen to be
+ * in scope. `sessionedD1()` preserves its argument's real type for callers.
+ */
+interface D1Meta {
+  served_by_region?: string;
+  served_by_primary?: boolean;
+}
+
+interface D1StatementLike {
+  bind(...values: unknown[]): D1StatementLike;
+  first(colName?: string): Promise<unknown>;
+  run(): Promise<{ meta?: D1Meta }>;
+  all(): Promise<{ meta?: D1Meta }>;
+  raw(options?: unknown): Promise<unknown>;
+}
+
+interface D1SessionLike {
+  prepare(query: string): D1StatementLike;
+  batch(statements: D1StatementLike[]): Promise<{ meta?: D1Meta }[]>;
+  getBookmark(): string | null;
+}
+
+interface D1DatabaseLike {
+  prepare(query: string): D1StatementLike;
+  batch(statements: D1StatementLike[]): Promise<{ meta?: D1Meta }[]>;
+  withSession?(constraintOrBookmark?: string): D1SessionLike;
+}
+
+/**
+ * Back-reference from a tracked statement to the real D1 statement. `batch()`
+ * is handed the statements `prepare()` returned, and the runtime only accepts
+ * its own objects there, so they are unwrapped on the way through.
+ */
+const NATIVE_STATEMENT = Symbol("d1.nativeStatement");
+
+interface TrackedStatement extends D1StatementLike {
+  [NATIVE_STATEMENT]: D1StatementLike;
+}
+
+interface D1SessionScope {
+  /** Bookmark or constraint this request's sessions start from. */
+  start: string;
+  /** Sessions API disabled for this request (`D1_SESSION_MODE=off`). */
+  bypass: boolean;
+  /** Created on first use and keyed by binding, so one scope can span bindings. */
+  sessions: Map<D1DatabaseLike, D1SessionLike>;
+  /** `meta` of the most recent query, for the replica-routing debug headers. */
+  lastMeta?: D1Meta;
+}
+
+const scopeStorage = new AsyncLocalStorage<D1SessionScope>();
+
+/** A bookmark from the untrusted client, or null if missing or malformed. */
+function readClientBookmark(request: Request): string | null {
+  const header = request.headers.get(D1_BOOKMARK_HEADER);
+  if (header && BOOKMARK_PATTERN.test(header)) return header;
+
+  const cookies = request.headers.get("cookie");
+  if (!cookies) return null;
+  for (const pair of cookies.split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq === -1) continue;
+    if (pair.slice(0, eq).trim() !== D1_BOOKMARK_COOKIE) continue;
+    const value = decodeURIComponent(pair.slice(eq + 1).trim());
+    return BOOKMARK_PATTERN.test(value) ? value : null;
+  }
+  return null;
+}
+
+/**
+ * Where this request's session should start. A bookmark always wins: it is
+ * both the fastest option (any replica that has caught up can answer it) and
+ * the strictest one (never older than what this client already saw). Without
+ * one, mutations start on the primary so a handler that writes and then reads
+ * back cannot miss its own write, and plain reads start anywhere.
+ */
+function resolveStart(request: Request, mode: D1SessionMode): string {
+  if (mode === "primary") return FIRST_PRIMARY;
+  if (mode === "unconstrained") return FIRST_UNCONSTRAINED;
+
+  const bookmark = readClientBookmark(request);
+  if (bookmark) return bookmark;
+
+  const method = request.method.toUpperCase();
+  return method === "GET" || method === "HEAD" ? FIRST_UNCONSTRAINED : FIRST_PRIMARY;
+}
+
+function normalizeMode(raw: unknown): D1SessionMode {
+  return raw === "primary" || raw === "unconstrained" || raw === "off" ? raw : "auto";
+}
+
+/**
+ * Open a D1 session scope for the duration of `fn`. Everything the request
+ * does through `sessionedD1()` — in any handler, on any binding — shares one
+ * session and therefore one consistent view of the database.
+ */
+export function runWithD1Session<T>(request: Request, mode: unknown, fn: () => T): T {
+  const resolved = normalizeMode(mode);
+  return scopeStorage.run(
+    { start: resolveStart(request, resolved), bypass: resolved === "off", sessions: new Map() },
+    fn,
+  );
+}
+
+/**
+ * Open a session scope outside of a request — background jobs, which have no
+ * client bookmark to resume from and generally write.
+ */
+export function runWithPrimaryD1Session<T>(fn: () => T): T {
+  return scopeStorage.run({ start: FIRST_PRIMARY, bypass: false, sessions: new Map() }, fn);
+}
+
+function currentTarget(binding: D1DatabaseLike): D1DatabaseLike | D1SessionLike {
+  const scope = scopeStorage.getStore();
+  if (!scope || scope.bypass || typeof binding.withSession !== "function") return binding;
+
+  let session = scope.sessions.get(binding);
+  if (!session) {
+    session = binding.withSession(scope.start);
+    scope.sessions.set(binding, session);
+  }
+  return session;
+}
+
+function record(scope: D1SessionScope | undefined, meta: D1Meta | undefined) {
+  if (scope && meta) scope.lastMeta = meta;
+}
+
+/**
+ * Re-expose a prepared statement so the `meta` D1 attaches to every remote
+ * query — including the region that served it — reaches `getD1ReplicaInfo()`.
+ * `bind()` returns a fresh statement, so the result is re-wrapped.
+ */
+function trackStatement(statement: D1StatementLike, scope: D1SessionScope | undefined): TrackedStatement {
+  return {
+    [NATIVE_STATEMENT]: statement,
+    bind: (...values: unknown[]) => trackStatement(statement.bind(...values), scope),
+    first: (colName?: string) => statement.first(colName),
+    raw: (options?: unknown) => statement.raw(options),
+    run: async () => {
+      const result = await statement.run();
+      record(scope, result?.meta);
+      return result;
+    },
+    all: async () => {
+      const result = await statement.all();
+      record(scope, result?.meta);
+      return result;
+    },
+  };
+}
+
+function unwrapStatement(statement: D1StatementLike): D1StatementLike {
+  return (statement as TrackedStatement)[NATIVE_STATEMENT] ?? statement;
+}
+
+/**
+ * Wrap a D1 binding so its queries run inside the current request's session.
+ *
+ * The wrapper is stable — it resolves the session per *call*, not once at
+ * construction — so a driver built over it and cached at module scope
+ * (drizzle, for instance) keeps working while each request still gets its own
+ * session. Methods this module does not intercept (`dump`, `exec`,
+ * `withSession`) fall through to the binding. Returns the binding's own type,
+ * so call sites need no cast.
+ */
+export function sessionedD1<T>(binding: T): T {
+  const raw = binding as unknown as D1DatabaseLike;
+
+  const overrides: D1DatabaseLike = {
+    prepare(query: string) {
+      const scope = scopeStorage.getStore();
+      return trackStatement(currentTarget(raw).prepare(query), scope);
+    },
+    async batch(statements: D1StatementLike[]) {
+      const scope = scopeStorage.getStore();
+      const results = await currentTarget(raw).batch(statements.map(unwrapStatement));
+      record(scope, results?.[results.length - 1]?.meta);
+      return results;
+    },
+  };
+
+  return new Proxy(overrides, {
+    get(target, property) {
+      if (property in target) return Reflect.get(target, property);
+      const value = (raw as unknown as Record<PropertyKey, unknown>)[property];
+      return typeof value === "function" ? (value as CallableFunction).bind(raw) : value;
+    },
+  }) as unknown as T;
+}
+
+/**
+ * The closing bookmark of this request's session, or null when the request
+ * never queried D1 (a static asset, a cache hit) and so has nothing to hand
+ * forward.
+ */
+export function getD1Bookmark(): string | null {
+  const scope = scopeStorage.getStore();
+  if (!scope) return null;
+  for (const session of scope.sessions.values()) {
+    const bookmark = session.getBookmark();
+    if (bookmark) return bookmark;
+  }
+  return null;
+}
+
+/** Which D1 instance answered this request's last query, for diagnostics. */
+export function getD1ReplicaInfo(): { region?: string; primary?: boolean } | null {
+  const meta = scopeStorage.getStore()?.lastMeta;
+  if (!meta) return null;
+  return { region: meta.served_by_region, primary: meta.served_by_primary };
+}
+
+/**
+ * Hand this request's bookmark back to the client so its next request resumes
+ * from the same database version — as a header for API clients, as a cookie
+ * for browser navigations. No-ops when D1 was not used, which is what keeps
+ * the `Set-Cookie` off static and otherwise cacheable responses.
+ *
+ * Returns the response to send: headers are set in place where the response
+ * allows it, and on a copy where it does not.
+ */
+export function applyD1Bookmark(response: Response, options?: { debug?: boolean }): Response {
+  const bookmark = getD1Bookmark();
+  if (!bookmark) return response;
+  // A 101 cannot be reconstructed and carries no headers worth setting.
+  if (response.status === 101) return response;
+
+  let target = response;
+  const set = () => {
+    target.headers.set(D1_BOOKMARK_HEADER, bookmark);
+    target.headers.append(
+      "set-cookie",
+      `${D1_BOOKMARK_COOKIE}=${encodeURIComponent(bookmark)}; Path=/; Max-Age=${BOOKMARK_MAX_AGE_SECONDS}; SameSite=Lax; Secure; HttpOnly`,
+    );
+    if (options?.debug) {
+      const info = getD1ReplicaInfo();
+      if (info?.region) target.headers.set("x-d1-served-by-region", info.region);
+      if (info?.primary !== undefined) target.headers.set("x-d1-served-by-primary", String(info.primary));
+    }
+  };
+
+  try {
+    set();
+  } catch {
+    target = new Response(response.body, response);
+    set();
+  }
+  return target;
+}

--- a/apps/qwksearch-web/lib/database/index.ts
+++ b/apps/qwksearch-web/lib/database/index.ts
@@ -4,14 +4,21 @@ import { createClient } from "@libsql/client";
 import { getCloudflareContext } from "../cloudflare/context";
 import { cache } from "react";
 import * as schema from "./schema";
+import { sessionedD1 } from "./d1-session";
 
+/**
+ * The D1 binding is routed through `sessionedD1()` so that, with read
+ * replication enabled, every query in a request shares one D1 session and
+ * therefore one sequentially consistent view of the database — see
+ * ./d1-session.ts. Outside a session scope it is a pass-through.
+ */
 export const getDB = cache(() => {
   try {
     // Try Cloudflare D1 first (production)
     const { env } = getCloudflareContext();
     if (env.DB) {
       console.log("[getDB] Using Cloudflare D1 database");
-      return drizzleD1(env.DB, { schema });
+      return drizzleD1(sessionedD1(env.DB), { schema });
     }
   } catch (err) {
     console.log("[getDB] D1 not available, trying local SQLite:", err);

--- a/apps/qwksearch-web/scripts/d1-read-replication.sh
+++ b/apps/qwksearch-web/scripts/d1-read-replication.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Show, enable or disable D1 read replication for this app's database.
+#
+# Read replication is a property of the database itself, not of the Worker, so
+# wrangler.jsonc cannot carry it — it is flipped once per database, either in
+# the dashboard (D1 > qwksearch-new > Settings > Enable Read Replication) or with
+# this script. Turning it on makes D1 answer reads from a replica in the
+# region nearest the request instead of from the single primary instance.
+#
+# The Sessions API wiring in lib/database/d1-session.ts is what keeps those
+# replica reads sequentially consistent. It is a no-op while replication is off and keeps
+# working if replication is turned back off later, so the two changes can be
+# made in either order.
+#
+# Usage:
+#   export CLOUDFLARE_ACCOUNT_ID=...
+#   export CLOUDFLARE_API_TOKEN=...     # D1:Read for status, D1:Edit to change
+#   ./scripts/d1-read-replication.sh [status|enable|disable]
+#
+# Note: disabling takes up to 24 hours for replicas to stop serving requests.
+set -euo pipefail
+
+DATABASE_NAME="qwksearch-new"
+DATABASE_ID="b0ba9a66-e256-43dd-9083-062977c282a4"
+ACTION="${1:-status}"
+
+: "${CLOUDFLARE_ACCOUNT_ID:?set CLOUDFLARE_ACCOUNT_ID}"
+: "${CLOUDFLARE_API_TOKEN:?set CLOUDFLARE_API_TOKEN}"
+
+API="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/d1/database/${DATABASE_ID}"
+
+case "$ACTION" in
+  status)
+    curl -fsS -X GET "$API" -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}"
+    ;;
+  enable)
+    curl -fsS -X PUT "$API" \
+      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d '{"read_replication": {"mode": "auto"}}'
+    ;;
+  disable)
+    curl -fsS -X PUT "$API" \
+      -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -d '{"read_replication": {"mode": "disabled"}}'
+    ;;
+  *)
+    echo "usage: $0 [status|enable|disable]   (database: $DATABASE_NAME)" >&2
+    exit 64
+    ;;
+esac
+
+echo

--- a/apps/qwksearch-web/worker/index.ts
+++ b/apps/qwksearch-web/worker/index.ts
@@ -8,9 +8,16 @@
 import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isImageOptimizationPath } from "vinext/server/image-optimization";
 import type { ImageConfig } from "vinext/server/image-optimization";
 import handler from "vinext/server/app-router-entry";
+import { applyD1Bookmark, runWithD1Session } from "../lib/database/d1-session";
 
 interface Env {
   ASSETS: Fetcher;
+  // See lib/database/d1-session.ts — "auto" (default), "primary",
+  // "unconstrained" or "off". Settable as a plain Variable in the dashboard.
+  D1_SESSION_MODE?: string;
+  // When set, responses carry x-d1-served-by-region / -primary so you can see
+  // which D1 instance answered.
+  D1_SESSION_DEBUG?: string;
   IMAGES: {
     input(stream: ReadableStream): {
       transform(options: Record<string, unknown>): {
@@ -52,6 +59,15 @@ export default {
     // Delegate everything else to vinext, forwarding ctx so that
     // ctx.waitUntil() is available to background cache writes and
     // other deferred work via getRequestExecutionContext().
-    return handler.fetch(request, env, ctx);
+    //
+    // The whole request runs inside one D1 read-replication session
+    // (lib/database/d1-session.ts): reads can be answered by the nearest
+    // replica, while the session's bookmark keeps them sequentially
+    // consistent. The closing bookmark rides back on the response so the
+    // client's next request never sees an older version of the database.
+    return runWithD1Session(request, env.D1_SESSION_MODE, async () => {
+      const response = await handler.fetch(request, env, ctx);
+      return applyD1Bookmark(response, { debug: Boolean(env.D1_SESSION_DEBUG) });
+    });
   },
 };

--- a/docs/D1_READ_REPLICATION.md
+++ b/docs/D1_READ_REPLICATION.md
@@ -1,0 +1,65 @@
+# D1 read replication
+
+`qwksearch-new` runs its primary instance in WNAM. With read replication turned
+on, D1 also keeps a replica in every supported region (ENAM, WNAM, WEUR, EEUR,
+APAC, OC) and answers reads from the one nearest the request. The saving is
+network round trips — a read from Europe stops crossing an ocean twice — not
+query time.
+
+The catch is that a replica can lag the primary. Left alone, that means a user
+can write a row and then not see it on the next page load. The Sessions API is
+the fix: every query in a session carries a *bookmark*, and D1 refuses to serve
+that session a database version older than anything it has already seen. Reads
+stay fast and stay sequentially consistent.
+
+## What is wired up
+
+`apps/qwksearch-web/lib/database/d1-session.ts` owns this. Per request:
+
+1. The Worker entry opens a session scope, seeded with the bookmark the client
+   returned from its previous request (the `x-d1-bookmark` header for API
+   clients, the `d1_bookmark` cookie for browser navigations).
+2. The `DB` binding is wrapped by `sessionedD1()`, so every statement
+   drizzle prepares runs inside that one session.
+3. The session's closing bookmark goes back on the response, so the client's
+   next request resumes from at least this version.
+
+Where a session starts, when the client has no bookmark to resume from:
+
+| Request | Starts on | Why |
+| --- | --- | --- |
+| `GET` / `HEAD` | any replica (`first-unconstrained`) | lowest latency; nothing has been written to miss |
+| everything else | the primary (`first-primary`) | a handler that writes and reads back must not miss its own write |
+| cron / background | the primary (`first-primary`) | no client bookmark exists, and these jobs write |
+
+Requests that never touch D1 never open a session, which is what keeps the
+bookmark cookie off static and otherwise cacheable responses.
+
+## Turning replication on
+
+Read replication is a property of the database, not of the Worker, so
+wrangler.jsonc cannot carry it. Either:
+
+- Cloudflare dashboard → D1 → `qwksearch-new` → Settings → Enable Read Replication, or
+- `apps/qwksearch-web/scripts/d1-read-replication.sh enable`, with `CLOUDFLARE_ACCOUNT_ID`
+  and a `CLOUDFLARE_API_TOKEN` holding `D1:Edit`.
+
+`apps/qwksearch-web/scripts/d1-read-replication.sh status` prints the database's current
+`read_replication.mode` (`auto` = on, `disabled` = off).
+
+The two halves are independent and can be done in either order: the Sessions
+API is a no-op on a database with replication off, and disabling replication
+later leaves this code working (replicas take up to 24 hours to stop serving).
+
+## Knobs
+
+Both are plain Worker Variables, so they can be changed in the dashboard
+without a redeploy.
+
+- `D1_SESSION_MODE` — `auto` (default), `primary` (always start on the primary),
+  `unconstrained` (always start anywhere), or `off` (bypass the Sessions API
+  entirely; the rollback switch).
+- `D1_SESSION_DEBUG` — when set, responses carry `x-d1-served-by-region` and
+  `x-d1-served-by-primary` from the last query's `meta`, so you can see which
+  instance actually answered. These fields are `undefined` under
+  `wrangler dev`; they only appear for remote D1 requests.


### PR DESCRIPTION
## Summary

Implements D1 read replication support using Cloudflare's Sessions API to maintain sequential consistency across distributed replicas. This allows reads to be served from the nearest regional replica while ensuring clients never see stale data relative to their previous requests.

## Key Changes

- **New `d1-session.ts` module**: Core implementation of the Sessions API integration
  - `runWithD1Session()` / `runWithPrimaryD1Session()` - Opens session scopes for requests with configurable constraints
  - `sessionedD1()` - Wraps D1 bindings to route all queries through the current request's session
  - `getD1Bookmark()` / `getD1ReplicaInfo()` - Exposes session metadata for diagnostics
  - `applyD1Bookmark()` - Propagates bookmarks back to clients via headers and cookies
  - Bookmark validation and client-side bookmark resumption from headers/cookies

- **Comprehensive test suite** (`d1-session.test.ts`):
  - Session constraint selection (reads on replicas, writes on primary)
  - Bookmark resumption and validation
  - Session mode overrides (`auto`, `primary`, `unconstrained`, `off`)
  - Fallthrough behavior outside session scopes
  - Bookmark propagation across requests

- **Worker integration** (`worker/index.ts`):
  - Wraps request handling with `runWithD1Session()` to establish session scope
  - Applies bookmarks to responses via `applyD1Bookmark()`
  - Adds `D1_SESSION_MODE` and `D1_SESSION_DEBUG` environment variables for configuration

- **Database layer** (`lib/database/index.ts`):
  - Wraps D1 binding with `sessionedD1()` for automatic session routing

- **Documentation and tooling**:
  - `D1_READ_REPLICATION.md` - Comprehensive guide on the feature, configuration, and behavior
  - `d1-read-replication.sh` - Script to enable/disable/check replication status via Cloudflare API

## Implementation Details

- Uses `AsyncLocalStorage` to maintain per-request session scope across async boundaries
- Bookmarks are opaque strings validated against a pattern to prevent injection attacks
- Session constraints are determined by HTTP method and client bookmark presence:
  - `GET`/`HEAD` without bookmark → `first-unconstrained` (any replica)
  - Other methods without bookmark → `first-primary` (primary instance)
  - With bookmark → resume from that bookmark
- Statements are wrapped to track metadata from D1 responses for diagnostics
- Gracefully degrades when Sessions API is unavailable (replication disabled or `D1_SESSION_MODE=off`)
- Bookmarks are propagated as both HTTP headers (for API clients) and secure HttpOnly cookies (for browser navigation)

https://claude.ai/code/session_013j6zyJiKPrJaUotbgZ34wU