### PR TITLE
feat(chat): randomize the AI chat loading animation

### DIFF
--- a/packages/research-agent-ui/src/components/ChatConversation/ChatConversationThread.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/ChatConversationThread.tsx
@@ -7,7 +7,7 @@
 
 import { Fragment, useEffect, useRef, useState } from 'react';
 import MessageBox from './ChatMessageBubble';
-import QuantumWaveOrbital from 'quantum-sphere-loading-icon/react';
+import RandomLoadingAnimation from './RandomLoadingAnimation';
 
 import { useChat } from '../../hooks/useChat';
 import { useExtractPanel } from '../ArticleReader/ExtractPanelContext';
@@ -97,18 +97,9 @@ const Chat = () => {
               </Fragment>
             );
           })}
-          {loading && !messageAppeared && (
-            <div className="flex items-center justify-center">
-
-              <div style={{ height: '200px', width: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                <QuantumWaveOrbital
-                  autoRandomize={true}
-                  onSphereClick={() => console.log('Sphere clicked')}
-                  className="my-custom-class"
-                />
-              </div>
-            </div>
-          )}
+          {/* Unmounts once the response starts streaming, so the next
+              response mounts a freshly randomized animation. */}
+          {loading && !messageAppeared && <RandomLoadingAnimation />}
           <div ref={messageEnd} className="h-0" />
         </div>
 

--- a/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.stories.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import RandomLoadingAnimation from './RandomLoadingAnimation';
+import {
+  LOADING_ANIMATION_NAMES,
+  QUANTUM_SPHERE_ANIMATION,
+  renderLoadingAnimation,
+} from './loading-animations';
+
+/**
+ * `RandomLoadingAnimation` is the chat's "thinking" loader. Each mount picks a
+ * different animation from the GRAB-URL spinner set (`grab-url/animations`)
+ * plus the quantum orbital sphere, so a new one appears on every response.
+ */
+const meta: Meta<typeof RandomLoadingAnimation> = {
+  title: 'ChatConversation/RandomLoadingAnimation',
+  component: RandomLoadingAnimation,
+};
+
+export default meta;
+type Story = StoryObj<typeof RandomLoadingAnimation>;
+
+/** One random pick — reload the story to draw another. */
+export const Default: Story = {};
+
+/** Four mounts side by side, each picking independently. */
+export const Several: Story = {
+  render: () => (
+    <div className="flex flex-wrap">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="w-1/2">
+          <RandomLoadingAnimation size={100} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+/** Every SVG spinner in the pool, for reviewing the set as a whole. */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-6">
+      {LOADING_ANIMATION_NAMES.filter(
+        (name) => name !== QUANTUM_SPHERE_ANIMATION,
+      ).map((name) => (
+        <figure key={name} className="flex flex-col items-center gap-2 w-32">
+          <div
+            dangerouslySetInnerHTML={{
+              __html: renderLoadingAnimation(name, 80),
+            }}
+          />
+          <figcaption className="text-xs text-muted-foreground">
+            {name}
+          </figcaption>
+        </figure>
+      ))}
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.tsx
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Chat "thinking" loader that shows a different animation every
+ * time it mounts, picked at random from the GRAB-URL spinner set
+ * (`grab-url/animations`) plus the quantum orbital sphere.
+ */
+'use client';
+
+import { useEffect, useState } from 'react';
+import QuantumWaveOrbital from 'quantum-sphere-loading-icon/react';
+import { cn } from '../../lib/utils';
+import {
+  QUANTUM_SPHERE_ANIMATION,
+  getRandomLoadingAnimation,
+  renderLoadingAnimation,
+} from './loading-animations';
+
+interface RandomLoadingAnimationProps {
+  /** Width and height of the SVG spinners, in pixels. */
+  size?: number;
+  /** Extra classes for the centering wrapper. */
+  className?: string;
+}
+
+/**
+ * Renders one randomly chosen loading animation.
+ *
+ * The pick happens in an effect rather than during render so server and client
+ * markup match; until it lands the wrapper renders empty at its final height,
+ * which keeps the surrounding layout from shifting.
+ *
+ * @returns {JSX.Element} The rendered loader
+ */
+const RandomLoadingAnimation = ({
+  size = 140,
+  className,
+}: RandomLoadingAnimationProps) => {
+  const [animation, setAnimation] = useState<string | null>(null);
+
+  useEffect(() => {
+    setAnimation(getRandomLoadingAnimation());
+  }, []);
+
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className={cn('flex items-center justify-center w-full h-[200px]', className)}
+    >
+      {animation === QUANTUM_SPHERE_ANIMATION ? (
+        <QuantumWaveOrbital autoRandomize={true} />
+      ) : animation ? (
+        <div
+          className="flex items-center justify-center"
+          // Static markup from `grab-url/animations`, not user content.
+          dangerouslySetInnerHTML={{
+            __html: renderLoadingAnimation(animation, size),
+          }}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default RandomLoadingAnimation;

--- a/packages/research-agent-ui/src/components/ChatConversation/loading-animations.ts
+++ b/packages/research-agent-ui/src/components/ChatConversation/loading-animations.ts
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Registry and random picker for the chat's "thinking" loader.
+ *
+ * The animated SVG spinners ship with `grab-url/animations` (the
+ * `loading-animations` package of the GRAB-URL monorepo) and the quantum
+ * orbital sphere ships with `quantum-sphere-loading-icon`. Both are pulled
+ * into one pool so the chat can show a different loader on every response.
+ */
+import * as grabUrlAnimations from 'grab-url/animations';
+
+/** Options accepted by every `grab-url/animations` spinner factory. */
+export interface LoadingAnimationOptions {
+  /** Hex colors substituted into the SVG, in order of appearance. */
+  colors?: string[];
+  /** Width of the SVG. */
+  width?: number;
+  /** Height of the SVG. */
+  height?: number;
+  /** Shorthand setting both width and height. */
+  size?: number;
+  /** Return the raw `<svg>` string instead of an `<img>` data-URI tag. */
+  raw?: boolean;
+}
+
+/** A `grab-url/animations` factory: options in, SVG markup out. */
+export type SvgLoadingAnimation = (options?: LoadingAnimationOptions) => string;
+
+/**
+ * Name of the quantum orbital sphere, which is rendered by a React component
+ * rather than an SVG string and so is kept out of {@link SVG_LOADING_ANIMATIONS}.
+ */
+export const QUANTUM_SPHERE_ANIMATION = 'quantumSphere';
+
+/**
+ * Every animated SVG spinner exported by `grab-url/animations`, keyed by its
+ * export name. Read off the module namespace rather than listed by hand, so
+ * spinners added in a later `grab-url` release join the rotation on upgrade.
+ */
+export const SVG_LOADING_ANIMATIONS: Record<string, SvgLoadingAnimation> =
+  Object.fromEntries(
+    Object.entries(grabUrlAnimations as Record<string, unknown>).filter(
+      ([name, factory]) =>
+        typeof factory === 'function' && name.startsWith('loading'),
+    ),
+  ) as Record<string, SvgLoadingAnimation>;
+
+/** Every loader the chat can show, sorted so the order is deterministic. */
+export const LOADING_ANIMATION_NAMES: string[] = [
+  QUANTUM_SPHERE_ANIMATION,
+  ...Object.keys(SVG_LOADING_ANIMATIONS).sort(),
+];
+
+/** The previous pick, skipped next time so the loader visibly changes. */
+let lastPicked: string | undefined;
+
+/**
+ * Picks one loader at random, never the same one twice in a row.
+ *
+ * @returns {string} A name from {@link LOADING_ANIMATION_NAMES}
+ */
+export function getRandomLoadingAnimation(): string {
+  const choices = LOADING_ANIMATION_NAMES.filter((name) => name !== lastPicked);
+  const pool = choices.length > 0 ? choices : LOADING_ANIMATION_NAMES;
+  lastPicked = pool[Math.floor(Math.random() * pool.length)];
+  return lastPicked;
+}
+
+/**
+ * Renders one spinner to a raw `<svg>` string.
+ *
+ * @param name - A name from {@link SVG_LOADING_ANIMATIONS}
+ * @param size - Width and height in pixels
+ * @returns {string} SVG markup, or an empty string for an unknown name
+ */
+export function renderLoadingAnimation(name: string, size: number): string {
+  const factory = SVG_LOADING_ANIMATIONS[name];
+  return factory ? factory({ size, raw: true }) : '';
+}

--- a/packages/research-agent-ui/test/loadingAnimations.test.ts
+++ b/packages/research-agent-ui/test/loadingAnimations.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Unit tests for the chat loader pool: the spinner registry read
+ * off `grab-url/animations`, the random picker, and SVG rendering.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+    LOADING_ANIMATION_NAMES,
+    QUANTUM_SPHERE_ANIMATION,
+    SVG_LOADING_ANIMATIONS,
+    getRandomLoadingAnimation,
+    renderLoadingAnimation,
+} from '../src/components/ChatConversation/loading-animations';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('SVG_LOADING_ANIMATIONS', () => {
+    it('collects the spinner factories exported by grab-url/animations', () => {
+        const names = Object.keys(SVG_LOADING_ANIMATIONS);
+
+        expect(names.length).toBeGreaterThan(1);
+        expect(names.every((name) => name.startsWith('loading'))).toBe(true);
+        expect(
+            Object.values(SVG_LOADING_ANIMATIONS).every(
+                (factory) => typeof factory === 'function',
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('LOADING_ANIMATION_NAMES', () => {
+    it('includes the quantum sphere alongside every SVG spinner', () => {
+        expect(LOADING_ANIMATION_NAMES).toContain(QUANTUM_SPHERE_ANIMATION);
+        expect(LOADING_ANIMATION_NAMES).toHaveLength(
+            Object.keys(SVG_LOADING_ANIMATIONS).length + 1,
+        );
+    });
+
+    it('has no duplicates', () => {
+        expect(new Set(LOADING_ANIMATION_NAMES).size).toBe(
+            LOADING_ANIMATION_NAMES.length,
+        );
+    });
+});
+
+describe('getRandomLoadingAnimation', () => {
+    it('always returns a name from the pool', () => {
+        for (let i = 0; i < 50; i++) {
+            expect(LOADING_ANIMATION_NAMES).toContain(getRandomLoadingAnimation());
+        }
+    });
+
+    it('stays in range when the RNG bottoms out', () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0);
+
+        expect(LOADING_ANIMATION_NAMES).toContain(getRandomLoadingAnimation());
+    });
+
+    it('stays in range when the RNG tops out', () => {
+        vi.spyOn(Math, 'random').mockReturnValue(0.999999);
+
+        expect(LOADING_ANIMATION_NAMES).toContain(getRandomLoadingAnimation());
+    });
+
+    it('never repeats the previous pick', () => {
+        let previous = getRandomLoadingAnimation();
+
+        for (let i = 0; i < 50; i++) {
+            const next = getRandomLoadingAnimation();
+            expect(next).not.toBe(previous);
+            previous = next;
+        }
+    });
+
+    it('eventually returns more than two distinct animations', () => {
+        const seen = new Set(
+            Array.from({ length: 200 }, () => getRandomLoadingAnimation()),
+        );
+
+        expect(seen.size).toBeGreaterThan(2);
+    });
+});
+
+describe('renderLoadingAnimation', () => {
+    it('renders a sized, animated svg for a known spinner', () => {
+        const name = Object.keys(SVG_LOADING_ANIMATIONS)[0];
+
+        const svg = renderLoadingAnimation(name, 64);
+
+        expect(svg.startsWith('<svg')).toBe(true);
+        expect(svg).toContain('width="64px"');
+        expect(svg).toContain('height="64px"');
+    });
+
+    it('returns an empty string for an unknown name', () => {
+        expect(renderLoadingAnimation('nope', 64)).toBe('');
+        expect(renderLoadingAnimation(QUANTUM_SPHERE_ANIMATION, 64)).toBe('');
+    });
+});

--- a/packages/research-agent-ui/test/randomLoadingAnimation.test.tsx
+++ b/packages/research-agent-ui/test/randomLoadingAnimation.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Render tests for the chat's randomized "thinking" loader:
+ * that it mounts an SVG spinner, mounts the quantum sphere when that is the
+ * pick, and exposes a status role for screen readers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import RandomLoadingAnimation from '../src/components/ChatConversation/RandomLoadingAnimation';
+import {
+    QUANTUM_SPHERE_ANIMATION,
+    SVG_LOADING_ANIMATIONS,
+    getRandomLoadingAnimation,
+} from '../src/components/ChatConversation/loading-animations';
+
+// The picker is random by design, so stub it to force each branch.
+vi.mock('../src/components/ChatConversation/loading-animations', async (importOriginal) => ({
+    ...(await importOriginal<
+        typeof import('../src/components/ChatConversation/loading-animations')
+    >()),
+    getRandomLoadingAnimation: vi.fn(),
+}));
+
+/** Forces the next mount onto one specific animation. */
+const pick = (name: string) => {
+    vi.mocked(getRandomLoadingAnimation).mockReturnValue(name);
+};
+
+beforeEach(() => {
+    pick(Object.keys(SVG_LOADING_ANIMATIONS)[0]);
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('RandomLoadingAnimation', () => {
+    it('renders a sized SVG spinner for an SVG pick', () => {
+        pick('loadingSpinner');
+
+        const { container } = render(<RandomLoadingAnimation size={64} />);
+
+        expect(getRandomLoadingAnimation).toHaveBeenCalled();
+        const svg = container.querySelector('svg');
+        expect(svg).toBeTruthy();
+        expect(svg?.getAttribute('width')).toBe('64px');
+        // loadingSpinner is the multi-colour rotating dial.
+        expect(container.innerHTML).toContain('animateTransform');
+    });
+
+    it('renders the quantum sphere when that is the pick', () => {
+        pick(QUANTUM_SPHERE_ANIMATION);
+
+        const { container } = render(<RandomLoadingAnimation />);
+
+        // The orbital sphere is built from CSS-animated divs, not an SVG.
+        expect(container.innerHTML).toContain('orbitalSpin');
+        expect(container.querySelector('svg')).toBeNull();
+    });
+
+    it('exposes a labelled status region for screen readers', () => {
+        render(<RandomLoadingAnimation />);
+
+        expect(screen.getByRole('status')).toHaveProperty('ariaLabel', 'Loading');
+    });
+});


### PR DESCRIPTION
The chat's "thinking" loader was always the quantum orbital sphere. It now picks at random from the GRAB-URL spinner set already shipped by the `grab-url` dependency (`grab-url/animations`) plus that sphere, so a different animation appears while each response is being generated.

The pool is read off the `grab-url/animations` module namespace rather than listed by hand, so spinners added in a later `grab-url` release join the rotation on upgrade. Consecutive picks never repeat, and the pick happens in an effect so server and client markup match.


Claude-Session: https://claude.ai/code/session_01F4urvba9ahSJMrP2nmfazp