### PR TITLE
feat(settings): show the city detected from IP geolocation

### DIFF
--- a/apps/qwksearch-web/app/api/geolocation/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/geolocation/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Route tests for the detected-location endpoint.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/cloudflare/ip-geolocation', () => ({ resolveClientLocation: vi.fn() }))
+
+import { resolveClientLocation } from '@/lib/cloudflare/ip-geolocation'
+import { GET } from '../route'
+
+const mockResolve = resolveClientLocation as unknown as ReturnType<typeof vi.fn>
+
+const request = (headers: Record<string, string> = {}) =>
+  new Request('http://localhost/api/geolocation', { headers }) as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/geolocation', () => {
+  it('returns the resolved location', async () => {
+    mockResolve.mockResolvedValue({ ip: '203.0.113.7', city: 'Berlin', source: 'edge' })
+    const res = await GET(request({ 'x-forwarded-for': '203.0.113.7' }))
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ip: '203.0.113.7', city: 'Berlin', source: 'edge' })
+  })
+
+  it('keeps the per-viewer answer off shared caches', async () => {
+    mockResolve.mockResolvedValue({ ip: null, source: 'none' })
+    const res = await GET(request())
+    expect(res.headers.get('cache-control')).toContain('private')
+  })
+
+  it('500s when resolution throws', async () => {
+    mockResolve.mockRejectedValue(new Error('boom'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const res = await GET(request())
+    expect(res.status).toBe(500)
+    errorSpy.mockRestore()
+  })
+})

