### PR TITLE
Add CLI and Node.js API for document-to-speech synthesis

### DIFF
--- a/packages/use-voice-control/README.md
+++ b/packages/use-voice-control/README.md
@@ -43,6 +43,12 @@ React hooks and components for seamless voice control and speech I/O (Speech-to-
 npm install use-voice-control
 ```
 
+Or read a document aloud straight from the terminal, no install and no code:
+
+```bash
+npx use-voice-control README.md -o readme.wav
+```
+
 ---
 
 ## 🎤 Features
@@ -58,6 +64,14 @@ npm install use-voice-control
 - **Deepgram TTS**: Enterprise-grade speech synthesis with 12 Aura voices
 - **Server & Client Support**: Run on backend or stream to client
 - **Multiple Output Formats**: WAV, PCM, or raw audio buffers
+
+### Markdown & Files
+
+- **Markdown aware**: `#`, `**` and backticks are never read out — headings are
+  spoken as headings, code blocks are announced, links keep their text
+- **Files in, audio out**: `.md` and `.txt` files rendered to WAV from the
+  [command line](#-command-line) or from Node
+- **Local synthesis**: Kokoro runs on the CPU, so document text never leaves the machine
 
 ### React Integration
 - **Custom Hooks**: `useVoiceControl()`, `useSpeechRecognition()`, `useSpeechSynthesis()`
@@ -119,6 +133,154 @@ export function VoiceOutput() {
 
 ---
 
+## 🖥️ Command Line
+
+Read a Markdown or text file aloud into an audio file, without writing any code:
+
+```bash
+npx use-voice-control README.md
+# wrote README.wav — 96.4s of audio from README.md in 41.2s
+```
+
+The Markdown is **converted before it is spoken**: `#`, `**`, backticks and the
+rest are never read out. Headings become their own spoken lines with a pause
+after them, list markers are dropped (ordered numbers are kept), links keep their
+text and lose their URL, tables are read row by row, and fenced code blocks are
+announced — "TypeScript code block." — instead of being spelled out character by
+character. See [Markdown → speech](#-markdown--speech) for the rules and how to
+change them.
+
+Speech is synthesized locally with [Kokoro](https://huggingface.co/hexgrad/Kokoro-82M)
+on the CPU: nothing is sent to a third-party service. The first run downloads the
+weights (about 90 MB at the default `q8`) into the Hugging Face cache; every run
+after that is offline.
+
+### Common commands
+
+```bash
+# Markdown or plain text in, WAV out (defaults to <input>.wav, next to the input)
+npx use-voice-control notes.md
+npx use-voice-control notes.txt -o spoken.wav
+
+# Pick a voice and a speaking rate
+npx use-voice-control notes.md -v am_michael -s 1.15
+npx use-voice-control --list-voices
+
+# Speak a string, no file needed
+npx use-voice-control --text "Build finished, three tests failed." -o alert.wav
+
+# Read from a pipe, and write the WAV to stdout
+cat notes.md | npx use-voice-control - -o - > notes.wav
+git log -1 --format=%B | npx use-voice-control - -o commit.wav
+
+# Check what will be spoken, without downloading the model
+npx use-voice-control README.md --print
+```
+
+`--print` is the fastest way to see the Markdown conversion — it converts the
+document, prints the text, and exits before any model is loaded.
+
+### Options
+
+| Option | Meaning |
+| --- | --- |
+| `<file>` | File to read. `-` reads stdin. `.md`, `.markdown`, `.mdx` are read as Markdown; everything else as plain text. |
+| `--text <string>` | Speak this string instead of reading a file. |
+| `-f, --format <fmt>` | `auto` (default), `markdown`, or `text`. Overrides the extension. |
+| `-o, --out <file>` | Audio file to write. Default: the input path with a `.wav` extension, or `out.wav` when the input is stdin or `--text`. `-` writes the WAV to stdout. |
+| `-p, --print` | Print the speakable text and exit — no model, no audio. |
+| `-q, --quiet` | No progress output. |
+| `-v, --voice <id>` | Voice id, default `af_heart`. See `--list-voices`. |
+| `-s, --speed <n>` | Speaking rate between 0.5 and 2. Default 1. |
+| `--headings <mode>` | `text` (default), `announce` ("Heading: Install"), or `skip`. |
+| `--code <mode>` | `announce` (default), `read`, or `skip`. |
+| `--links <mode>` | `text` (default) or `text-and-url`. |
+| `--tables <mode>` | `rows` (default) or `skip`. |
+| `--front-matter` | Read the YAML front matter instead of skipping it. |
+| `--model <id>` | Hugging Face model id. Default `onnx-community/Kokoro-82M-v1.0-ONNX`. |
+| `--dtype <type>` | `fp32`, `fp16`, `q8` (default), `q4`, `q4f16`. |
+| `--device <device>` | `cpu` (default), `wasm`, `webgpu`. |
+| `--chunk <chars>` | Target characters per synthesis chunk. Default 400. |
+| `--gap <ms>` | Silence inserted between chunks. Default 120. |
+| `-h, --help` | Show the full usage text. |
+| `-V, --version` | Print the package version. |
+
+Long documents are split on sentence and paragraph boundaries, synthesized chunk
+by chunk, and joined into one file — Kokoro's context is only a few hundred
+phonemes, so this is what makes a whole README work.
+
+The command exits `0` on success and `1` on a bad option, a missing file, a
+document with nothing to say, or a failed model load; progress goes to stderr, so
+`-o -` gives you a clean WAV on stdout.
+
+### From code
+
+The same thing without the shell:
+
+```ts
+import { renderDocument } from 'use-voice-control/node';
+
+const result = await renderDocument({
+  file: 'README.md',
+  output: 'readme.wav',
+  voice: 'af_heart',
+});
+
+console.log(`${result.durationSeconds.toFixed(1)}s of audio from ${result.source}`);
+```
+
+`use-voice-control/node` also exports `loadDocument` (file → speakable text),
+`synthesizeSamples` / `synthesizeWav` (text → audio), `runCli`, and the Markdown
+helpers below.
+
+---
+
+## 📝 Markdown → speech
+
+Markdown handed straight to a speech engine is read literally: *"hash hash
+Getting started"*, *"star star important star star"*. `markdownToSpeech` parses
+the document instead and emits only the words, keeping the structure the marks
+encoded.
+
+```ts
+import { markdownToSpeech } from 'use-voice-control/markdown';
+
+markdownToSpeech('## Install\n\nRun `npm i` and see the [docs](https://x.dev).');
+// "Install.
+//
+//  Run npm i and see the docs."
+```
+
+| Markdown | Spoken as |
+| --- | --- |
+| `# Heading` and setext underlines | The heading text on its own, with a pause after it |
+| `**bold**`, `_italic_`, `~~struck~~` | The words, no marks |
+| `` `code span` `` | The code text, no backticks |
+| A fenced code block | "TypeScript code block." (or the code, or nothing) |
+| `[text](url)` | The link text; the URL is dropped |
+| `![alt](src)` | The alt text |
+| `- item`, `1. item`, `- [x] task` | The item; bullets and checkboxes dropped, numbers kept |
+| `> quote` | The quoted words |
+| `\| a \| b \|` | "a, b." — the delimiter row is dropped |
+| `---`, `<!-- … -->`, `[ref]: url` | Nothing |
+| YAML front matter | Nothing, unless `frontMatter: true` |
+
+Options: `headings` (`text` \| `announce` \| `skip`), `codeBlocks` (`announce` \|
+`read` \| `skip`), `links` (`text` \| `text-and-url`), `images` (`alt` \| `skip`),
+`tables` (`rows` \| `skip`), `frontMatter`, and `addTerminalPunctuation`.
+
+`markdownToSpeechSegments` returns the same content as typed blocks —
+`{ type: 'heading' | 'paragraph' | 'list-item' | 'quote' | 'code' | 'table-row',
+text, level }` — for callers that want to highlight the current heading or skip
+between sections. `stripInlineMarkdown` handles a single line, and
+`looksLikeMarkdown` is the heuristic behind `--format auto`.
+
+The same conversion runs in the browser: `ReadAloudController` and `useReadAloud`
+convert text that looks like Markdown before speaking it, so an editor's raw
+document does not have its syntax read back to the listener.
+
+---
+
 ## 🗣️ Read Aloud & Live Dictation
 
 Two ready-made browser engines ship from `use-voice-control/client` (framework
@@ -148,8 +310,11 @@ function ReadButton({ text }: { text: string }) {
 }
 ```
 
-Options: `provider`, `voice`, `endpoint`, `maxChunkLength`, and `synthesize` to
-plug in your own TTS. Controls: `speak`, `pause`, `resume`, `stop`, `toggle`.
+Options: `provider`, `voice`, `endpoint`, `maxChunkLength`, `format`
+(`auto` \| `markdown` \| `text` — `auto` converts text that looks like Markdown so
+`##` and `**` are not read out), `markdown` for the conversion options, and
+`synthesize` to plug in your own TTS. Controls: `speak`, `pause`, `resume`,
+`stop`, `toggle`.
 
 ### Live dictation
 
@@ -294,30 +459,35 @@ interface VoiceControlOptions {
 
 #### Kokoro Voices
 
-16 professional voices optimized for natural speech synthesis:
+28 voices optimized for natural speech synthesis. Run `npx use-voice-control
+--list-voices` to print them with their accent and gender. The `a`/`b` prefix is
+the accent (American / British English) and the letter after it is the gender.
 
-**Female Voices:**
+**American English — female:**
 ```
-af_heart    - Warm, caring tone
-af_alloy    - Neutral, professional
-af_aoede    - Bright, energetic
-af_bella    - Soft, gentle
+af_heart    - Warm, caring tone      af_nicole   - Clear, articulate
+af_alloy    - Neutral, professional  af_nova     - Even, unhurried
+af_aoede    - Bright, energetic      af_river    - Calm, soothing
+af_bella    - Soft, gentle           af_sarah    - Warm, approachable
 af_jessica  - Friendly, conversational
-af_nicole   - Clear, articulate
-af_river    - Calm, soothing
-af_sarah    - Warm, approachable
-af_sky      - Young, vibrant
+af_kore     - Steady, measured       af_sky      - Young, vibrant
 ```
 
-**Male Voices:**
+**American English — male:**
 ```
-am_adam     - Deep, authoritative
-am_echo     - Resonant, smooth
-am_fable    - Narrative, engaging
-am_fenrir   - Bold, strong
+am_adam     - Deep, authoritative    am_michael  - Professional, clear
+am_echo     - Resonant, smooth       am_onyx     - Dark, mysterious
+am_eric     - Direct, matter-of-fact am_puck     - Playful, quick
+am_fenrir   - Bold, strong           am_santa    - Jovial, avuncular
 am_liam     - Friendly, warm
-am_michael  - Professional, clear
-am_onyx     - Dark, mysterious
+```
+
+**British English:**
+```
+bf_alice    - Crisp, precise         bm_daniel   - Measured, formal
+bf_emma     - Warm, unhurried        bm_fable    - Narrative, engaging
+bf_isabella - Bright, articulate     bm_george   - Deep, steady
+bf_lily     - Light, gentle          bm_lewis    - Relaxed, conversational
 ```
 
 **Example:**
@@ -401,15 +571,20 @@ Generate speech audio directly from the server or Edge runtime:
 ```ts
 import { generateSpeech } from 'use-voice-control/speech';
 
-// Generate Kokoro speech
+// Generate Kokoro speech — runs the model locally on the CPU via `kokoro-js`
 const audio = await generateSpeech({
   text: "Hello, world!",
   provider: 'kokoro',
   voice: 'af_heart'
 });
 
-// Returns: { audio: ArrayBuffer, contentType: string }
+// Returns: { audio: ArrayBuffer, contentType: string } — a 16-bit PCM WAV
 ```
+
+Text longer than the model's context is chunked on sentence boundaries and joined
+automatically, so a whole document can be passed in one call. Deepgram
+(`provider: 'deepgram'`) goes through a Cloudflare Workers AI binding instead and
+returns MP3; it is not available from the CLI.
 
 ### TypeScript Support
 
@@ -517,6 +692,7 @@ const SpeechWorker = require('use-voice-control/speech/worker.js');
 ## 🔐 Privacy & Security
 
 - **Client-side STT**: Moonshine.js runs entirely in the browser—no audio leaves your device
+- **Local CLI TTS**: `npx use-voice-control` runs Kokoro on your CPU; the document text is never uploaded
 - **Optional Server TTS**: Choose Kokoro (server-side) or Deepgram (with API key)
 - **No Tracking**: No analytics or usage telemetry
 - **HTTPS Required**: Microphone access requires secure context
@@ -548,6 +724,14 @@ const SpeechWorker = require('use-voice-control/speech/worker.js');
 // Read aloud & live dictation (implemented)
 export { ReadAloudController, LiveTranscriber, isTranscriptionSupported } from 'use-voice-control/client';
 export { useReadAloud, useLiveTranscription, SpokenPhraseOverlay } from 'use-voice-control/react';
+
+// Markdown → speech (implemented)
+export { markdownToSpeech, markdownToSpeechSegments, stripInlineMarkdown, looksLikeMarkdown } from 'use-voice-control/markdown';
+export type { MarkdownToSpeechOptions, SpeechSegment } from 'use-voice-control/markdown';
+
+// Files → audio, and the CLI (implemented, Node)
+export { renderDocument, loadDocument, synthesizeSamples, synthesizeWav, runCli } from 'use-voice-control/node';
+export type { RenderOptions, RenderResult, KokoroNodeOptions } from 'use-voice-control/node';
 
 // Hooks
 export { useSpeechRecognition } from 'use-voice-control/hooks';

--- a/packages/use-voice-control/bin/use-voice-control.mjs
+++ b/packages/use-voice-control/bin/use-voice-control.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Launcher for the `use-voice-control` command.
+ *
+ * The command itself is built into `dist/cli.js`; this file exists so the
+ * shebang lives in a plain, never-bundled file and so a missing build fails with
+ * an instruction rather than a module-resolution error.
+ */
+let runCli;
+try {
+  ({ runCli } = await import(new URL("../dist/cli.js", import.meta.url).href));
+} catch (error) {
+  process.stderr.write(
+    "use-voice-control: the package is not built — run `npm run build` in " +
+      `packages/use-voice-control first.\n(${error?.message ?? error})\n`
+  );
+  process.exit(1);
+}
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/packages/use-voice-control/package.json
+++ b/packages/use-voice-control/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-voice-control",
   "version": "0.1.86",
-  "description": "React voice control with speech transcription, vocalization, and interruption (STT/TTS/VAD) support.",
+  "description": "React voice control with speech transcription, vocalization, and interruption (STT/TTS/VAD) support, plus a CLI that reads Markdown and text files aloud to audio files.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
@@ -10,6 +10,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "use-voice-control": "./bin/use-voice-control.mjs"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -23,6 +26,14 @@
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react.js"
     },
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "import": "./dist/node.js"
+    },
+    "./markdown": {
+      "types": "./dist/utils/markdown-to-speech.d.ts",
+      "import": "./dist/markdown.js"
+    },
     "./api-client": {
       "types": "./speech/api-client.ts",
       "import": "./speech/api-client.ts"
@@ -31,6 +42,7 @@
   "files": [
     "dist",
     "speech",
+    "bin",
     "README.md"
   ],
   "scripts": {
@@ -43,9 +55,11 @@
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
     "lucide-react": "^0.344.0",
-    "@moonshine-ai/moonshine-js": "^0.1.29"
+    "@moonshine-ai/moonshine-js": "^0.1.29",
+    "kokoro-js": "^1.2.1"
   },
   "devDependencies": {
+    "@types/node": "^22.10.2",
     "@types/react": "^19.2.17",
     "@vitejs/plugin-react": "^4.3.4",
     "@types/react-dom": "^19.2.3",

--- a/packages/use-voice-control/speech/client/index.ts
+++ b/packages/use-voice-control/speech/client/index.ts
@@ -18,4 +18,14 @@ export {
   type TranscriberEngine,
 } from "./live-transcriber";
 
+export {
+  looksLikeMarkdown,
+  markdownToSpeech,
+  markdownToSpeechSegments,
+  stripInlineMarkdown,
+  type MarkdownToSpeechOptions,
+  type SpeechSegment,
+  type SpeechSegmentType,
+} from "../utils/markdown-to-speech";
+
 export type { TTSProvider, KokoroVoice, DeepgramSpeaker } from "../types/types";

--- a/packages/use-voice-control/speech/client/read-aloud.ts
+++ b/packages/use-voice-control/speech/client/read-aloud.ts
@@ -13,6 +13,11 @@
  * `speechSynthesis` rather than failing, so the feature still works everywhere.
  */
 import type { TTSProvider } from "../types/types";
+import {
+  looksLikeMarkdown,
+  markdownToSpeech,
+  type MarkdownToSpeechOptions,
+} from "../utils/markdown-to-speech";
 import { splitTextSmart } from "../utils/semantic-split.js";
 
 export type ReadAloudState = "idle" | "loading" | "speaking" | "paused";
@@ -44,6 +49,14 @@ export interface ReadAloudOptions {
    * seams between chunks more audible. Default 240.
    */
   maxChunkLength?: number;
+  /**
+   * How to read the text handed to `speak()`. `auto` (default) converts text
+   * that looks like Markdown so "##" and "**" are not read out; `markdown`
+   * always converts; `text` never does.
+   */
+  format?: "auto" | "markdown" | "text";
+  /** Markdown conversion options, when the text is read as Markdown. */
+  markdown?: MarkdownToSpeechOptions;
   /** Override synthesis entirely (tests, a bring-your-own-TTS host app). */
   synthesize?: SynthesizeFn;
   /** Called as each chunk starts playing. */
@@ -102,7 +115,7 @@ export class ReadAloudController {
     this.stop();
 
     const maxChunkLength = this.options.maxChunkLength ?? DEFAULT_MAX_CHUNK;
-    const chunks = splitTextSmart(text ?? "", maxChunkLength)
+    const chunks = splitTextSmart(this.toSpeakableText(text ?? ""), maxChunkLength)
       .map((chunk) => chunk.trim())
       .filter((chunk) => chunk.length > 0);
 
@@ -185,6 +198,19 @@ export class ReadAloudController {
       this.setState("idle");
       this.options.onEnd?.("stopped");
     }
+  }
+
+  /**
+   * Converts Markdown to spoken words before chunking, so a document read out
+   * of an editor does not have its syntax read back to the listener.
+   */
+  private toSpeakableText(text: string): string {
+    const format = this.options.format ?? "auto";
+    if (format === "text") return text;
+    if (format === "markdown" || looksLikeMarkdown(text)) {
+      return markdownToSpeech(text, this.options.markdown);
+    }
+    return text;
   }
 
   private setState(state: ReadAloudState): void {

--- a/packages/use-voice-control/speech/core/kokoro-node.ts
+++ b/packages/use-voice-control/speech/core/kokoro-node.ts
@@ -1,0 +1,164 @@
+/**
+ * @fileoverview Kokoro TTS running locally on Node (or Bun/Deno) via `kokoro-js`.
+ *
+ * This is the engine behind `generateSpeech({ provider: "kokoro" })` on a server
+ * and behind the `use-voice-control` CLI. The model runs on the CPU through
+ * onnxruntime, so nothing is sent to a third-party service; the first call
+ * downloads the weights (~90 MB at the default `q8`) into the Hugging Face cache
+ * and every later call reuses the instance held in this module.
+ *
+ * Kokoro's context is a few hundred phonemes, so anything longer than a
+ * paragraph has to be synthesized in pieces. `synthesizeSamples` chunks on
+ * sentence and paragraph boundaries with `splitTextSmart`, runs the chunks in
+ * order, and joins the audio with a short silence at each seam.
+ */
+import type { TTSResult } from "../types/types";
+import { splitTextSmart } from "../utils/semantic-split.js";
+import { concatSamples, encodeWav } from "../utils/wav";
+
+export type KokoroDtype = "fp32" | "fp16" | "q8" | "q4" | "q4f16";
+export type KokoroDevice = "wasm" | "webgpu" | "cpu";
+
+export interface KokoroNodeOptions {
+  /** Voice id, e.g. `af_heart`. Default `af_heart`. */
+  voice?: string;
+  /** Speaking rate; 1 is the model's natural pace. Default 1. */
+  speed?: number;
+  /** Hugging Face model id. Default `onnx-community/Kokoro-82M-v1.0-ONNX`. */
+  model?: string;
+  /** Weight quantization. `q8` (default) is the best size/quality trade on CPU. */
+  dtype?: KokoroDtype;
+  /** Execution device. Default `cpu`. */
+  device?: KokoroDevice;
+  /**
+   * Target chunk size in characters. Kokoro's context is limited, so long text
+   * is split before synthesis; 400 leaves headroom for phoneme expansion.
+   */
+  maxChunkLength?: number;
+  /** Silence inserted between chunks, in milliseconds. Default 120. */
+  gapMs?: number;
+  /** Model download/loading progress, forwarded from transformers.js. */
+  onModelProgress?: (progress: unknown) => void;
+  /** Called before each chunk is synthesized, for CLI progress output. */
+  onChunk?: (info: { index: number; total: number; text: string }) => void;
+}
+
+export interface KokoroAudio {
+  samples: Float32Array;
+  sampleRate: number;
+}
+
+const DEFAULT_MODEL = "onnx-community/Kokoro-82M-v1.0-ONNX";
+const DEFAULT_VOICE = "af_heart";
+const DEFAULT_DTYPE: KokoroDtype = "q8";
+const DEFAULT_DEVICE: KokoroDevice = "cpu";
+const DEFAULT_MAX_CHUNK = 400;
+const DEFAULT_GAP_MS = 120;
+
+/** One loaded model per model/dtype/device combination, keyed by those three. */
+const instances = new Map<string, Promise<any>>();
+
+/** True on Node, Bun and Deno — anywhere `kokoro-js` can load onnxruntime-node. */
+function isServerRuntime(): boolean {
+  const g = globalThis as any;
+  return Boolean(g.process?.versions?.node || g.Bun || g.Deno);
+}
+
+/**
+ * Loads (and caches) a `kokoro-js` instance.
+ *
+ * `kokoro-js` is an optional dependency: a browser-only consumer should not have
+ * to download onnxruntime-node, so a missing install is reported as an
+ * actionable error rather than a module-resolution stack trace.
+ */
+export async function loadKokoroTTS(options: KokoroNodeOptions = {}): Promise<any> {
+  const model = options.model ?? DEFAULT_MODEL;
+  const dtype = options.dtype ?? DEFAULT_DTYPE;
+  const device = options.device ?? (isServerRuntime() ? DEFAULT_DEVICE : "wasm");
+  const key = `${model}|${dtype}|${device}`;
+
+  const cached = instances.get(key);
+  if (cached) return cached;
+
+  const loading = (async () => {
+    let KokoroTTS: any;
+    try {
+      // Kept in a variable so bundlers treat this as an optional runtime
+      // dependency rather than something to resolve at build time.
+      const specifier = "kokoro-js";
+      ({ KokoroTTS } = await import(/* @vite-ignore */ specifier));
+    } catch (error) {
+      throw new Error(
+        "Local Kokoro speech needs the optional `kokoro-js` package. " +
+          "Install it with `npm install kokoro-js`. " +
+          `(import failed: ${error instanceof Error ? error.message : String(error)})`
+      );
+    }
+
+    return KokoroTTS.from_pretrained(model, {
+      dtype,
+      device,
+      progress_callback: options.onModelProgress,
+    });
+  })();
+
+  instances.set(key, loading);
+
+  try {
+    return await loading;
+  } catch (error) {
+    // A failed download must not poison every later attempt.
+    instances.delete(key);
+    throw error;
+  }
+}
+
+/** Drops cached model instances. Mainly useful in tests and long-lived workers. */
+export function resetKokoroCache(): void {
+  instances.clear();
+}
+
+/**
+ * Synthesizes `text` to raw samples, chunking anything longer than the model's
+ * comfortable context.
+ */
+export async function synthesizeSamples(
+  text: string,
+  options: KokoroNodeOptions = {}
+): Promise<KokoroAudio> {
+  const trimmed = (text ?? "").trim();
+  if (!trimmed) throw new Error("Text is required");
+
+  const chunks = splitTextSmart(trimmed, options.maxChunkLength ?? DEFAULT_MAX_CHUNK)
+    .map((chunk: string) => chunk.trim())
+    .filter((chunk: string) => chunk.length > 0);
+
+  const tts = await loadKokoroTTS(options);
+  const voice = options.voice ?? DEFAULT_VOICE;
+  const speed = options.speed ?? 1;
+
+  const rendered: Float32Array[] = [];
+  let sampleRate = 24000;
+
+  for (let index = 0; index < chunks.length; index += 1) {
+    options.onChunk?.({ index, total: chunks.length, text: chunks[index] });
+    const audio = await tts.generate(chunks[index], { voice, speed });
+    rendered.push(audio.audio);
+    sampleRate = audio.sampling_rate ?? sampleRate;
+  }
+
+  const gapMs = options.gapMs ?? DEFAULT_GAP_MS;
+  return {
+    samples: concatSamples(rendered, Math.round((gapMs / 1000) * sampleRate)),
+    sampleRate,
+  };
+}
+
+/** Synthesizes `text` and encodes it as a 16-bit PCM WAV file. */
+export async function synthesizeWav(
+  text: string,
+  options: KokoroNodeOptions = {}
+): Promise<TTSResult> {
+  const { samples, sampleRate } = await synthesizeSamples(text, options);
+  return { audio: encodeWav(samples, sampleRate), contentType: "audio/wav" };
+}

--- a/packages/use-voice-control/speech/core/kokoro.ts
+++ b/packages/use-voice-control/speech/core/kokoro.ts
@@ -1,81 +1,28 @@
 /**
- * @fileoverview Kokoro TTS provider implementation using Hugging Face transformers
- * Runs on Node.js CPU via transformers library
+ * @fileoverview Kokoro TTS provider for `generateSpeech`.
+ *
+ * The work happens in `kokoro-node.ts`, which runs the Kokoro model locally
+ * through `kokoro-js`; this file is the thin provider adapter that validates the
+ * voice and returns the package's `TTSResult` shape.
  */
 import type { TTSResult } from "../types/types";
 import { KOKORO_VOICES, type KokoroVoice } from "../types/types";
-
-let ttsInstance: any = null;
-let modelLoading: Promise<any> | null = null;
+import { synthesizeWav, type KokoroNodeOptions } from "./kokoro-node";
 
 /**
- * Lazy-load Kokoro model using Hugging Face transformers (happens once per server instance)
- */
-async function getKokoroTTS() {
-  if (ttsInstance) return ttsInstance;
-
-  if (modelLoading) {
-    await modelLoading;
-    return ttsInstance;
-  }
-
-  modelLoading = (async () => {
-    try {
-      // Dynamic import to load transformers library. The specifier is kept in
-      // a variable so the type-checker/bundler treats it as an optional runtime
-      // dependency (see optionalDependencies) rather than a build-time one.
-      const transformersModule = "@huggingface/transformers";
-      const transformers: any = await import(/* @vite-ignore */ transformersModule);
-      const { StyleTextToSpeech2Model, AutoTokenizer } = transformers;
-
-      const model_id = "hexgrad/Kokoro-82M";
-
-      // Load model and tokenizer in parallel
-      const [model, tokenizer] = await Promise.all([
-        StyleTextToSpeech2Model.from_pretrained(model_id, {
-          device: "cpu",
-          dtype: "q8"
-        }),
-        AutoTokenizer.from_pretrained(model_id)
-      ]);
-
-      ttsInstance = { model, tokenizer };
-
-      console.log("[Kokoro] Model loaded successfully");
-    } catch (error) {
-      console.error("[Kokoro] Failed to load model:", error);
-      throw error;
-    } finally {
-      modelLoading = null;
-    }
-  })();
-
-  await modelLoading;
-  return ttsInstance;
-}
-
-/**
- * Generate speech from text using Kokoro
+ * Generate speech from text using Kokoro.
+ *
+ * Long text is chunked and joined automatically. An unrecognised voice falls
+ * back to `af_heart` rather than failing the request.
  */
 export async function generateKokoroSpeech(
   text: string,
-  voice: string = "af_heart"
+  voice: string = "af_heart",
+  options: Omit<KokoroNodeOptions, "voice"> = {}
 ): Promise<TTSResult> {
-  // Validate voice
   const kokoroVoice = KOKORO_VOICES.includes(voice as KokoroVoice)
     ? (voice as KokoroVoice)
     : "af_heart";
 
-  const tts = await getKokoroTTS();
-
-  try {
-    // For Node.js server-side TTS, we'd need the complete transformers implementation
-    // This is a placeholder showing the expected interface
-    // Consider using the browser-based implementation via Web Workers for production
-
-    throw new Error("Server-side Kokoro TTS requires additional setup. Use the browser-based implementation via Web Workers.");
-  } catch (error) {
-    console.error("[Kokoro] Error generating speech:", error);
-    throw error;
-  }
+  return synthesizeWav(text, { ...options, voice: kokoroVoice });
 }

--- a/packages/use-voice-control/speech/index.ts
+++ b/packages/use-voice-control/speech/index.ts
@@ -10,6 +10,20 @@ import { generateDeepgramSpeech } from "./core/deepgram";
 
 export * from "./types/types";
 
+// Markdown handling is exported from the root entry so a server route can turn a
+// document into speakable text with the same rules the CLI and the browser use.
+export {
+  looksLikeMarkdown,
+  markdownToSpeech,
+  markdownToSpeechSegments,
+  stripInlineMarkdown,
+  type MarkdownToSpeechOptions,
+  type SpeechSegment,
+  type SpeechSegmentType,
+} from "./utils/markdown-to-speech";
+
+export { encodeWav, concatSamples, wavDurationSeconds } from "./utils/wav";
+
 /**
  * Generate speech from text using the specified provider
  *

--- a/packages/use-voice-control/speech/node/cli.ts
+++ b/packages/use-voice-control/speech/node/cli.ts
@@ -1,0 +1,509 @@
+/**
+ * @fileoverview The `use-voice-control` command line tool.
+ *
+ * Reads a Markdown or text file and speaks it to a WAV file:
+ *
+ * ```sh
+ * npx use-voice-control README.md -o readme.wav
+ * ```
+ *
+ * Argument parsing is a pure function (`parseArgs`) and every effect the command
+ * has — writing lines, reading stdin, synthesizing — is injectable, so the whole
+ * command is testable without loading a 90 MB model.
+ */
+import { describeKokoroVoice, KOKORO_VOICES } from "../types/types";
+import type { KokoroDevice, KokoroDtype } from "../core/kokoro-node";
+import type { MarkdownToSpeechOptions } from "../utils/markdown-to-speech";
+import { loadDocument, type RequestedFormat } from "./document";
+import { renderDocument, type RenderOptions } from "./render";
+
+export type CliCommand = "speak" | "print" | "help" | "version" | "list-voices";
+
+export interface CliOptions {
+  command: CliCommand;
+  /** Input path, or `-` for stdin. Undefined when `text` is set. */
+  input?: string;
+  /** Literal text passed with `--text`. */
+  text?: string;
+  output?: string;
+  format: RequestedFormat;
+  voice: string;
+  speed: number;
+  model?: string;
+  dtype?: KokoroDtype;
+  device?: KokoroDevice;
+  maxChunkLength?: number;
+  gapMs?: number;
+  markdown: MarkdownToSpeechOptions;
+  quiet: boolean;
+  /** Everything wrong with the command line. Non-empty means do not run. */
+  errors: string[];
+}
+
+export interface CliIO {
+  /** Writes a line to stdout. */
+  log?: (line: string) => void;
+  /** Writes a line to stderr — progress and errors go here so `-o -` stays clean. */
+  error?: (line: string) => void;
+  /** Overrides synthesis, for tests. */
+  synthesize?: RenderOptions["synthesize"];
+  /** Overrides reading stdin, for tests. */
+  readStdin?: () => Promise<string>;
+  /** Whether stdin is a terminal. When false and no input is given, stdin is read. */
+  stdinIsTTY?: boolean;
+}
+
+const FORMATS: Record<string, RequestedFormat> = {
+  auto: "auto",
+  markdown: "markdown",
+  md: "markdown",
+  text: "text",
+  txt: "text",
+  plain: "text",
+};
+
+const DTYPES: KokoroDtype[] = ["fp32", "fp16", "q8", "q4", "q4f16"];
+const DEVICES: KokoroDevice[] = ["wasm", "webgpu", "cpu"];
+
+export const USAGE = `use-voice-control — read a Markdown or text file aloud into an audio file
+
+Usage
+  npx use-voice-control <file.md|file.txt|-> [options]
+  npx use-voice-control --text "Hello there" -o hello.wav
+  cat notes.md | npx use-voice-control - -o notes.wav
+
+Markdown is converted before it is spoken: "#", "**" and the rest are not read
+out, headings become their own spoken lines, links keep their text, and fenced
+code blocks are announced instead of being spelled out.
+
+Input
+  <file>                 File to read. Use "-" to read stdin.
+  --text <string>        Speak this string instead of reading a file.
+  -f, --format <fmt>     auto (default), markdown, or text.
+
+Output
+  -o, --out <file>       Audio file to write. Default: the input path with a
+                         .wav extension. Use "-" to write the WAV to stdout.
+  -p, --print            Print the speakable text and exit — no model, no audio.
+                         Useful for checking the Markdown conversion.
+  -q, --quiet            No progress output.
+
+Voice
+  -v, --voice <id>       Voice id. Default af_heart. See --list-voices.
+  -s, --speed <n>        Speaking rate, 0.5-2. Default 1.
+      --list-voices      Print the available voices and exit.
+
+Markdown handling
+  --headings <mode>      text (default) | announce | skip
+  --code <mode>          announce (default) | read | skip
+  --links <mode>         text (default) | text-and-url
+  --tables <mode>        rows (default) | skip
+  --front-matter         Read the YAML front matter instead of skipping it.
+
+Model
+  --model <id>           Hugging Face model id.
+                         Default onnx-community/Kokoro-82M-v1.0-ONNX.
+  --dtype <type>         fp32 | fp16 | q8 (default) | q4 | q4f16
+  --device <device>      cpu (default) | wasm | webgpu
+  --chunk <chars>        Target characters per synthesis chunk. Default 400.
+  --gap <ms>             Silence between chunks. Default 120.
+
+Other
+  -h, --help             Show this help.
+  -V, --version          Print the package version.
+
+The first run downloads the Kokoro weights (about 90 MB at the default q8) into
+the Hugging Face cache; later runs are offline. Speech is synthesized locally —
+no text leaves the machine.`;
+
+/** Reads the next value for a flag, recording an error when it is missing. */
+function takeValue(
+  argv: string[],
+  index: number,
+  flag: string,
+  errors: string[]
+): { value?: string; next: number } {
+  const value = argv[index + 1];
+  if (value === undefined || value.startsWith("-")) {
+    errors.push(`${flag} needs a value`);
+    return { next: index + 1 };
+  }
+  return { value, next: index + 1 };
+}
+
+/** Parses a numeric flag, recording an error when it is not a finite number. */
+function toNumber(value: string | undefined, flag: string, errors: string[]): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    errors.push(`${flag} expects a number, got "${value}"`);
+    return undefined;
+  }
+  return parsed;
+}
+
+/** Parses an enum flag, recording an error when the value is not in `allowed`. */
+function toChoice<T extends string>(
+  value: string | undefined,
+  allowed: readonly T[],
+  flag: string,
+  errors: string[]
+): T | undefined {
+  if (value === undefined) return undefined;
+  if (!allowed.includes(value as T)) {
+    errors.push(`${flag} expects one of ${allowed.join(", ")} — got "${value}"`);
+    return undefined;
+  }
+  return value as T;
+}
+
+/**
+ * Parses the command line. Pure: it reads nothing and writes nothing, so the
+ * tests can assert on the whole option set.
+ */
+export function parseArgs(argv: string[]): CliOptions {
+  const errors: string[] = [];
+  const markdown: MarkdownToSpeechOptions = {};
+  const options: CliOptions = {
+    command: "speak",
+    format: "auto",
+    voice: "af_heart",
+    speed: 1,
+    markdown,
+    quiet: false,
+    errors,
+  };
+
+  let positionalsOnly = false;
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (positionalsOnly || !arg.startsWith("-") || arg === "-") {
+      if (options.input !== undefined) {
+        errors.push(`unexpected extra input "${arg}" — pass one file at a time`);
+      } else {
+        options.input = arg;
+      }
+      continue;
+    }
+
+    if (arg === "--") {
+      positionalsOnly = true;
+      continue;
+    }
+
+    // `--voice=af_bella` is the same as `--voice af_bella`.
+    const equals = arg.indexOf("=");
+    if (equals > 1) {
+      argv.splice(i, 1, arg.slice(0, equals), arg.slice(equals + 1));
+      i -= 1;
+      continue;
+    }
+
+    switch (arg) {
+      case "-h":
+      case "--help":
+        options.command = "help";
+        return options;
+
+      case "-V":
+      case "--version":
+        options.command = "version";
+        return options;
+
+      case "--list-voices":
+        options.command = "list-voices";
+        return options;
+
+      case "-p":
+      case "--print":
+      case "--dry-run":
+        options.command = "print";
+        break;
+
+      case "-q":
+      case "--quiet":
+        options.quiet = true;
+        break;
+
+      case "--front-matter":
+        markdown.frontMatter = true;
+        break;
+
+      case "-o":
+      case "--out":
+      case "--output": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        options.output = value;
+        i = next;
+        break;
+      }
+
+      case "--text": {
+        // Unlike every other value, this one may legitimately start with "-".
+        const value = argv[i + 1];
+        if (value === undefined) errors.push("--text needs a value");
+        else options.text = value;
+        i += 1;
+        break;
+      }
+
+      case "-f":
+      case "--format": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        if (value !== undefined) {
+          const format = FORMATS[value.toLowerCase()];
+          if (!format) {
+            errors.push(`--format expects auto, markdown or text — got "${value}"`);
+          } else {
+            options.format = format;
+          }
+        }
+        break;
+      }
+
+      case "-v":
+      case "--voice": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        if (value !== undefined) {
+          if (!KOKORO_VOICES.includes(value as (typeof KOKORO_VOICES)[number])) {
+            errors.push(`unknown voice "${value}" — run --list-voices to see them all`);
+          } else {
+            options.voice = value;
+          }
+        }
+        break;
+      }
+
+      case "-s":
+      case "--speed": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        const speed = toNumber(value, arg, errors);
+        if (speed !== undefined) {
+          if (speed < 0.5 || speed > 2) errors.push("--speed must be between 0.5 and 2");
+          else options.speed = speed;
+        }
+        break;
+      }
+
+      case "--model": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        options.model = value;
+        i = next;
+        break;
+      }
+
+      case "--dtype": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        options.dtype = toChoice(value, DTYPES, arg, errors) ?? options.dtype;
+        break;
+      }
+
+      case "--device": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        options.device = toChoice(value, DEVICES, arg, errors) ?? options.device;
+        break;
+      }
+
+      case "--chunk":
+      case "--chunk-length": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        const chunk = toNumber(value, arg, errors);
+        if (chunk !== undefined) {
+          if (chunk < 40) errors.push("--chunk must be at least 40 characters");
+          else options.maxChunkLength = chunk;
+        }
+        break;
+      }
+
+      case "--gap": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        const gap = toNumber(value, arg, errors);
+        if (gap !== undefined) {
+          if (gap < 0) errors.push("--gap cannot be negative");
+          else options.gapMs = gap;
+        }
+        break;
+      }
+
+      case "--headings": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        markdown.headings =
+          toChoice(value, ["text", "announce", "skip"] as const, arg, errors) ??
+          markdown.headings;
+        break;
+      }
+
+      case "--code":
+      case "--code-blocks": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        markdown.codeBlocks =
+          toChoice(value, ["announce", "read", "skip"] as const, arg, errors) ??
+          markdown.codeBlocks;
+        break;
+      }
+
+      case "--links": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        markdown.links =
+          toChoice(value, ["text", "text-and-url"] as const, arg, errors) ?? markdown.links;
+        break;
+      }
+
+      case "--tables": {
+        const { value, next } = takeValue(argv, i, arg, errors);
+        i = next;
+        markdown.tables =
+          toChoice(value, ["rows", "skip"] as const, arg, errors) ?? markdown.tables;
+        break;
+      }
+
+      default:
+        errors.push(`unknown option "${arg}" — run --help to see the options`);
+    }
+  }
+
+  if (options.text !== undefined && options.input !== undefined) {
+    errors.push("pass either a file or --text, not both");
+  }
+
+  return options;
+}
+
+/** The `--list-voices` table, derived from the ids so it cannot drift. */
+export function formatVoiceList(): string {
+  const rows = KOKORO_VOICES.map((id) => {
+    const voice = describeKokoroVoice(id);
+    return `  ${id.padEnd(14)}${voice.name.padEnd(12)}${voice.gender.padEnd(8)}${voice.accent}`;
+  });
+  return [`${KOKORO_VOICES.length} Kokoro voices:`, ...rows].join("\n");
+}
+
+/** Reads the package version, so `--version` matches what npx installed. */
+async function readVersion(): Promise<string> {
+  try {
+    const { readFile } = await import("node:fs/promises");
+    // From `dist/cli.js` the manifest is one level up; from a source checkout it
+    // is two. Try both before giving up.
+    for (const relative of ["../package.json", "../../package.json"]) {
+      try {
+        const url = new URL(relative, import.meta.url);
+        const manifest = JSON.parse(await readFile(url, "utf8"));
+        if (manifest?.name === "use-voice-control" && manifest.version) return manifest.version;
+      } catch {
+        // Try the next candidate.
+      }
+    }
+  } catch {
+    // No filesystem (bundled for a runtime without fs) — fall through.
+  }
+  return "unknown";
+}
+
+/**
+ * Runs the command line and resolves to the process exit code.
+ *
+ * @param argv Arguments after the executable and script, i.e. `process.argv.slice(2)`.
+ * @param io Injection points for output, stdin and synthesis.
+ */
+export async function runCli(argv: string[], io: CliIO = {}): Promise<number> {
+  const log = io.log ?? ((line: string) => process.stdout.write(`${line}\n`));
+  const warn = io.error ?? ((line: string) => process.stderr.write(`${line}\n`));
+
+  const options = parseArgs([...argv]);
+
+  if (options.command === "help") {
+    log(USAGE);
+    return 0;
+  }
+
+  if (options.command === "version") {
+    log(await readVersion());
+    return 0;
+  }
+
+  if (options.command === "list-voices") {
+    log(formatVoiceList());
+    return 0;
+  }
+
+  if (options.errors.length > 0) {
+    options.errors.forEach((message) => warn(`use-voice-control: ${message}`));
+    warn("Run `npx use-voice-control --help` for usage.");
+    return 1;
+  }
+
+  // With nothing named on the command line, a pipe is the intended input.
+  const stdinIsTTY = io.stdinIsTTY ?? Boolean(process.stdin.isTTY);
+  const input =
+    options.input ?? (options.text === undefined && !stdinIsTTY ? "-" : undefined);
+
+  if (input === undefined && options.text === undefined) {
+    warn("use-voice-control: no input — pass a file, pipe text in, or use --text");
+    warn("Run `npx use-voice-control --help` for usage.");
+    return 1;
+  }
+
+  const shared = {
+    file: input,
+    text: options.text,
+    format: options.format,
+    markdown: options.markdown,
+    readStdin: io.readStdin,
+  };
+
+  try {
+    if (options.command === "print") {
+      const document = await loadDocument(shared);
+      log(document.text);
+      return 0;
+    }
+
+    const started = Date.now();
+    const result = await renderDocument({
+      ...shared,
+      output: options.output,
+      voice: options.voice,
+      speed: options.speed,
+      model: options.model,
+      dtype: options.dtype,
+      device: options.device,
+      maxChunkLength: options.maxChunkLength,
+      gapMs: options.gapMs,
+      synthesize: io.synthesize,
+      onModelProgress: options.quiet
+        ? undefined
+        : (progress: any) => {
+            if (progress?.status === "progress" && progress.file && progress.total) {
+              const done = Math.round(((progress.loaded ?? 0) / progress.total) * 100);
+              warn(`downloading ${progress.file}: ${done}%`);
+            }
+          },
+      onChunk: options.quiet
+        ? undefined
+        : ({ index, total }) => warn(`speaking chunk ${index + 1}/${total}`),
+    });
+
+    if (!options.quiet) {
+      const seconds = result.durationSeconds.toFixed(1);
+      const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+      const target = result.output === "-" ? "stdout" : result.output;
+      warn(`wrote ${target} — ${seconds}s of audio from ${result.source} in ${elapsed}s`);
+    }
+    return 0;
+  } catch (error) {
+    warn(`use-voice-control: ${error instanceof Error ? error.message : String(error)}`);
+    return 1;
+  }
+}

