### PR TITLE
Add scrollable homepage with stacked features section

### DIFF
--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -599,6 +599,37 @@ pre[class*="language-"] {
   }
 }
 
+/* Homepage scroll cue — nudges downward to advertise that the page continues
+   past the workspace into the features sections. */
+@keyframes qs-scroll-cue-bob {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(3px);
+  }
+}
+
+.qs-scroll-cue-bob {
+  animation: qs-scroll-cue-bob 1.8s ease-in-out infinite;
+}
+
+/* Bottom-right, clearing the mobile dock — and lifted further by
+   `--qs-bottom-right-inset` while the cookie-consent banner (which claims the
+   same corner, see components/layout/CookieConsent.tsx) is showing. */
+.qs-scroll-cue {
+  bottom: calc(
+    72px + env(safe-area-inset-bottom, 0px) + var(--qs-bottom-right-inset, 0px)
+  );
+}
+
+@media (min-width: 48rem) {
+  .qs-scroll-cue {
+    bottom: calc(2rem + var(--qs-bottom-right-inset, 0px));
+  }
+}
+
 @keyframes qs-float {
   0%,
   100% {
@@ -668,7 +699,8 @@ pre[class*="language-"] {
   .qs-marquee-track,
   .qs-aurora-blob,
   .qs-border-beam::before,
-  .qs-shimmer-text {
+  .qs-shimmer-text,
+  .qs-scroll-cue-bob {
     animation: none !important;
   }
 

--- a/apps/qwksearch-web/app/page.tsx
+++ b/apps/qwksearch-web/app/page.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { MainWorkspaceView } from '@/components/layout/MainWorkspaceView';
+import { HomeScrollStack } from '@/components/layout/HomeScrollStack';
 
 const Home = () => {
-  return <MainWorkspaceView />;
+  return <HomeScrollStack />;
 };
 
 export default Home;

--- a/apps/qwksearch-web/components/layout/CookieConsent.tsx
+++ b/apps/qwksearch-web/components/layout/CookieConsent.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
 import { listFooterLinks, config } from '@/lib/config/site';
 
 export function CookieConsent() {
   const [isVisible, setIsVisible] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const cookieConsent = localStorage.getItem('cookie-consent');
@@ -14,6 +15,34 @@ export function CookieConsent() {
       setIsVisible(true);
     }
   }, []);
+
+  // This banner parks in the bottom-right corner, on top of anything else
+  // anchored there (the homepage's scroll cue). Publish its height while it
+  // is up so that chrome can sit above it rather than underneath it.
+  useEffect(() => {
+    const root = document.documentElement;
+    const card = cardRef.current;
+    if (!isVisible || !card) {
+      root.style.removeProperty('--qs-bottom-right-inset');
+      return;
+    }
+
+    const sync = () =>
+      root.style.setProperty(
+        '--qs-bottom-right-inset',
+        `${Math.ceil(card.getBoundingClientRect().height) + 16}px`,
+      );
+
+    sync();
+    const observer =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(sync);
+    observer?.observe(card);
+
+    return () => {
+      observer?.disconnect();
+      root.style.removeProperty('--qs-bottom-right-inset');
+    };
+  }, [isVisible]);
 
   const handleAcceptAll = () => {
     localStorage.setItem('cookie-consent', JSON.stringify({
@@ -43,7 +72,7 @@ export function CookieConsent() {
 
   return (
     <div className="fixed bottom-0 right-0 m-4 max-w-sm z-50">
-      <div className="bg-light-secondary dark:bg-dark-secondary rounded-lg shadow-lg border border-light-tertiary dark:border-dark-tertiary p-4 space-y-3">
+      <div ref={cardRef} className="bg-light-secondary dark:bg-dark-secondary rounded-lg shadow-lg border border-light-tertiary dark:border-dark-tertiary p-4 space-y-3">
         <div className="flex justify-between items-start gap-3">
           <div className="flex-1">
             <h3 className="font-semibold text-sm text-black dark:text-white mb-2">

--- a/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
+++ b/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import * as React from 'react';
+import dynamic from 'next/dynamic';
+import { ChevronDown } from 'lucide-react';
+
+import { MainWorkspaceView } from '@/components/layout/MainWorkspaceView';
+import { cn } from '@/lib/utils';
+
+/**
+ * The homepage: the research workspace on the first screen, with the whole
+ * /features page stacked directly underneath it.
+ *
+ * The workspace itself is a fixed 100vh app shell (ReasonDocs is
+ * `h-screen … overflow-hidden`), so it can simply be stacked above a normal
+ * document-flow section — the page scroll lives in the app's single scroll
+ * container (`#app-scroll-root`, from components/layout/Providers.tsx), not on
+ * `window`, which is why everything here measures and listens on that element.
+ */
+
+/**
+ * Marketing content nobody sees until they scroll past the workspace — kept out
+ * of the homepage's first-load bundle and streamed in behind the fold instead.
+ * The placeholder reserves a screen of height so the cue below always has
+ * somewhere to scroll to while the chunk is still in flight.
+ */
+const FeaturesView = dynamic(
+  () => import('@/components/features/FeaturesView').then((mod) => mod.FeaturesView),
+  { ssr: false, loading: () => <div className="min-h-screen" /> },
+);
+
+/** Nearest scrollable ancestor, for when the known scroll root isn't in the DOM. */
+function findScrollParent(node: HTMLElement | null): HTMLElement | null {
+  let el = node?.parentElement ?? null;
+  while (el) {
+    const overflowY = window.getComputedStyle(el).overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll') return el;
+    el = el.parentElement;
+  }
+  return null;
+}
+
+function usePrefersReducedMotion() {
+  const [reduced, setReduced] = React.useState(false);
+
+  React.useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduced(query.matches);
+    sync();
+    query.addEventListener('change', sync);
+    return () => query.removeEventListener('change', sync);
+  }, []);
+
+  return reduced;
+}
+
+/**
+ * How far the features slab has travelled into view: 0 while it still sits
+ * entirely below the fold, 1 once its top edge has risen through 55% of the
+ * viewport. Drives both the fade-in and which way the scroll cue points.
+ */
+function useEnterProgress(ref: React.RefObject<HTMLElement | null>) {
+  const [progress, setProgress] = React.useState(0);
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const scroller =
+      document.getElementById('app-scroll-root') ?? findScrollParent(el) ?? null;
+    const target: HTMLElement | Window = scroller ?? window;
+
+    let frame = 0;
+    const measure = () => {
+      frame = 0;
+      const viewport = window.innerHeight || 1;
+      const travelled = viewport - el.getBoundingClientRect().top;
+      const next = Math.min(1, Math.max(0, travelled / (viewport * 0.55)));
+      // Ignore sub-pixel churn so a scroll doesn't re-render the whole slab on
+      // every single frame.
+      setProgress((prev) => (Math.abs(prev - next) < 0.004 ? prev : next));
+    };
+
+    const onScroll = () => {
+      if (!frame) frame = window.requestAnimationFrame(measure);
+    };
+
+    measure();
+    target.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      target.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [ref]);
+
+  return progress;
+}
+
+function ScrollCue({
+  direction,
+  onClick,
+}: {
+  direction: 'down' | 'up';
+  onClick: () => void;
+}) {
+  const isDown = direction === 'down';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={isDown ? 'Scroll down to features' : 'Scroll back up to the workspace'}
+      title={isDown ? 'See what it does' : 'Back to the workspace'}
+      className={cn(
+        'qs-scroll-cue group fixed right-4 z-30 flex items-center gap-2',
+        'rounded-full border bg-background/80 py-2 pr-3 pl-4 shadow-lg backdrop-blur-md',
+        'text-muted-foreground hover:text-foreground text-xs font-medium',
+        'transition-[color,border-color,bottom] duration-300 hover:border-sky-500/50',
+        'md:right-6',
+      )}
+    >
+      <span className="hidden sm:inline">{isDown ? 'Features' : 'Top'}</span>
+      <ChevronDown
+        aria-hidden
+        className={cn(
+          'size-4 transition-transform duration-500',
+          isDown ? 'qs-scroll-cue-bob' : 'rotate-180',
+        )}
+      />
+    </button>
+  );
+}
+
+export function HomeScrollStack() {
+  const workspaceRef = React.useRef<HTMLDivElement>(null);
+  const featuresRef = React.useRef<HTMLDivElement>(null);
+  const reducedMotion = usePrefersReducedMotion();
+  const progress = useEnterProgress(featuresRef);
+
+  // Flip the cue only once the features cover more than half the screen —
+  // pointing "up" any earlier would strand a reader who is still on their way
+  // down. Read from the raw progress, not the fade below, so the direction
+  // stays correct when motion is reduced.
+  const showingFeatures = progress > 0.9;
+
+  const scrollTo = (ref: React.RefObject<HTMLElement | null>) => {
+    ref.current?.scrollIntoView({
+      behavior: reducedMotion ? 'auto' : 'smooth',
+      block: 'start',
+    });
+  };
+
+  return (
+    <div className="relative">
+      {/* First screen: the workspace, exactly as it renders on its own. This
+          wrapper stays untransformed and unpositioned on purpose — either would
+          turn it into a containing block and re-anchor the app's `fixed` and
+          `absolute` chrome (popovers, dialogs, the dock) to it. */}
+      <div ref={workspaceRef} className="h-screen">
+        <MainWorkspaceView />
+      </div>
+
+      <ScrollCue
+        direction={showingFeatures ? 'up' : 'down'}
+        onClick={() => scrollTo(showingFeatures ? workspaceRef : featuresRef)}
+      />
+
+      {/* Second screen onward: the full /features page, easing in as it is
+          scrolled up. Sections inside it keep their own staggered reveals.
+
+          The fade sits on an inner wrapper so the measured/scrolled-to element
+          stays untransformed: `getBoundingClientRect()` reports the translated
+          position, so measuring the moving element would feed the fade back
+          into its own input, and `scrollIntoView` would stop short of the real
+          section boundary by however much it is currently offset. */}
+      <div ref={featuresRef}>
+        <div
+          style={
+            reducedMotion
+              ? undefined
+              : {
+                  opacity: 0.12 + progress * 0.88,
+                  transform: `translate3d(0, ${(1 - progress) * 48}px, 0)`,
+                  willChange: progress < 1 ? 'opacity, transform' : undefined,
+                }
+          }
+        >
+          <FeaturesView />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -57,7 +57,17 @@ export function Providers({ children }: { children: React.ReactNode }) {
             <CategoryDockProvider>
               <SettingsModalProvider>
                 <MainViewProvider>
-                  <div className="w-screen h-screen overflow-auto pb-[calc(60px+env(safe-area-inset-bottom,0px))] md:pb-0">
+                  {/* The app's single scroll container. `overflow-x` is clipped
+                      rather than auto because full-bleed `w-screen` children
+                      (the workspace shell) measure 100vw, which overhangs this
+                      box by the scrollbar's width as soon as a page — the
+                      homepage, now that /features stacks below it — actually
+                      scrolls. Identified so scroll-driven UI can listen here
+                      instead of on `window`, which never scrolls. */}
+                  <div
+                    id="app-scroll-root"
+                    className="w-screen h-screen overflow-y-auto overflow-x-hidden pb-[calc(60px+env(safe-area-inset-bottom,0px))] md:pb-0"
+                  >
                     <CategoryDock />
                     <main className="bg-light-primary dark:bg-dark-primary min-h-screen">
                       {children}


### PR DESCRIPTION
## Summary
Transforms the homepage into a scrollable layout that stacks the features section below the workspace, creating a continuous scroll experience from the research interface into marketing content.

## Key Changes

- **New `HomeScrollStack` component** (`HomeScrollStack.tsx`): Implements a two-screen layout where the workspace occupies the first viewport height and the features section stacks below it. Includes:
  - Scroll progress tracking via `useEnterProgress` hook to measure how far the features section has scrolled into view
  - Dynamic scroll cue button that toggles between "down" (pointing to features) and "up" (back to workspace) based on scroll position
  - Smooth fade-in and translate animations for the features section as it enters the viewport
  - Respects `prefers-reduced-motion` preference

- **Updated homepage** (`app/page.tsx`): Replaced direct `MainWorkspaceView` render with `HomeScrollStack` wrapper

- **Enhanced scroll container** (`Providers.tsx`): 
  - Added `id="app-scroll-root"` to the main scroll container so scroll-driven UI can listen to it instead of `window`
  - Changed `overflow-auto` to `overflow-y-auto overflow-x-hidden` to prevent horizontal scrollbar overhang issues with full-bleed content

- **Cookie consent positioning** (`CookieConsent.tsx`): 
  - Added height tracking via `ResizeObserver` to publish banner dimensions
  - Sets CSS custom property `--qs-bottom-right-inset` so the scroll cue can position itself above the banner without overlap

- **Styling** (`globals.css`):
  - Added `qs-scroll-cue-bob` keyframe animation for the bobbing chevron icon
  - Added positioning styles for `.qs-scroll-cue` that respect the cookie banner's height via CSS variable
  - Updated reduced-motion media query to disable the new animation

## Implementation Details

The scroll progress calculation uses a threshold of 55% viewport height to determine when the features section is "entering" (0 to 1 progress), with sub-pixel churn filtering to avoid excessive re-renders. The scroll cue only flips direction once progress exceeds 0.9 to prevent confusing UX during the transition. The features section is dynamically imported to keep it out of the initial bundle.

https://claude.ai/code/session_01JoTesnpTbhB1UB9z8v6iE1