### PR TITLE
fix(auth): stop Google sign-in asking for the user's whole Drive

### DIFF
--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -26,6 +26,10 @@ configureResearchAgentUI({
   downloadWindowsStoreId: config.downloadWindowsStoreId,
   footerLinks: listFooterLinks,
   googleApiKey: process.env.NEXT_PUBLIC_GOOGLE_API_KEY || '',
+  // Cloud project number the Drive picker identifies this app by. It is the
+  // numeric prefix of the OAuth client ID, so it needs no separate secret.
+  googleAppId:
+    process.env.NEXT_PUBLIC_GOOGLE_APP_ID || config.googleClientId.split('-')[0],
   getAutoMediaSearch: () => true,
 });
 

--- a/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
+++ b/apps/qwksearch-web/lib/auth/__tests__/index.test.ts
@@ -99,4 +99,43 @@ describe("auth configuration", () => {
       vi.unstubAllEnvs();
     });
   });
+
+  describe("google sign-in scopes", () => {
+    const buildConfig = async () => {
+      // initAuth memoizes its instance at module scope, so the config has to
+      // be rebuilt to observe a fresh betterAuth() call.
+      vi.resetModules();
+      const { initAuth } = await import("../index");
+      await initAuth();
+      return betterAuthMock.mock.calls.at(-1)![0];
+    };
+
+    it("asks Google for identity only, never for Drive or Docs", async () => {
+      // The same OAuth client backs sign-in and the optional Drive connector.
+      // If a connector scope reached the sign-in request, a first-time Google
+      // sign-in would ask the user to hand over their whole Drive.
+      vi.stubEnv("GOOGLE_CLIENT_ID", "client-id");
+      vi.stubEnv("GOOGLE_CLIENT_SECRET", "client-secret");
+
+      const { socialProviders } = await buildConfig();
+
+      expect(socialProviders.google.scope).toEqual(["openid", "email", "profile"]);
+      expect(socialProviders.google.scope.join(" ")).not.toMatch(
+        /drive|documents/,
+      );
+
+      vi.unstubAllEnvs();
+    });
+
+    it("leaves Google unconfigured when no credentials are set", async () => {
+      vi.stubEnv("GOOGLE_CLIENT_ID", "");
+      vi.stubEnv("GOOGLE_CLIENT_SECRET", "");
+
+      const { socialProviders } = await buildConfig();
+
+      expect(socialProviders.google).toBeUndefined();
+
+      vi.unstubAllEnvs();
+    });
+  });
 });

