### PR TITLE
feat(sidebar): move file-tree actions into the Files panel header

### DIFF
--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -258,6 +258,9 @@ export const Sidebar = ({
     topicsProps,
     tabItems,
     onNewChat,
+    onFileManagerOpen: () => setIsFileManagerOpen(true),
+    deletedDocs,
+    onRestore,
   };
 
   const footerProps = {

--- a/packages/reason-editor-sidebar/src/SidebarContent.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarContent.tsx
@@ -5,6 +5,8 @@
  * vertically — Open Tabs always above the Files tree — in a resizable split
  * inferred whenever two or more panels are active, matching whatever
  * `panels` list the {@link SidebarViewMenu} has configured for that side.
+ * The "Open Tabs" and "Files" panels each carry their own header strip of
+ * quick actions (new file/chat, new folder, trash, file manager).
  */
 import { RefObject, useState, useCallback, useMemo, useRef } from 'react';
 import type { OutlineViewHandle } from './search/OutlineView';
@@ -27,9 +29,16 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from './app-ui/context-menu';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from './app-ui/dropdown-menu';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
-import { X, XCircle, ArrowDownFromLine, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
+import { X, XCircle, ArrowDownFromLine, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, FolderPlus, Folders, Trash2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
 import './split-pane.css';
 
 import type { DocumentTreeHandle } from './file-tree/filetree';
@@ -80,6 +89,9 @@ export const SidebarContent = ({
   topicsProps,
   tabItems,
   onNewChat,
+  onFileManagerOpen,
+  deletedDocs = [],
+  onRestore,
 }: SidebarContentProps) => {
   // Track copied document for copy/paste operations
   const [copiedDocId, setCopiedDocId] = useState<string | null>(null);
@@ -291,8 +303,77 @@ export const SidebarContent = ({
     </div>
   );
 
+  /** Compact icon button used by the panel headers (matches the Open Tabs header). */
+  const panelHeaderButtonClass =
+    'h-5 w-5 flex items-center justify-center rounded text-muted-foreground hover:bg-sidebar-accent hover:text-foreground';
+
   const renderFiles = () => (
     <div className="h-full overflow-auto">
+      <div className="flex items-center justify-between px-3 py-1">
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">Files</p>
+        <div className="flex items-center gap-0.5">
+          <button
+            className={panelHeaderButtonClass}
+            title="New File"
+            onClick={() => onAdd(activeId, false)}
+          >
+            <FilePlus2 className="h-3.5 w-3.5" />
+          </button>
+          <button
+            className={panelHeaderButtonClass}
+            title="New Folder"
+            onClick={() => onAdd(activeId, true)}
+          >
+            <FolderPlus className="h-3.5 w-3.5" />
+          </button>
+          {onRestore && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className={panelHeaderButtonClass} title="Trash">
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-56">
+                {deletedDocs.length > 0 ? (
+                  <>
+                    {deletedDocs.slice(0, 5).map((doc) => (
+                      <DropdownMenuItem
+                        key={doc.id}
+                        className="flex items-center justify-between"
+                        onClick={() => onRestore?.(doc.id)}
+                      >
+                        <span className="truncate flex-1">{doc.title || 'Untitled'}</span>
+                        <RotateCcw className="h-3 w-3 ml-2 opacity-60" />
+                      </DropdownMenuItem>
+                    ))}
+                    {deletedDocs.length > 5 && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem disabled className="text-xs text-center">
+                          {deletedDocs.length - 5} more in trash...
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </>
+                ) : (
+                  <DropdownMenuItem disabled className="text-center text-muted-foreground">
+                    Trash is empty
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          {onFileManagerOpen && (
+            <button
+              className={panelHeaderButtonClass}
+              title="File Manager"
+              onClick={onFileManagerOpen}
+            >
+              <Folders className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
       <FileTree
         ref={effectiveTreeRef}
         documents={activeDocuments}

--- a/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
@@ -2,7 +2,9 @@
  * @module SidebarToolbar
  * @description Compact icon toolbar rendered at the top of the sidebar. Shows
  * context-sensitive controls based on `leftPanels`: file-source switcher, search,
- * file manager, new file/folder, and expand/collapse buttons.
+ * and expand/collapse buttons. The file-tree actions (new file/folder, trash,
+ * file manager) render here only when the "Files" panel — which hosts them in
+ * its own header — is hidden.
  */
 import { RefObject } from 'react';
 import type { AnyFileSource } from './app-types/fileSource';
@@ -133,6 +135,10 @@ export const SidebarToolbar = ({
   documents = [],
   tabItems,
 }: SidebarToolbarProps) => {
+  // File-tree actions (new file/folder, trash, file manager) live in the
+  // "Files" panel header when that panel is on screen, so the toolbar only
+  // offers them as a fallback when the tree isn't visible.
+  const filesPanelVisible = leftPanels.includes('files');
   const getDocTitle = (id: string) => documents.find(d => d.id === id)?.title || 'Untitled';
   const resolvedTabItems: OpenTabItem[] = tabItems ?? openTabs.map((tabId) => ({
     id: tabId,
@@ -217,53 +223,57 @@ export const SidebarToolbar = ({
                 </TooltipContent>
               </Tooltip>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={onFileManagerOpen}
-                    className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                  >
-                    <Folders className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p>File Manager</p>
-                </TooltipContent>
-              </Tooltip>
+              {!filesPanelVisible && (
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={onFileManagerOpen}
+                        className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                      >
+                        <Folders className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>File Manager</p>
+                    </TooltipContent>
+                  </Tooltip>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onAdd(activeId, false)}
-                    className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                  >
-                    <FilePlus className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p>New File</p>
-                </TooltipContent>
-              </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onAdd(activeId, false)}
+                        className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                      >
+                        <FilePlus className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>New File</p>
+                    </TooltipContent>
+                  </Tooltip>
 
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onAdd(activeId, true)}
-                    className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                  >
-                    <FolderPlus className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  <p>New Folder</p>
-                </TooltipContent>
-              </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onAdd(activeId, true)}
+                        className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                      >
+                        <FolderPlus className="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>New Folder</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </>
+              )}
 
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -286,52 +296,54 @@ export const SidebarToolbar = ({
               </Tooltip>
 
               {/* Trash Dropdown */}
-              <DropdownMenu>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">
-                    <p>Trash</p>
-                  </TooltipContent>
-                </Tooltip>
-                <DropdownMenuContent align="end" className="w-56">
-                  {deletedDocs.length > 0 ? (
-                    <>
-                      {deletedDocs.slice(0, 5).map((doc) => (
-                        <DropdownMenuItem
-                          key={doc.id}
-                          className="flex items-center justify-between"
-                          onClick={() => onRestore?.(doc.id)}
+              {!filesPanelVisible && (
+                <DropdownMenu>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
                         >
-                          <span className="truncate flex-1">{doc.title || 'Untitled'}</span>
-                          <RotateCcw className="h-3 w-3 ml-2 opacity-60" />
-                        </DropdownMenuItem>
-                      ))}
-                      {deletedDocs.length > 5 && (
-                        <>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem disabled className="text-xs text-center">
-                            {deletedDocs.length - 5} more in trash...
+                          <Trash2 className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">
+                      <p>Trash</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <DropdownMenuContent align="end" className="w-56">
+                    {deletedDocs.length > 0 ? (
+                      <>
+                        {deletedDocs.slice(0, 5).map((doc) => (
+                          <DropdownMenuItem
+                            key={doc.id}
+                            className="flex items-center justify-between"
+                            onClick={() => onRestore?.(doc.id)}
+                          >
+                            <span className="truncate flex-1">{doc.title || 'Untitled'}</span>
+                            <RotateCcw className="h-3 w-3 ml-2 opacity-60" />
                           </DropdownMenuItem>
-                        </>
-                      )}
-                    </>
-                  ) : (
-                    <DropdownMenuItem disabled className="text-center text-muted-foreground">
-                      Trash is empty
-                    </DropdownMenuItem>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                        ))}
+                        {deletedDocs.length > 5 && (
+                          <>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem disabled className="text-xs text-center">
+                              {deletedDocs.length - 5} more in trash...
+                            </DropdownMenuItem>
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      <DropdownMenuItem disabled className="text-center text-muted-foreground">
+                        Trash is empty
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
 
               {/* All Tabs Dropdown */}
               {resolvedTabItems.length > 0 && onTabChange && (

--- a/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
+++ b/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
@@ -220,4 +220,10 @@ export interface SidebarContentProps {
   tabItems?: OpenTabItem[];
   /** Opens a new chat tab from the "Open Tabs" panel header. */
   onNewChat?: () => void;
+  /** Opens the file manager modal from the "Files" panel header. */
+  onFileManagerOpen?: () => void;
+  /** Soft-deleted documents listed in the "Files" panel header trash menu. */
+  deletedDocs?: Document[];
+  /** Restores a soft-deleted document by ID (from the trash menu). */
+  onRestore?: (id: string) => void;
 }


### PR DESCRIPTION
The Files panel had no header of its own, so its actions lived in the sidebar's top toolbar, far from the tree they act on. Give it a header strip matching the Open Tabs one, carrying New File, New Folder, Trash, and File Manager.

The top toolbar keeps those buttons only when the Files panel is hidden, so the actions stay reachable when the tree isn't on screen. The trash menu renders only when an onRestore handler is supplied, keeping it out of the right panel where restoring isn't wired up.


Claude-Session: https://claude.ai/code/session_013A15ymymbD59cMafcatAuj