### PR TITLE
docs: add grab.js.org badge next to Next.js badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     <a href="https://discord.gg/SJdBqBz3tV"><img src="https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat" alt="Join Discord" /></a>
     <a href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg"
             alt="PRs Welcome" /></a>
-<img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI"> <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare">  <img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" />
+<img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI"> <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare">  <img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" /> <a href="https://grab.js.org"><img src="https://i.imgur.com/EWze7Ew.png" height="20" alt="grab.js.org" /></a>
  </p>
 
 ## 🧠💻 Reimagine the Internet as Self-Organizing Mind Map


### PR DESCRIPTION
## Summary
- Add the grab.js.org badge (linking to https://grab.js.org, same badge asset used in the upstream GRAB-URL repo) next to the Next.js badge in the README's top badge row.

## Test plan
- [x] Rendered badge row reviewed for correct markup/placement (docs-only change, no build/test impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfVS1D8tBMvCsnkP92ThXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfVS1D8tBMvCsnkP92ThXc)_