### PR TITLE
features: add favicons and site links to comparison table headers

### DIFF
--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -39,6 +39,7 @@ import {
   PROVIDERS,
   SEARCH_CATEGORIES,
   STATS,
+  faviconUrl,
   type ComparisonStatus,
 } from "@/components/features/data";
 import { config } from "@/lib/config/site";
@@ -369,14 +370,32 @@ function Comparison() {
                             column.highlight && "qs-accent-soft",
                           )}
                         >
-                          <div
+                          <a
+                            href={column.href}
+                            target="_blank"
+                            rel="noreferrer noopener"
                             className={cn(
-                              "font-semibold",
+                              "flex items-center justify-center gap-1.5 font-semibold hover:underline",
                               column.highlight && "qs-accent-text",
                             )}
                           >
+                            <img
+                              src={faviconUrl(column.domain)}
+                              alt=""
+                              aria-hidden
+                              width={16}
+                              height={16}
+                              loading="lazy"
+                              className="size-4 shrink-0 rounded-[3px]"
+                              onError={(event) => {
+                                // Ad blockers routinely block the Google
+                                // favicon endpoint. Drop the mark rather than
+                                // leaving a broken-image glyph in the header.
+                                event.currentTarget.style.display = "none";
+                              }}
+                            />
                             {column.name}
-                          </div>
+                          </a>
                           {column.detail && (
                             <div className="text-muted-foreground text-[11px] font-normal">
                               {column.detail}

--- a/apps/qwksearch-web/components/features/data.tsx
+++ b/apps/qwksearch-web/components/features/data.tsx
@@ -410,15 +410,43 @@ export const COMPARISON_COLUMNS: {
   name: string;
   detail?: string;
   highlight?: boolean;
+  /** Homepage the column header links to. */
+  href: string;
+  /** Domain handed to the Google favicon service for the header icon. */
+  domain: string;
 }[] = [
-  { name: "QwkSearch", highlight: true },
-  { name: "Perplexity" },
-  { name: "ChatGPT" },
-  { name: "Claude" },
-  { name: "Google", detail: "Search / Gemini" },
-  { name: "Grok" },
-  { name: "Venice.ai" },
+  {
+    name: "QwkSearch",
+    highlight: true,
+    href: "https://qwksearch.com",
+    domain: "qwksearch.com",
+  },
+  {
+    name: "Perplexity",
+    href: "https://www.perplexity.ai",
+    domain: "perplexity.ai",
+  },
+  { name: "ChatGPT", href: "https://chatgpt.com", domain: "chatgpt.com" },
+  { name: "Claude", href: "https://claude.ai", domain: "claude.ai" },
+  {
+    name: "Google",
+    detail: "Search / Gemini",
+    href: "https://gemini.google.com",
+    domain: "google.com",
+  },
+  { name: "Grok", href: "https://grok.com", domain: "grok.com" },
+  { name: "Venice.ai", href: "https://venice.ai", domain: "venice.ai" },
 ];
+
+/**
+ * Google's public favicon service. Used rather than checking a dozen logo files
+ * into `public/` — it follows each site's own favicon, so the marks stay current
+ * when a competitor rebrands. Rendered with a plain <img> for the same reason as
+ * the login logo: the Worker's image optimizer only proxies local assets.
+ */
+export function faviconUrl(domain: string, size = 64): string {
+  return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=${size}`;
+}
 
 export const COMPARISON_ROWS: ComparisonRow[] = [
   {


### PR DESCRIPTION
Each column in the "How it compares" table on `/features` now shows the product's own favicon and links to that product's homepage.

## Changes

`apps/qwksearch-web/components/features/data.tsx`
- `COMPARISON_COLUMNS` entries gained `href` and `domain` fields.
- New `faviconUrl(domain, size = 64)` helper builds a Google favicon service URL.

`apps/qwksearch-web/components/features/FeaturesView.tsx`
- The header `<div>` became an `<a target="_blank" rel="noreferrer noopener">` laying out a 16px favicon beside the product name, with `hover:underline`. The accent color on the highlighted QwkSearch column and the "Search / Gemini" sub-label are unchanged.

| Column | Favicon domain | Links to |
|---|---|---|
| QwkSearch | qwksearch.com | https://qwksearch.com |
| Perplexity | perplexity.ai | https://www.perplexity.ai |
| ChatGPT | chatgpt.com | https://chatgpt.com |
| Claude | claude.ai | https://claude.ai |
| Google (Search / Gemini) | google.com | https://gemini.google.com |
| Grok | grok.com | https://grok.com |
| Venice.ai | venice.ai | https://venice.ai |

## Notes on two judgment calls

**Plain `<img>` rather than `next/image`** — follows the precedent (and the explanatory comment) in `components/layout/LoginPage.tsx`: the Worker's image optimizer only proxies assets out of the local ASSETS bundle. `next.config.ts` also only allowlists `s2.googleusercontent.com`, not `www.google.com`, so `next/image` would have required a config change as well.

**`onError` hides the icon** — ad blockers commonly block `google.com/s2/favicons`. Without the handler the header would render a broken-image glyph; instead it degrades to just the product name.

Favicons come from the service rather than checked-in logo files so the marks follow each site's own icon if a competitor rebrands.

## Testing

- `tsc --noEmit` is clean for both changed files.
- Both hunks match Prettier's output. Note both files already carried pre-existing Prettier drift at `master`, which this PR leaves alone rather than mixing a reformat into the diff.
- A full `next build` was not run: a bare build in this environment fails with 156 module-not-found errors for unbuilt workspace packages (`chat-agent-toolkit`, `extract-youtube`, …) that turbo normally builds first. None of them touch `components/features/`.
- The favicon URLs could not be fetched from the sandbox (its proxy returns 403 for google.com), so **the rendered icons still want a look in a browser**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdTbfMQuVNvpr3GLL8BKW4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdTbfMQuVNvpr3GLL8BKW4)_