### PR TITLE
fix(ci): stop one failing package from cancelling the whole npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -67,9 +67,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # Note: intentionally no `-e`. Per-package outcomes are handled
-          # explicitly so one package's failure can't abort the whole run.
+          # GitHub runs `run:` steps with `bash -e -o pipefail`, so simply not
+          # writing `set -e` here does not disable errexit — `set -uo pipefail`
+          # leaves it on. With errexit on, the first package whose publish fails
+          # kills the whole step: `chat-agent-toolkit` sorts first in
+          # `packages/*/`, so once its publish started returning npm E404 every
+          # later package stopped being evaluated at all and the whole workspace
+          # went unreleased. Turn errexit off explicitly; per-package outcomes
+          # are handled through $rc below, and the run still exits non-zero at
+          # the end if anything failed.
           set -uo pipefail
+          set +e
 
           failed_packages=""
           skipped_builds=""

--- a/bun.lock
+++ b/bun.lock
@@ -1011,12 +1011,17 @@
     "packages/use-voice-control": {
       "name": "use-voice-control",
       "version": "0.1.86",
+      "bin": {
+        "use-voice-control": "./bin/use-voice-control.mjs",
+      },
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
         "@moonshine-ai/moonshine-js": "^0.1.29",
+        "kokoro-js": "^1.2.1",
         "lucide-react": "^0.344.0",
       },
       "devDependencies": {
+        "@types/node": "^22.10.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",


### PR DESCRIPTION
`npx use-voice-control README.md -o out.wav` fails with "could not determine executable to run": the CLI landed in #338 but the published tarball is still 0.1.86 from 2026-08-18, which has no `bin` field and no `dist/cli.js`. Nothing in the workspace has been released since that date.

The publish loop is why. Its comment claims "intentionally no `-e`", but GitHub runs `run:` steps with `bash -e -o pipefail` and `set -uo pipefail` does not clear errexit — it only adds nounset and pipefail. So the subshell that publishes a package aborts the entire step the moment it exits non-zero, and `rc=$?` never runs. `chat-agent-toolkit` sorts first in `packages/*/` and has been failing with an npm E404 on PUT since mid-August, so every run has died there before evaluating any other package: the last run logged one "Evaluating", then exit 1, 50 seconds in.

Turn errexit off explicitly with `set +e`. Per-package failures are already collected in `failed_packages` and re-raised as a non-zero exit at the end of the step, so a broken package is still reported — it just no longer takes the other nineteen down with it.

Also regenerate the `packages/use-voice-control` entry in bun.lock, which never picked up the `bin`, `kokoro-js` and `@types/node` additions from #338.

Note: the `chat-agent-toolkit` E404 itself is an npm credential problem, not a code one, and still needs NPM_TOKEN re-issued (or trusted publishing configured) for that package.


Claude-Session: https://claude.ai/code/session_01Y8cfcSwbKqKxUkMpbfZPw2