--- a/packages/use-voice-control/speech/node/document.ts
+++ b/packages/use-voice-control/speech/node/document.ts
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview Turning a document on disk (or on stdin) into speakable text.
+ *
+ * A `.md` file is converted with `markdownToSpeech` so the marks become
+ * structure rather than words; a `.txt` file is passed through as it is. When
+ * the source has no filename — piped stdin, a `--text` string — the format is
+ * guessed from the content.
+ */
+import {
+  looksLikeMarkdown,
+  markdownToSpeech,
+  type MarkdownToSpeechOptions,
+} from "../utils/markdown-to-speech";
+
+export type DocumentFormat = "markdown" | "text";
+/** What the caller asked for; `auto` defers to the extension, then the content. */
+export type RequestedFormat = DocumentFormat | "auto";
+
+/** Extensions read as Markdown. Everything else is treated as plain text. */
+export const MARKDOWN_EXTENSIONS = [".md", ".markdown", ".mdown", ".mkd", ".mdx"];
+
+/** Extensions the CLI accepts without complaint. Others still work, with a warning. */
+export const TEXT_EXTENSIONS = [".txt", ".text", ""];
+
+/** Lowercased extension of a path, including the dot (`""` when there is none). */
+export function extensionOf(filename: string): string {
+  const base = filename.split(/[\\/]/).pop() ?? "";
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot).toLowerCase() : "";
+}
+
+/**
+ * Decides how to read a document.
+ *
+ * An explicit `requested` format always wins — a `.txt` file full of Markdown is
+ * still the user's call. Otherwise the extension decides, and content sniffing
+ * is the last resort for input that arrived without a name.
+ */
+export function detectFormat(
+  content: string,
+  filename?: string,
+  requested: RequestedFormat = "auto"
+): DocumentFormat {
+  if (requested !== "auto") return requested;
+
+  if (filename) {
+    const extension = extensionOf(filename);
+    if (MARKDOWN_EXTENSIONS.includes(extension)) return "markdown";
+    if (TEXT_EXTENSIONS.includes(extension)) return "text";
+  }
+
+  return looksLikeMarkdown(content) ? "markdown" : "text";
+}
+
+/** Converts document content to the text that should be spoken. */
+export function toSpeechText(
+  content: string,
+  format: DocumentFormat,
+  options: MarkdownToSpeechOptions = {}
+): string {
+  if (format === "text") {
+    // Plain text is already speakable; only normalise line endings and the
+    // trailing whitespace that would otherwise become an empty final chunk.
+    return content.replace(/\r\n?/g, "\n").trim();
+  }
+  return markdownToSpeech(content, options);
+}
+
+export interface LoadedDocument {
+  /** The speakable text, Markdown already converted. */
+  text: string;
+  /** How the content was read. */
+  format: DocumentFormat;
+  /** Where it came from, for log lines: a path, `stdin`, or `--text`. */
+  source: string;
+}
+
+export interface LoadDocumentOptions {
+  /** Path to read. Use `-` for stdin. Mutually exclusive with `text`. */
+  file?: string;
+  /** Literal content to speak, instead of reading a file. */
+  text?: string;
+  format?: RequestedFormat;
+  markdown?: MarkdownToSpeechOptions;
+  /** Reads stdin. Injected so the CLI tests do not need a real pipe. */
+  readStdin?: () => Promise<string>;
+}
+
+/**
+ * Reads a document from a path, stdin, or an inline string and returns the text
+ * to synthesize.
+ */
+export async function loadDocument(
+  options: LoadDocumentOptions
+): Promise<LoadedDocument> {
+  const { file, text, format = "auto", markdown = {} } = options;
+
+  if (text !== undefined) {
+    const resolved = detectFormat(text, undefined, format);
+    return { text: toSpeechText(text, resolved, markdown), format: resolved, source: "--text" };
+  }
+
+  if (!file) throw new Error("No input: pass a file path, `-` for stdin, or --text");
+
+  if (file === "-") {
+    const stdin = options.readStdin
+      ? await options.readStdin()
+      : await readStdinToString();
+    const resolved = detectFormat(stdin, undefined, format);
+    return { text: toSpeechText(stdin, resolved, markdown), format: resolved, source: "stdin" };
+  }
+
+  const { readFile } = await import("node:fs/promises");
+  const content = await readFile(file, "utf8");
+  const resolved = detectFormat(content, file, format);
+  return { text: toSpeechText(content, resolved, markdown), format: resolved, source: file };
+}
+
+/** Collects all of stdin as UTF-8 text. */
+export async function readStdinToString(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/packages/use-voice-control/speech/node/index.ts
+++ b/packages/use-voice-control/speech/node/index.ts
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Server-side entry point: read a document, speak it to a file.
+ *
+ * ```ts
+ * import { renderDocument } from "use-voice-control/node";
+ *
+ * const result = await renderDocument({ file: "README.md", output: "readme.wav" });
+ * console.log(`${result.durationSeconds.toFixed(1)}s of audio`);
+ * ```
+ *
+ * The same code backs the `use-voice-control` command, exported here as
+ * `runCli` for hosts that want to wrap it.
+ */
+export {
+  detectFormat,
+  extensionOf,
+  loadDocument,
+  readStdinToString,
+  toSpeechText,
+  MARKDOWN_EXTENSIONS,
+  TEXT_EXTENSIONS,
+  type DocumentFormat,
+  type LoadDocumentOptions,
+  type LoadedDocument,
+  type RequestedFormat,
+} from "./document";
+
+export {
+  defaultOutputPath,
+  renderDocument,
+  type RenderOptions,
+  type RenderResult,
+} from "./render";
+
+export {
+  formatVoiceList,
+  parseArgs,
+  runCli,
+  USAGE,
+  type CliCommand,
+  type CliIO,
+  type CliOptions,
+} from "./cli";
+
+export {
+  loadKokoroTTS,
+  resetKokoroCache,
+  synthesizeSamples,
+  synthesizeWav,
+  type KokoroAudio,
+  type KokoroDevice,
+  type KokoroDtype,
+  type KokoroNodeOptions,
+} from "../core/kokoro-node";
+
+export {
+  looksLikeMarkdown,
+  markdownToSpeech,
+  markdownToSpeechSegments,
+  stripInlineMarkdown,
+  type MarkdownToSpeechOptions,
+  type SpeechSegment,
+  type SpeechSegmentType,
+} from "../utils/markdown-to-speech";

--- a/packages/use-voice-control/speech/node/render.ts
+++ b/packages/use-voice-control/speech/node/render.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Rendering a loaded document to an audio file on disk.
+ *
+ * Sits between `document.ts` (what to say) and `core/kokoro-node.ts` (how to say
+ * it): resolves the output path, runs the synthesizer, and writes the WAV.
+ */
+import {
+  synthesizeSamples,
+  type KokoroAudio,
+  type KokoroNodeOptions,
+} from "../core/kokoro-node";
+import { encodeWav, wavDurationSeconds } from "../utils/wav";
+import { extensionOf, loadDocument, type LoadDocumentOptions } from "./document";
+
+export interface RenderOptions extends LoadDocumentOptions, KokoroNodeOptions {
+  /** Where to write the audio. `-` writes the WAV to stdout. */
+  output?: string;
+  /**
+   * Replace the synthesizer. Used by the tests, and by hosts that already have a
+   * model loaded and do not want a second copy.
+   */
+  synthesize?: (text: string, options: KokoroNodeOptions) => Promise<KokoroAudio>;
+}
+
+export interface RenderResult {
+  /** Path written, or `-` when the audio went to stdout. */
+  output: string;
+  /** The text that was spoken, after Markdown conversion. */
+  text: string;
+  format: "markdown" | "text";
+  source: string;
+  durationSeconds: number;
+  bytes: number;
+}
+
+/** `notes.md` becomes `notes.wav`, next to the original. */
+export function defaultOutputPath(input: string): string {
+  const extension = extensionOf(input);
+  const base = extension ? input.slice(0, -extension.length) : input;
+  return `${base}.wav`;
+}
+
+/**
+ * Reads a document, synthesizes it, and writes a WAV file.
+ *
+ * Returns the spoken text alongside the file details so a caller can show what
+ * was read without converting the document a second time.
+ */
+export async function renderDocument(options: RenderOptions): Promise<RenderResult> {
+  const document = await loadDocument(options);
+
+  if (!document.text.trim()) {
+    throw new Error(`Nothing to speak: ${document.source} has no readable text`);
+  }
+
+  const synthesize = options.synthesize ?? synthesizeSamples;
+  const { samples, sampleRate } = await synthesize(document.text, options);
+  const audio = encodeWav(samples, sampleRate);
+
+  const output =
+    options.output ??
+    (options.file && options.file !== "-" ? defaultOutputPath(options.file) : "out.wav");
+
+  if (output === "-") {
+    process.stdout.write(Buffer.from(audio));
+  } else {
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(output, Buffer.from(audio));
+  }
+
+  return {
+    output,
+    text: document.text,
+    format: document.format,
+    source: document.source,
+    durationSeconds: wavDurationSeconds(samples, sampleRate),
+    bytes: audio.byteLength,
+  };
+}

--- a/packages/use-voice-control/speech/react/useReadAloud.ts
+++ b/packages/use-voice-control/speech/react/useReadAloud.ts
@@ -93,6 +93,8 @@ export function useReadAloud(options: UseReadAloudOptions = {}): UseReadAloudRet
     options.voice,
     options.endpoint,
     options.maxChunkLength,
+    options.format,
+    options.markdown,
     options.synthesize,
   ]);
 

