### PR TITLE
Fix API error handling to read status from response object

### DIFF
--- a/packages/qwksearch-api-client/test/error-result-shape.test.ts
+++ b/packages/qwksearch-api-client/test/error-result-shape.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Pins the shape the generated client resolves to on a non-2xx
+ * response.
+ *
+ * Callers need the HTTP status to tell "your session expired" (401) apart from
+ * "the server broke" (500). The client puts the *parsed body* in `error` and
+ * never copies the status onto it, so the status has to come from `response`.
+ * Reading `error.status` silently yields `undefined` and every branch on it is
+ * dead code — which is how a stale-session fallback in research-agent-ui came
+ * to never run.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { createClient } from '../src/client/client.gen';
+
+function respondWith(body: string, init: ResponseInit & { type?: string }) {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(body, {
+      ...init,
+      headers: { 'Content-Type': init.type ?? 'application/json' },
+    }),
+  );
+  return createClient({ baseUrl: 'https://example.test', fetch: fetchMock as never });
+}
+
+describe('generated client error result', () => {
+  it('exposes the status on response, not on error', async () => {
+    const client = respondWith(JSON.stringify({ message: 'Authentication required' }), {
+      status: 401,
+    });
+
+    const result = await client.get({ url: '/agent/chats' });
+
+    expect(result.response.status).toBe(401);
+    expect((result.error as Record<string, unknown>).status).toBeUndefined();
+  });
+
+  it('puts the handler JSON body in error', async () => {
+    const client = respondWith(JSON.stringify({ message: 'An error has occurred.' }), {
+      status: 500,
+    });
+
+    const result = await client.get({ url: '/agent/chats' });
+
+    expect(result.error).toEqual({ message: 'An error has occurred.' });
+  });
+
+  it('puts a non-JSON body in error as a raw string', async () => {
+    // A 500 raised outside the route handler never carries this app's
+    // `{ message }` shape, so `error.message` is undefined.
+    const client = respondWith('<!DOCTYPE html><title>Error 1101</title>', {
+      status: 500,
+      type: 'text/html',
+    });
+
+    const result = await client.get({ url: '/agent/chats' });
+
+    expect(typeof result.error).toBe('string');
+    expect((result.error as unknown as { message?: string }).message).toBeUndefined();
+  });
+});

--- a/packages/research-agent-ui/src/components/ChatHistoryDropdown/useHistoryState.ts
+++ b/packages/research-agent-ui/src/components/ChatHistoryDropdown/useHistoryState.ts
@@ -12,6 +12,7 @@ import {
   clearAllGuestChats,
   type GuestChat,
 } from "../../lib/guest";
+import { apiErrorMessage } from "../../lib/apiError";
 import { Chat } from "../../types/research";
 import { toast } from "sonner";
 import { listChats, deleteChatById, deleteAllChats, searchChats } from "qwksearch-api-client";
