### PR TITLE
Fix line endings and add editor state binding validation

### DIFF
--- a/packages/reason-editor/src/editor/useReasonDocsState.ts
+++ b/packages/reason-editor/src/editor/useReasonDocsState.ts
@@ -469,7 +469,7 @@ export function useReasonDocsState(openFilesSidebarSignal?: number | string) {
     setLeftPanels((prev) =>
       prev.includes("openTabs") ? prev : [...prev, "openTabs"],
     );
-    setLeftSplit(true);
+    // No split flag to set: two or more panels already render as a split.
     // Runs once on mount only.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/reason-editor/test/editor-state-bindings.test.ts
+++ b/packages/reason-editor/test/editor-state-bindings.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Guards the editor shell against calling a state setter that no longer
+ * exists.
+ *
+ * `useReasonDocsState` holds the workspace's UI state, and its setters are
+ * plain locals — nothing type-checks this package before it ships, because
+ * the library builds through Vite/esbuild, which transpiles without running
+ * `tsc`. So when the `leftSplit`/`rightSplit` flags were dropped in favour of
+ * inferring a split from the panel list, a leftover `setLeftSplit(true)` in a
+ * mount effect survived the build and threw `ReferenceError: setLeftSplit is
+ * not defined` on first render, taking the whole workspace tree down with it.
+ *
+ * The check is deliberately textual rather than a render test: the failure is
+ * a dangling identifier, and every `setSomething(...)` call in these modules
+ * has to resolve to a binding declared in the same file (a `useState` /
+ * `useLocalStorage` tuple, a destructured prop, a parameter) or to a browser
+ * global. Setters reached through an object — `state.setSplitViewDocId(...)`
+ * — are somebody else's contract and are left alone.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const EDITOR_DIR = path.resolve(import.meta.dirname, '../src/editor');
+
+/** Timer setters that are ambient globals, not module-local bindings. */
+const GLOBAL_SETTERS = new Set(['setTimeout', 'setInterval', 'setImmediate']);
+
+/** A bare (non-member) `setX` identifier reference. */
+const SETTER_REFERENCE = /(?<![.\w$])(set[A-Z]\w*)/g;
+
+/**
+ * Blanks out comments and string/template literals so identifiers mentioned
+ * in prose or in a storage key are not mistaken for code.
+ */
+function stripCommentsAndStrings(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '')
+    .replace(/`(?:\\.|[^`\\])*`/g, '``')
+    .replace(/'(?:\\.|[^'\\])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\])*"/g, '""');
+}
+
+/**
+ * Returns the setter names a module calls without ever declaring them.
+ *
+ * A name that appears somewhere other than immediately before `(` — as the
+ * second half of a `useState` tuple, in a returned object, in a parameter
+ * list — counts as declared; a name that only ever appears as a call is a
+ * dangling reference.
+ */
+function unresolvedSetters(source: string): string[] {
+  const code = stripCommentsAndStrings(source);
+  const followers = new Map<string, Set<string>>();
+
+  for (const match of code.matchAll(SETTER_REFERENCE)) {
+    const name = match[1];
+    const next = code.slice(match.index + match[0].length).trimStart().slice(0, 1);
+    const seen = followers.get(name) ?? new Set<string>();
+    seen.add(next);
+    followers.set(name, seen);
+  }
+
+  const unresolved: string[] = [];
+  for (const [name, seen] of followers) {
+    const isCalled = seen.has('(');
+    const isDeclared = [...seen].some((follower) => follower !== '(');
+    if (isCalled && !isDeclared && !GLOBAL_SETTERS.has(name)) unresolved.push(name);
+  }
+  return unresolved.sort();
+}
+
+const editorModules = fs
+  .readdirSync(EDITOR_DIR)
+  .filter((name) => name.endsWith('.ts') || name.endsWith('.tsx'));
+
+describe('editor state setters', () => {
+  it('finds modules to check', () => {
+    expect(editorModules).toContain('useReasonDocsState.ts');
+  });
+
+  it.each(editorModules)('%s calls only setters it declares', (name) => {
+    const source = fs.readFileSync(path.join(EDITOR_DIR, name), 'utf8');
+
+    expect(unresolvedSetters(source)).toEqual([]);
+  });
+
+  it('catches a setter left behind by a removed state hook', () => {
+    const withDanglingSetter = `
+      const [leftPanels, setLeftPanels] = useLocalStorage("panels", []);
+      useEffect(() => {
+        setLeftPanels(["openTabs"]);
+        setLeftSplit(true);
+      }, []);
+    `;
+
+    expect(unresolvedSetters(withDanglingSetter)).toEqual(['setLeftSplit']);
+  });
+});


### PR DESCRIPTION
## Summary
This PR normalizes line endings in `useReasonDocsState.ts` from CRLF to LF and adds a new test suite to prevent dangling state setter references that could cause runtime errors.

## Key Changes

- **Line ending normalization**: Converted `useReasonDocsState.ts` from CRLF to LF line endings for consistency with the rest of the codebase
- **Removed dangling state setter call**: Eliminated a leftover `setLeftSplit(true)` call in the mount effect that was referencing a non-existent state setter (the split view is now inferred from the panel list rather than a dedicated flag)
- **Added editor state binding validation test**: Created `editor-state-bindings.test.ts` to catch future instances of dangling setter references before they ship

## Implementation Details

The new test suite uses textual analysis to detect bare `setX` identifier references that aren't declared in the same module. This catches issues like the `setLeftSplit` bug that survived the build process because Vite/esbuild transpiles without running TypeScript type checking. The test explicitly allows:
- Global timer setters (`setTimeout`, `setInterval`, `setImmediate`)
- Member access patterns (`state.setSomething()`)
- Declarations in useState/useLocalStorage tuples, parameters, or returned objects

This prevents a class of runtime errors where a state setter is removed but a call to it remains, causing `ReferenceError` on first render.

https://claude.ai/code/session_0167t2QV43TvnPPAkm4SkNxW