--- a/apps/qwksearch-web/app/api/geolocation/route.ts
+++ b/apps/qwksearch-web/app/api/geolocation/route.ts
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Reports the city the current request geolocates to, so
+ * Settings can show which location the app is inferring from your IP (the
+ * same location the homepage weather widget auto-detects).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { resolveClientLocation } from "@/lib/cloudflare/ip-geolocation";
+
+export async function GET(req: NextRequest) {
+  try {
+    const location = await resolveClientLocation(req.headers);
+    return NextResponse.json(location, {
+      // Per-viewer answer; keep it briefly warm but never on a shared cache.
+      headers: { "Cache-Control": "private, max-age=300" },
+    });
+  } catch (error) {
+    console.error("Error resolving client location:", error);
+    return NextResponse.json(
+      { message: "Failed to resolve location." },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/qwksearch-web/components/Settings/DetectedLocation.tsx
+++ b/apps/qwksearch-web/components/Settings/DetectedLocation.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import grab from 'grab-url';
+import { Loader2, MapPin, RefreshCw } from 'lucide-react';
+import { AnchorTitle } from './anchors';
+
+interface ClientLocation {
+  ip: string | null;
+  city?: string;
+  region?: string;
+  country?: string;
+  countryCode?: string;
+  timezone?: string;
+  latitude?: number;
+  longitude?: number;
+  source: 'edge' | 'ipapi' | 'none';
+}
+
+const ANCHOR_ID = 'search-detectedLocation';
+
+const formatPlace = (location: ClientLocation) =>
+  [location.city, location.region, location.country ?? location.countryCode]
+    .filter(Boolean)
+    .join(', ');
+
+const formatCoordinates = (location: ClientLocation) =>
+  typeof location.latitude === 'number' && typeof location.longitude === 'number'
+    ? `${location.latitude.toFixed(2)}, ${location.longitude.toFixed(2)}`
+    : null;
+
+/**
+ * Read-only card showing the city the server geolocated the current request
+ * to. This is the location the homepage weather widget falls back to when
+ * "Weather Locations" is left blank, so it lives alongside that setting.
+ */
+const DetectedLocation = () => {
+  const [location, setLocation] = useState<ClientLocation | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [failed, setFailed] = useState(false);
+
+  const fetchLocation = useCallback(async () => {
+    setIsLoading(true);
+    setFailed(false);
+    try {
+      const data = await grab('geolocation');
+      // grab resolves with the body even on HTTP errors, so an error payload
+      // ({ message }) would otherwise be rendered as a location.
+      if (!data || typeof data.source !== 'string') {
+        throw new Error(data?.message ?? 'Invalid geolocation response.');
+      }
+      setLocation(data as ClientLocation);
+    } catch (error) {
+      console.error('Error fetching detected location:', error);
+      setFailed(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchLocation();
+  }, [fetchLocation]);
+
+  const place = location ? formatPlace(location) : '';
+  const coordinates = location ? formatCoordinates(location) : null;
+
+  return (
+    <section
+      id={ANCHOR_ID}
+      className="scroll-mt-4 rounded-xl border border-light-200 bg-light-primary/80 p-4 lg:p-6 transition-colors dark:border-dark-200 dark:bg-dark-primary/80"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1">
+          <h4 className="text-sm text-black dark:text-white">
+            <AnchorTitle anchorId={ANCHOR_ID}>Detected Location</AnchorTitle>
+          </h4>
+          <p className="text-[11px] text-black/50 dark:text-white/50">
+            The city we infer from your IP address. Used to auto-detect your
+            weather location when &ldquo;Weather Locations&rdquo; is blank.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={fetchLocation}
+          disabled={isLoading}
+          title="Re-check location"
+          aria-label="Re-check location"
+          className="shrink-0 rounded-lg p-1.5 text-black/50 transition duration-200 hover:bg-light-200 active:scale-95 disabled:opacity-50 dark:text-white/50 dark:hover:bg-dark-200"
+        >
+          <RefreshCw size={14} className={isLoading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      <div className="mt-4">
+        {isLoading && !location ? (
+          <div className="flex items-center gap-2 text-xs text-black/50 dark:text-white/50">
+            <Loader2 size={14} className="animate-spin" />
+            <span>Detecting your location…</span>
+          </div>
+        ) : failed ? (
+          <p className="text-xs text-black/50 dark:text-white/50">
+            Couldn&apos;t detect your location right now.
+          </p>
+        ) : place ? (
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-2">
+              <MapPin size={15} className="shrink-0 text-black/40 dark:text-white/40" />
+              <span className="text-sm text-black dark:text-white">{place}</span>
+            </div>
+            <p className="text-[11px] text-black/50 dark:text-white/50">
+              {[
+                location?.timezone,
+                coordinates,
+                location?.ip ? `IP ${location.ip}` : null,
+              ]
+                .filter(Boolean)
+                .join(' · ')}
+            </p>
+          </div>
+        ) : (
+          <p className="text-xs text-black/50 dark:text-white/50">
+            No city could be resolved for your IP address
+            {location?.ip ? ` (${location.ip})` : ''}. Set a location manually
+            under &ldquo;Weather Locations&rdquo; below.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default DetectedLocation;

--- a/apps/qwksearch-web/components/Settings/Sections/Search.tsx
+++ b/apps/qwksearch-web/components/Settings/Sections/Search.tsx
@@ -1,4 +1,5 @@
 import { UIConfigField } from '../../../lib/config/types';
+import DetectedLocation from '../DetectedLocation';
 import SettingsField from '../SettingsField';
 
 const Search = ({
@@ -10,6 +11,7 @@ const Search = ({
 }) => {
   return (
     <div className="flex-1 space-y-6 overflow-y-auto px-6 py-6">
+      <DetectedLocation />
       {fields.map((field) => (
         <SettingsField
           key={field.key}

--- a/apps/qwksearch-web/lib/cloudflare/__tests__/ip-geolocation.test.ts
+++ b/apps/qwksearch-web/lib/cloudflare/__tests__/ip-geolocation.test.ts
@@ -7,7 +7,13 @@ vi.mock('is-vpn', () => ({
   check: (...args: any[]) => checkMock(...args),
 }))
 
-import { detectVpnAndLocation } from '../ip-geolocation'
+import {
+  detectVpnAndLocation,
+  getClientIp,
+  locationFromEdgeHeaders,
+  lookupIpLocation,
+  resolveClientLocation,
+} from '../ip-geolocation'
 
 let fetchMock: ReturnType<typeof vi.fn>
 
@@ -62,5 +68,134 @@ describe('detectVpnAndLocation', () => {
     fetchMock.mockRejectedValue(new Error('geo down'))
     const result = await detectVpnAndLocation('3.3.3.3')
     expect(result).toEqual({ city: undefined, isVpn: true })
+  })
+})
+
+describe('getClientIp', () => {
+  it('takes the leftmost x-forwarded-for hop', () => {
+    const headers = new Headers({ 'x-forwarded-for': '203.0.113.7, 70.41.3.18' })
+    expect(getClientIp(headers)).toBe('203.0.113.7')
+  })
+
+  it('falls back to x-real-ip and then cf-connecting-ip', () => {
+    expect(getClientIp(new Headers({ 'x-real-ip': '203.0.113.8' }))).toBe('203.0.113.8')
+    expect(getClientIp(new Headers({ 'cf-connecting-ip': '203.0.113.9' }))).toBe('203.0.113.9')
+  })
+
+  it('rejects private, loopback and CGNAT addresses', () => {
+    for (const ip of ['127.0.0.1', '::1', '10.0.0.4', '192.168.1.5', '172.20.0.1', '169.254.1.1', '100.64.0.1', 'fd00::1']) {
+      expect(getClientIp(new Headers({ 'x-forwarded-for': ip }))).toBeNull()
+    }
+  })
+
+  it('returns null when no proxy header is present', () => {
+    expect(getClientIp(new Headers())).toBeNull()
+  })
+})
+
+describe('locationFromEdgeHeaders', () => {
+  it('reads Cloudflare geo headers', () => {
+    const headers = new Headers({
+      'cf-ipcity': 'Berlin',
+      'cf-region': 'Berlin',
+      'cf-ipcountry': 'DE',
+      'cf-timezone': 'Europe/Berlin',
+      'cf-iplatitude': '52.52',
+      'cf-iplongitude': '13.40',
+    })
+    expect(locationFromEdgeHeaders(headers)).toEqual({
+      city: 'Berlin',
+      region: 'Berlin',
+      countryCode: 'DE',
+      timezone: 'Europe/Berlin',
+      latitude: 52.52,
+      longitude: 13.4,
+    })
+  })
+
+  it('decodes the percent-encoded Vercel city header', () => {
+    const headers = new Headers({
+      'x-vercel-ip-city': 'San%20Francisco',
+      'x-vercel-ip-country-region': 'CA',
+      'x-vercel-ip-country': 'US',
+    })
+    expect(locationFromEdgeHeaders(headers)?.city).toBe('San Francisco')
+  })
+
+  it('returns null when no edge city is present', () => {
+    expect(locationFromEdgeHeaders(new Headers({ 'cf-ipcountry': 'DE' }))).toBeNull()
+  })
+
+  it('drops unparseable coordinates', () => {
+    const headers = new Headers({ 'cf-ipcity': 'Berlin', 'cf-iplatitude': 'n/a' })
+    expect(locationFromEdgeHeaders(headers)?.latitude).toBeUndefined()
+  })
+})
+
+describe('lookupIpLocation', () => {
+  it('maps an ipapi.co payload', async () => {
+    fetchMock.mockResolvedValue({
+      json: async () => ({
+        city: 'Paris',
+        region: 'Ile-de-France',
+        country_name: 'France',
+        country_code: 'FR',
+        timezone: 'Europe/Paris',
+        latitude: 48.85,
+        longitude: 2.35,
+      }),
+    })
+    expect(await lookupIpLocation('203.0.113.7')).toEqual({
+      city: 'Paris',
+      region: 'Ile-de-France',
+      country: 'France',
+      countryCode: 'FR',
+      timezone: 'Europe/Paris',
+      latitude: 48.85,
+      longitude: 2.35,
+    })
+  })
+
+  it('returns null on an ipapi.co error payload or a missing city', async () => {
+    fetchMock.mockResolvedValue({ json: async () => ({ error: true, reason: 'quota' }) })
+    expect(await lookupIpLocation('203.0.113.7')).toBeNull()
+    fetchMock.mockResolvedValue({ json: async () => ({ country_name: 'France' }) })
+    expect(await lookupIpLocation('203.0.113.7')).toBeNull()
+  })
+
+  it('returns null when the lookup rejects', async () => {
+    fetchMock.mockRejectedValue(new Error('geo down'))
+    expect(await lookupIpLocation('203.0.113.7')).toBeNull()
+  })
+})
+
+describe('resolveClientLocation', () => {
+  it('prefers edge headers over an outbound lookup', async () => {
+    const headers = new Headers({
+      'x-forwarded-for': '203.0.113.7',
+      'cf-ipcity': 'Berlin',
+      'cf-ipcountry': 'DE',
+    })
+    const result = await resolveClientLocation(headers)
+    expect(result).toMatchObject({ ip: '203.0.113.7', city: 'Berlin', source: 'edge' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to ipapi.co when the edge supplied no city', async () => {
+    fetchMock.mockResolvedValue({ json: async () => ({ city: 'Paris', country_name: 'France' }) })
+    const result = await resolveClientLocation(new Headers({ 'x-forwarded-for': '203.0.113.7' }))
+    expect(result).toMatchObject({ ip: '203.0.113.7', city: 'Paris', source: 'ipapi' })
+  })
+
+  it('reports source "none" without a usable IP', async () => {
+    const result = await resolveClientLocation(new Headers({ 'x-forwarded-for': '127.0.0.1' }))
+    expect(result).toEqual({ ip: null, source: 'none' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the IP when the lookup resolves nothing', async () => {
+    fetchMock.mockResolvedValue({ json: async () => ({ error: true }) })
+    const result = await resolveClientLocation(new Headers({ 'x-real-ip': '203.0.113.7' }))
+    expect(result).toEqual({ ip: '203.0.113.7', source: 'none' })
   })
 })

--- a/apps/qwksearch-web/lib/cloudflare/ip-geolocation.ts
+++ b/apps/qwksearch-web/lib/cloudflare/ip-geolocation.ts
@@ -1,9 +1,34 @@
+/**
+ * @fileoverview IP geolocation helpers.
+ *
+ * Two entry points:
+ * - {@link detectVpnAndLocation} resolves a stored session IP (used to label
+ *   the session list in Settings → Account).
+ * - {@link resolveClientLocation} resolves the *current* request's location so
+ *   Settings can show which city the app thinks you are in. It prefers the
+ *   edge headers the host already attaches (Cloudflare / Vercel), and only
+ *   falls back to an ipapi.co lookup when those are absent.
+ */
 import isVpnModule from 'is-vpn';
 
 interface IpGeolocationData {
   city?: string;
   state?: string;
   isVpn: boolean;
+}
+
+export interface ClientLocation {
+  /** The IP the lookup was performed against, or null when undetectable. */
+  ip: string | null;
+  city?: string;
+  region?: string;
+  country?: string;
+  countryCode?: string;
+  timezone?: string;
+  latitude?: number;
+  longitude?: number;
+  /** Where the answer came from — useful when nothing resolved. */
+  source: 'edge' | 'ipapi' | 'none';
 }
 
 const isVpn = isVpnModule as any;
@@ -33,4 +58,121 @@ export async function detectVpnAndLocation(
     console.error('Failed to detect VPN/location:', error);
     return { city: undefined, state: undefined, isVpn: false };
   }
+}
+
+/** Loopback / RFC1918 / link-local / CGNAT ranges, which never geolocate. */
+const PRIVATE_IP =
+  /^(::1|::ffff:127\.|127\.|10\.|192\.168\.|169\.254\.|172\.(1[6-9]|2\d|3[01])\.|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.|fc|fd|fe80:)/i;
+
+/**
+ * Extracts the caller's IP from proxy headers. Mirrors the resolution order
+ * used by the chat handler: `x-forwarded-for` (leftmost hop) → `x-real-ip` →
+ * `cf-connecting-ip`. Private and loopback addresses resolve to null, since a
+ * geolocation lookup on them is guaranteed to be useless.
+ */
+export function getClientIp(headers: Headers): string | null {
+  const candidate =
+    headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    headers.get('x-real-ip')?.trim() ||
+    headers.get('cf-connecting-ip')?.trim() ||
+    '';
+
+  if (!candidate || PRIVATE_IP.test(candidate)) return null;
+  return candidate;
+}
+
+/** Vercel percent-encodes the city header ("San%20Francisco"). */
+const decodeHeader = (value: string | null): string | undefined => {
+  if (!value) return undefined;
+  try {
+    const decoded = decodeURIComponent(value).trim();
+    return decoded || undefined;
+  } catch {
+    return value.trim() || undefined;
+  }
+};
+
+const toCoordinate = (value: string | null): number | undefined => {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+/**
+ * Reads the geo headers Cloudflare and Vercel attach at the edge. Returns null
+ * when neither platform supplied a city, so the caller can fall back to an
+ * outbound lookup.
+ */
+export function locationFromEdgeHeaders(
+  headers: Headers
+): Omit<ClientLocation, 'ip' | 'source'> | null {
+  const city =
+    decodeHeader(headers.get('cf-ipcity')) ??
+    decodeHeader(headers.get('x-vercel-ip-city'));
+  if (!city) return null;
+
+  return {
+    city,
+    region:
+      decodeHeader(headers.get('cf-region')) ??
+      decodeHeader(headers.get('x-vercel-ip-country-region')),
+    // Both platforms only expose the two-letter code, never a country name.
+    countryCode:
+      decodeHeader(headers.get('cf-ipcountry')) ??
+      decodeHeader(headers.get('x-vercel-ip-country')),
+    timezone:
+      decodeHeader(headers.get('cf-timezone')) ??
+      decodeHeader(headers.get('x-vercel-ip-timezone')),
+    latitude:
+      toCoordinate(headers.get('cf-iplatitude')) ??
+      toCoordinate(headers.get('x-vercel-ip-latitude')),
+    longitude:
+      toCoordinate(headers.get('cf-iplongitude')) ??
+      toCoordinate(headers.get('x-vercel-ip-longitude')),
+  };
+}
+
+/** Looks a public IP up against ipapi.co. Never throws. */
+export async function lookupIpLocation(
+  ip: string
+): Promise<Omit<ClientLocation, 'ip' | 'source'> | null> {
+  try {
+    const res = await fetch(`https://ipapi.co/${encodeURIComponent(ip)}/json/`);
+    const data: any = await res.json();
+    if (!data || data.error || !data.city) return null;
+
+    return {
+      city: data.city,
+      region: data.region || undefined,
+      country: data.country_name || undefined,
+      countryCode: data.country_code || undefined,
+      timezone: data.timezone || undefined,
+      latitude: toCoordinate(data.latitude != null ? String(data.latitude) : null),
+      longitude: toCoordinate(data.longitude != null ? String(data.longitude) : null),
+    };
+  } catch (error) {
+    console.error('Failed to look up IP location:', error);
+    return null;
+  }
+}
+
+/**
+ * Resolves the city (and surrounding context) for the current request. Edge
+ * headers win because they cost nothing; ipapi.co is the fallback for local
+ * dev and self-hosted deployments.
+ */
+export async function resolveClientLocation(
+  headers: Headers
+): Promise<ClientLocation> {
+  const ip = getClientIp(headers);
+
+  const fromEdge = locationFromEdgeHeaders(headers);
+  if (fromEdge) return { ip, ...fromEdge, source: 'edge' };
+
+  if (!ip) return { ip: null, source: 'none' };
+
+  const fromApi = await lookupIpLocation(ip);
+  if (!fromApi) return { ip, source: 'none' };
+
+  return { ip, ...fromApi, source: 'ipapi' };
 }


### PR DESCRIPTION
Search Settings now opens with a read-only "Detected Location" card naming the city the app infers from your IP — the same location the homepage weather widget falls back to when "Weather Locations" is left blank.

- `GET /api/geolocation` resolves the caller's location, preferring the geo headers Cloudflare/Vercel already attach at the edge and falling back to an ipapi.co lookup for local dev and self-hosted deploys.
- `lib/cloudflare/ip-geolocation` gains `getClientIp`, `locationFromEdgeHeaders`, `lookupIpLocation` and `resolveClientLocation` alongside the existing session-oriented `detectVpnAndLocation`. Private, loopback and CGNAT addresses short-circuit to no lookup.
- The card shows city/region/country plus timezone, coordinates and the IP, with a re-check button and explicit empty/error states.


Claude-Session: https://claude.ai/code/session_01JtPK2DWWawdAfb1xMYHUa4