### PR TITLE
fix(sidebar): wire up FileTree's onExpandedFoldersChange prop

### DIFF
--- a/packages/reason-editor-sidebar/src/file-tree/filetree.tsx
+++ b/packages/reason-editor-sidebar/src/file-tree/filetree.tsx
@@ -32,7 +32,6 @@ export type DocumentTreeHandle = {
   edit: (nodeId: string) => void;
   expandAll: () => void;
   expandToLevel: (level: number) => void;
-  cancelExpand: () => void;
   /** Deepest folder level currently fully expanded (0 = fully collapsed). */
   getExpandLevel: () => number;
   /** Deepest folder nesting level in the tree (0 = no folders at all). */
@@ -86,6 +85,14 @@ interface FileTreeProps {
    * depth or the tree's own depth changes, and with zeroes on unmount.
    */
   onExpandStateChange?: (state: { level: number; maxLevel: number }) => void;
+  /**
+   * Hands the tree's current expanded-folder set to the host whenever it
+   * changes, so the host can persist it. Without this, a stepped
+   * expand/collapse lives only in the tree's local state and the next
+   * document change (e.g. a rename) resets the tree back to the persisted
+   * `isExpanded` flags, throwing the cycle away.
+   */
+  onExpandedFoldersChange?: (folderIds: string[]) => void;
 }
 
 const ROOT_ID = "__root__";
@@ -161,7 +168,7 @@ function buildItems(documents: Document[]): Record<string, FileTreeItem> {
 }
 
 const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
-  ({ activeId, documents, onMove, onRename, onSelect, onDelete, onDuplicate, onAddChild, onAddChildFolder, onAddSibling, onAddSiblingFolder, onCopy, onPaste, onNewFile: _onNewFile, onNewFolder: _onNewFolder, onManageTags, onExpandStateChange }, ref) => {
+  ({ activeId, documents, onMove, onRename, onSelect, onDelete, onDuplicate, onAddChild, onAddChildFolder, onAddSibling, onAddSiblingFolder, onCopy, onPaste, onNewFile: _onNewFile, onNewFolder: _onNewFolder, onManageTags, onExpandStateChange, onExpandedFoldersChange }, ref) => {
     const items = useMemo(() => {
       const built = buildItems(documents);
       return built;
@@ -177,8 +184,6 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
     });
     const [copiedNodeId, setCopiedNodeId] = useState<string | null>(null);
     const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
-    // Must survive re-renders so a queued expandAll can actually be cancelled.
-    const expandCancelToken = useRef(false);
 
     const tree = useTree<FileTreeItem>({
       canReorder: true,
@@ -297,10 +302,23 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
       [],
     );
 
+    // Reports the tree's live expanded-folder set to the host so it can be
+    // persisted, keyed by content (not array identity) so it only fires when
+    // the actual set changes.
+    const currentExpandedItems = state.expandedItems ?? [];
+    const onExpandedFoldersChangeRef = useRef(onExpandedFoldersChange);
+    useEffect(() => {
+      onExpandedFoldersChangeRef.current = onExpandedFoldersChange;
+    }, [onExpandedFoldersChange]);
+    const currentExpandedItemsKey = currentExpandedItems.join('\n');
+    useEffect(() => {
+      onExpandedFoldersChangeRef.current?.(currentExpandedItems);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentExpandedItemsKey]);
+
     useImperativeHandle(ref, () => ({
       collapseAll: () => {
-        expandCancelToken.current = true;
-        tree.collapseAll();
+        setState((prev) => ({ ...prev, expandedItems: [] }));
       },
       edit: (nodeId: string) => {
         if (onRename) {
@@ -308,16 +326,12 @@ const FileTree = forwardRef<DocumentTreeHandle, FileTreeProps>(
         }
       },
       expandAll: () => {
-        expandCancelToken.current = false;
-        tree.expandAll(expandCancelToken);
-      },
-      expandToLevel: (level: number) => {
-        expandCancelToken.current = true;
-        const ids = getFolderIdsUpToLevel(items, ROOT_ID, Math.min(level, maxExpandLevel));
+        const ids = getFolderIdsUpToLevel(items, ROOT_ID, maxExpandLevel);
         setState((prev) => ({ ...prev, expandedItems: ids }));
       },
-      cancelExpand: () => {
-        expandCancelToken.current = true;
+      expandToLevel: (level: number) => {
+        const ids = getFolderIdsUpToLevel(items, ROOT_ID, Math.min(level, maxExpandLevel));
+        setState((prev) => ({ ...prev, expandedItems: ids }));
       },
       getExpandLevel: () => expandLevel,
       getMaxExpandLevel: () => maxExpandLevel,


### PR DESCRIPTION
## Summary

`SidebarContent.tsx` already passed `onExpandedFoldersChange` to `FileTree` (and a test already covered it), but `FileTree`'s `FileTreeProps` never declared or implemented the prop. That broke the `qwksearch-web` production build:

```
src/SidebarContent.tsx(403,9): error TS2322: Type '{ ... }' is not assignable to type 'IntrinsicAttributes & FileTreeProps & RefAttributes<DocumentTreeHandle>'.
  Property 'onExpandedFoldersChange' does not exist on type 'IntrinsicAttributes & FileTreeProps & RefAttributes<DocumentTreeHandle>'.
```

- Added `onExpandedFoldersChange?: (folderIds: string[]) => void` to `FileTreeProps`, wired through `forwardRef`'s destructured props, and added an effect that reports the tree's live `expandedItems` set to the host whenever it changes (mirroring the existing `onExpandStateChange` pattern), so a stepped expand/collapse survives being persisted.
- While tracing why the associated test suite (`test/file-tree/expandCycle.test.tsx`) was still failing after that fix, found that `collapseAll`/`expandAll` on the imperative handle called `tree.collapseAll()`/`tree.expandAll()` from `@headless-tree/core`, but those methods only exist when `expandAllFeature` is registered — it isn't, so both threw `TypeError` at runtime. This matches exactly what the prior commit's message described doing ("Expand-all becomes a synchronous set of every folder id rather than headless-tree's async walk, which makes the cancel token — and the `cancelExpand` handle method that existed only to trip it — dead code.") but the actual diff never made that change. Applied it now: `collapseAll`/`expandAll`/`expandToLevel` all just write `expandedItems` synchronously via `setState`, and the now-unused `cancelExpand` handle method plus its cancellation token ref were removed.

## Test plan

- [x] `bun run build` in `packages/reason-editor-sidebar` — passes (previously failed with TS2322)
- [x] `npm run prebuild` in `apps/qwksearch-web` (the exact chain from the CI failure) — passes
- [x] `bunx vitest run` in `packages/reason-editor-sidebar` — 72/72 tests pass (previously 2-3 failing in `expandCycle.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019eqtvx1uwiR5GMpNhpuswy

---
_Generated by [Claude Code](https://claude.ai/code/session_019eqtvx1uwiR5GMpNhpuswy)_