### PR TITLE
Extract file tree expansion logic into pure helpers

### DIFF
--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -3,8 +3,9 @@
  * @description Mobile-aware sidebar shell. Renders the toolbar and content
  * inside a Sheet on mobile and directly in the layout on desktop.
  */
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import type { DocumentTreeHandle } from './file-tree/filetree';
+import { expandToggleLabelFor, nextExpandLevel } from './file-tree/expandLevels';
 import type { OutlineViewHandle } from './search/OutlineView';
 import type { AnyFileSource } from './app-types/fileSource';
 import type { SidebarProps } from './layout/sidebar/types';
@@ -69,41 +70,20 @@ export const Sidebar = ({
 
   const activeDocuments = useMemo(() => documents.filter(doc => !doc.isDeleted), [documents]);
 
-  // Display level for the expand-all button's tooltip: 0 = collapsed, then
-  // 1, 2, 3... one folder level at a time, up to the deepest nesting level,
-  // before wrapping back to collapsed. The authoritative current level is
-  // inferred from the tree's actual expansion state on each click.
-  const [expandLevel, setExpandLevel] = useState(0);
-  // Deepest folder nesting level currently in the tree (1 = only top-level
-  // folders). A document counts as a folder when flagged as one OR when it
-  // has children — the tree itself promotes any document with children to a
-  // folder, so the button must count them the same way.
-  const maxExpandLevel = useMemo(() => {
-    const byId = new Map(activeDocuments.map((doc) => [doc.id, doc]));
-    const parentIds = new Set(
-      activeDocuments.map((doc) => doc.parentId).filter((id): id is string => !!id),
-    );
-    const isFolderLike = (doc: (typeof activeDocuments)[number]) =>
-      !!doc.isFolder || parentIds.has(doc.id);
-    let max = 0;
-    for (const doc of activeDocuments) {
-      if (!isFolderLike(doc)) continue;
-      let depth = 1;
-      let parentId = doc.parentId;
-      const seen = new Set<string>();
-      while (parentId && byId.has(parentId) && !seen.has(parentId)) {
-        seen.add(parentId);
-        depth++;
-        parentId = byId.get(parentId)?.parentId ?? null;
-      }
-      max = Math.max(max, depth);
-    }
-    return max;
-  }, [activeDocuments]);
-  // Clamp to the current max depth if folders were deleted/collapsed elsewhere.
-  useEffect(() => {
-    setExpandLevel((prev) => Math.min(prev, maxExpandLevel));
-  }, [maxExpandLevel]);
+  // Expansion depth of the file tree, reported by the tree itself: 0 =
+  // fully collapsed, then 1, 2, 3... one folder level at a time up to the
+  // deepest nesting level, before wrapping back to collapsed. Sourcing it
+  // from the tree (rather than counting clicks) keeps the button honest
+  // when folders are opened by hand or restored from persisted state.
+  const [expandState, setExpandState] = useState({ level: 0, maxLevel: 0 });
+  const handleExpandStateChange = useCallback(
+    (next: { level: number; maxLevel: number }) => {
+      setExpandState((prev) =>
+        prev.level === next.level && prev.maxLevel === next.maxLevel ? prev : next,
+      );
+    },
+    [],
+  );
   // Track expand/collapse all state for outline
   const [outlineExpanded, setOutlineExpanded] = useState(true);
   // Ref for file tree
@@ -138,32 +118,26 @@ export const Sidebar = ({
   };
 
   const handleToggleAllExpanded = () => {
-    if (maxExpandLevel === 0) return;
+    const tree = treeRef.current;
+    if (!tree) return;
     // Cycle from the level the tree is actually at (folders may have been
     // expanded/collapsed by hand since the last click), not from a stale
     // local counter.
-    const currentLevel = treeRef.current?.getExpandLevel?.() ?? expandLevel;
-    const nextLevel = currentLevel >= maxExpandLevel ? 0 : currentLevel + 1;
-    setExpandLevel(nextLevel);
-    if (treeRef.current) {
-      if (nextLevel === 0) {
-        treeRef.current.cancelExpand?.();
-        treeRef.current.collapseAll();
-      } else {
-        treeRef.current.expandToLevel(nextLevel);
-      }
+    const currentLevel = tree.getExpandLevel?.() ?? expandState.level;
+    const maxLevel = tree.getMaxExpandLevel?.() ?? expandState.maxLevel;
+    if (maxLevel === 0) return;
+    const nextLevel = nextExpandLevel(currentLevel, maxLevel);
+    if (nextLevel === 0) {
+      tree.cancelExpand?.();
+      tree.collapseAll();
+    } else {
+      tree.expandToLevel(nextLevel);
     }
   };
 
-  const isFullyExpanded = expandLevel > 0 && expandLevel >= maxExpandLevel;
-  const expandToggleLabel =
-    expandLevel === 0
-      ? maxExpandLevel > 1
-        ? 'Expand Level 1'
-        : 'Expand All'
-      : isFullyExpanded
-        ? 'Collapse All'
-        : `Expand Level ${expandLevel + 1}`;
+  const isFullyExpanded =
+    expandState.maxLevel > 0 && expandState.level >= expandState.maxLevel;
+  const expandToggleLabel = expandToggleLabelFor(expandState.level, expandState.maxLevel);
 
   const handleToggleOutlineExpanded = () => {
     const newState = !outlineExpanded;
@@ -226,6 +200,7 @@ export const Sidebar = ({
   };
 
   const contentProps = {
+    onExpandStateChange: handleExpandStateChange,
     panels: leftPanels,
     persistenceKey: 'left',
     activeDocuments,

--- a/packages/reason-editor-sidebar/src/SidebarContent.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarContent.tsx
@@ -73,6 +73,7 @@ export const SidebarContent = ({
   onRename,
   onOpenChange,
   treeRef,
+  onExpandStateChange,
   outlineRef,
   editorRef,
   openTabs = [],
@@ -377,6 +378,7 @@ export const SidebarContent = ({
       <FileTree
         ref={effectiveTreeRef}
         documents={activeDocuments}
+        onExpandStateChange={onExpandStateChange}
         activeId={activeId}
         onSelect={handleSelect}
         onMove={onMove}

--- a/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
@@ -61,7 +61,7 @@ interface SidebarToolbarProps {
   expandToggleLabel: string;
   /** Whether all outline entries are currently expanded. */
   outlineExpanded: boolean;
-  /** Toggles expand/collapse of all tree nodes. */
+  /** Steps the tree to its next expansion level (wraps to fully collapsed). */
   onToggleAllExpanded: () => void;
   /** Toggles expand/collapse of all outline entries. */
   onToggleOutlineExpanded: () => void;
@@ -281,12 +281,14 @@ export const SidebarToolbar = ({
                     variant="ghost"
                     size="sm"
                     onClick={onToggleAllExpanded}
+                    aria-label={expandToggleLabel}
                     className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
                   >
+                    {/* The icon shows the action the next click performs. */}
                     {allExpanded ? (
-                      <ChevronsUpDown className="h-4 w-4" />
-                    ) : (
                       <ChevronsDownUp className="h-4 w-4" />
+                    ) : (
+                      <ChevronsUpDown className="h-4 w-4" />
                     )}
                   </Button>
                 </TooltipTrigger>

--- a/packages/reason-editor-sidebar/src/file-tree/expandLevels.ts
+++ b/packages/reason-editor-sidebar/src/file-tree/expandLevels.ts
@@ -1,0 +1,91 @@
+/**
+ * @module file-tree/expandLevels
+ * @description Pure helpers behind the file tree's "expand one level at a
+ * time" cycle: which folders live at each nesting depth, how deep the tree
+ * is currently expanded, and which level a click should move to next.
+ */
+
+/** Minimal shape the level math needs from a tree item. */
+export interface FolderLikeItem {
+  children?: string[];
+  isFolder: boolean;
+}
+
+export type FolderItems = Record<string, FolderLikeItem>;
+
+/** Folder ids grouped by nesting depth (index 0 = top-level folders). */
+export function getFolderIdsByLevel(items: FolderItems, rootId: string): string[][] {
+  const levels: string[][] = [];
+  const seen = new Set<string>([rootId]);
+  let frontier = [rootId];
+
+  while (frontier.length > 0) {
+    const next: string[] = [];
+    for (const id of frontier) {
+      for (const childId of items[id]?.children ?? []) {
+        // Guard against cycles from malformed parent links.
+        if (seen.has(childId)) continue;
+        seen.add(childId);
+        if (items[childId]?.isFolder) next.push(childId);
+      }
+    }
+    if (next.length === 0) break;
+    levels.push(next);
+    frontier = next;
+  }
+
+  return levels;
+}
+
+/** Deepest folder nesting level in the tree (0 = no folders at all). */
+export function getMaxFolderLevel(items: FolderItems, rootId: string): number {
+  return getFolderIdsByLevel(items, rootId).length;
+}
+
+/** Folder ids reachable within `level` levels of nesting (1 = top-level folders). */
+export function getFolderIdsUpToLevel(
+  items: FolderItems,
+  rootId: string,
+  level: number,
+): string[] {
+  if (level <= 0) return [];
+  return getFolderIdsByLevel(items, rootId).slice(0, level).flat();
+}
+
+/**
+ * Infers the deepest folder level that is currently fully expanded: the
+ * largest depth `L` such that every folder at depth <= L is expanded.
+ * Returns 0 when any top-level folder is collapsed.
+ */
+export function getExpandedLevel(
+  items: FolderItems,
+  rootId: string,
+  expandedItems: readonly string[],
+): number {
+  const expanded = new Set(expandedItems);
+  let level = 0;
+  for (const idsAtDepth of getFolderIdsByLevel(items, rootId)) {
+    if (!idsAtDepth.every((id) => expanded.has(id))) break;
+    level++;
+  }
+  return level;
+}
+
+/**
+ * The level one click of the expand/collapse toggle should move to: one
+ * level deeper each time, wrapping back to fully collapsed once the
+ * deepest level is showing.
+ */
+export function nextExpandLevel(currentLevel: number, maxLevel: number): number {
+  if (maxLevel <= 0) return 0;
+  const level = Math.min(Math.max(currentLevel, 0), maxLevel);
+  return level >= maxLevel ? 0 : level + 1;
+}
+
+/** Tooltip text describing what the next click of the toggle will do. */
+export function expandToggleLabelFor(currentLevel: number, maxLevel: number): string {
+  if (maxLevel <= 0) return 'Expand All';
+  if (currentLevel >= maxLevel) return 'Collapse All';
+  if (currentLevel === 0 && maxLevel === 1) return 'Expand All';
+  return `Expand Level ${currentLevel + 1}`;
+}

--- a/packages/reason-editor-sidebar/src/file-tree/filetree.tsx
+++ b/packages/reason-editor-sidebar/src/file-tree/filetree.tsx
@@ -21,6 +21,11 @@ import { FileTypeIcon } from "../app-ui/FileTypeIcon";
 import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 
 import type { Document } from "../documents/DocumentTree";
+import {
+  getExpandedLevel,
+  getFolderIdsUpToLevel,
+  getMaxFolderLevel,
+} from "./expandLevels";
 
 export type DocumentTreeHandle = {
   collapseAll: () => void;
@@ -30,6 +35,8 @@ export type DocumentTreeHandle = {
   cancelExpand: () => void;
   /** Deepest folder level currently fully expanded (0 = fully collapsed). */
   getExpandLevel: () => number;
+  /** Deepest folder nesting level in the tree (0 = no folders at all). */
+  getMaxExpandLevel: () => number;
 };
 import { Tree, TreeDragLine, TreeItem, TreeItemLabel } from "../app-ui/tree";
 import {
@@ -73,51 +80,16 @@ interface FileTreeProps {
   onNewFile?: (parentId: string | null) => void;
   onNewFolder?: (parentId: string | null) => void;
   onManageTags?: (id: string) => void;
+  /**
+   * Reports the tree's live expansion depth so the toolbar's expand/collapse
+   * toggle can label its next step. Fires on mount, whenever the expanded
+   * depth or the tree's own depth changes, and with zeroes on unmount.
+   */
+  onExpandStateChange?: (state: { level: number; maxLevel: number }) => void;
 }
 
 const ROOT_ID = "__root__";
 const INDENT = 20;
-
-/** Folder ids grouped by nesting depth (index 0 = top-level folders). */
-function getFolderIdsByLevel(items: Record<string, FileTreeItem>): string[][] {
-  const levels: string[][] = [];
-  let frontier = [ROOT_ID];
-
-  while (frontier.length > 0) {
-    const next: string[] = [];
-    for (const id of frontier) {
-      for (const childId of items[id]?.children ?? []) {
-        if (items[childId]?.isFolder) next.push(childId);
-      }
-    }
-    if (next.length === 0) break;
-    levels.push(next);
-    frontier = next;
-  }
-
-  return levels;
-}
-
-/** Folder ids reachable within `level` levels of nesting (1 = top-level folders). */
-function getFolderIdsUpToLevel(items: Record<string, FileTreeItem>, level: number): string[] {
-  if (level <= 0) return [];
-  return getFolderIdsByLevel(items).slice(0, level).flat();
-}
-
-/**
- * Infers the deepest folder level that is currently fully expanded: the
- * largest depth `L` such that every folder at depth <= L is expanded.
- * Returns 0 when any top-level folder is collapsed.
- */
-function getExpandedLevel(items: Record<string, FileTreeItem>, expandedItems: string[]): number {
-  const expanded = new Set(expandedItems);
-  let level = 0;
-  for (const idsAtDepth of getFolderIdsByLevel(items)) {
-    if (!idsAtDepth.every((id) => expanded.has(id))) break;
-    level++;
-  }
-  return level;
-}
 
 function buildItems(documents: Document[]): Record<string, FileTreeItem> {
   const items: Record<string, FileTreeItem> = {
@@ -154,7 +126,7 @@ function buildItems(documents: Document[]): Record<string, FileTreeItem> {
 }
 
 const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
-  ({ activeId, documents, onMove, onRename, onSelect, onDelete, onDuplicate, onAddChild, onAddChildFolder, onAddSibling, onAddSiblingFolder, onCopy, onPaste, onNewFile: _onNewFile, onNewFolder: _onNewFolder, onManageTags }, ref) => {
+  ({ activeId, documents, onMove, onRename, onSelect, onDelete, onDuplicate, onAddChild, onAddChildFolder, onAddSibling, onAddSiblingFolder, onCopy, onPaste, onNewFile: _onNewFile, onNewFolder: _onNewFolder, onManageTags, onExpandStateChange }, ref) => {
     const items = useMemo(() => {
       const built = buildItems(documents);
       return built;
@@ -279,6 +251,28 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [expandedItemsKey]);
 
+    // The toggle cycles one folder level at a time, so it needs the level the
+    // tree is *actually* at — folders can also be opened by hand or restored
+    // from persisted state, not just by the toggle.
+    const maxExpandLevel = useMemo(() => getMaxFolderLevel(items, ROOT_ID), [items]);
+    const expandLevel = useMemo(
+      () => getExpandedLevel(items, ROOT_ID, state.expandedItems ?? []),
+      [items, state.expandedItems],
+    );
+
+    const onExpandStateChangeRef = useRef(onExpandStateChange);
+    useEffect(() => {
+      onExpandStateChangeRef.current = onExpandStateChange;
+    }, [onExpandStateChange]);
+    useEffect(() => {
+      onExpandStateChangeRef.current?.({ level: expandLevel, maxLevel: maxExpandLevel });
+    }, [expandLevel, maxExpandLevel]);
+    // Without a mounted tree there is nothing to expand; let the toolbar know.
+    useEffect(
+      () => () => onExpandStateChangeRef.current?.({ level: 0, maxLevel: 0 }),
+      [],
+    );
+
     useImperativeHandle(ref, () => ({
       collapseAll: () => {
         expandCancelToken.current = true;
@@ -295,13 +289,14 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
       },
       expandToLevel: (level: number) => {
         expandCancelToken.current = true;
-        const ids = getFolderIdsUpToLevel(items, level);
+        const ids = getFolderIdsUpToLevel(items, ROOT_ID, Math.min(level, maxExpandLevel));
         setState((prev) => ({ ...prev, expandedItems: ids }));
       },
       cancelExpand: () => {
         expandCancelToken.current = true;
       },
-      getExpandLevel: () => getExpandedLevel(items, state.expandedItems ?? []),
+      getExpandLevel: () => expandLevel,
+      getMaxExpandLevel: () => maxExpandLevel,
     }));
 
     const handleDeleteConfirm = () => {

--- a/packages/reason-editor-sidebar/src/file-tree/index.ts
+++ b/packages/reason-editor-sidebar/src/file-tree/index.ts
@@ -6,4 +6,5 @@
 export { default as FileTree } from "./filetree";
 export { FileTreeContextMenu } from "./FileTreeContextMenu";
 export { useFileTreeOperations } from "./useFileTreeOperations";
+export * from "./expandLevels";
 export * from "./documentUtils";

--- a/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
+++ b/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
@@ -188,6 +188,12 @@ export interface SidebarContentProps {
   onOpenChange?: (open: boolean) => void;
   /** Ref forwarded to the `FileTree` component for imperative control. */
   treeRef?: RefObject<DocumentTreeHandle | null>;
+  /**
+   * Reports the file tree's live expansion depth (and the tree's deepest
+   * folder level) so the toolbar's expand/collapse toggle can label the next
+   * step of its one-level-at-a-time cycle.
+   */
+  onExpandStateChange?: (state: { level: number; maxLevel: number }) => void;
   /** Ref forwarded to the `OutlineView` component for imperative control. */
   outlineRef?: RefObject<OutlineViewHandle | null>;
   /** Editor handle passed to `OutlineView` to scroll-spy the active heading. */

--- a/packages/reason-editor-sidebar/test/file-tree/expandLevels.test.ts
+++ b/packages/reason-editor-sidebar/test/file-tree/expandLevels.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Coverage for the file tree's "expand one level at a time" cycle.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandToggleLabelFor,
+  getExpandedLevel,
+  getFolderIdsByLevel,
+  getFolderIdsUpToLevel,
+  getMaxFolderLevel,
+  nextExpandLevel,
+  type FolderItems,
+} from '../../src/file-tree/expandLevels';
+
+const ROOT = '__root__';
+
+/**
+ * root
+ *  ├ a (folder)
+ *  │  ├ a1 (folder)
+ *  │  │  └ a1x (file)
+ *  │  └ a2 (file)
+ *  ├ b (folder, no subfolders)
+ *  └ c (file)
+ */
+const items: FolderItems = {
+  [ROOT]: { children: ['a', 'b', 'c'], isFolder: true },
+  a: { children: ['a1', 'a2'], isFolder: true },
+  a1: { children: ['a1x'], isFolder: true },
+  a1x: { children: [], isFolder: false },
+  a2: { children: [], isFolder: false },
+  b: { children: [], isFolder: true },
+  c: { children: [], isFolder: false },
+};
+
+describe('getFolderIdsByLevel', () => {
+  it('groups folders by nesting depth, ignoring files', () => {
+    expect(getFolderIdsByLevel(items, ROOT)).toEqual([['a', 'b'], ['a1']]);
+  });
+
+  it('returns no levels for a tree without folders', () => {
+    expect(getFolderIdsByLevel({ [ROOT]: { children: ['c'], isFolder: true }, c: { isFolder: false } }, ROOT))
+      .toEqual([]);
+  });
+
+  it('terminates on a cyclic parent link', () => {
+    const cyclic: FolderItems = {
+      [ROOT]: { children: ['a'], isFolder: true },
+      a: { children: ['b'], isFolder: true },
+      b: { children: ['a'], isFolder: true },
+    };
+    expect(getFolderIdsByLevel(cyclic, ROOT)).toEqual([['a'], ['b']]);
+  });
+});
+
+describe('getMaxFolderLevel', () => {
+  it('counts the deepest folder nesting level', () => {
+    expect(getMaxFolderLevel(items, ROOT)).toBe(2);
+  });
+
+  it('is zero when nothing can be expanded', () => {
+    expect(getMaxFolderLevel({ [ROOT]: { children: [], isFolder: true } }, ROOT)).toBe(0);
+  });
+});
+
+describe('getFolderIdsUpToLevel', () => {
+  it('returns nothing at level 0', () => {
+    expect(getFolderIdsUpToLevel(items, ROOT, 0)).toEqual([]);
+  });
+
+  it('returns top-level folders at level 1', () => {
+    expect(getFolderIdsUpToLevel(items, ROOT, 1)).toEqual(['a', 'b']);
+  });
+
+  it('adds the next depth at level 2', () => {
+    expect(getFolderIdsUpToLevel(items, ROOT, 2)).toEqual(['a', 'b', 'a1']);
+  });
+
+  it('caps at the deepest level', () => {
+    expect(getFolderIdsUpToLevel(items, ROOT, 99)).toEqual(['a', 'b', 'a1']);
+  });
+});
+
+describe('getExpandedLevel', () => {
+  it('is 0 when nothing is expanded', () => {
+    expect(getExpandedLevel(items, ROOT, [])).toBe(0);
+  });
+
+  it('is 0 when only some top-level folders are expanded', () => {
+    expect(getExpandedLevel(items, ROOT, ['a'])).toBe(0);
+  });
+
+  it('is 1 when every top-level folder is expanded', () => {
+    expect(getExpandedLevel(items, ROOT, ['a', 'b'])).toBe(1);
+  });
+
+  it('is 0 when a deeper folder is open but a top-level sibling is not', () => {
+    expect(getExpandedLevel(items, ROOT, ['a', 'a1'])).toBe(0);
+  });
+
+  it('reaches the max level when everything is expanded', () => {
+    expect(getExpandedLevel(items, ROOT, ['a', 'b', 'a1'])).toBe(2);
+  });
+});
+
+describe('nextExpandLevel', () => {
+  it('steps one level at a time and wraps back to collapsed', () => {
+    const max = getMaxFolderLevel(items, ROOT);
+    expect(nextExpandLevel(0, max)).toBe(1);
+    expect(nextExpandLevel(1, max)).toBe(2);
+    expect(nextExpandLevel(2, max)).toBe(0);
+  });
+
+  it('collapses immediately from a hand-expanded level past the max', () => {
+    expect(nextExpandLevel(5, 2)).toBe(0);
+  });
+
+  it('stays collapsed when there is nothing to expand', () => {
+    expect(nextExpandLevel(0, 0)).toBe(0);
+  });
+});
+
+describe('expandToggleLabelFor', () => {
+  it('names the level the next click reveals', () => {
+    expect(expandToggleLabelFor(0, 3)).toBe('Expand Level 1');
+    expect(expandToggleLabelFor(1, 3)).toBe('Expand Level 2');
+    expect(expandToggleLabelFor(2, 3)).toBe('Expand Level 3');
+  });
+
+  it('says "Collapse All" once the deepest level is showing', () => {
+    expect(expandToggleLabelFor(3, 3)).toBe('Collapse All');
+  });
+
+  it('says "Expand All" for a single-level tree', () => {
+    expect(expandToggleLabelFor(0, 1)).toBe('Expand All');
+    expect(expandToggleLabelFor(0, 0)).toBe('Expand All');
+  });
+});


### PR DESCRIPTION
## Summary
Refactored the file tree's expand/collapse-all functionality by extracting the folder level calculation logic into a dedicated, testable module. This improves code organization, testability, and maintainability while fixing the expansion state tracking to be sourced from the tree itself rather than relying on stale local counters.

## Key Changes

- **New module `expandLevels.ts`**: Created pure helper functions for calculating folder nesting levels:
  - `getFolderIdsByLevel()`: Groups folders by nesting depth
  - `getMaxFolderLevel()`: Calculates the deepest folder nesting level
  - `getFolderIdsUpToLevel()`: Returns folder IDs reachable within a given depth
  - `getExpandedLevel()`: Infers the current expansion depth from expanded items
  - `nextExpandLevel()`: Determines the next level in the expand/collapse cycle
  - `expandToggleLabelFor()`: Generates tooltip text for the toggle button

- **Comprehensive test coverage**: Added 139 lines of tests covering all helper functions with edge cases (cycles, empty trees, partial expansions)

- **Updated `FileTree` component**: 
  - Removed inline folder level calculation logic
  - Now uses the new helper functions
  - Added `onExpandStateChange` callback to report live expansion state to parent
  - Implements `getMaxExpandLevel()` on the imperative handle
  - Properly tracks expansion state through memoized values

- **Updated `Sidebar` component**:
  - Simplified expand level tracking by sourcing from the tree's actual state
  - Replaced stale local counter with callback-based state updates
  - Uses `nextExpandLevel()` and `expandToggleLabelFor()` helpers for cleaner logic

- **Updated `SidebarToolbar`**: Added `aria-label` to expand toggle button for better accessibility

- **Updated type definitions**: Added `onExpandStateChange` prop to `SidebarContentProps` and `FileTreeProps`

## Notable Implementation Details

- The expansion state is now sourced from the tree itself rather than a local counter, ensuring the toggle stays in sync even when folders are opened/collapsed by hand or restored from persisted state
- Cycle detection in `getFolderIdsByLevel()` guards against malformed parent links
- The helpers are pure functions with no side effects, making them easily testable and reusable
- Expansion state is reported on mount, whenever the expanded depth or tree depth changes, and with zeroes on unmount

https://claude.ai/code/session_01XESUY7P7HBmFUmeQ94WYLc