--- a/apps/qwksearch-web/lib/auth/index.ts
+++ b/apps/qwksearch-web/lib/auth/index.ts
@@ -50,12 +50,24 @@ function originOfRequest(request: Request | undefined): string | undefined {
 async function authBuilder() {
   const db = getDB();
 
-  const socialProviders: Record<string, { clientId: string; clientSecret: string }> = {};
+  const socialProviders: Record<
+    string,
+    { clientId: string; clientSecret: string; scope?: string[] }
+  > = {};
 
   if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
     socialProviders.google = {
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      // Signing in asks for identity only. The same OAuth client also backs
+      // the optional Google Drive connector (lib/integrations/googleDocsService),
+      // and none of that connector's scopes may leak into the login consent
+      // screen: a first-time Google sign-in should read "name, email address,
+      // profile picture", never "see and download all your Google Drive
+      // files". Drive access is granted separately and incrementally, the
+      // first time the user actually connects Drive. Pinning the list here
+      // (rather than relying on the provider default) keeps it that way.
+      scope: ["openid", "email", "profile"],
     };
   }
 

--- a/apps/qwksearch-web/lib/integrations/__tests__/googleDocsService.test.ts
+++ b/apps/qwksearch-web/lib/integrations/__tests__/googleDocsService.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The service module reaches for the database at import time; the OAuth URL
+// builder under test is static and touches none of it.
+vi.mock('@/lib/database/turso', () => ({ tursoQueries: {} }));
+
+import { GoogleDocsService } from '../googleDocsService';
+
+const authUrl = () =>
+  new URL(
+    GoogleDocsService.getAuthUrl({
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      redirectUri: 'https://qwksearch.com/api/doc/google-docs/callback',
+    }),
+  );
+
+describe('GoogleDocsService.getAuthUrl', () => {
+  it('requests only per-file Drive access', () => {
+    // `drive.file` covers everything the connector does — read the files the
+    // user picks, write the docs it creates — without the consent screen
+    // asking for the user's entire Drive.
+    expect(authUrl().searchParams.get('scope')).toBe(
+      'https://www.googleapis.com/auth/drive.file',
+    );
+  });
+
+  it('never asks for the restricted whole-Drive scopes', () => {
+    const scope = authUrl().searchParams.get('scope') ?? '';
+
+    expect(scope).not.toContain('auth/drive.readonly');
+    expect(scope).not.toContain('auth/documents');
+  });
+
+  it('adds the grant to the scopes the account already approved', () => {
+    // Without incremental authorization, connecting Drive would replace the
+    // identity grant made at sign-in rather than extend it.
+    const params = authUrl().searchParams;
+
+    expect(params.get('include_granted_scopes')).toBe('true');
+    expect(params.get('access_type')).toBe('offline');
+  });
+
+  it('sends the caller-supplied client and redirect', () => {
+    const params = authUrl().searchParams;
+
+    expect(params.get('client_id')).toBe('client-id');
+    expect(params.get('redirect_uri')).toBe(
+      'https://qwksearch.com/api/doc/google-docs/callback',
+    );
+    expect(params.get('response_type')).toBe('code');
+  });
+});

--- a/apps/qwksearch-web/lib/integrations/googleDocsService.ts
+++ b/apps/qwksearch-web/lib/integrations/googleDocsService.ts
@@ -53,6 +53,25 @@ export class GoogleDocsService {
     this.refreshToken = refreshToken;
   }
 
+  /**
+   * Scopes requested when a user connects Google Drive.
+   *
+   * `drive.file` is the per-file scope: it grants access only to files the
+   * user explicitly hands over through the Google Picker plus files this app
+   * creates itself, which is the whole of what the connector does (download
+   * picked files, create/update docs it exported). It replaces the pair this
+   * used to request — `drive.readonly` and `documents` — which Google renders
+   * on the consent screen as "See and download all your Google Drive files"
+   * and "See, edit, create and delete all your Google Docs documents". Those
+   * are restricted scopes: they cover the user's entire Drive, they drag the
+   * OAuth client through Google's restricted-scope verification, and because
+   * this app uses one OAuth client for both sign-in and Drive they made the
+   * account's first Google consent look like a demand for the whole Drive.
+   */
+  static readonly AUTH_SCOPES: readonly string[] = [
+    'https://www.googleapis.com/auth/drive.file',
+  ];
+
   static getAuthUrl(config: GoogleDocsConfig): string {
     const params = new URLSearchParams({
       client_id: config.clientId,
@@ -60,10 +79,11 @@ export class GoogleDocsService {
       response_type: 'code',
       access_type: 'offline',
       prompt: 'consent',
-      scope: [
-        'https://www.googleapis.com/auth/documents',
-        'https://www.googleapis.com/auth/drive.readonly',
-      ].join(' '),
+      // Layer this grant on top of whatever the account already approved (the
+      // identity scopes from sign-in) instead of replacing it, so connecting
+      // Drive never silently drops the sign-in grant.
+      include_granted_scopes: 'true',
+      scope: GoogleDocsService.AUTH_SCOPES.join(' '),
     });
     return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
   }

--- a/packages/research-agent-ui/src/components/FileUpload/GoogleDrivePicker.tsx
+++ b/packages/research-agent-ui/src/components/FileUpload/GoogleDrivePicker.tsx
@@ -67,7 +67,7 @@ export const useGooglePicker = () => {
 
     try {
       const { picker } = googleApi;
-      const pickerInstance = new picker.PickerBuilder()
+      const builder = new picker.PickerBuilder()
         .addView(picker.ViewId.DOCS)
         .addView(picker.ViewId.DOCS_IMAGES)
         .addView(picker.ViewId.DOCS_VIDEOS)
@@ -79,7 +79,16 @@ export const useGooglePicker = () => {
             )
         )
         .setOAuthToken(accessToken)
-        .setDeveloperKey(researchAgentUIConfig.googleApiKey)
+        .setDeveloperKey(researchAgentUIConfig.googleApiKey);
+
+      // The Drive connector is authorized with the per-file `drive.file`
+      // scope, so picking a file is what grants access to it — and Google
+      // only issues that grant when the picker names the app asking for it.
+      if (researchAgentUIConfig.googleAppId) {
+        builder.setAppId(researchAgentUIConfig.googleAppId);
+      }
+
+      const pickerInstance = builder
         .setCallback((data: google.picker.ResponseObject) => {
           if (data.action === picker.Action.PICKED) {
             const files = data.docs;

--- a/packages/research-agent-ui/src/config.ts
+++ b/packages/research-agent-ui/src/config.ts
@@ -38,6 +38,14 @@ export interface ResearchAgentUIConfig {
   footerLinks: FooterLink[];
   /** Google API key used by the Google Drive file picker. */
   googleApiKey: string;
+  /**
+   * Google Cloud project number, passed to the Drive picker as its app ID.
+   * The connector holds the per-file `drive.file` scope rather than blanket
+   * Drive access, and Google only grants the app a picked file when the
+   * picker knows which app is asking — so leaving this empty means picked
+   * files come back but downloading them 403s.
+   */
+  googleAppId: string;
   /** Whether to auto-trigger image/video media search after a response completes. */
   getAutoMediaSearch: () => boolean;
   /**
@@ -69,6 +77,7 @@ export const researchAgentUIConfig: ResearchAgentUIConfig = {
   downloadWindowsStoreId: '9PCGF9GNK460',
   footerLinks: [],
   googleApiKey: '',
+  googleAppId: '',
   getAutoMediaSearch: () => true,
 };
 


### PR DESCRIPTION
Signing in with Google shared one OAuth client with the optional Google Drive connector, and that connector asked for `drive.readonly` plus `documents` — rendered on Google's consent screen as "See and download all your Google Drive files" and "See, edit, create and delete all your Google Docs documents". A first-time signup was therefore presented as a demand for the account's entire Drive.

- Pin the sign-in provider to identity scopes only (openid/email/profile) so nothing the connector needs can reach the login consent screen.
- Narrow the Drive connector to the per-file `drive.file` scope, which is all it actually uses: download the files the user picks in the Google Picker, and create/update the docs it exports. Restricted whole-Drive scopes are gone, along with the verification they drag in.
- Request the Drive grant incrementally (include_granted_scopes) so connecting Drive extends the sign-in grant rather than replacing it.
- Pass the Cloud project number to the Picker as its app ID; with `drive.file`, picking a file is what grants access to it, and Google only issues that grant when the picker names the app asking.

Covered by tests over the auth config and the Drive authorization URL.


Claude-Session: https://claude.ai/code/session_01A94ohxvnLd4eY68peRamX9