### PR TITLE
Fix login page sign-in failures and use the brand logo

### DIFF
--- a/apps/qwksearch-web/app/layout.tsx
+++ b/apps/qwksearch-web/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     "Search, extract, vectorize, outline graph, and monitor the web for a topic",
   icons: {
     icon: '/favicon.ico',
-    apple: '/icons/apple-touch-icon.png'
+    apple: '/apple-touch-icon.png'
   },
   manifest: "/manifest.webmanifest",
 };

--- a/apps/qwksearch-web/components/layout/LoginPage.tsx
+++ b/apps/qwksearch-web/components/layout/LoginPage.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import Image from "next/image"
 import Link from "next/link"
 import { Mail } from "lucide-react"
 import { FaGoogle, FaDiscord, FaFacebook, FaLinkedin } from 'react-icons/fa'
@@ -14,6 +13,35 @@ import { Label } from "@/components/ui/label"
 import { authClient } from "@/lib/auth/client"
 import { config } from "@/lib/config/site"
 
+/**
+ * Brand mark shown above the sign-in form. Served from an external host, so it
+ * uses a plain <img> rather than next/image: the Worker's image optimizer only
+ * proxies assets out of the local ASSETS bundle (see worker/index.ts), which is
+ * why the previous "/icons/apple-touch-icon.png" — a path that does not exist,
+ * the file lives at "/apple-touch-icon.png" — came back as a 404.
+ */
+const LOGO_URL = "https://i.imgur.com/VRrWzUG.png"
+
+/**
+ * Turns a better-auth client error into something a signed-out visitor can act
+ * on. A 403 here is the origin check rejecting the request, which means the
+ * host the app is being served from is not in the backend's trustedOrigins.
+ */
+function describeAuthError(
+    error: { message?: string; status?: number; statusText?: string } | null,
+    label: string,
+): string {
+    if (error?.status === 403) {
+        return `${label} sign-in was rejected by the server for this domain (${
+            typeof window !== "undefined" ? window.location.origin : "this origin"
+        }). Add it to BETTER_AUTH_TRUSTED_ORIGINS.`
+    }
+    if (error?.status === 404) {
+        return `${label} sign-in is not configured on the server.`
+    }
+    return error?.message || error?.statusText || `${label} sign-in failed. Please try again.`
+}
+
 // Google Sign In Button
 function GoogleSignIn() {
     const [isLoading, setIsLoading] = useState(false)
@@ -21,10 +49,18 @@ function GoogleSignIn() {
     const handleSignIn = async () => {
         setIsLoading(true)
         try {
-            await authClient.signIn.social({
+            // better-auth's client resolves with `{ data, error }` instead of
+            // rejecting, so a failed sign-in has to be read off `error` — a
+            // bare try/catch silently swallowed every failure and left the
+            // button doing nothing at all.
+            const { error } = await authClient.signIn.social({
                 provider: "google",
                 callbackURL: "/",
             })
+            if (error) {
+                console.error("Google sign-in error:", error)
+                toast.error(describeAuthError(error, "Google"))
+            }
         } catch (error: any) {
             console.error("Google sign-in error:", error)
             toast.error(error?.message ?? "Failed to sign in with Google. Provider may not be configured.")
@@ -54,16 +90,21 @@ interface OAuthSignInProps {
 function OAuthSignIn({ provider }: OAuthSignInProps) {
     const [isLoading, setIsLoading] = useState(false)
 
+    const providerName = provider.charAt(0).toUpperCase() + provider.slice(1)
+
     const handleSignIn = async () => {
         setIsLoading(true)
         try {
-            await authClient.signIn.social({
+            const { error } = await authClient.signIn.social({
                 provider,
                 callbackURL: "/",
             })
+            if (error) {
+                console.error(`${provider} sign-in error:`, error)
+                toast.error(describeAuthError(error, providerName))
+            }
         } catch (error: any) {
             console.error(`${provider} sign-in error:`, error)
-            const providerName = provider.charAt(0).toUpperCase() + provider.slice(1)
             toast.error(error?.message ?? `${providerName} sign-in is not configured. Please use magic link or contact support.`)
         } finally {
             setIsLoading(false)
@@ -78,9 +119,7 @@ function OAuthSignIn({ provider }: OAuthSignInProps) {
         }
     }
 
-    const getLabel = () => {
-        return provider.charAt(0).toUpperCase() + provider.slice(1)
-    }
+    const getLabel = () => providerName
 
     return (
         <Button
@@ -106,10 +145,17 @@ function MagicLinkSignIn() {
         setIsLoading(true)
 
         try {
-            await authClient.signIn.magicLink({
+            // Same `{ data, error }` contract as the social providers: without
+            // this check a rejected request still showed "Magic link sent!".
+            const { error } = await authClient.signIn.magicLink({
                 email,
                 callbackURL: "/",
             })
+            if (error) {
+                console.error("Magic link error:", error)
+                toast.error(describeAuthError(error, "Magic link"))
+                return
+            }
             setEmailSent(true)
             toast.success("Magic link sent! Check your email (or console in dev mode).")
         } catch (error) {
@@ -205,18 +251,13 @@ export default function LoginPage() {
         <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted p-4">
             <Card className="w-full max-w-md">
                 <CardHeader className="flex flex-col items-center gap-4">
-                    <div className="flex items-center gap-2">
-                        <div className="flex h-10 w-10 items-center justify-center rounded-lg overflow-hidden">
-                            <Image
-                                src="/icons/apple-touch-icon.png"
-                                alt="Logo"
-                                width={40}
-                                height={40}
-                                className="h-full w-full object-cover"
-                            />
-                        </div>
-                        <span className="text-2xl font-bold">{config.appName}</span>
-                    </div>
+                    <img
+                        src={LOGO_URL}
+                        alt={config.appName}
+                        width={160}
+                        height={160}
+                        className="h-20 w-auto object-contain"
+                    />
                     <div className="text-center">
                         <p className="text-sm text-muted-foreground">
                             {hasOAuthProviders ? "Sign in to continue" : "Sign in with email"}

--- a/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
+++ b/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
@@ -45,4 +45,58 @@ describe("auth configuration", () => {
       }),
     );
   });
+
+  describe("trustedOrigins", () => {
+    const resolveOrigins = async (requestUrl: string) => {
+      // initAuth memoizes its instance at module scope, so the config has to be
+      // rebuilt to observe a fresh betterAuth() call.
+      vi.resetModules();
+      const { initAuth } = await import("../index");
+      await initAuth();
+      const { trustedOrigins } = betterAuthMock.mock.calls.at(-1)![0];
+      return trustedOrigins(new Request(requestUrl, { method: "POST" }));
+    };
+
+    it("trusts the origin the request was actually served from", async () => {
+      // better-auth answers a sign-in POST from an untrusted origin with a 403,
+      // so a deploy on a host nobody listed at build time (workers.dev,
+      // preview URLs, a dev server on another port) could never sign in.
+      expect(await resolveOrigins("https://qwksearch.pages.dev/api/auth/sign-in/social"))
+        .toContain("https://qwksearch.pages.dev");
+      expect(await resolveOrigins("http://localhost:4321/api/auth/sign-in/social"))
+        .toContain("http://localhost:4321");
+    });
+
+    it("keeps the statically configured origins", async () => {
+      const origins = await resolveOrigins("https://qwksearch.com/api/auth/sign-in/social");
+
+      expect(origins).toEqual(
+        expect.arrayContaining([
+          "https://qwksearch.com",
+          "https://*.qwksearch.com",
+          "http://localhost:3000",
+        ]),
+      );
+    });
+
+    it("normalizes configured origins to bare origins", async () => {
+      // Non-wildcard entries are compared by exact string equality, so a
+      // trailing slash or path would silently never match.
+      vi.stubEnv(
+        "BETTER_AUTH_TRUSTED_ORIGINS",
+        " https://staging.example.com/ ,https://app.example.com/dashboard",
+      );
+
+      const origins = await resolveOrigins("https://qwksearch.com/api/auth/sign-in/social");
+
+      expect(origins).toEqual(
+        expect.arrayContaining([
+          "https://staging.example.com",
+          "https://app.example.com",
+        ]),
+      );
+
+      vi.unstubAllEnvs();
+    });
+  });
 });

--- a/apps/qwksearch-web/lib/auth/index.ts
+++ b/apps/qwksearch-web/lib/auth/index.ts
@@ -19,6 +19,34 @@ export interface Env {
   };
 }
 
+/**
+ * Reduces a configured entry to the bare origin better-auth compares against.
+ * Non-wildcard entries are matched by exact string equality with the request's
+ * origin, so a stray trailing slash or path (`https://qwksearch.com/`) would
+ * silently never match. Wildcard patterns are passed through untouched — they
+ * are glob-matched, not parsed as URLs.
+ */
+function normalizeTrustedOrigin(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.includes("*") || trimmed.includes("?")) return trimmed;
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return trimmed.replace(/\/+$/, "");
+  }
+}
+
+/** The origin this request was actually addressed to, or undefined if unparseable. */
+function originOfRequest(request: Request | undefined): string | undefined {
+  if (!request?.url) return undefined;
+  try {
+    return new URL(request.url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 async function authBuilder() {
   const db = getDB();
 
@@ -52,7 +80,7 @@ async function authBuilder() {
   // and omits the CORS headers, which surfaced as a blocked preflight when
   // signing in from beta.qwksearch.com. Extra origins can be supplied via the
   // BETTER_AUTH_TRUSTED_ORIGINS env var (comma-separated).
-  const trustedOrigins = Array.from(
+  const staticTrustedOrigins = Array.from(
     new Set(
       [
         config.baseUrl,
@@ -61,14 +89,25 @@ async function authBuilder() {
         "http://localhost:3000",
         ...(process.env.BETTER_AUTH_TRUSTED_ORIGINS?.split(",") ?? []),
       ]
-        .map((origin) => origin?.trim())
+        .map(normalizeTrustedOrigin)
         .filter((origin): origin is string => Boolean(origin)),
     ),
   );
 
   return betterAuth({
     baseURL: config.baseUrl || "http://localhost:3000",
-    trustedOrigins,
+    // Resolved per request so the origin the app is actually being served from
+    // is always trusted. The static list can only ever name hosts known at
+    // build time, so any other one (a *.workers.dev deploy, a preview URL, a
+    // dev server on a port other than 3000, an apex/`www.` variant) had its
+    // POST /api/auth/sign-in/social rejected with a 403 by better-auth's
+    // origin check, which is what broke the login page. Echoing the request's
+    // own origin does not weaken CSRF protection: a cross-site request carries
+    // the attacker's `Origin` header, never this host's, so it still fails.
+    trustedOrigins: (request: Request) => {
+      const self = originOfRequest(request);
+      return self ? [...staticTrustedOrigins, self] : staticTrustedOrigins;
+    },
     database: drizzleAdapter(db, {
       provider: "sqlite",
       schema,

--- a/apps/qwksearch-web/lib/config/site.ts
+++ b/apps/qwksearch-web/lib/config/site.ts
@@ -41,7 +41,7 @@ export const listFooterLinks: FooterLink[] = [
   //   icon: "HelpCircle",
   // },
   {
-    url: "https://www.linkedin.com/company/104158840/admin/page-posts/published/",
+    url: "https://www.linkedin.com/company/qwksearch/posts/",
     text: "Blog",
     icon: "Newspaper",
   },


### PR DESCRIPTION
The login page was failing in two independent ways.

**403 on POST /api/auth/sign-in/social.** better-auth's origin check rejects any request whose `Origin` is not in `trustedOrigins`, and that list could only ever name hosts known at build time (the apex, the `*.qwksearch.com` wildcard, and localhost:3000). Every other host the app is actually served from — a `*.workers.dev` deploy, a preview URL, a dev server on another port — got a 403 before the request ever reached Google. `trustedOrigins` is now resolved per request and always includes the origin the request was addressed to. That does not weaken CSRF protection: a cross-site request carries the attacker's `Origin`, never this host's, so it still fails the check. Configured entries are also normalized to bare origins, since non-wildcard entries are compared by exact string equality and a trailing slash would silently never match.

**Every failure was silent.** better-auth's client resolves with `{ data, error }` rather than rejecting, so the `try/catch` around each sign-in call never fired: the Google/Discord/LinkedIn buttons just re-enabled themselves with no toast, and the magic-link form reported "Magic link sent!" even when the request had failed. All three paths now read `error` and surface it, with a message naming the offending origin for the 403 case.

Also replaces the login header's logo — it pointed at `/icons/apple-touch-icon.png`, a path that does not exist (the file is at `/apple-touch-icon.png`), which is the 404 in the console — with the brand mark, and drops the app-name text beside it. It is a plain `<img>` rather than `next/image` because the Worker's image optimizer only proxies assets out of the local ASSETS bundle. The same broken icon path in the root layout's metadata is corrected too.

Finally, points the footer's Blog link at the public LinkedIn posts page instead of the admin-only published-posts view.


Claude-Session: https://claude.ai/code/session_018gpUTkkBeD3dmrjJbwAA4H