### PR TITLE
Add request-access flow for documents you don't own

### DIFF
--- a/apps/qwksearch-web/app/api/doc/documents/[id]/access-request/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/doc/documents/[id]/access-request/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview Route tests for requesting access to a document owned by
+ * someone else — in particular, that a second request for the same
+ * document+requester never sends a second email (the "no spam" contract).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/database', () => ({ getDB: vi.fn() }))
+vi.mock('@/lib/auth/session', () => ({ requireUserId: vi.fn() }))
+vi.mock('@/lib/cloudflare/context', () => ({ getCloudflareContext: vi.fn() }))
+
+import { getDB } from '@/lib/database'
+import { requireUserId } from '@/lib/auth/session'
+import { getCloudflareContext } from '@/lib/cloudflare/context'
+import { createFakeDb, routeContext, type FakeDb } from '../../../../../__tests__/helpers/fake-db'
+import { POST } from '../route'
+
+const mockGetDB = getDB as unknown as ReturnType<typeof vi.fn>
+const mockRequireUserId = requireUserId as unknown as ReturnType<typeof vi.fn>
+const mockGetCloudflareContext = getCloudflareContext as unknown as ReturnType<typeof vi.fn>
+
+const send = vi.fn().mockResolvedValue({ id: 'email-1' })
+
+function setup(options: Parameters<typeof createFakeDb>[0] = {}, requesterId = 'requester-1'): FakeDb {
+  const db = createFakeDb(options)
+  mockGetDB.mockReturnValue(db)
+  mockRequireUserId.mockResolvedValue(requesterId)
+  mockGetCloudflareContext.mockReturnValue({ env: { EMAIL: { send } }, cf: undefined, ctx: null })
+  return db
+}
+
+const post = (id = '1') =>
+  POST(new Request(`http://localhost/api/doc/documents/${id}/access-request`, { method: 'POST' }) as any, routeContext({ id }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  send.mockClear()
+})
+
+describe('POST /api/doc/documents/[id]/access-request', () => {
+  it('401s for an unauthenticated caller', async () => {
+    mockGetDB.mockReturnValue(createFakeDb())
+    mockRequireUserId.mockRejectedValue(new Error('Unauthorized'))
+
+    expect((await post()).status).toBe(401)
+  })
+
+  it('404s for a missing document', async () => {
+    setup({ select: (i) => (i === 0 ? [] : []) })
+
+    expect((await post('99')).status).toBe(404)
+  })
+
+  it("400s when the document doesn't require access (no owner)", async () => {
+    setup({ select: (i) => (i === 0 ? [{ id: 1, userId: null, title: 'Open' }] : []) })
+
+    const res = await post()
+    expect(res.status).toBe(400)
+  })
+
+  it('400s when the requester already owns the document', async () => {
+    setup({ select: (i) => (i === 0 ? [{ id: 1, userId: 'requester-1', title: 'Mine' }] : []) }, 'requester-1')
+
+    expect((await post()).status).toBe(400)
+  })
+
+  it('sends one notification email and records the request', async () => {
+    const db = setup(
+      {
+        select: (i) => {
+          if (i === 0) return [{ id: 1, userId: 'owner-1', title: 'Doc', name: 'Doc' }]
+          if (i === 1) return [] // no existing request yet
+          if (i === 2) return [{ id: 'owner-1', email: 'owner@test.com', name: 'Owner' }]
+          return [{ id: 'requester-1', email: 'req@test.com', name: 'Requester' }]
+        },
+        insert: [{ id: 5, documentId: 1, requesterUserId: 'requester-1' }],
+      },
+      'requester-1',
+    )
+
+    const res = await post()
+
+    expect(res.status).toBe(201)
+    expect(await res.json()).toEqual({ success: true, accessRequested: true })
+    expect(db.calls.values[0][0]).toMatchObject({
+      documentId: 1,
+      requesterUserId: 'requester-1',
+      ownerUserId: 'owner-1',
+    })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send.mock.calls[0][0].to).toBe('owner@test.com')
+  })
+
+  it('409s without sending another email when a request already exists', async () => {
+    setup({
+      select: (i) => {
+        if (i === 0) return [{ id: 1, userId: 'owner-1', title: 'Doc' }]
+        return [{ id: 42 }] // existing request found on the very next select
+      },
+    })
+
+    const res = await post()
+
+    expect(res.status).toBe(409)
+    expect((await res.json()).accessRequested).toBe(true)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('409s when a concurrent request wins the unique-index race on insert', async () => {
+    const db = createFakeDb({
+      select: (i) => {
+        if (i === 0) return [{ id: 1, userId: 'owner-1', title: 'Doc' }]
+        return [] // no existing request seen by this request's own check
+      },
+    })
+    db.insert = () => {
+      throw new Error('UNIQUE constraint failed: document_access_requests.documentId, document_access_requests.requesterUserId')
+    }
+    mockGetDB.mockReturnValue(db)
+    mockRequireUserId.mockResolvedValue('requester-1')
+    mockGetCloudflareContext.mockReturnValue({ env: { EMAIL: { send } }, cf: undefined, ctx: null })
+
+    const res = await post()
+
+    expect(res.status).toBe(409)
+    expect(send).not.toHaveBeenCalled()
+  })
+})

--- a/apps/qwksearch-web/app/api/doc/documents/[id]/access-request/route.ts
+++ b/apps/qwksearch-web/app/api/doc/documents/[id]/access-request/route.ts
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Requests access to a document owned by someone else. Sends
+ * one email notification to the document's owner and records the request so
+ * the same requester can never trigger a second email for the same document
+ * (enforced by a unique index on documentId+requesterUserId, not just this
+ * check — see lib/database/schema.ts).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { getDB } from "@/lib/database";
+import { documents, documentAccessRequests, user } from "@/lib/database/schema";
+import { eq, and } from "drizzle-orm";
+import { requireUserId } from "@/lib/auth/session";
+import { getCloudflareContext } from "@/lib/cloudflare/context";
+import { config } from "@/lib/config/site";
+import type { Env } from "@/lib/auth";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const db = getDB();
+    const requesterUserId = await requireUserId();
+    const { id } = await params;
+    const documentId = parseInt(id);
+
+    const [document] = await db
+      .select()
+      .from(documents)
+      .where(eq(documents.id, documentId))
+      .limit(1);
+
+    if (!document) {
+      return NextResponse.json(
+        { error: "Document not found" },
+        { status: 404 },
+      );
+    }
+
+    if (!document.userId) {
+      return NextResponse.json(
+        { error: "This document does not require access" },
+        { status: 400 },
+      );
+    }
+
+    if (document.userId === requesterUserId) {
+      return NextResponse.json(
+        { error: "You already have access to this document" },
+        { status: 400 },
+      );
+    }
+
+    const [existingRequest] = await db
+      .select({ id: documentAccessRequests.id })
+      .from(documentAccessRequests)
+      .where(
+        and(
+          eq(documentAccessRequests.documentId, documentId),
+          eq(documentAccessRequests.requesterUserId, requesterUserId),
+        ),
+      )
+      .limit(1);
+
+    if (existingRequest) {
+      return NextResponse.json(
+        { error: "Access request already sent", accessRequested: true },
+        { status: 409 },
+      );
+    }
+
+    // Insert first so a duplicate click (or a second tab) races into the
+    // unique index instead of sending a second email.
+    let inserted;
+    try {
+      [inserted] = await db
+        .insert(documentAccessRequests)
+        .values({
+          documentId,
+          requesterUserId,
+          ownerUserId: document.userId,
+          status: "sent",
+        })
+        .returning();
+    } catch {
+      // Unique constraint violation from a concurrent request.
+      return NextResponse.json(
+        { error: "Access request already sent", accessRequested: true },
+        { status: 409 },
+      );
+    }
+
+    const [[owner], [requester]] = await Promise.all([
+      db.select().from(user).where(eq(user.id, document.userId)).limit(1),
+      db.select().from(user).where(eq(user.id, requesterUserId)).limit(1),
+    ]);
+
+    try {
+      const ctx = getCloudflareContext();
+      const env = ctx.env as Env;
+      if (!env.EMAIL) throw new Error("EMAIL binding not configured");
+      if (!owner?.email) throw new Error("Document owner has no email on file");
+
+      const docTitle = document.title || document.name || "Untitled";
+      const requesterLabel = requester?.name || requester?.email || "Someone";
+      const docUrl = `${config.baseUrl}/?docs=${document.id}`;
+
+      await env.EMAIL.send({
+        from: config.appEmail || "noreply@example.com",
+        to: owner.email,
+        subject: `${requesterLabel} requested access to "${docTitle}"`,
+        html: `<p>${requesterLabel}${requester?.email ? ` (${requester.email})` : ""} requested access to your ${config.appName} document "${docTitle}".</p><p><a href="${docUrl}">Open the document</a> to review and share it with them.</p>`,
+      });
+    } catch (error) {
+      console.error("[access-request] Failed to send notification email:", error);
+      await db
+        .update(documentAccessRequests)
+        .set({ status: "failed" })
+        .where(eq(documentAccessRequests.id, inserted.id));
+    }
+
+    return NextResponse.json({ success: true, accessRequested: true }, { status: 201 });
+  } catch (error) {
+    if (error instanceof Error && error.message === "Unauthorized") {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
+
+    console.error("Error creating access request:", error);
+    return NextResponse.json(
+      { error: "Failed to send access request" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/qwksearch-web/app/api/doc/documents/[id]/route.ts
+++ b/apps/qwksearch-web/app/api/doc/documents/[id]/route.ts
@@ -5,8 +5,8 @@
  */
 import { NextRequest, NextResponse } from "next/server";
 import { getDB } from "@/lib/database";
-import { documents } from "@/lib/database/schema";
-import { eq } from "drizzle-orm";
+import { documents, documentAccessRequests } from "@/lib/database/schema";
+import { eq, and } from "drizzle-orm";
 import { initAuth } from "@/lib/auth";
 import { AuthSession } from "@/lib/auth/session";
 
@@ -41,7 +41,28 @@ export async function GET(
 
     // Check access permissions
     if (document.userId && document.userId !== userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 403 });
+      // Let the caller know whether this user has already sent an access
+      // request, so the UI can render "request pending" instead of a
+      // fresh "Request access" button on reload.
+      let accessRequested = false;
+      if (userId) {
+        const [existingRequest] = await db
+          .select({ id: documentAccessRequests.id })
+          .from(documentAccessRequests)
+          .where(
+            and(
+              eq(documentAccessRequests.documentId, document.id),
+              eq(documentAccessRequests.requesterUserId, userId),
+            ),
+          )
+          .limit(1);
+        accessRequested = Boolean(existingRequest);
+      }
+
+      return NextResponse.json(
+        { error: "Unauthorized", accessRequested },
+        { status: 403 },
+      );
     }
 
     return NextResponse.json(document);

--- a/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
+++ b/apps/qwksearch-web/components/layout/MainWorkspaceView.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { ChatInputBox, ChatWindow, configureResearchAgentUI, useChat } from 'research-agent-ui';
+import { ChatInputBox, ChatWindow, configureResearchAgentUI, useChat, useSession } from 'research-agent-ui';
 import { ReasonDocs } from 'react-reason-editor/reason-docs';
 import { themeActions } from 'react-reason-editor/theme';
 import { localeActions } from 'react-reason-editor/locale-bundle';
@@ -20,6 +20,7 @@ export function MainWorkspaceView() {
   const { activeView, toggleToDocs, toggleToResearch, filesSidebarRequestId } = useMainView();
   const { chatTabs, activeChatId, openChat, newChat, closeChat } = useChatTabs();
   const { sendMessage } = useChat();
+  const { signIn } = useSession();
   const searchParams = useSearchParams();
   const [activeDocId, setActiveDocId] = useState<string | null>(null);
   const [initialDocId, setInitialDocId] = useState<string | null>(null);
@@ -141,6 +142,7 @@ export function MainWorkspaceView() {
     onGenerateTips: handleGenerateTips,
     onGenerateTopics: handleGenerateTopics,
     onSearchTopic: handleSearchTopic,
+    onSignIn: signIn,
   };
 
   return activeView === 'docs' ? (

--- a/apps/qwksearch-web/drizzle/0008_add_document_access_requests.sql
+++ b/apps/qwksearch-web/drizzle/0008_add_document_access_requests.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `document_access_requests` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`documentId` integer NOT NULL,
+	`requesterUserId` text NOT NULL,
+	`ownerUserId` text NOT NULL,
+	`status` text DEFAULT 'sent' NOT NULL,
+	`createdAt` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`documentId`) REFERENCES `documents`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`requesterUserId`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_document_access_requests_doc_requester` ON `document_access_requests` (`documentId`,`requesterUserId`);
+--> statement-breakpoint
+CREATE INDEX `idx_document_access_requests_documentId` ON `document_access_requests` (`documentId`);
+--> statement-breakpoint
+CREATE INDEX `idx_document_access_requests_requesterUserId` ON `document_access_requests` (`requesterUserId`);

--- a/apps/qwksearch-web/lib/database/schema.ts
+++ b/apps/qwksearch-web/lib/database/schema.ts
@@ -237,6 +237,44 @@ export const documents = sqliteTable(
   },
 );
 
+// One row per user who has requested access to a document they don't own.
+// The unique constraint on (documentId, requesterUserId) is what enforces
+// "only one request per user per document" — the access-request API relies
+// on this to refuse a second send rather than re-checking application-side.
+export const documentAccessRequests = sqliteTable(
+  "document_access_requests",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    documentId: integer("documentId")
+      .notNull()
+      .references(() => documents.id, { onDelete: "cascade" }),
+    requesterUserId: text("requesterUserId")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    ownerUserId: text("ownerUserId").notNull(),
+    status: text("status", { enum: ["sent", "failed"] })
+      .notNull()
+      .default("sent"),
+    createdAt: text("createdAt")
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => {
+    return {
+      documentIdIdx: index("idx_document_access_requests_documentId").on(
+        table.documentId,
+      ),
+      requesterUserIdIdx: index(
+        "idx_document_access_requests_requesterUserId",
+      ).on(table.requesterUserId),
+      uniqueRequest: unique("uq_document_access_requests_doc_requester").on(
+        table.documentId,
+        table.requesterUserId,
+      ),
+    };
+  },
+);
+
 export const googleDocsSync = sqliteTable(
   "google_docs_sync",
   {

--- a/packages/reason-editor/src/app-hooks/useDocumentAccessRequest.ts
+++ b/packages/reason-editor/src/app-hooks/useDocumentAccessRequest.ts
@@ -1,0 +1,139 @@
+/**
+ * @module useDocumentAccessRequest
+ * @description Resolves a document ID that isn't in the locally-cached
+ * document list (e.g. restored from a shared `?docs=` URL on a browser that
+ * has never loaded it) by fetching it from the server, and exposes a
+ * one-shot "request access" action for when the server reports the caller
+ * can't open it.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Document } from 'react-reason-editor-sidebar';
+
+export type DocumentAccessState =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'denied'; accessRequested: boolean; requesting: boolean }
+  | { status: 'not-found' }
+  | { status: 'sign-in-required' }
+  | { status: 'error' };
+
+/**
+ * @param docId - Document ID to resolve (typically a host-supplied
+ *   `initialDocId` restored from a URL param), or `null` when there is none.
+ * @param documents - The current locally-cached document list; if `docId`
+ *   already appears here, nothing is fetched.
+ * @param onResolved - Called with the fetched document once the server
+ *   confirms the caller can access it, so the host can merge it into its
+ *   local document list and select it.
+ */
+export function useDocumentAccessRequest(
+  docId: string | null,
+  documents: Document[],
+  onResolved: (doc: Document) => void,
+) {
+  const [state, setState] = useState<DocumentAccessState>({ status: 'idle' });
+  const documentsRef = useRef(documents);
+  documentsRef.current = documents;
+  const onResolvedRef = useRef(onResolved);
+  onResolvedRef.current = onResolved;
+  // Tracks which docId this hook has already attempted to resolve, so a
+  // parent re-render (which hands back a new `documents` array reference
+  // from useLocalStorage) never re-triggers the fetch.
+  const attemptedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!docId || documentsRef.current.some((doc) => doc.id === docId)) {
+      setState({ status: 'idle' });
+      return;
+    }
+    if (attemptedRef.current === docId) return;
+    attemptedRef.current = docId;
+
+    let cancelled = false;
+    setState({ status: 'loading' });
+
+    (async () => {
+      try {
+        const res = await fetch(`/api/doc/documents/${docId}`, {
+          credentials: 'include',
+        });
+        if (cancelled) return;
+
+        if (res.ok) {
+          const doc = await res.json();
+          onResolvedRef.current({
+            id: doc.id.toString(),
+            title: doc.title || doc.name || 'Untitled',
+            content: doc.content || '',
+            parentId: doc.parentId ? doc.parentId.toString() : null,
+            children: [],
+            isExpanded: doc.isExpanded === 1,
+            isFolder: doc.isFolder === 1,
+            tags: doc.metadata ? JSON.parse(doc.metadata).tags || [] : [],
+          } as Document);
+          setState({ status: 'idle' });
+          return;
+        }
+
+        if (res.status === 401) {
+          setState({ status: 'sign-in-required' });
+          return;
+        }
+
+        if (res.status === 403) {
+          const body = await res.json().catch(() => ({}) as any);
+          setState({
+            status: 'denied',
+            accessRequested: Boolean(body?.accessRequested),
+            requesting: false,
+          });
+          return;
+        }
+
+        if (res.status === 404) {
+          setState({ status: 'not-found' });
+          return;
+        }
+
+        setState({ status: 'error' });
+      } catch {
+        if (!cancelled) setState({ status: 'error' });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [docId]);
+
+  const requestAccess = useCallback(async () => {
+    if (!docId) return;
+    setState((prev) =>
+      prev.status === 'denied' ? { ...prev, requesting: true } : prev,
+    );
+    try {
+      const res = await fetch(`/api/doc/documents/${docId}/access-request`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      // 201 (sent now) and 409 (already sent, e.g. a race with another tab)
+      // both resolve to the same "sent" UI — either way, no further request
+      // can go out for this document.
+      if (res.ok || res.status === 409) {
+        setState({ status: 'denied', accessRequested: true, requesting: false });
+      } else {
+        setState((prev) =>
+          prev.status === 'denied' ? { ...prev, requesting: false } : prev,
+        );
+      }
+    } catch {
+      setState((prev) =>
+        prev.status === 'denied' ? { ...prev, requesting: false } : prev,
+      );
+    }
+  }, [docId]);
+
+  const dismiss = useCallback(() => setState({ status: 'idle' }), []);
+
+  return { state, requestAccess, dismiss };
+}

--- a/packages/reason-editor/src/dialogs/DocumentAccessDialog.tsx
+++ b/packages/reason-editor/src/dialogs/DocumentAccessDialog.tsx
@@ -1,0 +1,113 @@
+/**
+ * @module DocumentAccessDialog
+ * @description Shown when a document ID restored from a URL (e.g. a shared
+ * `?docs=` link) can't be opened by the current user. Offers a one-shot
+ * "Request access" action that notifies the document's owner; once sent,
+ * the button is permanently disabled for this user+document pair to avoid
+ * spamming the owner with repeat requests.
+ */
+import { Lock, Mail, Check, HelpCircle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '../app-ui/dialog';
+import { Button } from '../app-ui/button';
+import type { DocumentAccessState } from '../app-hooks/useDocumentAccessRequest';
+
+interface DocumentAccessDialogProps {
+  state: DocumentAccessState;
+  onRequestAccess: () => void;
+  onOpenChange: (open: boolean) => void;
+  onSignIn?: () => void;
+}
+
+export const DocumentAccessDialog = ({
+  state,
+  onRequestAccess,
+  onOpenChange,
+  onSignIn,
+}: DocumentAccessDialogProps) => {
+  const open = state.status === 'denied' || state.status === 'not-found' || state.status === 'sign-in-required';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {state.status === 'denied' && (
+          <>
+            <DialogHeader>
+              <div className="flex items-center gap-2">
+                <Lock className="h-5 w-5 text-muted-foreground" />
+                <DialogTitle>You don&apos;t have access to this document</DialogTitle>
+              </div>
+              <DialogDescription>
+                Ask the owner for access — they&apos;ll get a one-time email letting them know you&apos;d like to view it.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+              <Button
+                onClick={onRequestAccess}
+                disabled={state.accessRequested || state.requesting}
+              >
+                {state.accessRequested ? (
+                  <>
+                    <Check className="h-4 w-4" />
+                    Request sent
+                  </>
+                ) : (
+                  <>
+                    <Mail className="h-4 w-4" />
+                    {state.requesting ? 'Sending…' : 'Request access'}
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {state.status === 'sign-in-required' && (
+          <>
+            <DialogHeader>
+              <div className="flex items-center gap-2">
+                <Lock className="h-5 w-5 text-muted-foreground" />
+                <DialogTitle>Sign in to open this document</DialogTitle>
+              </div>
+              <DialogDescription>
+                This document belongs to someone else. Sign in so we know who to request access for.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+              {onSignIn && <Button onClick={onSignIn}>Sign in</Button>}
+            </DialogFooter>
+          </>
+        )}
+
+        {state.status === 'not-found' && (
+          <>
+            <DialogHeader>
+              <div className="flex items-center gap-2">
+                <HelpCircle className="h-5 w-5 text-muted-foreground" />
+                <DialogTitle>Document not found</DialogTitle>
+              </div>
+              <DialogDescription>
+                This link doesn&apos;t point to a document that exists anymore.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button onClick={() => onOpenChange(false)}>Close</Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -16,7 +16,9 @@ import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
 import { ssrSafeLocalStorage } from '../utils/storage';
 import { Menu, PanelRight } from 'lucide-react';
-import type { OpenTabItem, SidebarProps, SidebarContentProps } from 'react-reason-editor-sidebar';
+import type { OpenTabItem, SidebarProps, SidebarContentProps, Document } from 'react-reason-editor-sidebar';
+import { useDocumentAccessRequest } from '../app-hooks/useDocumentAccessRequest';
+import { DocumentAccessDialog } from '../dialogs/DocumentAccessDialog';
 import '../app-styles/split-pane.css';
 
 /** A non-document tab (e.g. a chat conversation) supplied by the host app. */
@@ -94,6 +96,12 @@ interface ReasonDocsProps {
    * capability to offer, hiding the "Search topics" section's click action.
    */
   onSearchTopic?: (topic: string) => void;
+  /**
+   * Called when the "Sign in" action is shown in the document-access
+   * dialog (i.e. `initialDocId` points at someone else's document and the
+   * viewer isn't authenticated). Omitted hides that action.
+   */
+  onSignIn?: () => void;
 }
 
 /**
@@ -118,6 +126,7 @@ const Index = ({
   onGenerateTips,
   onGenerateTopics,
   onSearchTopic,
+  onSignIn,
 }: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState(openFilesSidebarSignal);
@@ -139,6 +148,19 @@ const Index = ({
       }
     }
   }, [initialDocId, state.documents, state.activeDocId, state.handleSelectDocument]);
+
+  // When `initialDocId` isn't already in the locally-cached document list
+  // (e.g. a shared `?docs=` link opened on a browser that never loaded this
+  // doc before), fetch it from the server. If the caller can't access it,
+  // this surfaces a "Request access" prompt instead of silently doing
+  // nothing, as the effect above would.
+  const { state: accessState, requestAccess, dismiss: dismissAccessDialog } = useDocumentAccessRequest(
+    initialDocId ?? null,
+    state.documents,
+    (doc: Document) => {
+      state.setDocuments((docs) => (docs.some((d) => d.id === doc.id) ? docs : [...docs, doc]));
+    },
+  );
 
   // Mirror the active document back to the host so it can sync a URL param.
   useEffect(() => {
@@ -467,6 +489,13 @@ const Index = ({
         onToggleTheme={handleToggleTheme}
         currentTheme={theme}
         onUpdateTags={state.handleUpdateTags}
+      />
+
+      <DocumentAccessDialog
+        state={accessState}
+        onRequestAccess={requestAccess}
+        onOpenChange={(open) => { if (!open) dismissAccessDialog(); }}
+        onSignIn={onSignIn}
       />
     </div>
   );


### PR DESCRIPTION
Opening a `?docs=<id>` link (or any REASON doc URL) for a document you don't have access to now shows a "Request access" prompt instead of doing nothing. Sending the request notifies the doc owner by email and is recorded per (document, requester); a unique index plus a duplicate-request check keep it from ever firing a second email for the same pair, so the button becomes permanently disabled ("Request sent") after one use.

- documents/[id] GET now reports accessRequested on its 403 so the client can render "already sent" without a second round-trip.
- New POST /api/doc/documents/[id]/access-request endpoint persists the request (documentAccessRequests table, unique on documentId+requesterUserId) and emails the owner via the existing Cloudflare EMAIL binding.
- reason-editor's ReasonDocs now fetches an initialDocId that isn't in the local document cache from the server, and shows the new DocumentAccessDialog on 403/404/401 instead of silently no-oping.


Claude-Session: https://claude.ai/code/session_01QCc5zzbfXe25vYZ4gYEuG7