### PR TITLE
Add per-package Codecov components and README coverage badges

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -82,6 +82,99 @@ component_management:
         - packages/qwksearch-api-client/**
         - packages/notebooklm-api-client/**
 
+    # One component per `packages/*` directory, scoped to that folder only,
+    # so each package's README can link a badge that reports just its own
+    # coverage rather than the project total. Kept alongside the grouped
+    # components above, which remain the areas the PR comment digest uses.
+    - component_id: package-chat-agent-toolkit
+      name: "Package: chat-agent-toolkit"
+      paths:
+        - packages/chat-agent-toolkit/**
+    - component_id: package-domain-rank
+      name: "Package: domain-rank"
+      paths:
+        - packages/domain-rank/**
+    - component_id: package-extract-pdf
+      name: "Package: extract-pdf"
+      paths:
+        - packages/extract-pdf/**
+    - component_id: package-extract-webpage
+      name: "Package: extract-webpage"
+      paths:
+        - packages/extract-webpage/**
+    - component_id: package-extract-youtube
+      name: "Package: extract-youtube"
+      paths:
+        - packages/extract-youtube/**
+    - component_id: package-html-renderer-api
+      name: "Package: html-renderer-api"
+      paths:
+        - packages/html-renderer-api/**
+    - component_id: package-language-model-training
+      name: "Package: language-model-training"
+      paths:
+        - packages/language-model-training/**
+    - component_id: package-notebooklm-api-client
+      name: "Package: notebooklm-api-client"
+      paths:
+        - packages/notebooklm-api-client/**
+    - component_id: package-qwksearch-api-client
+      name: "Package: qwksearch-api-client"
+      paths:
+        - packages/qwksearch-api-client/**
+    - component_id: package-qwksearch-mcp-server
+      name: "Package: qwksearch-mcp-server"
+      paths:
+        - packages/qwksearch-mcp-server/**
+    - component_id: package-react-weather-forecast
+      name: "Package: react-weather-forecast"
+      paths:
+        - packages/react-weather-forecast/**
+    - component_id: package-reason-editor
+      name: "Package: reason-editor"
+      paths:
+        - packages/reason-editor/**
+    - component_id: package-reason-editor-sidebar
+      name: "Package: reason-editor-sidebar"
+      paths:
+        - packages/reason-editor-sidebar/**
+    - component_id: package-render-url-to-html
+      name: "Package: render-url-to-html"
+      paths:
+        - packages/render-url-to-html/**
+    - component_id: package-research-agent-ui
+      name: "Package: research-agent-ui"
+      paths:
+        - packages/research-agent-ui/**
+    - component_id: package-search-web-api
+      name: "Package: search-web-api"
+      paths:
+        - packages/search-web-api/**
+    - component_id: package-searxng-search-cloudflare
+      name: "Package: searxng-search-cloudflare"
+      paths:
+        - packages/searxng-search-cloudflare/**
+    - component_id: package-shadcn-app-dock
+      name: "Package: shadcn-app-dock"
+      paths:
+        - packages/shadcn-app-dock/**
+    - component_id: package-shadcn-settings
+      name: "Package: shadcn-settings"
+      paths:
+        - packages/shadcn-settings/**
+    - component_id: package-trending-news-api
+      name: "Package: trending-news-api"
+      paths:
+        - packages/trending-news-api/**
+    - component_id: package-use-voice-control
+      name: "Package: use-voice-control"
+      paths:
+        - packages/use-voice-control/**
+    - component_id: package-write-language
+      name: "Package: write-language"
+      paths:
+        - packages/write-language/**
+
 ignore:
   - "**/node_modules/**"
   - "**/dist/**"

--- a/packages/chat-agent-toolkit/README.md
+++ b/packages/chat-agent-toolkit/README.md
@@ -26,6 +26,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-chat-agent-toolkit" alt="Coverage" /></a>
 </p>
 
 Multi-provider AI agent toolkit for generating language responses, searching the web, extracting page content, and managing long-term memory across 10+ LLM providers.

--- a/packages/domain-rank/readme.md
+++ b/packages/domain-rank/readme.md
@@ -27,6 +27,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-domain-rank" alt="Coverage" /></a>
 </p>
 
 

--- a/packages/extract-pdf/README.md
+++ b/packages/extract-pdf/README.md
@@ -25,6 +25,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-extract-pdf" alt="Coverage" /></a>
 </p>
 
 # extract-pdf

--- a/packages/extract-webpage/README.md
+++ b/packages/extract-webpage/README.md
@@ -25,6 +25,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-extract-webpage" alt="Coverage" /></a>
 </p>
 
 <p align="center">

--- a/packages/extract-youtube/README.md
+++ b/packages/extract-youtube/README.md
@@ -27,6 +27,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-extract-youtube" alt="Coverage" /></a>
 </p>
 
 # Extract YouTube Transcript 

--- a/packages/html-renderer-api/readme.md
+++ b/packages/html-renderer-api/readme.md
@@ -1,5 +1,7 @@
 # Advanced Puppeteer API with Authentication & Cookie Management
 
+[![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-html-renderer-api)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
+
 A production-ready Cloudflare Worker API that renders web pages using Puppeteer with advanced features including password authentication, session management, cookie persistence, resource blocking, and comprehensive OpenAPI documentation.
 
 ## 🌟 Key Features

--- a/packages/language-model-training/README.md
+++ b/packages/language-model-training/README.md
@@ -2,6 +2,8 @@
 
 # Transformer Language Model Training with Tinygrad
 
+[![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-language-model-training)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
+
 A from-scratch GPT-style transformer implementation on [Tinygrad](https://github.com/tinygrad/tinygrad), with three ways to run it depending on scale:
 
 | Mode | What it does | Where |

--- a/packages/notebooklm-api-client/readme.md
+++ b/packages/notebooklm-api-client/readme.md
@@ -25,6 +25,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-notebooklm-api-client" alt="Coverage" /></a>
 </p>
 
 # notebooklm-api

--- a/packages/qwksearch-api-client/README.md
+++ b/packages/qwksearch-api-client/README.md
@@ -19,6 +19,7 @@
     <br />
     <img src="https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff" alt="Claude AI"> <img src="https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white" alt="Cloudflare"> <img src="https://img.shields.io/badge/shadcn%2Fui-000?logo=shadcnui&logoColor=fff" alt="shadcn/ui"> <img src="https://img.shields.io/badge/Next.js-black" alt="Next.js" />
     <a href="https://better-auth.com/docs/introduction" target="_blank"><img src="https://i.imgur.com/eaGdjBq.png" alt="better-auth" /></a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-qwksearch-api-client" alt="Coverage" /></a>
  </p>
 
 <p align="center">

--- a/packages/react-weather-forecast/README.md
+++ b/packages/react-weather-forecast/README.md
@@ -1,5 +1,7 @@
 # use-weather-forecast
 
+[![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-react-weather-forecast)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
+
 React weather forecast component using Open-Meteo for current, hourly, and daily forecasts and Cloudflare/ipapi.co for IP geolocation.
 
 ## Features

--- a/packages/reason-editor/README.md
+++ b/packages/reason-editor/README.md
@@ -4,6 +4,7 @@
     alt="npm bundle size "
   />
 </a>
+<a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-reason-editor" alt="Coverage" /></a>
 
 ![logo](https://i.imgur.com/EIqHZVO.png)
 

--- a/packages/research-agent-ui/README.md
+++ b/packages/research-agent-ui/README.md
@@ -25,6 +25,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-research-agent-ui" alt="Coverage" /></a>
 </p>
 
 # research-agent-ui

--- a/packages/search-web-api/README.md
+++ b/packages/search-web-api/README.md
@@ -26,6 +26,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-search-web-api" alt="Coverage" /></a>
 </p>
 
     

--- a/packages/searxng-search-cloudflare/readme.md
+++ b/packages/searxng-search-cloudflare/readme.md
@@ -1,5 +1,7 @@
 # SearXNG on Render.com - Deployment Guide
 
+[![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-searxng-search-cloudflare)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
+
 Deploy your own private SearXNG search engine proxy on Render.com with custom configuration in minutes.
 
 ## 🌟 What is SearXNG?

--- a/packages/shadcn-app-dock/README.md
+++ b/packages/shadcn-app-dock/README.md
@@ -25,6 +25,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-shadcn-app-dock" alt="Coverage" /></a>
 </p>
 
 # shadcn-app-dock

--- a/packages/shadcn-settings/README.md
+++ b/packages/shadcn-settings/README.md
@@ -1,5 +1,7 @@
 # shadcn-settings
 
+[![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-shadcn-settings)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
+
 Schema-driven **settings form renderer** for React, built on
 [shadcn/ui](https://ui.shadcn.com) + Radix primitives.
 

--- a/packages/trending-news-api/README.md
+++ b/packages/trending-news-api/README.md
@@ -1,5 +1,7 @@
 # trending-news-api
 
+[![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-trending-news-api)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
+
 React trending news widget: daily top Wikipedia pages (via the Wikimedia Pageviews API) matched
 against headlines from [The News API](https://www.thenewsapi.com/), served through a bundled
 Cloudflare Worker so the News API key never reaches the browser.

--- a/packages/use-voice-control/README.md
+++ b/packages/use-voice-control/README.md
@@ -26,6 +26,7 @@
     <a href="https://codespaces.new/OpenSourceAGI/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-use-voice-control" alt="Coverage" /></a>
 </p>
 
 <p align="center">

--- a/packages/write-language/README.md
+++ b/packages/write-language/README.md
@@ -25,6 +25,7 @@
     <a href="https://codespaces.new/vtempest/qwksearch-research-agent">
     <img src="https://github.com/codespaces/badge.svg" width="150" height="20" />
     </a>
+    <a href="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent"><img src="https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-write-language" alt="Coverage" /></a>
 </p>
 
 # write-language


### PR DESCRIPTION
Add a package-<name> Codecov component (scoped to packages/<name>/**) for every packages/* directory, alongside the existing grouped components, and link each package's README to its own component badge so coverage reads per-package rather than only as a total.


Claude-Session: https://claude.ai/code/session_01M9Qg6gVyq4NVPQSYWh7dA5