### PR TITLE
Improve compact weather card layout and add tab context menu options

### DIFF
--- a/packages/react-weather-forecast/src/components/WeatherForecast.tsx
+++ b/packages/react-weather-forecast/src/components/WeatherForecast.tsx
@@ -122,8 +122,11 @@ const styles = {
     width: '100%',
     boxSizing: 'border-box',
   } as React.CSSProperties,
-  // Current conditions stack down the left side of the card.
-  compactBody: { display: 'flex', flexDirection: 'column', gap: 10, flex: '1 1 200px', minWidth: 0 } as React.CSSProperties,
+  // Current conditions form two spread-out rows down the left side of the
+  // card (rather than five stacked lines), so the card stays short and each
+  // row uses the full available width.
+  compactBody: { display: 'flex', flexDirection: 'column', justifyContent: 'space-between', gap: 14, flex: '1 1 200px', minWidth: 0 } as React.CSSProperties,
+  compactRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: 10 } as React.CSSProperties,
   compactCity: { fontSize: 15, fontWeight: 700, lineHeight: 1.2 } as React.CSSProperties,
   compactHeader: { display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 8 } as React.CSSProperties,
   compactTemp: { fontSize: 32, fontWeight: 600, lineHeight: 1 } as React.CSSProperties,
@@ -237,40 +240,44 @@ function SingleWeatherForecast(props: Props) {
     return (
       <div className={props.className} style={{ ...styles.compactRoot, ...props.style }}>
         <div style={styles.compactBody}>
-          <div style={styles.compactCity}>
-            {data.location?.city || 'Current location'}
-            {data.location?.region ? `, ${data.location.region}` : ''}
-          </div>
-
-          <div style={styles.compactHeader}>
-            <WeatherIcon condition={data.current.icon} width={30} height={30} title="Current weather" />
-            <strong style={styles.compactTemp}>{data.current.temperature}</strong>
-            {renderUnitSwitch(13)}
-          </div>
-
-          <div>
-            <div style={styles.compactTime}>
-              {currentClock.main}
-              {currentClock.tail && <span style={styles.compactSeconds}>{currentClock.tail}</span>}
+          <div style={styles.compactRow}>
+            <div style={styles.compactCity}>
+              {data.location?.city || 'Current location'}
+              {data.location?.region ? `, ${data.location.region}` : ''}
             </div>
-            <div style={styles.compactDate}>
-              {currentDate}
-              {currentZone ? ` · ${currentZone}` : ''}
+
+            <div style={styles.compactHeader}>
+              <WeatherIcon condition={data.current.icon} width={30} height={30} title="Current weather" />
+              <strong style={styles.compactTemp}>{data.current.temperature}</strong>
+              {renderUnitSwitch(13)}
             </div>
           </div>
 
-          <div style={styles.compactStats}>
-            {today && (
+          <div style={styles.compactRow}>
+            <div>
+              <div style={styles.compactTime}>
+                {currentClock.main}
+                {currentClock.tail && <span style={styles.compactSeconds}>{currentClock.tail}</span>}
+              </div>
+              <div style={styles.compactDate}>
+                {currentDate}
+                {currentZone ? ` · ${currentZone}` : ''}
+              </div>
+            </div>
+
+            <div style={styles.compactStats}>
+              {today && (
+                <span style={styles.compactStat}>
+                  <WeatherIcon condition={today.icon} width={16} height={16} title="Today's high and low" />
+                  {today.max}&deg; / {today.min}&deg;
+                  <RainBadge probability={today.precipitationProbabilityMax} compact />
+                </span>
+              )}
               <span style={styles.compactStat}>
-                <WeatherIcon condition={today.icon} width={16} height={16} title="Today's high and low" />
-                {today.max}&deg; / {today.min}&deg;
-                <RainBadge probability={today.precipitationProbabilityMax} compact />
+                <WindIcon width={16} height={16} title="Wind speed" />
+                {data.current.windSpeed !== undefined ? `${Math.round(data.current.windSpeed)} ${windSpeedUnitLabel}` : '—'}
               </span>
-            )}
-            <span style={styles.compactStat}>
-              <WindIcon width={16} height={16} title="Wind speed" />
-              {data.current.windSpeed !== undefined ? `${Math.round(data.current.windSpeed)} ${windSpeedUnitLabel}` : '—'}
-            </span>
+            </div>
           </div>
         </div>
 

--- a/packages/reason-editor-sidebar/src/SidebarContent.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarContent.tsx
@@ -29,7 +29,7 @@ import {
 } from './app-ui/context-menu';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
-import { X, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
+import { X, XCircle, ArrowDownFromLine, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
 import './split-pane.css';
 
 import type { DocumentTreeHandle } from './file-tree/filetree';
@@ -156,6 +156,18 @@ export const SidebarContent = ({
     kind: 'file' as const,
   }));
 
+  const handleCloseOtherTabs = (tabId: string) => {
+    if (!onTabClose) return;
+    resolvedTabItems.filter((tab) => tab.id !== tabId).forEach((tab) => onTabClose(tab.id));
+  };
+
+  const handleCloseTabsBelow = (tabId: string) => {
+    if (!onTabClose) return;
+    const index = resolvedTabItems.findIndex((tab) => tab.id === tabId);
+    if (index === -1) return;
+    resolvedTabItems.slice(index + 1).forEach((tab) => onTabClose(tab.id));
+  };
+
   const renderOpenTabs = () => (
     <div className="h-full overflow-auto">
       <div className="px-1 py-1">
@@ -183,9 +195,11 @@ export const SidebarContent = ({
         {resolvedTabItems.length === 0 ? (
           <div className="px-2 py-3 text-xs text-muted-foreground">No open tabs</div>
         ) : (
-          resolvedTabItems.map(({ id: tabId, title, kind }) => {
+          resolvedTabItems.map(({ id: tabId, title, kind }, tabIndex) => {
             const isActive = tabId === activeTab;
             const isChat = kind === 'chat';
+            const hasTabsBelow = tabIndex < resolvedTabItems.length - 1;
+            const hasOtherTabs = resolvedTabItems.length > 1;
             return (
               <ContextMenu key={tabId}>
                 <ContextMenuTrigger>
@@ -232,6 +246,24 @@ export const SidebarContent = ({
                     >
                       <X className="mr-2 h-4 w-4" />
                       Close
+                    </ContextMenuItem>
+                  )}
+                  {onTabClose && (
+                    <ContextMenuItem
+                      onClick={() => handleCloseTabsBelow(tabId)}
+                      disabled={!hasTabsBelow}
+                    >
+                      <ArrowDownFromLine className="mr-2 h-4 w-4" />
+                      Close Tabs Below
+                    </ContextMenuItem>
+                  )}
+                  {onTabClose && (
+                    <ContextMenuItem
+                      onClick={() => handleCloseOtherTabs(tabId)}
+                      disabled={!hasOtherTabs}
+                    >
+                      <XCircle className="mr-2 h-4 w-4" />
+                      Close Other Tabs
                     </ContextMenuItem>
                   )}
                   {!isChat && (onSplitRight || onReopenLastClosed) && <ContextMenuSeparator />}


### PR DESCRIPTION
## Summary
This PR makes two distinct improvements: reorganizes the compact weather forecast card to display information in two rows instead of five stacked lines, and adds context menu options for managing multiple open tabs.

## Key Changes

### Weather Forecast Component
- **Reorganized compact layout**: Changed from vertically stacked elements to a two-row layout using a new `compactRow` style
  - First row: Location, weather icon, temperature, and unit switch
  - Second row: Time/date/timezone and weather statistics (high/low, wind speed)
- **Updated styles**: 
  - Added `justifyContent: 'space-between'` to `compactBody` to spread rows vertically
  - Increased gap from 10 to 14 for better spacing
  - Created new `compactRow` style with flexbox properties to distribute content horizontally
- **Result**: Card stays more compact vertically while utilizing full available width

### Sidebar Content Component
- **Added tab context menu actions**:
  - "Close Tabs Below": Closes all tabs below the current tab
  - "Close Other Tabs": Closes all tabs except the current one
- **Implementation details**:
  - Added `handleCloseOtherTabs()` and `handleCloseTabsBelow()` helper functions
  - Menu items are properly disabled when not applicable (e.g., no tabs below, only one tab open)
  - Imported new icons (`XCircle`, `ArrowDownFromLine`) from lucide-react
  - Tracks tab index and calculates availability of actions dynamically

https://claude.ai/code/session_01MfDHq1vYG67T8SwfJwjWst