@@ -104,9 +105,9 @@ export function useHistoryState() {
 
     try {
       if (isAuthenticated) {
-        const { data, error } = await listChats();
+        const { data, error, response } = await listChats();
 
-        if (error && (error as any).status === 401) {
+        if (error && response?.status === 401) {
           // Stale session — fall back to guest chats silently
           const guestChats = getGuestChats().map((chat) => ({
             ...chat,
@@ -119,7 +120,9 @@ export function useHistoryState() {
         }
 
         if (error) {
-          throw new Error(`Failed to fetch chats: ${(error as any).message}`);
+          throw new Error(
+            `Failed to fetch chats: ${apiErrorMessage(error, response?.status)}`,
+          );
         }
 
         setChats(Array.isArray(data?.chats) ? data.chats : []);
@@ -156,10 +159,14 @@ export function useHistoryState() {
     setDeleting(true);
     try {
       if (isAuthenticated) {
-        const { error } = await deleteChatById({ path: { id: chatToDelete } });
+        const { error, response } = await deleteChatById({
+          path: { id: chatToDelete },
+        });
 
         if (error) {
-          throw new Error(`Failed to delete chat: ${(error as any).message}`);
+          throw new Error(
+            `Failed to delete chat: ${apiErrorMessage(error, response?.status)}`,
+          );
         }
       } else {
         deleteGuestChat(chatToDelete);
@@ -183,10 +190,12 @@ export function useHistoryState() {
     setClearingAll(true);
     try {
       if (isAuthenticated) {
-        const { error } = await deleteAllChats();
+        const { error, response } = await deleteAllChats();
 
         if (error) {
-          throw new Error(`Failed to clear history: ${(error as any).message}`);
+          throw new Error(
+            `Failed to clear history: ${apiErrorMessage(error, response?.status)}`,
+          );
         }
       } else {
         clearAllGuestChats();
@@ -222,10 +231,14 @@ export function useHistoryState() {
       setSearching(true);
       try {
         if (isAuthenticated) {
-          const { data, error } = await searchChats({ query: { q: query } });
+          const { data, error, response } = await searchChats({
+            query: { q: query },
+          });
 
           if (error) {
-            throw new Error(`Failed to search chats: ${(error as any).message}`);
+            throw new Error(
+              `Failed to search chats: ${apiErrorMessage(error, response?.status)}`,
+            );
           }
 
           setSearchResults(Array.isArray(data?.chats) ? data.chats : []);

--- a/packages/research-agent-ui/src/lib/apiError.ts
+++ b/packages/research-agent-ui/src/lib/apiError.ts
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Reads a human-readable message out of a qwksearch-api-client
+ * error.
+ *
+ * The generated client resolves to `{ data, error, request, response }`. On a
+ * non-2xx it puts the *parsed response body* in `error` — the handler's JSON
+ * when one was returned, the raw text otherwise (a Worker error page, a
+ * gateway timeout, an HTML 502 from in front of the app). It never copies the
+ * HTTP status onto `error`, so `error.status` is always `undefined` and the
+ * status has to be read from `response.status` instead.
+ *
+ * Reading `.message` straight off that body is what produced the
+ * "Failed to fetch chats: undefined" toast: a platform 500 answers with text,
+ * not with this app's `{ message }` shape.
+ */
+
+/** Longest error text worth putting in a toast; the rest is noise. */
+const MAX_MESSAGE_LENGTH = 200;
+
+/** Body keys the handlers in this repo use to carry an error string. */
+const MESSAGE_KEYS = ["message", "error", "detail"] as const;
+
+function truncate(text: string): string {
+    return text.length > MAX_MESSAGE_LENGTH
+        ? `${text.slice(0, MAX_MESSAGE_LENGTH - 1).trimEnd()}…`
+        : text;
+}
+
+/**
+ * Best-effort description of a failed API call, for logs and toasts.
+ *
+ * Falls back to the HTTP status so the caller never renders the literal
+ * "undefined" — an unparseable body still tells the user *something* went
+ * wrong and tells us which status it was.
+ *
+ * @param error `error` from a generated-client result — a parsed JSON body, a
+ *   raw string, or undefined.
+ * @param status `response.status` from that same result, when the request
+ *   reached the server at all.
+ */
+export function apiErrorMessage(error: unknown, status?: number): string {
+    const fallback = status ? `HTTP ${status}` : "Unknown error";
+
+    if (typeof error === "string") {
+        const text = error.trim();
+        // An HTML error page is a wall of markup, never a message worth showing.
+        if (!text || text.startsWith("<")) return fallback;
+        return truncate(text);
+    }
+
+    if (error && typeof error === "object") {
+        const body = error as Record<string, unknown>;
+        for (const key of MESSAGE_KEYS) {
+            const value = body[key];
+            if (typeof value === "string" && value.trim()) {
+                return truncate(value.trim());
+            }
+        }
+    }
+
+    return fallback;
+}

--- a/packages/research-agent-ui/test/apiError.test.ts
+++ b/packages/research-agent-ui/test/apiError.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Unit tests for reading a message out of a generated-client error.
+ */
+import { describe, expect, it } from 'vitest';
+import { apiErrorMessage } from '../src/lib/apiError';
+
+describe('apiErrorMessage', () => {
+    it('reads the { message } shape the app handlers return', () => {
+        expect(apiErrorMessage({ message: 'Authentication required' }, 401)).toBe(
+            'Authentication required',
+        );
+    });
+
+    it('reads the { error } shape the article route returns', () => {
+        expect(apiErrorMessage({ error: 'Failed to fetch article' }, 500)).toBe(
+            'Failed to fetch article',
+        );
+    });
+
+    it('prefers message over the other keys', () => {
+        expect(apiErrorMessage({ message: 'first', error: 'second' }, 500)).toBe('first');
+    });
+
+    it('falls back to the status instead of "undefined" for a body with no message', () => {
+        // The regression: a platform 500 answers with a body this app never wrote,
+        // and reading `.message` off it rendered the literal string "undefined".
+        expect(apiErrorMessage({}, 500)).toBe('HTTP 500');
+        expect(apiErrorMessage(undefined, 500)).toBe('HTTP 500');
+        expect(apiErrorMessage({ message: '   ' }, 500)).toBe('HTTP 500');
+    });
+
+    it('uses a plain-text error body as the message', () => {
+        expect(apiErrorMessage('Internal Server Error', 500)).toBe('Internal Server Error');
+    });
+
+    it('does not surface an HTML error page as the message', () => {
+        expect(apiErrorMessage('<!DOCTYPE html><title>500</title>', 500)).toBe('HTTP 500');
+    });
+
+    it('truncates a long message so a toast stays readable', () => {
+        const result = apiErrorMessage('x'.repeat(500), 500);
+        expect(result).toHaveLength(200);
+        expect(result.endsWith('…')).toBe(true);
+    });
+
+    it('says so when the request never reached the server', () => {
+        expect(apiErrorMessage(undefined, undefined)).toBe('Unknown error');
+    });
+});


### PR DESCRIPTION
## Summary
This PR fixes a bug where API error messages were displaying "undefined" in toasts due to incorrect error handling. The generated API client puts the HTTP status on the `response` object, not on the `error` object, but the code was trying to read `error.status` which is always undefined.

## Key Changes
- **New utility function** (`apiErrorMessage`): Extracts human-readable error messages from API responses with proper fallbacks
  - Handles multiple error body shapes: `{ message }`, `{ error }`, `{ detail }`
  - Filters out HTML error pages (platform errors) and returns HTTP status instead
  - Truncates long messages to keep toasts readable
  - Falls back to HTTP status code when no message is available

- **Test coverage**: Added comprehensive tests for both the utility function and the generated client's error shape
  - Documents the expected error result structure from the generated client
  - Validates all error message extraction scenarios

- **Updated error handling** in `useHistoryState.ts`:
  - Changed `error.status` checks to `response?.status` to correctly detect 401 stale sessions
  - Replaced direct `error.message` access with `apiErrorMessage()` calls
  - Applied fix to all API calls: `listChats`, `deleteChatById`, `deleteAllChats`, `searchChats`

## Implementation Details
The generated API client resolves to `{ data, error, request, response }` where:
- On non-2xx responses, the parsed response body goes into `error` (or raw text if unparseable)
- The HTTP status is always on `response.status`, never on `error.status`
- This means reading `error.status` silently returns `undefined`, making any conditional logic on it dead code

The new `apiErrorMessage` function provides a robust way to extract meaningful error text from various response formats while gracefully handling edge cases like platform errors and missing message fields.

https://claude.ai/code/session_01J7MjKCYUBKAZQ1mniweqKc