### PR TITLE
Exclude @napi-rs/canvas from bundling and remove unused split props

### DIFF
--- a/apps/qwksearch-web/vite.config.ts
+++ b/apps/qwksearch-web/vite.config.ts
@@ -47,7 +47,10 @@ export default defineConfig(({ command }) => ({
       // "liteparse" ParseMethod, behind a try/catch) ships a native napi addon
       // that workerd cannot load; nothing in this app opts into that method,
       // so keep it external rather than trying to bundle the .node binary.
-      external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse"],
+      // `@napi-rs/canvas` (dynamically imported by extract-pdf's Docling OCR
+      // page rasterizer, behind a try/catch fallback) is likewise a native
+      // napi addon workerd cannot load.
+      external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse", "@napi-rs/canvas"],
     },
     rolldownOptions: {
       // Rolldown (Vite 8.x bundler) needs its own external list.
@@ -67,9 +70,9 @@ export default defineConfig(({ command }) => ({
       // bundled client-side; the `externalize-kokoro-on-server` plugin below
       // keeps it external in the server (rsc/ssr) worker build instead.
       //
-      // `@llamaindex/liteparse` is likewise kept external — see the comment
-      // in `rollupOptions.external` above.
-      external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse"],
+      // `@llamaindex/liteparse` and `@napi-rs/canvas` are likewise kept
+      // external — see the comments in `rollupOptions.external` above.
+      external: ["fsevents", /^@mastra\//, "@llamaindex/liteparse", "@napi-rs/canvas"],
     },
   },
   environments: {

--- a/bun.lock
+++ b/bun.lock
@@ -308,6 +308,9 @@
     "packages/extract-pdf": {
       "name": "extract-pdf",
       "version": "0.1.260",
+      "dependencies": {
+        "grab-url": "^1.6.22",
+      },
       "devDependencies": {
         "terser": "^5.46.0",
         "typescript": "^5.9.3",

--- a/packages/extract-pdf/package.json
+++ b/packages/extract-pdf/package.json
@@ -28,7 +28,9 @@
     "dev:docling": "node --watch server/server.js",
     "ship": "npm run build && npx standard-version --release-as patch; rm -f CHANGELOG.md; npm publish"
   },
-  "dependencies": {},
+  "dependencies": {
+    "grab-url": "^1.6.22"
+  },
   "optionalDependencies": {
     "@hono/node-server": "^1.8.2",
     "@hono/swagger-ui": "^0.2.1",

--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -262,13 +262,9 @@ export const Sidebar = ({
 
   const footerProps = {
     leftPanels,
-    leftSplit,
     onLeftPanelsChange,
-    onLeftSplitChange,
     rightPanels,
-    rightSplit,
     onRightPanelsChange,
-    onRightSplitChange,
     isMobile,
     deletedDocs,
     onRestore,


### PR DESCRIPTION
## Summary
This PR makes two key changes: (1) excludes the `@napi-rs/canvas` native addon from bundling in both Rollup and Rolldown configurations, and (2) removes unused split-related props from the Sidebar component's footer.

## Key Changes
- **Vite config updates**: Added `@napi-rs/canvas` to the external dependencies list in both `rollupOptions` and `rolldownOptions` to prevent bundling of this native NAPI addon, which cannot be loaded by workerd. This package is dynamically imported by extract-pdf's Docling OCR page rasterizer with a try/catch fallback.
- **Sidebar component cleanup**: Removed unused props (`leftSplit`, `onLeftSplitChange`, `rightSplit`, `onRightSplitChange`) from the footer props object in the Sidebar component.
- **Package dependency**: Added `grab-url` as a dependency in the extract-pdf package.

## Implementation Details
The `@napi-rs/canvas` exclusion follows the same pattern already established for `@llamaindex/liteparse` and `@mastra/*` packages, with updated comments explaining the rationale for keeping it external rather than attempting to bundle the native binary.

https://claude.ai/code/session_019vQUma23qQ4NV54ahsNn2m