--- a/packages/use-voice-control/speech/types/types.ts
+++ b/packages/use-voice-control/speech/types/types.ts
@@ -15,15 +15,44 @@ export interface TTSResult {
   contentType: string;
 }
 
-// Kokoro voices from the model
+// Kokoro voices from the model. The `a`/`b` prefix is the accent (American /
+// British English) and the `f`/`m` that follows it is the voice's gender, which
+// is how `describeKokoroVoice` derives a listing without a second catalog.
 export const KOKORO_VOICES = [
-  "af_heart", "af_alloy", "af_aoede", "af_bella",
-  "af_jessica", "af_nicole", "af_river", "af_sarah", "af_sky",
-  "am_adam", "am_echo", "am_fable", "am_fenrir",
-  "am_liam", "am_michael", "am_onyx"
+  "af_heart", "af_alloy", "af_aoede", "af_bella", "af_jessica",
+  "af_kore", "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky",
+  "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam",
+  "am_michael", "am_onyx", "am_puck", "am_santa",
+  "bf_alice", "bf_emma", "bf_isabella", "bf_lily",
+  "bm_daniel", "bm_fable", "bm_george", "bm_lewis",
 ] as const;
 
 export type KokoroVoice = (typeof KOKORO_VOICES)[number];
+
+export interface KokoroVoiceDescription {
+  id: string;
+  /** Display name, e.g. `Heart` for `af_heart`. */
+  name: string;
+  /** `American English` or `British English`. */
+  accent: string;
+  gender: "Female" | "Male";
+}
+
+/**
+ * Describes a voice from its id, so listings (`--list-voices`, a voice picker)
+ * do not need a hand-maintained table that can drift from `KOKORO_VOICES`.
+ */
+export function describeKokoroVoice(id: string): KokoroVoiceDescription {
+  const [accentCode, genderCode] = id;
+  const suffix = id.slice(3) || id;
+
+  return {
+    id,
+    name: suffix.charAt(0).toUpperCase() + suffix.slice(1),
+    accent: accentCode === "b" ? "British English" : "American English",
+    gender: genderCode === "m" ? "Male" : "Female",
+  };
+}
 
 // Deepgram Aura speakers
 export const DEEPGRAM_SPEAKERS = [

--- a/packages/use-voice-control/speech/utils/markdown-to-speech.ts
+++ b/packages/use-voice-control/speech/utils/markdown-to-speech.ts
@@ -1,0 +1,426 @@
+/**
+ * @fileoverview Turns Markdown into text a speech synthesizer can read.
+ *
+ * Markdown handed straight to a TTS engine is read literally: "hash hash Getting
+ * started", "star star important star star". This module parses the document
+ * instead and emits only the words, keeping the *structure* the marks encoded —
+ * a heading becomes its own spoken segment ending in a full stop so the
+ * synthesizer pauses, a list item becomes one sentence, a fenced code block is
+ * announced rather than spelled out.
+ *
+ * It is deliberately dependency-free and runs in the browser as well as Node, so
+ * `ReadAloudController` and the CLI can share it.
+ */
+
+/** Kind of block the converter recognised. */
+export type SpeechSegmentType =
+  | "heading"
+  | "paragraph"
+  | "list-item"
+  | "quote"
+  | "code"
+  | "table-row";
+
+export interface SpeechSegment {
+  type: SpeechSegmentType;
+  /** Spoken text of the block, with every Markdown mark already removed. */
+  text: string;
+  /** Heading level 1-6. Only set on `heading` segments. */
+  level?: number;
+}
+
+export interface MarkdownToSpeechOptions {
+  /**
+   * How headings are spoken. `text` (default) reads the heading words on their
+   * own so they land between pauses; `announce` prefixes them with "Heading:";
+   * `skip` drops them entirely.
+   */
+  headings?: "text" | "announce" | "skip";
+  /**
+   * What to do with fenced code blocks. `announce` (default) replaces the block
+   * with a short spoken note, `read` reads the code verbatim, `skip` drops it.
+   */
+  codeBlocks?: "announce" | "read" | "skip";
+  /** `text` (default) speaks the link text and drops the URL; `text-and-url` reads both. */
+  links?: "text" | "text-and-url";
+  /** `alt` (default) speaks the image's alt text; `skip` drops images. */
+  images?: "alt" | "skip";
+  /** Read the YAML front matter block. Off by default. */
+  frontMatter?: boolean;
+  /** `rows` (default) reads table rows as comma-separated cells; `skip` drops tables. */
+  tables?: "rows" | "skip";
+  /**
+   * Append a full stop to blocks that do not end in punctuation, so the
+   * synthesizer pauses between them instead of running them together.
+   * Default true.
+   */
+  addTerminalPunctuation?: boolean;
+}
+
+type ResolvedOptions = Required<MarkdownToSpeechOptions>;
+
+const DEFAULTS: ResolvedOptions = {
+  headings: "text",
+  codeBlocks: "announce",
+  links: "text",
+  images: "alt",
+  frontMatter: false,
+  tables: "rows",
+  addTerminalPunctuation: true,
+};
+
+/** Spoken names for code fence languages that would otherwise be read as letters. */
+const LANGUAGE_NAMES: Record<string, string> = {
+  js: "JavaScript",
+  jsx: "JavaScript",
+  mjs: "JavaScript",
+  cjs: "JavaScript",
+  ts: "TypeScript",
+  tsx: "TypeScript",
+  py: "Python",
+  rb: "Ruby",
+  rs: "Rust",
+  sh: "shell",
+  bash: "shell",
+  zsh: "shell",
+  shell: "shell",
+  console: "shell",
+  yml: "YAML",
+  yaml: "YAML",
+  md: "Markdown",
+  json: "JSON",
+  html: "HTML",
+  css: "CSS",
+  sql: "SQL",
+  go: "Go",
+  java: "Java",
+  c: "C",
+  cpp: "C plus plus",
+  cs: "C sharp",
+  php: "PHP",
+  swift: "Swift",
+  kt: "Kotlin",
+  diff: "diff",
+  text: "",
+  txt: "",
+  plaintext: "",
+};
+
+const ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+  mdash: "—",
+  ndash: "–",
+  hellip: "…",
+  ldquo: '"',
+  rdquo: '"',
+  lsquo: "'",
+  rsquo: "'",
+};
+
+const ATX_HEADING = /^ {0,3}(#{1,6})(?:\s+(.*?))?\s*$/;
+const SETEXT_UNDERLINE = /^ {0,3}(=+|-+)\s*$/;
+const THEMATIC_BREAK = /^ {0,3}([-*_])[ \t]*(?:\1[ \t]*){2,}$/;
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})\s*([^`]*)$/;
+const LIST_ITEM = /^ *(?:[-+*]|\d{1,9}[.)])(?:\s+(.*))?$/;
+const ORDERED_ITEM = /^ *(\d{1,9})[.)]\s+(.*)$/;
+const TASK_MARKER = /^\[([ xX])\]\s+/;
+const LINK_REFERENCE_DEFINITION = /^ {0,3}\[[^\]]+\]:\s*\S+.*$/;
+const TABLE_DELIMITER_ROW = /^[\s|:-]*-[\s|:-]*$/;
+
+/** Marks the slot where a protected substring was lifted out of the line. */
+const PLACEHOLDER_OPEN = "\u0000";
+const PLACEHOLDER_CLOSE = "\u0001";
+const PLACEHOLDER_PATTERN = /\u0000(\d+)\u0001/g;
+
+/** Ends a block with a full stop unless it already ends in sentence punctuation. */
+function withTerminalPunctuation(text: string): string {
+  return /[.!?:;,…]["')\]]?$/.test(text) ? text : `${text}.`;
+}
+
+/** Replaces `&amp;`-style entities with the characters they stand for. */
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&#(\d{1,7});/g, (_m, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#[xX]([0-9a-fA-F]{1,6});/g, (_m, code) =>
+      String.fromCodePoint(parseInt(code, 16))
+    )
+    .replace(/&([a-zA-Z]+);/g, (match, name) => ENTITIES[name.toLowerCase()] ?? match);
+}
+
+/**
+ * Strips the inline marks — emphasis, code spans, links, images, raw HTML — from
+ * a single line, leaving the words behind.
+ */
+export function stripInlineMarkdown(
+  input: string,
+  options: MarkdownToSpeechOptions = {}
+): string {
+  const opts: ResolvedOptions = { ...DEFAULTS, ...options };
+  const protectedRuns: string[] = [];
+  const hold = (value: string): string =>
+    `${PLACEHOLDER_OPEN}${protectedRuns.push(value) - 1}${PLACEHOLDER_CLOSE}`;
+
+  let text = input;
+
+  // Backslash escapes and code spans come out first: whatever they contain must
+  // survive the emphasis pass untouched.
+  text = text.replace(/\\([\\`*_{}[\]()#+\-.!>~|])/g, (_m, char) => hold(char));
+  text = text.replace(/(`+)([^`]|[^`][\s\S]*?[^`])\1(?!`)/g, (_m, _ticks, code) =>
+    hold(String(code).trim())
+  );
+
+  text = text.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Images before links: `![alt](src)` is a link whose text starts with `!`.
+  text = text.replace(/!\[([^\]]*)\]\([^)]*\)/g, (_m, alt) =>
+    opts.images === "skip" ? "" : String(alt)
+  );
+  text = text.replace(/!\[([^\]]*)\]\[[^\]]*\]/g, (_m, alt) =>
+    opts.images === "skip" ? "" : String(alt)
+  );
+
+  // Footnote references carry no spoken meaning.
+  text = text.replace(/\[\^[^\]]+\]/g, "");
+
+  text = text.replace(/\[([^\]]*)\]\(\s*<?([^\s)]*)>?[^)]*\)/g, (_m, label, url) =>
+    opts.links === "text-and-url" && url ? `${label}, ${url}` : String(label)
+  );
+  text = text.replace(/\[([^\]]*)\]\[[^\]]*\]/g, "$1");
+
+  // Autolinks: `<https://example.com>` reads better as the bare address.
+  text = text.replace(/<((?:https?|mailto):[^>\s]+)>/gi, (_m, url) =>
+    opts.links === "text-and-url"
+      ? String(url)
+      : String(url).replace(/^mailto:/i, "")
+  );
+
+  // Remaining angle brackets are raw HTML tags.
+  text = text.replace(/<\/?[a-zA-Z][^>]*>/g, "");
+
+  text = text.replace(/\*\*\*(?=\S)([\s\S]*?\S)\*\*\*/g, "$1");
+  text = text.replace(/\*\*(?=\S)([\s\S]*?\S)\*\*/g, "$1");
+  text = text.replace(/(?<![A-Za-z0-9_])__(?=\S)([\s\S]*?\S)__(?![A-Za-z0-9_])/g, "$1");
+  text = text.replace(/~~(?=\S)([\s\S]*?\S)~~/g, "$1");
+  text = text.replace(/\*(?=\S)([^*\n]*?\S)\*/g, "$1");
+  // Underscores are only emphasis between word boundaries, so `snake_case` survives.
+  text = text.replace(/(?<![A-Za-z0-9_])_(?=\S)([^_\n]*?\S)_(?![A-Za-z0-9_])/g, "$1");
+
+  text = decodeEntities(text);
+  text = text.replace(
+    PLACEHOLDER_PATTERN,
+    (_m, index) => protectedRuns[Number(index)] ?? ""
+  );
+
+  return text.replace(/[ \t]+/g, " ").trim();
+}
+
+/** Spoken stand-in for a fenced code block, e.g. "TypeScript code block." */
+function announceCode(language: string): string {
+  const key = language.trim().split(/[\s,{]/)[0]?.toLowerCase() ?? "";
+  const name = key in LANGUAGE_NAMES ? LANGUAGE_NAMES[key] : key;
+  return name ? `${name} code block.` : "Code block.";
+}
+
+/**
+ * Parses Markdown into the blocks that should be spoken, in reading order.
+ *
+ * Use this when the caller wants the structure — to highlight the current
+ * heading, say, or to skip to a section. Callers that only need something to
+ * feed a synthesizer want {@link markdownToSpeech}.
+ */
+export function markdownToSpeechSegments(
+  markdown: string,
+  options: MarkdownToSpeechOptions = {}
+): SpeechSegment[] {
+  const opts: ResolvedOptions = { ...DEFAULTS, ...options };
+  const segments: SpeechSegment[] = [];
+
+  let source = (markdown ?? "").replace(/\r\n?/g, "\n").replace(/\t/g, "    ");
+  source = source.replace(/<!--[\s\S]*?-->/g, "");
+
+  const lines = source.split("\n");
+  let index = 0;
+
+  // YAML front matter: only when it opens on the very first line.
+  if (!opts.frontMatter && /^---\s*$/.test(lines[0] ?? "")) {
+    const closing = lines.findIndex((line, i) => i > 0 && /^(---|\.\.\.)\s*$/.test(line));
+    if (closing > 0) index = closing + 1;
+  }
+
+  /** Soft-wrapped lines of the paragraph being accumulated. */
+  let paragraph: string[] = [];
+  let quoting = false;
+
+  const push = (type: SpeechSegmentType, text: string, level?: number): void => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const spoken = opts.addTerminalPunctuation ? withTerminalPunctuation(trimmed) : trimmed;
+    segments.push(level === undefined ? { type, text: spoken } : { type, text: spoken, level });
+  };
+
+  const flushParagraph = (): void => {
+    if (paragraph.length === 0) return;
+    const text = stripInlineMarkdown(paragraph.join(" "), opts);
+    paragraph = [];
+    const type = quoting ? "quote" : "paragraph";
+    quoting = false;
+    push(type, text);
+  };
+
+  for (; index < lines.length; index += 1) {
+    let line = lines[index];
+
+    // A fence closes any paragraph before it and swallows lines until it ends.
+    const fence = FENCE_OPEN.exec(line);
+    if (fence) {
+      flushParagraph();
+      const marker = fence[1];
+      const language = fence[2] ?? "";
+      const closingFence = new RegExp(`^ {0,3}\\${marker[0]}{${marker.length},}\\s*$`);
+      const body: string[] = [];
+      index += 1;
+      for (; index < lines.length; index += 1) {
+        if (closingFence.test(lines[index])) break;
+        body.push(lines[index]);
+      }
+      if (opts.codeBlocks === "announce") {
+        push("code", announceCode(language));
+      } else if (opts.codeBlocks === "read") {
+        push("code", body.join(" ").replace(/\s+/g, " "));
+      }
+      continue;
+    }
+
+    if (line.trim() === "") {
+      flushParagraph();
+      continue;
+    }
+
+    // Blockquote markers are stripped so the quoted content is parsed normally.
+    let isQuote = false;
+    while (/^ {0,3}>\s?/.test(line)) {
+      line = line.replace(/^ {0,3}>\s?/, "");
+      isQuote = true;
+    }
+    if (isQuote) {
+      if (paragraph.length === 0) quoting = true;
+      if (line.trim() === "") {
+        flushParagraph();
+        continue;
+      }
+    }
+
+    if (THEMATIC_BREAK.test(line)) {
+      flushParagraph();
+      continue;
+    }
+
+    const heading = ATX_HEADING.exec(line);
+    if (heading) {
+      flushParagraph();
+      if (opts.headings === "skip") continue;
+      // A closing run of hashes (`## Title ##`) is decoration, not content.
+      const text = stripInlineMarkdown((heading[2] ?? "").replace(/\s+#+$/, ""), opts);
+      if (!text) continue;
+      push("heading", opts.headings === "announce" ? `Heading: ${text}` : text, heading[1].length);
+      continue;
+    }
+
+    // Setext heading: the underline applies to the single line above it.
+    const underline = SETEXT_UNDERLINE.exec(line);
+    if (underline && paragraph.length > 0 && opts.headings !== "skip") {
+      const text = stripInlineMarkdown(paragraph.join(" "), opts);
+      paragraph = [];
+      quoting = false;
+      if (text) {
+        push(
+          "heading",
+          opts.headings === "announce" ? `Heading: ${text}` : text,
+          underline[1].startsWith("=") ? 1 : 2
+        );
+      }
+      continue;
+    }
+
+    if (LINK_REFERENCE_DEFINITION.test(line) && paragraph.length === 0) continue;
+
+    if (line.trimStart().startsWith("|")) {
+      flushParagraph();
+      if (opts.tables === "skip" || TABLE_DELIMITER_ROW.test(line)) continue;
+      const cells = line
+        .trim()
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split(/(?<!\\)\|/)
+        .map((cell) => stripInlineMarkdown(cell, opts))
+        .filter((cell) => cell.length > 0);
+      if (cells.length > 0) push("table-row", cells.join(", "));
+      continue;
+    }
+
+    const item = LIST_ITEM.exec(line);
+    if (item) {
+      flushParagraph();
+      const ordered = ORDERED_ITEM.exec(line);
+      // Keep the number — a listener needs it — but drop bullets and checkboxes.
+      const body = (ordered ? ordered[2] : (item[1] ?? "")).replace(TASK_MARKER, "");
+      const text = stripInlineMarkdown(body, opts);
+      if (!text) continue;
+      push("list-item", ordered ? `${ordered[1]}. ${text}` : text);
+      continue;
+    }
+
+    paragraph.push(line.trim());
+  }
+
+  flushParagraph();
+  return segments;
+}
+
+/**
+ * Converts Markdown to plain text ready for a speech synthesizer.
+ *
+ * Blocks are separated by blank lines so downstream chunkers (`splitTextSmart`)
+ * break on them; runs of list items and table rows stay in one block so a list
+ * is not chopped into one request per bullet.
+ */
+export function markdownToSpeech(
+  markdown: string,
+  options: MarkdownToSpeechOptions = {}
+): string {
+  const segments = markdownToSpeechSegments(markdown, options);
+
+  return segments.reduce((out, segment, i) => {
+    if (i === 0) return segment.text;
+    const previous = segments[i - 1].type;
+    const runsOn =
+      (segment.type === "list-item" || segment.type === "table-row") &&
+      previous === segment.type;
+    return `${out}${runsOn ? "\n" : "\n\n"}${segment.text}`;
+  }, "");
+}
+
+/**
+ * Guesses whether a blob of text is Markdown, for callers with no filename to go
+ * on (piped stdin, a paste). Errs towards `false`: prose read as Markdown is
+ * mostly unchanged anyway, so only reasonably clear signals count.
+ */
+export function looksLikeMarkdown(text: string): boolean {
+  if (!text) return false;
+  const sample = text.slice(0, 20000);
+  const signals = [
+    /^ {0,3}#{1,6}\s+\S/m,
+    /^ {0,3}(?:```|~~~)/m,
+    /^ {0,3}[-+*]\s+\S/m,
+    /^ {0,3}>\s+\S/m,
+    /\[[^\]]+\]\([^)]+\)/,
+    /(?<![A-Za-z0-9])\*\*\S[\s\S]*?\S\*\*/,
+    /^ {0,3}\|.*\|\s*$/m,
+  ];
+  return signals.filter((pattern) => pattern.test(sample)).length >= 2;
+}

--- a/packages/use-voice-control/speech/utils/wav.ts
+++ b/packages/use-voice-control/speech/utils/wav.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Minimal WAV (RIFF) encoder for raw Float32 PCM.
+ *
+ * The browser path gets its WAV from `convertAudioBufferToWav`, which needs a Web
+ * Audio `AudioBuffer`. Node has no such thing: the Kokoro model hands back a bare
+ * `Float32Array`, and long documents are synthesized one chunk at a time and
+ * joined before encoding. Both of those are pure buffer work, so they live here
+ * with no platform dependency.
+ */
+
+/** Number of bytes in the fixed RIFF/fmt/data header this encoder writes. */
+const HEADER_BYTES = 44;
+
+/**
+ * Joins per-chunk sample buffers into one contiguous track.
+ *
+ * @param chunks Sample buffers in playback order.
+ * @param silenceSamples Samples of silence to insert between chunks, so the
+ *   seams between separately synthesized chunks do not sound clipped.
+ */
+export function concatSamples(
+  chunks: Float32Array[],
+  silenceSamples = 0
+): Float32Array {
+  const gaps = Math.max(chunks.length - 1, 0) * Math.max(silenceSamples, 0);
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0) + gaps;
+  const out = new Float32Array(total);
+
+  let offset = 0;
+  chunks.forEach((chunk, i) => {
+    out.set(chunk, offset);
+    offset += chunk.length;
+    if (i < chunks.length - 1) offset += Math.max(silenceSamples, 0);
+  });
+
+  return out;
+}
+
+/**
+ * Encodes Float32 samples (nominally -1..1) as a 16-bit PCM WAV file.
+ *
+ * @param samples Interleaved samples when `channels` is greater than 1.
+ * @param sampleRate Sample rate of the audio, e.g. 24000 for Kokoro.
+ * @param channels Channel count. Kokoro is mono.
+ */
+export function encodeWav(
+  samples: Float32Array,
+  sampleRate = 24000,
+  channels = 1
+): ArrayBuffer {
+  const buffer = new ArrayBuffer(HEADER_BYTES + samples.length * 2);
+  const view = new DataView(buffer);
+
+  const writeString = (offset: number, value: string): void => {
+    for (let i = 0; i < value.length; i += 1) {
+      view.setUint8(offset + i, value.charCodeAt(i));
+    }
+  };
+
+  const byteRate = sampleRate * channels * 2;
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM header size
+  view.setUint16(20, 1, true); // format: PCM
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, channels * 2, true); // block align
+  view.setUint16(34, 16, true); // bits per sample
+  writeString(36, "data");
+  view.setUint32(40, samples.length * 2, true);
+
+  for (let i = 0; i < samples.length; i += 1) {
+    // Clamp before scaling: the model occasionally overshoots 1.0 and wrapping
+    // a 16-bit sample turns that into a loud click.
+    const sample = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(HEADER_BYTES + i * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+  }
+
+  return buffer;
+}
+
+/** Duration of a Float32 track in seconds, for progress and log lines. */
+export function wavDurationSeconds(samples: Float32Array, sampleRate: number): number {
+  return sampleRate > 0 ? samples.length / sampleRate : 0;
+}

--- a/packages/use-voice-control/test/cli.test.ts
+++ b/packages/use-voice-control/test/cli.test.ts
@@ -1,0 +1,334 @@
+/**
+ * @fileoverview Tests for the `use-voice-control` command: option parsing, the
+ * document-to-speakable-text path, and a full run with the synthesizer stubbed
+ * out so no model is downloaded.
+ */
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { formatVoiceList, parseArgs, runCli, USAGE } from '../speech/node/cli';
+import { detectFormat, loadDocument, toSpeechText } from '../speech/node/document';
+import { defaultOutputPath } from '../speech/node/render';
+
+/** Stands in for Kokoro: one sample per character, so length is predictable. */
+const fakeSynthesize = async (text: string) => ({
+  samples: new Float32Array(text.length),
+  sampleRate: 24000,
+});
+
+/** Runs the CLI with every effect captured, and nothing on stdin. */
+async function run(argv: string[], overrides: Record<string, unknown> = {}) {
+  const out: string[] = [];
+  const err: string[] = [];
+  const code = await runCli(argv, {
+    log: (line) => out.push(line),
+    error: (line) => err.push(line),
+    synthesize: fakeSynthesize,
+    stdinIsTTY: true,
+    ...overrides,
+  });
+  return { code, out: out.join('\n'), err: err.join('\n') };
+}
+
+const tempFiles: string[] = [];
+
+async function tempMarkdown(content: string, name = 'doc.md'): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'use-voice-control-'));
+  const path = join(dir, name);
+  await writeFile(path, content, 'utf8');
+  tempFiles.push(path);
+  return path;
+}
+
+afterEach(() => {
+  tempFiles.length = 0;
+});
+
+describe('parseArgs', () => {
+  it('defaults to speaking the given file with af_heart', () => {
+    const options = parseArgs(['notes.md']);
+
+    expect(options).toMatchObject({
+      command: 'speak',
+      input: 'notes.md',
+      voice: 'af_heart',
+      speed: 1,
+      format: 'auto',
+      quiet: false,
+      errors: [],
+    });
+  });
+
+  it('reads the short and long forms of the common flags', () => {
+    const options = parseArgs(['a.md', '-o', 'a.wav', '-v', 'am_adam', '-s', '1.25', '-q']);
+
+    expect(options).toMatchObject({
+      output: 'a.wav',
+      voice: 'am_adam',
+      speed: 1.25,
+      quiet: true,
+      errors: [],
+    });
+  });
+
+  it('accepts --flag=value', () => {
+    expect(parseArgs(['a.md', '--voice=bf_emma']).voice).toBe('bf_emma');
+  });
+
+  it('maps format aliases onto the two real formats', () => {
+    expect(parseArgs(['a.txt', '--format', 'md']).format).toBe('markdown');
+    expect(parseArgs(['a.md', '-f', 'txt']).format).toBe('text');
+  });
+
+  it('collects the Markdown handling flags', () => {
+    const options = parseArgs([
+      'a.md',
+      '--headings',
+      'announce',
+      '--code',
+      'skip',
+      '--links',
+      'text-and-url',
+      '--tables',
+      'skip',
+      '--front-matter',
+    ]);
+
+    expect(options.markdown).toEqual({
+      headings: 'announce',
+      codeBlocks: 'skip',
+      links: 'text-and-url',
+      tables: 'skip',
+      frontMatter: true,
+    });
+  });
+
+  it('treats "-" as an input rather than a flag', () => {
+    expect(parseArgs(['-']).input).toBe('-');
+  });
+
+  it('lets --text start with a dash', () => {
+    expect(parseArgs(['--text', '-5 degrees']).text).toBe('-5 degrees');
+  });
+
+  it('switches to the standalone commands', () => {
+    expect(parseArgs(['--help']).command).toBe('help');
+    expect(parseArgs(['-V']).command).toBe('version');
+    expect(parseArgs(['--list-voices']).command).toBe('list-voices');
+    expect(parseArgs(['a.md', '--print']).command).toBe('print');
+  });
+
+  it('rejects an unknown voice and names the way to list them', () => {
+    const options = parseArgs(['a.md', '--voice', 'af_nobody']);
+
+    expect(options.errors).toHaveLength(1);
+    expect(options.errors[0]).toContain('--list-voices');
+  });
+
+  it('rejects a speed outside the supported range', () => {
+    expect(parseArgs(['a.md', '--speed', '9']).errors).toEqual([
+      '--speed must be between 0.5 and 2',
+    ]);
+  });
+
+  it('rejects a non-numeric speed', () => {
+    expect(parseArgs(['a.md', '--speed', 'fast']).errors[0]).toContain('expects a number');
+  });
+
+  it('rejects an unknown option and an unknown enum value', () => {
+    expect(parseArgs(['a.md', '--nope']).errors[0]).toContain('unknown option');
+    expect(parseArgs(['a.md', '--dtype', 'q3']).errors[0]).toContain('fp32');
+  });
+
+  it('rejects a flag whose value is missing', () => {
+    expect(parseArgs(['a.md', '--voice']).errors).toEqual(['--voice needs a value']);
+  });
+
+  it('rejects a second input file and a file combined with --text', () => {
+    expect(parseArgs(['a.md', 'b.md']).errors[0]).toContain('one file at a time');
+    expect(parseArgs(['a.md', '--text', 'hi']).errors).toContain(
+      'pass either a file or --text, not both'
+    );
+  });
+
+  it('treats everything after -- as an input path', () => {
+    expect(parseArgs(['--', '--weird-name.md']).input).toBe('--weird-name.md');
+  });
+});
+
+describe('document handling', () => {
+  it('picks the format from the extension', () => {
+    expect(detectFormat('# hi', 'a.md')).toBe('markdown');
+    expect(detectFormat('# hi', 'a.txt')).toBe('text');
+    expect(detectFormat('# hi', 'A.MARKDOWN')).toBe('markdown');
+  });
+
+  it('lets an explicit format override the extension', () => {
+    expect(detectFormat('# hi', 'a.txt', 'markdown')).toBe('markdown');
+  });
+
+  it('falls back to sniffing the content when there is no filename', () => {
+    expect(detectFormat('# Title\n\n- a\n- b')).toBe('markdown');
+    expect(detectFormat('Just a sentence.')).toBe('text');
+  });
+
+  it('passes plain text through, only trimming it', () => {
+    expect(toSpeechText('  hello there  \r\n', 'text')).toBe('hello there');
+  });
+
+  it('converts Markdown files read from disk', async () => {
+    const path = await tempMarkdown('# Title\n\nSome **bold** words.\n');
+    const document = await loadDocument({ file: path });
+
+    expect(document.format).toBe('markdown');
+    expect(document.text).toBe('Title.\n\nSome bold words.');
+    expect(document.source).toBe(path);
+  });
+
+  it('reads stdin for "-"', async () => {
+    const document = await loadDocument({
+      file: '-',
+      readStdin: async () => '## Piped\n\n- item\n',
+    });
+
+    expect(document.text).toBe('Piped.\n\nitem.');
+    expect(document.source).toBe('stdin');
+  });
+
+  it('refuses to guess when given no input at all', async () => {
+    await expect(loadDocument({})).rejects.toThrow(/No input/);
+  });
+});
+
+describe('defaultOutputPath', () => {
+  it('swaps the extension for .wav', () => {
+    expect(defaultOutputPath('/tmp/notes.md')).toBe('/tmp/notes.wav');
+    expect(defaultOutputPath('notes.markdown')).toBe('notes.wav');
+  });
+
+  it('appends .wav when there is no extension', () => {
+    expect(defaultOutputPath('/tmp/notes')).toBe('/tmp/notes.wav');
+  });
+});
+
+describe('runCli', () => {
+  it('prints usage for --help', async () => {
+    const { code, out } = await run(['--help']);
+
+    expect(code).toBe(0);
+    expect(out).toBe(USAGE);
+  });
+
+  it('lists every voice with its accent and gender', async () => {
+    const { code, out } = await run(['--list-voices']);
+
+    expect(code).toBe(0);
+    expect(out).toBe(formatVoiceList());
+    expect(out).toContain('af_heart');
+    expect(out).toContain('British English');
+  });
+
+  it('prints the speakable text for --print without synthesizing', async () => {
+    const path = await tempMarkdown('# Title\n\nSee [docs](https://example.com).\n');
+    const { code, out } = await run([path, '--print']);
+
+    expect(code).toBe(0);
+    expect(out).toBe('Title.\n\nSee docs.');
+  });
+
+  it('honours the Markdown flags when printing', async () => {
+    const path = await tempMarkdown('# Title\n\n```js\nx\n```\n');
+    const { out } = await run([path, '--print', '--headings', 'announce', '--code', 'skip']);
+
+    expect(out).toBe('Heading: Title.');
+  });
+
+  it('writes a WAV file next to the input by default', async () => {
+    const path = await tempMarkdown('# Title\n\nBody text.\n');
+    const { code, err } = await run([path]);
+
+    expect(code).toBe(0);
+    const written = await readFile(path.replace(/\.md$/, '.wav'));
+    expect(written.subarray(0, 4).toString()).toBe('RIFF');
+    expect(err).toContain('wrote');
+  });
+
+  it('writes to the path given with -o and stays silent with --quiet', async () => {
+    const path = await tempMarkdown('Hello there.\n', 'note.txt');
+    const output = path.replace(/note\.txt$/, 'spoken.wav');
+    const { code, err } = await run([path, '-o', output, '--quiet']);
+
+    expect(code).toBe(0);
+    expect(err).toBe('');
+    expect((await readFile(output)).subarray(0, 4).toString()).toBe('RIFF');
+  });
+
+  it('speaks --text without touching the filesystem for input', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'use-voice-control-'));
+    const output = join(dir, 'inline.wav');
+    const { code } = await run(['--text', 'Hello there.', '-o', output]);
+
+    expect(code).toBe(0);
+    expect((await readFile(output)).byteLength).toBeGreaterThan(44);
+  });
+
+  it('reads stdin when nothing is named and stdin is a pipe', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'use-voice-control-'));
+    const output = join(dir, 'piped.wav');
+    const { code } = await run(['-o', output], {
+      stdinIsTTY: false,
+      readStdin: async () => '# Piped\n\nBody.',
+    });
+
+    expect(code).toBe(0);
+    expect((await readFile(output)).subarray(0, 4).toString()).toBe('RIFF');
+  });
+
+  it('fails with usage advice when there is no input', async () => {
+    const { code, err } = await run([]);
+
+    expect(code).toBe(1);
+    expect(err).toContain('no input');
+    expect(err).toContain('--help');
+  });
+
+  it('reports every parse error and does not synthesize', async () => {
+    const { code, err } = await run(['a.md', '--voice', 'nope', '--speed', '9']);
+
+    expect(code).toBe(1);
+    expect(err).toContain('unknown voice');
+    expect(err).toContain('--speed must be between 0.5 and 2');
+  });
+
+  it('reports a missing file instead of throwing', async () => {
+    const { code, err } = await run(['/nope/missing.md']);
+
+    expect(code).toBe(1);
+    expect(err).toContain('use-voice-control:');
+  });
+
+  it('refuses a document with nothing to say', async () => {
+    const path = await tempMarkdown('<!-- only a comment -->\n');
+    const { code, err } = await run([path]);
+
+    expect(code).toBe(1);
+    expect(err).toContain('Nothing to speak');
+  });
+
+  it('passes the voice and speed through to the synthesizer', async () => {
+    const seen: Record<string, unknown>[] = [];
+    const dir = await mkdtemp(join(tmpdir(), 'use-voice-control-'));
+    const output = join(dir, 'voiced.wav');
+
+    await run(['--text', 'Hi.', '-o', output, '-v', 'bm_george', '-s', '1.5'], {
+      synthesize: async (text: string, options: Record<string, unknown>) => {
+        seen.push(options);
+        return fakeSynthesize(text);
+      },
+    });
+
+    expect(seen[0]).toMatchObject({ voice: 'bm_george', speed: 1.5 });
+  });
+});

--- a/packages/use-voice-control/test/markdown-to-speech.test.ts
+++ b/packages/use-voice-control/test/markdown-to-speech.test.ts
@@ -1,0 +1,236 @@
+/**
+ * @fileoverview Tests for the Markdown-to-speech converter: that the marks stop
+ * being read out, that the structure they encoded survives as spoken blocks, and
+ * that the per-element options behave.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  looksLikeMarkdown,
+  markdownToSpeech,
+  markdownToSpeechSegments,
+  stripInlineMarkdown,
+} from '../speech/utils/markdown-to-speech';
+
+describe('stripInlineMarkdown', () => {
+  it('drops emphasis marks but keeps the words', () => {
+    expect(stripInlineMarkdown('a **bold** and *italic* and ***both***')).toBe(
+      'a bold and italic and both'
+    );
+  });
+
+  it('drops strikethrough and underscore emphasis', () => {
+    expect(stripInlineMarkdown('~~gone~~ and __strong__ and _quiet_')).toBe(
+      'gone and strong and quiet'
+    );
+  });
+
+  it('leaves underscores inside identifiers alone', () => {
+    expect(stripInlineMarkdown('call snake_case_name twice')).toBe('call snake_case_name twice');
+  });
+
+  it('reads code spans without their backticks', () => {
+    expect(stripInlineMarkdown('run `npm install` now')).toBe('run npm install now');
+  });
+
+  it('does not treat marks inside a code span as emphasis', () => {
+    expect(stripInlineMarkdown('`a * b * c`')).toBe('a * b * c');
+  });
+
+  it('speaks link text and drops the URL', () => {
+    expect(stripInlineMarkdown('see [the docs](https://example.com/docs) first')).toBe(
+      'see the docs first'
+    );
+  });
+
+  it('reads the URL too when asked', () => {
+    expect(
+      stripInlineMarkdown('see [docs](https://example.com)', { links: 'text-and-url' })
+    ).toBe('see docs, https://example.com');
+  });
+
+  it('speaks image alt text, or nothing when images are skipped', () => {
+    expect(stripInlineMarkdown('![a red bus](bus.png)')).toBe('a red bus');
+    expect(stripInlineMarkdown('![a red bus](bus.png)', { images: 'skip' })).toBe('');
+  });
+
+  it('keeps escaped marks as literal characters', () => {
+    expect(stripInlineMarkdown('literal \\*stars\\* here')).toBe('literal *stars* here');
+  });
+
+  it('strips raw HTML tags and decodes entities', () => {
+    expect(stripInlineMarkdown('<span class="x">tea &amp; toast</span>')).toBe('tea & toast');
+  });
+
+  it('drops footnote references', () => {
+    expect(stripInlineMarkdown('a claim[^1] stands')).toBe('a claim stands');
+  });
+});
+
+describe('markdownToSpeechSegments', () => {
+  it('reads a heading as a heading rather than its hashes', () => {
+    const segments = markdownToSpeechSegments('## Getting Started');
+
+    expect(segments).toEqual([{ type: 'heading', text: 'Getting Started.', level: 2 }]);
+  });
+
+  it('records the heading level and ignores closing hashes', () => {
+    const segments = markdownToSpeechSegments('#### Deep ####');
+
+    expect(segments[0]).toEqual({ type: 'heading', text: 'Deep.', level: 4 });
+  });
+
+  it('recognises setext headings', () => {
+    const segments = markdownToSpeechSegments('Title\n=====\n\nBody text.');
+
+    expect(segments).toEqual([
+      { type: 'heading', text: 'Title.', level: 1 },
+      { type: 'paragraph', text: 'Body text.' },
+    ]);
+  });
+
+  it('announces headings when asked, and skips them when asked', () => {
+    expect(markdownToSpeechSegments('# Intro', { headings: 'announce' })[0].text).toBe(
+      'Heading: Intro.'
+    );
+    expect(markdownToSpeechSegments('# Intro\n\nBody.', { headings: 'skip' })).toEqual([
+      { type: 'paragraph', text: 'Body.' },
+    ]);
+  });
+
+  it('joins the soft-wrapped lines of a paragraph', () => {
+    const segments = markdownToSpeechSegments('one line\nand its continuation');
+
+    expect(segments).toEqual([{ type: 'paragraph', text: 'one line and its continuation.' }]);
+  });
+
+  it('strips list markers and keeps ordered numbers', () => {
+    const segments = markdownToSpeechSegments('- first\n* second\n1. third');
+
+    expect(segments.map((s) => s.text)).toEqual(['first.', 'second.', '1. third.']);
+    expect(segments.every((s) => s.type === 'list-item')).toBe(true);
+  });
+
+  it('strips task list checkboxes', () => {
+    expect(markdownToSpeechSegments('- [ ] todo\n- [x] done').map((s) => s.text)).toEqual([
+      'todo.',
+      'done.',
+    ]);
+  });
+
+  it('announces a fenced code block instead of reading it', () => {
+    const segments = markdownToSpeechSegments('```ts\nconst x = 1;\n```');
+
+    expect(segments).toEqual([{ type: 'code', text: 'TypeScript code block.' }]);
+  });
+
+  it('reads or skips code blocks on request', () => {
+    expect(markdownToSpeechSegments('```\nhi there\n```', { codeBlocks: 'read' })[0].text).toBe(
+      'hi there.'
+    );
+    expect(markdownToSpeechSegments('```\nhi\n```', { codeBlocks: 'skip' })).toEqual([]);
+  });
+
+  it('never reads the contents of an announced code block', () => {
+    const text = markdownToSpeech('```js\n### not a heading\n**not bold**\n```');
+
+    expect(text).toBe('JavaScript code block.');
+  });
+
+  it('strips blockquote markers and marks the block as a quote', () => {
+    expect(markdownToSpeechSegments('> a quoted line')).toEqual([
+      { type: 'quote', text: 'a quoted line.' },
+    ]);
+  });
+
+  it('reads table rows as cells and drops the delimiter row', () => {
+    const segments = markdownToSpeechSegments('| Name | Age |\n| --- | --- |\n| Ada | 36 |');
+
+    expect(segments.map((s) => s.text)).toEqual(['Name, Age.', 'Ada, 36.']);
+    expect(segments.every((s) => s.type === 'table-row')).toBe(true);
+  });
+
+  it('skips YAML front matter by default and reads it on request', () => {
+    const doc = '---\ntitle: Notes\n---\n\nBody.';
+
+    expect(markdownToSpeechSegments(doc).map((s) => s.text)).toEqual(['Body.']);
+    expect(markdownToSpeechSegments(doc, { frontMatter: true }).map((s) => s.text)).toContain(
+      'title: Notes.'
+    );
+  });
+
+  it('drops horizontal rules, comments and link reference definitions', () => {
+    const doc = 'Before.\n\n---\n\n<!-- hidden -->\n\n[ref]: https://example.com\n\nAfter.';
+
+    expect(markdownToSpeechSegments(doc).map((s) => s.text)).toEqual(['Before.', 'After.']);
+  });
+
+  it('adds a full stop only where one is missing', () => {
+    const segments = markdownToSpeechSegments('# Ready?\n\nAlready done.\n\nNo punctuation');
+
+    expect(segments.map((s) => s.text)).toEqual(['Ready?', 'Already done.', 'No punctuation.']);
+  });
+
+  it('leaves the text alone when terminal punctuation is turned off', () => {
+    expect(
+      markdownToSpeechSegments('# Ready', { addTerminalPunctuation: false })[0].text
+    ).toBe('Ready');
+  });
+
+  it('handles an empty document', () => {
+    expect(markdownToSpeechSegments('')).toEqual([]);
+    expect(markdownToSpeech('')).toBe('');
+  });
+});
+
+describe('markdownToSpeech', () => {
+  it('never leaves a Markdown mark in the spoken text', () => {
+    const doc = [
+      '# Title',
+      '',
+      'A paragraph with **bold**, `code`, and a [link](https://example.com).',
+      '',
+      '## Section',
+      '',
+      '- one',
+      '- two',
+      '',
+      '> quoted',
+      '',
+      '```py',
+      'print("hi")',
+      '```',
+    ].join('\n');
+
+    const spoken = markdownToSpeech(doc);
+
+    expect(spoken).not.toMatch(/[#*`>|]/);
+    expect(spoken).not.toContain('https://example.com');
+    expect(spoken).toContain('Title.');
+    expect(spoken).toContain('Python code block.');
+  });
+
+  it('separates blocks with a blank line so the chunker breaks on them', () => {
+    expect(markdownToSpeech('# Title\n\nBody.')).toBe('Title.\n\nBody.');
+  });
+
+  it('keeps a run of list items in one block', () => {
+    expect(markdownToSpeech('- one\n- two')).toBe('one.\ntwo.');
+  });
+});
+
+describe('looksLikeMarkdown', () => {
+  it('recognises a document with several Markdown signals', () => {
+    expect(looksLikeMarkdown('# Title\n\n- a bullet\n- another')).toBe(true);
+  });
+
+  it('does not mistake prose for Markdown', () => {
+    expect(looksLikeMarkdown('Just a couple of ordinary sentences. Nothing special.')).toBe(
+      false
+    );
+  });
+
+  it('is false for empty input', () => {
+    expect(looksLikeMarkdown('')).toBe(false);
+  });
+});

--- a/packages/use-voice-control/test/read-aloud.test.ts
+++ b/packages/use-voice-control/test/read-aloud.test.ts
@@ -191,4 +191,38 @@ describe('ReadAloudController', () => {
       (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length
     ).toBeLessThanOrEqual(2);
   });
+  it('does not read Markdown marks out loud', async () => {
+    const spoken: string[] = [];
+    const controller = new ReadAloudController({
+      synthesize: async (text) => {
+        spoken.push(text);
+        return audioBlob();
+      },
+    });
+
+    await controller.speak('# Getting Started\n\nInstall the **package** first.');
+
+    expect(spoken.join(' ')).not.toMatch(/[#*]/);
+    expect(spoken.join(' ')).toContain('Getting Started.');
+    expect(spoken.join(' ')).toContain('Install the package first.');
+  });
+
+  it('leaves prose alone, and can be forced either way', async () => {
+    const spoken: string[] = [];
+    const synthesize = async (text: string) => {
+      spoken.push(text);
+      return audioBlob();
+    };
+
+    await new ReadAloudController({ synthesize }).speak('Two times three * four is not bold.');
+    expect(spoken[0]).toBe('Two times three * four is not bold.');
+
+    spoken.length = 0;
+    await new ReadAloudController({ synthesize, format: 'text' }).speak('# Not a heading');
+    expect(spoken[0]).toBe('# Not a heading');
+
+    spoken.length = 0;
+    await new ReadAloudController({ synthesize, format: 'markdown' }).speak('# A heading');
+    expect(spoken[0]).toBe('A heading.');
+  });
 });

--- a/packages/use-voice-control/test/wav.test.ts
+++ b/packages/use-voice-control/test/wav.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Tests for the WAV encoder used by the Node/CLI path: header
+ * fields, sample conversion, clamping, and joining separately synthesized chunks.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { concatSamples, encodeWav, wavDurationSeconds } from '../speech/utils/wav';
+
+const ascii = (view: DataView, offset: number, length: number): string =>
+  Array.from({ length }, (_, i) => String.fromCharCode(view.getUint8(offset + i))).join('');
+
+describe('encodeWav', () => {
+  it('writes a RIFF/WAVE header describing the audio', () => {
+    const buffer = encodeWav(new Float32Array(100), 24000);
+    const view = new DataView(buffer);
+
+    expect(ascii(view, 0, 4)).toBe('RIFF');
+    expect(ascii(view, 8, 4)).toBe('WAVE');
+    expect(ascii(view, 12, 4)).toBe('fmt ');
+    expect(ascii(view, 36, 4)).toBe('data');
+    expect(view.getUint16(20, true)).toBe(1); // PCM
+    expect(view.getUint16(22, true)).toBe(1); // mono
+    expect(view.getUint32(24, true)).toBe(24000); // sample rate
+    expect(view.getUint32(28, true)).toBe(48000); // byte rate
+    expect(view.getUint16(34, true)).toBe(16); // bits per sample
+  });
+
+  it('sizes the file as a 44-byte header plus 16-bit samples', () => {
+    const buffer = encodeWav(new Float32Array(10), 24000);
+    const view = new DataView(buffer);
+
+    expect(buffer.byteLength).toBe(44 + 20);
+    expect(view.getUint32(4, true)).toBe(36 + 20);
+    expect(view.getUint32(40, true)).toBe(20);
+  });
+
+  it('converts float samples to signed 16-bit values', () => {
+    const view = new DataView(encodeWav(Float32Array.from([0, 1, -1]), 24000));
+
+    expect(view.getInt16(44, true)).toBe(0);
+    expect(view.getInt16(46, true)).toBe(32767);
+    expect(view.getInt16(48, true)).toBe(-32768);
+  });
+
+  it('clamps overshoot instead of letting it wrap into a click', () => {
+    const view = new DataView(encodeWav(Float32Array.from([1.8, -2.4]), 24000));
+
+    expect(view.getInt16(44, true)).toBe(32767);
+    expect(view.getInt16(46, true)).toBe(-32768);
+  });
+
+  it('doubles the byte rate and block align for stereo', () => {
+    const view = new DataView(encodeWav(new Float32Array(4), 48000, 2));
+
+    expect(view.getUint32(28, true)).toBe(48000 * 2 * 2);
+    expect(view.getUint16(32, true)).toBe(4);
+  });
+});
+
+describe('concatSamples', () => {
+  it('joins chunks in order', () => {
+    const joined = concatSamples([Float32Array.from([1, 2]), Float32Array.from([3])]);
+
+    expect(Array.from(joined)).toEqual([1, 2, 3]);
+  });
+
+  it('inserts silence between chunks but not around them', () => {
+    const joined = concatSamples([Float32Array.from([1]), Float32Array.from([2])], 2);
+
+    expect(Array.from(joined)).toEqual([1, 0, 0, 2]);
+  });
+
+  it('returns an empty track for no chunks', () => {
+    expect(concatSamples([], 5).length).toBe(0);
+  });
+
+  it('adds no gap for a single chunk', () => {
+    expect(concatSamples([Float32Array.from([1, 2])], 10).length).toBe(2);
+  });
+});
+
+describe('wavDurationSeconds', () => {
+  it('reports the length of the track in seconds', () => {
+    expect(wavDurationSeconds(new Float32Array(48000), 24000)).toBe(2);
+  });
+
+  it('is zero rather than infinite for a missing sample rate', () => {
+    expect(wavDurationSeconds(new Float32Array(10), 0)).toBe(0);
+  });
+});

--- a/packages/use-voice-control/tsconfig.json
+++ b/packages/use-voice-control/tsconfig.json
@@ -12,7 +12,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": []
+    "types": ["node"]
   },
   "include": [
     "speech/index.ts",
@@ -20,6 +20,9 @@
     "speech/types",
     "speech/client",
     "speech/react",
+    "speech/node",
+    "speech/utils/markdown-to-speech.ts",
+    "speech/utils/wav.ts",
     "speech/utils/semantic-split.d.ts",
     "speech/utils/sentence-detector.d.ts",
     "vite.config.ts"

--- a/packages/use-voice-control/vite.config.ts
+++ b/packages/use-voice-control/vite.config.ts
@@ -6,7 +6,9 @@ import dts from "vite-plugin-dts";
 // Library build for the published entry points. The source lives under `speech/`:
 // `speech/index.ts` is the server-side TTS API (`generateSpeech` + types),
 // `speech/client` the framework-agnostic browser engines (read-aloud playback,
-// live dictation), and `speech/react` the hooks and overlay that wrap them.
+// live dictation), `speech/react` the hooks and overlay that wrap them, and
+// `speech/node` the document-to-audio renderer behind the `use-voice-control`
+// command (`bin/use-voice-control.mjs` loads the `cli` entry built here).
 export default defineConfig({
   plugins: [
     react(),
@@ -17,6 +19,9 @@ export default defineConfig({
         "speech/types",
         "speech/client",
         "speech/react",
+        "speech/node",
+        "speech/utils/markdown-to-speech.ts",
+        "speech/utils/wav.ts",
         "speech/utils/*.d.ts",
       ],
     }),
@@ -33,6 +38,9 @@ export default defineConfig({
         index: resolve(__dirname, "speech/index.ts"),
         client: resolve(__dirname, "speech/client/index.ts"),
         react: resolve(__dirname, "speech/react/index.ts"),
+        node: resolve(__dirname, "speech/node/index.ts"),
+        markdown: resolve(__dirname, "speech/utils/markdown-to-speech.ts"),
+        cli: resolve(__dirname, "speech/node/cli.ts"),
       },
       formats: ["es"],
       fileName: (_format, entryName) => `${entryName}.js`,
@@ -40,6 +48,10 @@ export default defineConfig({
     rollupOptions: {
       // Keep runtime/optional peers out of the bundle so consumers provide them.
       external: [
+        // Node builtins are only reached from the `node`/`cli` entries.
+        /^node:/,
+        // Runs the Kokoro model locally; never wanted in a browser bundle.
+        "kokoro-js",
         "react",
         "react-dom",
         "react/jsx-runtime",

--- a/packages/use-voice-control/vitest.config.ts
+++ b/packages/use-voice-control/vitest.config.ts
@@ -14,9 +14,14 @@ export default defineConfig({
       // phonemize.js is deliberately absent: it imports espeak-ng from a
       // jsDelivr URL at module scope, so it cannot be loaded outside a browser.
       include: [
+        'speech/node/cli.ts',
+        'speech/node/document.ts',
+        'speech/node/render.ts',
         'speech/utils/audio-utils.js',
+        'speech/utils/markdown-to-speech.ts',
         'speech/utils/semantic-split.js',
         'speech/utils/sentence-detector.js',
+        'speech/utils/wav.ts',
       ],
       exclude: ['node_modules/**', 'dist/**', '**/*.test.js', '**/*.test.ts'],
     },


### PR DESCRIPTION
## Summary

This PR adds a complete command-line interface and Node.js API for converting Markdown and text documents to speech using the Kokoro TTS model. Users can now read files aloud directly from the terminal without writing any code, while developers can integrate document synthesis into their Node.js applications.

## Key Changes

- **Command-line tool** (`speech/node/cli.ts`): Full-featured CLI with argument parsing, support for files/stdin/`--text`, voice selection, speed control, and Markdown-specific options. Includes help text, version info, and voice listing.

- **Markdown-to-speech converter** (`speech/utils/markdown-to-speech.ts`): Dependency-free module that converts Markdown to speakable text by removing formatting marks while preserving document structure. Headings become separate spoken segments, code blocks are announced, links keep their text, and tables are read row-by-row. Runs in both Node and browser.

- **Node.js document handling** (`speech/node/document.ts`): Loads documents from disk or stdin, auto-detects format from extension or content, and converts to speakable text using the Markdown converter.

- **Document rendering** (`speech/node/render.ts`): Orchestrates synthesis by resolving output paths, calling the synthesizer, and writing WAV files to disk or stdout.

- **Kokoro Node integration** (`speech/core/kokoro-node.ts`): Wraps `kokoro-js` for local CPU synthesis with smart text chunking on sentence/paragraph boundaries, configurable quantization (fp32/fp16/q8/q4/q4f16), and progress callbacks.

- **WAV encoding** (`speech/utils/wav.ts`): Minimal RIFF/WAV encoder for Float32 PCM samples, with support for joining separately synthesized chunks with silence gaps.

- **Node entry point** (`speech/node/index.ts`): Public API exporting document loading, rendering, CLI, and Kokoro synthesis functions.

- **CLI launcher** (`bin/use-voice-control.mjs`): Executable shebang script for the `npx use-voice-control` command.

- **Comprehensive tests**: Full test coverage for argument parsing, document format detection, Markdown conversion, WAV encoding, and end-to-end CLI execution.

- **Documentation**: Updated README with CLI usage examples, common commands, and option reference.

## Notable Implementation Details

- **Pure argument parsing**: `parseArgs()` is a pure function with no side effects, making it fully testable without I/O.

- **Injected effects**: The CLI accepts a `CliIO` interface for logging, error reporting, synthesis, and stdin reading, enabling comprehensive testing without downloading the 90 MB model.

- **Markdown structure preservation**: The converter removes formatting marks while keeping the semantic structure—headings trigger pauses, lists become individual segments, code blocks are announced rather than spelled out.

- **Smart text chunking**: Long documents are split on sentence and paragraph boundaries before synthesis to respect Kokoro's limited context window, with configurable silence gaps between chunks.

- **Shared utilities**: The Markdown converter is dependency-free and runs in both Node and browser, allowing `ReadAloudController` and the CLI to share the same conversion logic.

- **Local synthesis**: All processing happens on the CPU via `kokoro-js`—no text leaves the machine. The first run downloads weights (~90 MB at default q8) into the Hugging Face cache; subsequent runs are offline.

https://claude.ai/code/session_01SD7hD8qepgsoMZvTXYuMTx