### PR TITLE
Resolve the engine's extraction settings, and repair the D1 auth routing #374 left half-applied

### DIFF
--- a/apps/qwksearch-web/lib/database/__tests__/d1-session.test.ts
+++ b/apps/qwksearch-web/lib/database/__tests__/d1-session.test.ts
@@ -163,19 +163,6 @@ describe("session constraints", () => {
     expect(d1.opened).toEqual(["first-unconstrained"]);
   });
 
-  it("still lets D1_SESSION_MODE unconstrain auth requests", async () => {
-    const d1 = fakeD1();
-    const db = sessionedD1(d1.binding);
-
-    await runWithD1Session(
-      new Request("https://example.test/api/auth/callback/google"),
-      "unconstrained",
-      () => db.prepare("select 1").run(),
-    );
-
-    expect(d1.opened).toEqual(["first-unconstrained"]);
-  });
-
   it("resumes from the client's bookmark, header or cookie", async () => {
     const d1 = fakeD1();
     const db = sessionedD1(d1.binding);

--- a/apps/qwksearch-web/lib/database/d1-session.ts
+++ b/apps/qwksearch-web/lib/database/d1-session.ts
@@ -68,7 +68,8 @@ export const FIRST_PRIMARY = "first-primary";
  *                   writes and any replica for reads
  *   primary         always start on the primary — replicas still serve, but
  *                   only from the latest version
- *   unconstrained   always start anywhere — lowest latency, weakest freshness
+ *   unconstrained   always start anywhere — lowest latency, weakest freshness,
+ *                   except /api/auth/*, which stays pinned to the primary
  *   off             bypass the Sessions API entirely (rollback switch)
  */
 export type D1SessionMode = "auto" | "primary" | "unconstrained" | "off";
@@ -194,10 +195,10 @@ function needsPrimary(request: Request): boolean {
  */
 function resolveStart(request: Request, mode: D1SessionMode): string {
   if (mode === "primary") return FIRST_PRIMARY;
-  if (requiresPrimary(request)) return FIRST_PRIMARY;
-  if (mode === "unconstrained") return FIRST_UNCONSTRAINED;
-
+  // Before the `unconstrained` check on purpose: for auth traffic neither a
+  // client bookmark nor the low-latency override is a strong enough guarantee.
   if (needsPrimary(request)) return FIRST_PRIMARY;
+  if (mode === "unconstrained") return FIRST_UNCONSTRAINED;
 
   const bookmark = readClientBookmark(request);
   if (bookmark) return bookmark;

--- a/packages-lobe/README.md
+++ b/packages-lobe/README.md
@@ -84,6 +84,15 @@ data is reused as-is.
 
   `extract-webpage` is loaded through a lazy, injectable loader (`worker/qwksearch/extractQwkSearch.ts`),
   so a missing or broken install degrades to the next tier instead of taking the Worker down.
+- **Extraction settings** (`worker/qwksearch/extractSettings.ts`): the chain's knobs — transcript
+  language, citation style, render backend, PDF OCR mode, which tiers run — are resolved rather
+  than hard-coded, layering operator config over the shipped defaults and then per-request
+  preferences over that. Every value is validated on the way in, and an unparseable one falls back
+  to the layer below instead of failing the request. `GET /api/doc/article` accepts exactly two of
+  them as query parameters, `cite` (`apa` | `mla` | `chicago`) and `lang` (comma-separated
+  transcript languages); hosts, credentials and the OCR mode are environment-only, because a
+  caller-supplied backend URL would make the endpoint an open request proxy. This is the sink the
+  Extraction settings pane writes to when it lands.
 - **Branding**: `BRANDING_NAME`/`ORG_NAME` = QwkSearch, QwkSearch favicons under `public/`,
   support/social URLs point at qwksearch.com.
 
@@ -149,7 +158,23 @@ Secrets (`wrangler secret put …`):
 | `QSTASH_TOKEN`, `QSTASH_*_SIGNING_KEY` | LobeHub workflows (Upstash QStash) |
 
 Plain vars (`APP_URL`, `DATABASE_DRIVER`, `DISABLE_REDIS`, `EMAIL_SERVICE_PROVIDER`, `SMTP_FROM`,
-`SCRAPER_URL`, `SEARCH_PROVIDERS`, `QWKSEARCH_SEARCH_URL`) are in `wrangler.jsonc`; `keep_vars` keeps dashboard-entered vars across deploys. Run
+`SCRAPER_URL`, `SEARCH_PROVIDERS`, `QWKSEARCH_SEARCH_URL`) are in `wrangler.jsonc`; `keep_vars` keeps dashboard-entered vars across deploys.
+
+Extraction is tuned by an optional group of vars, all defaulted (`worker/qwksearch/extractSettings.ts`):
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `QWKSEARCH_CITATION_STYLE` | `apa` | `apa`, `mla` or `chicago` |
+| `QWKSEARCH_EXTRACT_LANGUAGES` | `en` | preferred YouTube transcript languages, most-preferred first (max 5) |
+| `QWKSEARCH_EXTRACT_TIMEOUT` | `10` | `extract-webpage` request timeout, seconds (1–60) |
+| `QWKSEARCH_EXTRACT_TIERS` | all four | which tiers may run, in order: `qwksearch,scraper,tavily,crawler` |
+| `QWKSEARCH_SCRAPER_DEADLINE_MS` | `8000` | Puppeteer render budget (1000–30000) |
+| `QWKSEARCH_PDF_PROCESSOR` | `frontend` | `extract-pdf` OCR mode: `frontend` (none), `hybrid`, `docling` |
+| `QWKSEARCH_PDF_PROCESSOR_URL` | — | remote docling-compatible processor for `hybrid`/`docling` |
+| `QWKSEARCH_EXTRACT_PROXY` | — | outbound proxy for the extractor's own fetches |
+| `QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP` | `false` | let the extractor fall back to a third-party reader |
+
+Run
 LobeHub's Postgres migrations once against the database: `bun run db:migrate` with `DATABASE_URL` set.
 
 ## Tests

--- a/packages-lobe/worker/qwksearch/extract.test.ts
+++ b/packages-lobe/worker/qwksearch/extract.test.ts
@@ -16,8 +16,10 @@ import {
   looksLikeChallenge,
   markdownToSimpleHtml,
   tiersForUrl,
+  toQwkSearchExtractOptions,
 } from './extract';
 import type { ExtractWebpageModule } from './extractQwkSearch';
+import { type ExtractionSettings, resolveExtractionSettings } from './extractSettings';
 
 /** A stand-in for `extract-webpage`, so tests never load the real extractor. */
 const fakeModule = (overrides: Partial<ExtractWebpageModule> = {}): ExtractWebpageModule => ({
@@ -65,17 +67,53 @@ describe('classifyUrl', () => {
 });
 
 describe('tiersForUrl', () => {
+  const ids = (url: string, settings?: ExtractionSettings) =>
+    tiersForUrl(url, undefined, settings ?? resolveExtractionSettings({})).map((t) => t.tierId);
+
   it('gives youtube and pdf the qwksearch extractor alone', () => {
     // The remaining tiers render HTML, which for these URLs is page chrome
     // rather than the transcript or the document.
-    expect(tiersForUrl('https://youtu.be/dQw4w9WgXcQ')).toEqual([extractViaQwkSearch]);
-    expect(tiersForUrl('https://example.com/paper.pdf')).toEqual([extractViaQwkSearch]);
+    expect(ids('https://youtu.be/dQw4w9WgXcQ')).toEqual(['qwksearch']);
+    expect(ids('https://example.com/paper.pdf')).toEqual(['qwksearch']);
   });
 
   it('gives articles the full chain, qwksearch first', () => {
-    const tiers = tiersForUrl('https://example.com/post');
-    expect(tiers[0]).toBe(extractViaQwkSearch);
-    expect(tiers).toHaveLength(4);
+    expect(ids('https://example.com/post')).toEqual(['qwksearch', 'scraper', 'tavily', 'crawler']);
+  });
+
+  it('drops the tiers the operator switched off, keeping the chain order', () => {
+    const settings = resolveExtractionSettings({ QWKSEARCH_EXTRACT_TIERS: 'crawler,qwksearch' });
+    expect(ids('https://example.com/post', settings)).toEqual(['qwksearch', 'crawler']);
+  });
+
+  it('returns an empty chain when no enabled tier can serve the url kind', () => {
+    // `scraper` renders HTML, which is not what a PDF needs; rather than run a
+    // tier the operator disabled, the caller gets the "no tier" error.
+    const settings = resolveExtractionSettings({ QWKSEARCH_EXTRACT_TIERS: 'scraper' });
+    expect(ids('https://example.com/paper.pdf', settings)).toEqual([]);
+  });
+
+  it('projects the resolved settings onto the extractor options', async () => {
+    let seen: Record<string, unknown> | undefined;
+    const settings = resolveExtractionSettings({
+      QWKSEARCH_EXTRACT_LANGUAGES: 'de,fr',
+      QWKSEARCH_EXTRACT_TIMEOUT: '25',
+      QWKSEARCH_PDF_PROCESSOR: 'hybrid',
+    });
+    // The loader is a test seam rather than a setting, so it is injected here
+    // instead of going through `toQwkSearchExtractOptions`.
+    await extractViaQwkSearch('https://example.com/paper.pdf', {
+      ...toQwkSearchExtractOptions(settings),
+      loader: async () =>
+        fakeModule({
+          extractContent: vi.fn(async (_url: string, options?: Record<string, unknown>) => {
+            seen = options;
+            return { html: '<p>body</p>' };
+          }),
+        }),
+    });
+
+    expect(seen).toMatchObject({ languages: ['de', 'fr'], processor: 'hybrid', timeout: 25 });
   });
 });
 
@@ -97,6 +135,13 @@ describe('markdownToSimpleHtml', () => {
 });
 
 describe('buildCite / countWords', () => {
+  const article = {
+    author_cite: 'Lovelace, A.',
+    date: '2024-03-05',
+    source: 'example.com',
+    title: 'T',
+  };
+
   it('builds an APA-ish citation with a year when the date is valid', () => {
     const cite = buildCite(
       { date: '2024-03-05', source: 'example.com', title: 'T' },
@@ -104,6 +149,34 @@ describe('buildCite / countWords', () => {
     );
     expect(cite).toContain('(2024, Mar 5)');
     expect(cite).toContain('<b>T</b>');
+  });
+
+  it('formats MLA with the day-first date and a quoted title', () => {
+    const cite = buildCite(article, 'https://example.com/a', 'mla');
+    expect(cite).toContain('Lovelace, A. "<b>T</b>."');
+    expect(cite).toContain('5 Mar. 2024');
+    expect(cite).toContain('<i>example.com</i>');
+    expect(cite.endsWith('.')).toBe(true);
+  });
+
+  it('formats Chicago with a full month name', () => {
+    const cite = buildCite(article, 'https://example.com/a', 'chicago');
+    expect(cite).toContain('March 5, 2024');
+    expect(cite).toContain('Lovelace, A. "<b>T</b>."');
+  });
+
+  it('omits an epoch-shaped date in every style rather than claiming 1970', () => {
+    // Unparsed dates and missing timestamps both land on the Unix epoch.
+    for (const style of ['apa', 'chicago', 'mla'] as const) {
+      const cite = buildCite({ ...article, date: '1970-01-01' }, 'https://example.com/a', style);
+      expect(cite).not.toContain('1970');
+    }
+  });
+
+  it('drops the empty segments instead of printing stray punctuation', () => {
+    const cite = buildCite({ title: 'Only a title' }, 'https://example.com/a', 'mla');
+    expect(cite).not.toContain(', ,');
+    expect(cite).toContain('<b>Only a title</b>');
   });
 
   it('counts words ignoring tags', () => {
@@ -182,6 +255,26 @@ describe('extractViaQwkSearch', () => {
         }),
     });
     expect(article.cite).toBe('Upstream cite');
+  });
+
+  it('rebuilds the extractor citation when a non-APA style is asked for', async () => {
+    // The extractor only ever emits APA, so honouring another style means
+    // rebuilding from the fields it resolved.
+    const article = await extractViaQwkSearch('https://example.com/a', {
+      citationStyle: 'mla',
+      loader: async () =>
+        fakeModule({
+          extractContent: vi.fn(async () => ({
+            author_cite: 'Lovelace, A.',
+            cite: 'Lovelace, A. (1843, Oct 1). <b>Notes</b>.',
+            date: '1990-10-01',
+            html: '<p>hi</p>',
+            title: 'Notes',
+          })),
+        }),
+    });
+    expect(article.cite).toContain('Lovelace, A. "<b>Notes</b>."');
+    expect(article.cite).toContain('1 Oct. 1990');
   });
 
   it('returns an error instead of throwing when the package cannot be loaded', async () => {

--- a/packages-lobe/worker/qwksearch/extract.ts
+++ b/packages-lobe/worker/qwksearch/extract.ts
@@ -23,6 +23,13 @@ import {
   runQwkSearchExtractor,
   runQwkSearchHtmlExtractor,
 } from './extractQwkSearch';
+import {
+  type CitationStyle,
+  DEFAULT_TIER_ORDER,
+  type ExtractionSettings,
+  resolveExtractionSettings,
+  type TierId,
+} from './extractSettings';
 
 export interface ExtractedArticle {
   author?: string;
@@ -128,16 +135,92 @@ export const countWords = (text?: string | null): number =>
         .filter(Boolean).length
     : 0;
 
-/** APA-ish citation string, same shape as the original extractor's URL branch. */
-export const buildCite = (article: ExtractedArticle, url: string): string => {
+/**
+ * A publication date we are willing to print.
+ *
+ * Anything at or before 1971 is treated as absent: unparsed dates and missing
+ * timestamps land on the Unix epoch, and a citation that claims an article was
+ * published in 1970 is worse than one with no date at all.
+ */
+const citableDate = (article: ExtractedArticle): Date | undefined => {
+  const parsed = article.date ? new Date(article.date) : undefined;
+  if (!parsed || Number.isNaN(parsed.getTime()) || parsed.getFullYear() <= 1971) return undefined;
+  return parsed;
+};
+
+const citeLink = (url: string) => `<a href="${url}" target="_blank">${url}</a>`;
+
+/** Terminal punctuation MLA and Chicago treat as already closing a segment. */
+const ENDS_SENTENCE = /[!.?]$/;
+
+/**
+ * `Lovelace, A.` → `Lovelace, A. ` — one period, not two.
+ *
+ * `author_cite` arrives as `Last, F.` from the extractor's name database, so
+ * appending the style's own period unconditionally doubles it.
+ */
+const citeSegment = (value?: string): string =>
+  value ? `${ENDS_SENTENCE.test(value) ? value : `${value}.`} ` : '';
+
+/** MLA/Chicago title: quoted, with the period inside unless it ends in ? or !. */
+const citeTitle = (title?: string): string =>
+  title ? `"<b>${title}</b>${ENDS_SENTENCE.test(title) ? '' : '.'}" ` : '';
+
+const buildApaCite = (article: ExtractedArticle, url: string, date?: Date): string => {
   const source = article.source || '';
-  const parsedDate = article.date ? new Date(article.date) : undefined;
-  const year = parsedDate ? parsedDate.getFullYear() : Number.NaN;
-  const apaDate =
-    parsedDate && year > 1971
-      ? ` (${year}, ${parsedDate.toLocaleDateString('en-US', { day: 'numeric', month: 'short' })})`
-      : '';
-  return `${article.author_cite || source || ' '}${apaDate}. <b>${article.title || ''}</b>. <i>${source}</i>. <a href="${url}" target="_blank">${url}</a>`;
+  const apaDate = date
+    ? ` (${date.getFullYear()}, ${date.toLocaleDateString('en-US', { day: 'numeric', month: 'short' })})`
+    : '';
+  return `${article.author_cite || source || ' '}${apaDate}. <b>${article.title || ''}</b>. <i>${source}</i>. ${citeLink(url)}`;
+};
+
+/** `Lovelace, A. "Title." Source, 5 Mar. 2024, url.` */
+const buildMlaCite = (article: ExtractedArticle, url: string, date?: Date): string => {
+  const head = citeSegment(article.author_cite);
+  const title = citeTitle(article.title);
+  const day = date
+    ? `${date.getDate()} ${date.toLocaleDateString('en-US', { month: 'short' })}. ${date.getFullYear()}`
+    : '';
+  const tail = [article.source ? `<i>${article.source}</i>` : '', day, citeLink(url)]
+    .filter(Boolean)
+    .join(', ');
+  return `${head}${title}${tail}.`;
+};
+
+/** `Lovelace, A. "Title." Source, March 5, 2024. url.` */
+const buildChicagoCite = (article: ExtractedArticle, url: string, date?: Date): string => {
+  const head = citeSegment(article.author_cite);
+  const title = citeTitle(article.title);
+  const day = date
+    ? date.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+    : '';
+  const mid = [article.source ? `<i>${article.source}</i>` : '', day].filter(Boolean).join(', ');
+  return `${head}${title}${mid}${mid ? '. ' : ''}${citeLink(url)}.`;
+};
+
+/**
+ * Citation string for an article, in the configured style.
+ *
+ * APA is the default and keeps the exact shape the extractor's own URL branch
+ * produces, so an APA deployment sees no change from before styles existed.
+ */
+export const buildCite = (
+  article: ExtractedArticle,
+  url: string,
+  style: CitationStyle = 'apa',
+): string => {
+  const date = citableDate(article);
+  switch (style) {
+    case 'chicago': {
+      return buildChicagoCite(article, url, date);
+    }
+    case 'mla': {
+      return buildMlaCite(article, url, date);
+    }
+    default: {
+      return buildApaCite(article, url, date);
+    }
+  }
 };
 
 const escapeHtml = (s: string) =>
@@ -171,6 +254,7 @@ export const articleFromHtml = (
   html: string,
   url: string,
   via: ExtractedArticle['via'],
+  citationStyle: CitationStyle = 'apa',
 ): ExtractedArticle => {
   const parsed = htmlToMarkdown(html, { filterOptions: { enableReadability: true }, url });
   if (!parsed.content || parsed.content.trim().length < 50) {
@@ -189,7 +273,7 @@ export const articleFromHtml = (
     via,
     word_count: countWords(parsed.content),
   };
-  article.cite = buildCite(article, url);
+  article.cite = buildCite(article, url, citationStyle);
   return article;
 };
 
@@ -214,11 +298,18 @@ const completeQwkArticle = (
   article: ExtractedArticle,
   url: string,
   html: string,
+  citationStyle: CitationStyle = 'apa',
 ): ExtractedArticle => {
   article.content = contentFromExtractedHtml(html, article.url || url);
   article.source ||= hostnameOf(article.url || url);
   article.word_count ||= countWords(article.content || html);
-  article.cite ||= buildCite(article, article.url || url);
+  // The extractor builds its own citation, and it is APA — so it is kept as-is
+  // when APA is what was asked for, and rebuilt from the extracted fields when
+  // it is not. Rebuilding unconditionally would throw away the name-database
+  // formatting APA users are getting today.
+  if (!article.cite || citationStyle !== 'apa') {
+    article.cite = buildCite(article, article.url || url, citationStyle);
+  }
   return article;
 };
 
@@ -231,7 +322,7 @@ const completeQwkArticle = (
  */
 export const extractViaQwkSearch = async (
   url: string,
-  options: QwkSearchExtractOptions = {},
+  options: QwkSearchExtractOptions & { citationStyle?: CitationStyle } = {},
 ): Promise<ExtractedArticle> => {
   let raw;
   try {
@@ -249,7 +340,7 @@ export const extractViaQwkSearch = async (
   if (looksLikeChallenge(article.html)) {
     return { error: 'QwkSearch extractor returned a challenge page' };
   }
-  return completeQwkArticle(article, url, article.html);
+  return completeQwkArticle(article, url, article.html, options.citationStyle);
 };
 
 /**
@@ -265,20 +356,24 @@ export const articleFromRenderedHtml = async (
   url: string,
   fallbackVia: ExtractedArticle['via'],
   loader?: ExtractWebpageLoader,
+  citationStyle: CitationStyle = 'apa',
 ): Promise<ExtractedArticle> => {
   try {
     const raw = await runQwkSearchHtmlExtractor(html, url, { loader });
     const article = fromQwkArticle(raw, url, 'qwksearch-html') as ExtractedArticle;
-    if (!article.error && article.html) return completeQwkArticle(article, url, article.html);
+    if (!article.error && article.html) {
+      return completeQwkArticle(article, url, article.html, citationStyle);
+    }
   } catch {
     // Fall through to LobeHub readability below.
   }
-  return articleFromHtml(html, url, fallbackVia);
+  return articleFromHtml(html, url, fallbackVia, citationStyle);
 };
 
 export interface ScraperConfig {
   apiKey?: string;
   baseUrl?: string;
+  citationStyle?: CitationStyle;
   deadlineMs?: number;
   fetcher?: typeof fetch;
   /** Injected in tests; production uses the real `extract-webpage`. */
@@ -327,7 +422,13 @@ export const extractViaScraper = async (
       return { error: 'Scraper returned a challenge page or no content' };
     }
 
-    return await articleFromRenderedHtml(html, data?.url || url, 'scraper', config.loader);
+    return await articleFromRenderedHtml(
+      html,
+      data?.url || url,
+      'scraper',
+      config.loader,
+      config.citationStyle,
+    );
   } catch (error) {
     const e = error as Error;
     const aborted = e?.name === 'AbortError' || controller.signal.aborted;
@@ -346,6 +447,7 @@ export const extractViaTavily = async (
   url: string,
   apiKey = process.env.TAVILY_API_KEY,
   fetcher: typeof fetch = fetch,
+  citationStyle: CitationStyle = 'apa',
 ): Promise<ExtractedArticle> => {
   if (!apiKey) return { error: 'No Tavily API key configured' };
 
@@ -381,14 +483,17 @@ export const extractViaTavily = async (
     via: 'tavily',
     word_count: countWords(result.raw_content),
   };
-  article.cite = buildCite(article, url);
+  article.cite = buildCite(article, url, citationStyle);
   return article;
 };
 
 /**
  * Tier 3: LobeHub's own crawler (plain fetch + readability), no external service.
  */
-export const extractViaCrawler = async (url: string): Promise<ExtractedArticle> => {
+export const extractViaCrawler = async (
+  url: string,
+  citationStyle: CitationStyle = 'apa',
+): Promise<ExtractedArticle> => {
   try {
     const { Crawler } = await import('@lobechat/web-crawler');
     const crawler = new Crawler({ impls: ['naive'] });
@@ -414,7 +519,7 @@ export const extractViaCrawler = async (url: string): Promise<ExtractedArticle> 
       via: 'crawler',
       word_count: countWords(data.content),
     };
-    article.cite = buildCite(article, url);
+    article.cite = buildCite(article, url, citationStyle);
     return article;
   } catch (error) {
     return { error: (error as Error)?.message || 'Crawler failed' };
@@ -423,26 +528,72 @@ export const extractViaCrawler = async (url: string): Promise<ExtractedArticle> 
 
 const isUsable = (article: ExtractedArticle) => !!article.html && !article.error;
 
-export type ExtractionTier = (url: string) => Promise<ExtractedArticle>;
+/**
+ * One step of the chain. Carries the id it was built from so a caller — or a
+ * test — can see *which* tiers a URL got without invoking them.
+ */
+export interface ExtractionTier {
+  (url: string): Promise<ExtractedArticle>;
+  tierId?: TierId;
+}
+
+/** The options `extract-webpage` needs, projected out of the settings. */
+export const toQwkSearchExtractOptions = (
+  settings: ExtractionSettings,
+): QwkSearchExtractOptions & { citationStyle: CitationStyle } => ({
+  citationStyle: settings.citationStyle,
+  languages: settings.languages,
+  pdfProcessor: settings.pdfProcessor,
+  pdfProcessorUrl: settings.pdfProcessorUrl,
+  proxy: settings.proxy ?? null,
+  timeoutSeconds: settings.timeoutSeconds,
+  useThirdPartyBackup: settings.useThirdPartyBackup,
+});
+
+/** The Puppeteer render tier's config, projected out of the settings. */
+export const toScraperConfig = (settings: ExtractionSettings): ScraperConfig => ({
+  apiKey: settings.scraperApiKey,
+  baseUrl: settings.scraperUrl,
+  citationStyle: settings.citationStyle,
+  deadlineMs: settings.scraperDeadlineMs,
+});
+
+const tagTier = (tierId: TierId, run: (url: string) => Promise<ExtractedArticle>): ExtractionTier =>
+  Object.assign(run, { tierId });
 
 /**
- * The tier chain for a URL, by kind.
+ * The tier chain for a URL, by kind, bound to the resolved settings.
  *
  * YouTube and PDF get the QwkSearch extractor alone: the remaining tiers render
  * or fetch HTML, which for a video page is the description and chrome rather
  * than the transcript, and for a PDF is bytes readability cannot parse. Serving
  * that would be worse than reporting the extraction failure.
+ *
+ * `settings.tiers` then filters what is left. It can legitimately empty the
+ * chain — `QWKSEARCH_EXTRACT_TIERS=scraper` leaves a PDF URL with nothing to run
+ * — and when it does the caller gets the "no tier configured" error rather than
+ * a tier the operator switched off.
  */
-export const tiersForUrl = (url: string, kind: UrlKind = classifyUrl(url)): ExtractionTier[] => {
-  switch (kind) {
-    case 'pdf':
-    case 'youtube': {
-      return [extractViaQwkSearch];
-    }
-    default: {
-      return [extractViaQwkSearch, extractViaScraper, extractViaTavily, extractViaCrawler];
-    }
-  }
+export const tiersForUrl = (
+  url: string,
+  kind: UrlKind = classifyUrl(url),
+  settings: ExtractionSettings = resolveExtractionSettings(),
+): ExtractionTier[] => {
+  const build: Record<TierId, () => ExtractionTier> = {
+    crawler: () => tagTier('crawler', (u) => extractViaCrawler(u, settings.citationStyle)),
+    qwksearch: () =>
+      tagTier('qwksearch', (u) => extractViaQwkSearch(u, toQwkSearchExtractOptions(settings))),
+    scraper: () => tagTier('scraper', (u) => extractViaScraper(u, toScraperConfig(settings))),
+    tavily: () =>
+      tagTier('tavily', (u) =>
+        extractViaTavily(u, settings.tavilyApiKey, undefined, settings.citationStyle),
+      ),
+  };
+
+  const candidates: TierId[] =
+    kind === 'pdf' || kind === 'youtube' ? ['qwksearch'] : DEFAULT_TIER_ORDER;
+
+  return candidates.filter((id) => settings.tiers.includes(id)).map((id) => build[id]());
 };
 
 /**

--- a/packages-lobe/worker/qwksearch/extractQwkSearch.ts
+++ b/packages-lobe/worker/qwksearch/extractQwkSearch.ts
@@ -76,10 +76,21 @@ export interface QwkSearchExtractOptions {
   /** Preferred transcript languages for YouTube URLs. Defaults to `['en']`. */
   languages?: string[];
   loader?: ExtractWebpageLoader;
+  /**
+   * Where `extract-pdf` does OCR: `frontend` (all JS, no OCR), `hybrid` (OCR
+   * only the pages that scan as infographics or tables) or `docling` (OCR every
+   * page). `extractContent` forwards its whole options object to
+   * `convertPDFToHTML`, so these two reach the PDF branch unchanged.
+   */
+  pdfProcessor?: string;
+  /** Docling-compatible processor base URL for `hybrid` / `docling`. */
+  pdfProcessorUrl?: string;
   /** Outbound proxy for the extractor's own fetch, when one is configured. */
   proxy?: null | string;
   /** Seconds, matching `extract-webpage`'s own unit. Defaults to 10. */
   timeoutSeconds?: number;
+  /** Let the extractor fall back to a third-party reader service. */
+  useThirdPartyBackup?: boolean;
 }
 
 export const QWKSEARCH_TIMEOUT_SECONDS = 10;
@@ -158,9 +169,14 @@ export const runQwkSearchExtractor = async (
     images: true,
     languages: options.languages?.length ? options.languages : ['en'],
     links: true,
+    // `extract-webpage` reads `processor` only on its PDF branch, and treats an
+    // absent one as `frontend`; sending it for an HTML URL is inert.
+    ...(options.pdfProcessor ? { processor: options.pdfProcessor } : {}),
+    ...(options.pdfProcessorUrl ? { processorUrl: options.pdfProcessorUrl } : {}),
     proxy: options.proxy ?? null,
     timeout: options.timeoutSeconds ?? QWKSEARCH_TIMEOUT_SECONDS,
     url,
+    useThirdPartyBackup: options.useThirdPartyBackup ?? false,
   });
 };
 

--- a/packages-lobe/worker/qwksearch/extractSettings.test.ts
+++ b/packages-lobe/worker/qwksearch/extractSettings.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_EXTRACTION_SETTINGS,
+  DEFAULT_SCRAPER_URL,
+  extractionSettingsFromEnv,
+  normalizeCitationStyle,
+  normalizeHttpUrl,
+  normalizeLanguages,
+  normalizePdfProcessor,
+  normalizeTiers,
+  parseClientExtractionOverrides,
+  redactExtractionSettings,
+  resolveExtractionSettings,
+} from './extractSettings';
+
+/** Turns a plain object into the query reader the route passes in. */
+const query = (params: Record<string, string>) => (name: string) => params[name];
+
+describe('normalizers', () => {
+  it('accepts the three citation styles case-insensitively and nothing else', () => {
+    expect(normalizeCitationStyle('MLA')).toBe('mla');
+    expect(normalizeCitationStyle(' chicago ')).toBe('chicago');
+    expect(normalizeCitationStyle('harvard')).toBeUndefined();
+    expect(normalizeCitationStyle('')).toBeUndefined();
+    expect(normalizeCitationStyle(undefined)).toBeUndefined();
+  });
+
+  it('accepts the three pdf processor modes and nothing else', () => {
+    expect(normalizePdfProcessor('hybrid')).toBe('hybrid');
+    expect(normalizePdfProcessor('DOCLING')).toBe('docling');
+    // A URL is a valid `ProcessorMode` upstream, but accepting one here would
+    // make the OCR endpoint configurable from a settings value.
+    expect(normalizePdfProcessor('https://docling.example.com')).toBeUndefined();
+  });
+
+  it('keeps well-formed language tags, deduplicated and capped', () => {
+    expect(normalizeLanguages('en, pt-BR, zh-Hans-CN')).toEqual(['en', 'pt-br', 'zh-hans-cn']);
+    expect(normalizeLanguages(['en', 'EN', 'fr'])).toEqual(['en', 'fr']);
+    expect(normalizeLanguages('a,b,c,d,e,f,g,h')).toBeUndefined();
+    expect(normalizeLanguages('en,fr,de,es,it,ja,ko')).toHaveLength(5);
+  });
+
+  it('drops a malformed tag instead of rejecting the whole list', () => {
+    expect(normalizeLanguages('en, klingon!, fr')).toEqual(['en', 'fr']);
+  });
+
+  it('returns undefined for a list with nothing valid left, so the layer below wins', () => {
+    expect(normalizeLanguages('!!,??')).toBeUndefined();
+    expect(normalizeLanguages('')).toBeUndefined();
+  });
+
+  it('keeps the recognised tier ids in the order given', () => {
+    expect(normalizeTiers('crawler, qwksearch')).toEqual(['crawler', 'qwksearch']);
+    expect(normalizeTiers('qwksearch,nonsense,qwksearch')).toEqual(['qwksearch']);
+    // A typo that leaves nothing must not silently disable extraction.
+    expect(normalizeTiers('nonsense')).toBeUndefined();
+  });
+
+  it('accepts only http(s) urls, without a trailing slash', () => {
+    expect(normalizeHttpUrl('https://proxy.example.com/')).toBe('https://proxy.example.com');
+    expect(normalizeHttpUrl('http://localhost:8787')).toBe('http://localhost:8787');
+    expect(normalizeHttpUrl('file:///etc/passwd')).toBeUndefined();
+    expect(normalizeHttpUrl('not a url')).toBeUndefined();
+  });
+});
+
+describe('extractionSettingsFromEnv', () => {
+  it('reads the operator layer, keeping the existing variable names', () => {
+    const env = extractionSettingsFromEnv({
+      QWKSEARCH_CITATION_STYLE: 'mla',
+      QWKSEARCH_EXTRACT_LANGUAGES: 'de,fr',
+      QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP: 'true',
+      QWKSEARCH_EXTRACT_TIMEOUT: '30',
+      QWKSEARCH_PDF_PROCESSOR: 'hybrid',
+      QWKSEARCH_SCRAPER_DEADLINE_MS: '12000',
+      SCRAPER_API_KEY: 'sk-scraper',
+      SCRAPER_URL: 'https://render.example.com',
+      TAVILY_API_KEY: 'tvly-key',
+    });
+
+    expect(env).toMatchObject({
+      citationStyle: 'mla',
+      languages: ['de', 'fr'],
+      pdfProcessor: 'hybrid',
+      scraperApiKey: 'sk-scraper',
+      scraperDeadlineMs: 12_000,
+      scraperUrl: 'https://render.example.com',
+      tavilyApiKey: 'tvly-key',
+      timeoutSeconds: 30,
+      useThirdPartyBackup: true,
+    });
+  });
+
+  it('leaves unset and unparseable variables undefined so defaults apply', () => {
+    const env = extractionSettingsFromEnv({
+      QWKSEARCH_CITATION_STYLE: 'harvard',
+      SCRAPER_URL: '   ',
+    });
+    expect(env.citationStyle).toBeUndefined();
+    expect(env.scraperUrl).toBeUndefined();
+    expect(env.tavilyApiKey).toBeUndefined();
+  });
+});
+
+describe('resolveExtractionSettings', () => {
+  it('falls back to the shipped defaults with an empty environment', () => {
+    expect(resolveExtractionSettings({})).toEqual(DEFAULT_EXTRACTION_SETTINGS);
+    expect(resolveExtractionSettings({}).scraperUrl).toBe(DEFAULT_SCRAPER_URL);
+  });
+
+  it('layers overrides over the environment, last one winning', () => {
+    const settings = resolveExtractionSettings(
+      { QWKSEARCH_CITATION_STYLE: 'mla', QWKSEARCH_EXTRACT_LANGUAGES: 'de' },
+      { citationStyle: 'chicago' },
+      { languages: ['ja'] },
+    );
+    expect(settings.citationStyle).toBe('chicago');
+    expect(settings.languages).toEqual(['ja']);
+  });
+
+  it('ignores an override that fails validation instead of erasing the layer below', () => {
+    const settings = resolveExtractionSettings(
+      { QWKSEARCH_CITATION_STYLE: 'mla', QWKSEARCH_EXTRACT_LANGUAGES: 'de' },
+      { citationStyle: 'harvard' as never, languages: [''] },
+    );
+    expect(settings.citationStyle).toBe('mla');
+    expect(settings.languages).toEqual(['de']);
+  });
+
+  it('clamps out-of-range numbers rather than passing them to the extractor', () => {
+    expect(resolveExtractionSettings({}, { timeoutSeconds: 9999 }).timeoutSeconds).toBe(60);
+    expect(resolveExtractionSettings({}, { timeoutSeconds: 0 }).timeoutSeconds).toBe(1);
+    expect(
+      resolveExtractionSettings({ QWKSEARCH_SCRAPER_DEADLINE_MS: '99' }).scraperDeadlineMs,
+    ).toBe(1000);
+  });
+
+  it('never lets an override reach a host or a credential', () => {
+    const settings = resolveExtractionSettings({ SCRAPER_URL: 'https://render.example.com' }, {
+      // Fields outside `UserExtractionOverrides`; a caller casting past the
+      // type must still not be able to redirect the render backend.
+      scraperApiKey: 'stolen',
+      scraperUrl: 'https://attacker.example.com',
+      tavilyApiKey: 'stolen',
+    } as never);
+
+    expect(settings.scraperUrl).toBe('https://render.example.com');
+    expect(settings.scraperApiKey).toBeUndefined();
+    expect(settings.tavilyApiKey).toBeUndefined();
+  });
+});
+
+describe('parseClientExtractionOverrides', () => {
+  it('reads only the citation style and transcript languages', () => {
+    expect(parseClientExtractionOverrides(query({ cite: 'mla', lang: 'fr,de' }))).toEqual({
+      citationStyle: 'mla',
+      languages: ['fr', 'de'],
+    });
+  });
+
+  it('ignores every network-facing parameter a caller might try', () => {
+    const overrides = parseClientExtractionOverrides(
+      query({
+        pdfProcessor: 'docling',
+        pdfProcessorUrl: 'https://attacker.example.com',
+        proxy: 'https://attacker.example.com',
+        scraperUrl: 'https://attacker.example.com',
+        tiers: 'crawler',
+      }),
+    ) as Record<string, unknown>;
+
+    expect(Object.keys(overrides)).toEqual([]);
+  });
+
+  it('returns an empty object for an empty query string', () => {
+    expect(parseClientExtractionOverrides(() => undefined)).toEqual({});
+  });
+});
+
+describe('redactExtractionSettings', () => {
+  it('reports whether each credential is set without revealing it', () => {
+    const redacted = redactExtractionSettings(
+      resolveExtractionSettings({ TAVILY_API_KEY: 'tvly-secret' }),
+    );
+    expect(redacted.tavilyApiKey).toBe(true);
+    expect(redacted.scraperApiKey).toBe(false);
+    expect(JSON.stringify(redacted)).not.toContain('tvly-secret');
+  });
+});

--- a/packages-lobe/worker/qwksearch/extractSettings.ts
+++ b/packages-lobe/worker/qwksearch/extractSettings.ts
@@ -1,0 +1,311 @@
+/**
+ * Resolved configuration for the article extraction chain.
+ *
+ * Before this module every knob in `extract.ts` was a literal: `['en']` for
+ * transcript languages, an APA-shaped citation, `SCRAPER_URL` read straight off
+ * `process.env` inside the tier, a 10-second extractor timeout. That is fine
+ * while there is one caller, and wrong the moment the Extraction settings pane
+ * (migration to-do § 2.2) needs somewhere to write to.
+ *
+ * So the chain now takes an {@link ExtractionSettings} value, and this module is
+ * the only place that decides what one contains:
+ *
+ * ```
+ * DEFAULT_EXTRACTION_SETTINGS   the shipped behaviour
+ *   ← environment (Worker vars + secrets)      server operator
+ *   ← UserExtractionOverrides                  the signed-in user's settings
+ *   ← ClientExtractionOverrides                per-request query parameters
+ * ```
+ *
+ * Each layer only *narrows* the one above it, and every value is validated on
+ * the way in — an unparseable setting falls back rather than throwing, because
+ * a bad preference should not turn into a 500 on an article fetch.
+ *
+ * ## Why the layers are not symmetric
+ *
+ * The network-facing fields — `scraperUrl`, `scraperApiKey`, `tavilyApiKey`,
+ * `pdfProcessorUrl`, `proxy` — are resolvable **from the environment only**.
+ * They name hosts the Worker will send requests (and bearer tokens) to, so
+ * accepting them from a query parameter would turn `/api/doc/article` into an
+ * open request proxy and leak the configured keys to whatever host the caller
+ * chose. {@link ClientExtractionOverrides} is deliberately typed to exclude
+ * them, and {@link parseClientExtractionOverrides} never reads them.
+ *
+ * `pdfProcessor` is similarly withheld from the client layer: `docling` mode
+ * runs OCR over every page, so letting an anonymous caller select it is a
+ * compute-amplification lever, not a preference.
+ */
+
+/** Citation format for {@link buildCite} in `extract.ts`. */
+export type CitationStyle = 'apa' | 'chicago' | 'mla';
+
+/**
+ * Where `extract-pdf` does OCR. Mirrors that package's `ProcessorMode`:
+ * `frontend` is all-JS with no OCR, `hybrid` scans pages and OCRs only the ones
+ * that look like infographics or tables, `docling` OCRs every page.
+ */
+export type PdfProcessor = 'docling' | 'frontend' | 'hybrid';
+
+/** The tiers of the extraction chain, by the order they normally run in. */
+export type TierId = 'crawler' | 'qwksearch' | 'scraper' | 'tavily';
+
+export interface ExtractionSettings {
+  /** Citation format used whenever the chain builds a `cite` itself. */
+  citationStyle: CitationStyle;
+  /** Preferred YouTube transcript languages, most-preferred first. */
+  languages: string[];
+  /** OCR strategy handed to `extract-pdf` for PDF and arXiv URLs. */
+  pdfProcessor: PdfProcessor;
+  /** Docling-compatible processor base URL, for `hybrid` / `docling`. */
+  pdfProcessorUrl?: string;
+  /** Outbound proxy for the extractor's own fetches. */
+  proxy?: string;
+  scraperApiKey?: string;
+  /** Wall-clock budget for the Puppeteer render tier. */
+  scraperDeadlineMs: number;
+  /** Base URL of the Puppeteer render worker. */
+  scraperUrl: string;
+  tavilyApiKey?: string;
+  /** Which tiers may run, in order. Tiers absent here are skipped entirely. */
+  tiers: TierId[];
+  /** `extract-webpage`'s own request timeout, in seconds. */
+  timeoutSeconds: number;
+  /** Let `extract-webpage` fall back to a third-party reader service. */
+  useThirdPartyBackup: boolean;
+}
+
+/** Settings a signed-in user may choose. Excludes every host and credential. */
+export type UserExtractionOverrides = Partial<
+  Pick<
+    ExtractionSettings,
+    | 'citationStyle'
+    | 'languages'
+    | 'pdfProcessor'
+    | 'tiers'
+    | 'timeoutSeconds'
+    | 'useThirdPartyBackup'
+  >
+>;
+
+/**
+ * Settings an unauthenticated caller may pass as query parameters. Narrower
+ * than {@link UserExtractionOverrides} on purpose — see the module comment.
+ */
+export type ClientExtractionOverrides = Partial<
+  Pick<ExtractionSettings, 'citationStyle' | 'languages'>
+>;
+
+export const DEFAULT_SCRAPER_URL = 'https://proxy.qwksearch.com';
+export const DEFAULT_SCRAPER_DEADLINE_MS = 8000;
+export const DEFAULT_TIMEOUT_SECONDS = 10;
+
+/** Full chain order. `tiersForUrl` still narrows this per URL kind. */
+export const DEFAULT_TIER_ORDER: TierId[] = ['qwksearch', 'scraper', 'tavily', 'crawler'];
+
+export const CITATION_STYLES: CitationStyle[] = ['apa', 'chicago', 'mla'];
+export const PDF_PROCESSORS: PdfProcessor[] = ['docling', 'frontend', 'hybrid'];
+
+export const DEFAULT_EXTRACTION_SETTINGS: ExtractionSettings = {
+  citationStyle: 'apa',
+  languages: ['en'],
+  pdfProcessor: 'frontend',
+  scraperDeadlineMs: DEFAULT_SCRAPER_DEADLINE_MS,
+  scraperUrl: DEFAULT_SCRAPER_URL,
+  tiers: DEFAULT_TIER_ORDER,
+  timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+  useThirdPartyBackup: false,
+};
+
+/** A BCP-47-shaped tag: `en`, `pt-BR`, `zh-Hans-CN`. */
+const LANGUAGE_TAG = /^[a-z]{2,3}(?:-[a-z\d]{2,8})*$/i;
+
+const MAX_LANGUAGES = 5;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+/** A trimmed non-empty string, or `undefined`. Never `''`. */
+const text = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const list = (value: unknown): string[] | undefined => {
+  if (Array.isArray(value)) return value.map((v) => text(v)).filter((v): v is string => !!v);
+  const raw = text(value);
+  return raw
+    ? raw
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : undefined;
+};
+
+const boolish = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') return value;
+  const raw = text(value)?.toLowerCase();
+  if (raw === undefined) return undefined;
+  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on') return true;
+  if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'off') return false;
+  return undefined;
+};
+
+const integer = (value: unknown, min: number, max: number): number | undefined => {
+  const raw = typeof value === 'number' ? value : Number(text(value));
+  if (!Number.isFinite(raw)) return undefined;
+  return clamp(Math.round(raw), min, max);
+};
+
+export const normalizeCitationStyle = (value: unknown): CitationStyle | undefined => {
+  const raw = text(value)?.toLowerCase();
+  return CITATION_STYLES.includes(raw as CitationStyle) ? (raw as CitationStyle) : undefined;
+};
+
+export const normalizePdfProcessor = (value: unknown): PdfProcessor | undefined => {
+  const raw = text(value)?.toLowerCase();
+  return PDF_PROCESSORS.includes(raw as PdfProcessor) ? (raw as PdfProcessor) : undefined;
+};
+
+/**
+ * Keep the well-formed language tags, deduplicated, capped at five.
+ *
+ * Malformed entries are dropped rather than rejecting the whole list: a user
+ * whose preferences read `en, klingon` should still get English transcripts.
+ * A list with nothing valid left in it returns `undefined`, so the caller falls
+ * back to the layer above instead of asking for transcripts in no language.
+ */
+export const normalizeLanguages = (value: unknown): string[] | undefined => {
+  const entries = list(value);
+  if (!entries) return undefined;
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (!LANGUAGE_TAG.test(entry)) continue;
+    const tag = entry.toLowerCase();
+    if (!seen.has(tag)) seen.add(tag);
+    if (seen.size >= MAX_LANGUAGES) break;
+  }
+  return seen.size > 0 ? [...seen] : undefined;
+};
+
+/**
+ * Keep the recognised tier ids, deduplicated, in the order given.
+ *
+ * An empty result returns `undefined` rather than `[]`: a typo in
+ * `QWKSEARCH_EXTRACT_TIERS` should not silently disable extraction entirely.
+ */
+export const normalizeTiers = (value: unknown): TierId[] | undefined => {
+  const entries = list(value);
+  if (!entries) return undefined;
+  const seen = new Set<TierId>();
+  for (const entry of entries) {
+    const tier = entry.toLowerCase() as TierId;
+    if (DEFAULT_TIER_ORDER.includes(tier)) seen.add(tier);
+  }
+  return seen.size > 0 ? [...seen] : undefined;
+};
+
+/** A `URL`-parseable http(s) origin. Anything else is dropped. */
+export const normalizeHttpUrl = (value: unknown): string | undefined => {
+  const raw = text(value);
+  if (!raw) return undefined;
+  try {
+    const parsed = new URL(raw);
+    return /^https?:$/.test(parsed.protocol) ? parsed.toString().replace(/\/$/, '') : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export type ExtractionEnv = Record<string, string | undefined>;
+
+/**
+ * The environment layer: Worker vars and secrets.
+ *
+ * `SCRAPER_URL`, `SCRAPER_API_KEY` and `TAVILY_API_KEY` keep the names the
+ * tiers already read, so existing deployments need no change. The rest are new
+ * and all optional.
+ */
+export const extractionSettingsFromEnv = (
+  env: ExtractionEnv = process.env as ExtractionEnv,
+): Partial<ExtractionSettings> => ({
+  citationStyle: normalizeCitationStyle(env.QWKSEARCH_CITATION_STYLE),
+  languages: normalizeLanguages(env.QWKSEARCH_EXTRACT_LANGUAGES),
+  pdfProcessor: normalizePdfProcessor(env.QWKSEARCH_PDF_PROCESSOR),
+  pdfProcessorUrl: normalizeHttpUrl(env.QWKSEARCH_PDF_PROCESSOR_URL),
+  proxy: normalizeHttpUrl(env.QWKSEARCH_EXTRACT_PROXY),
+  scraperApiKey: text(env.SCRAPER_API_KEY),
+  scraperDeadlineMs: integer(env.QWKSEARCH_SCRAPER_DEADLINE_MS, 1000, 30_000),
+  scraperUrl: normalizeHttpUrl(env.SCRAPER_URL),
+  tavilyApiKey: text(env.TAVILY_API_KEY),
+  tiers: normalizeTiers(env.QWKSEARCH_EXTRACT_TIERS),
+  timeoutSeconds: integer(env.QWKSEARCH_EXTRACT_TIMEOUT, 1, 60),
+  useThirdPartyBackup: boolish(env.QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP),
+});
+
+/** Drop `undefined` values so a partial layer cannot erase the layer below it. */
+const defined = <T extends object>(value: T): Partial<T> =>
+  Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as Partial<T>;
+
+/**
+ * Validate and clamp an override layer. Applied to user and client overrides
+ * alike, so a value that reaches {@link resolveExtractionSettings} through
+ * either path gets the same treatment.
+ */
+export const normalizeOverrides = (
+  overrides: UserExtractionOverrides = {},
+): UserExtractionOverrides =>
+  defined({
+    citationStyle: normalizeCitationStyle(overrides.citationStyle),
+    languages: normalizeLanguages(overrides.languages),
+    pdfProcessor: normalizePdfProcessor(overrides.pdfProcessor),
+    tiers: normalizeTiers(overrides.tiers),
+    timeoutSeconds: integer(overrides.timeoutSeconds, 1, 60),
+    useThirdPartyBackup: boolish(overrides.useThirdPartyBackup),
+  });
+
+/** Reads a request's query parameters; `c.req.query` satisfies it directly. */
+export type QueryReader = (name: string) => null | string | undefined;
+
+/**
+ * The two extraction preferences safe to take straight off the query string.
+ *
+ * Everything else either names a host we would then send credentials to, or
+ * buys the caller compute — see the module comment.
+ */
+export const parseClientExtractionOverrides = (query: QueryReader): ClientExtractionOverrides =>
+  defined({
+    citationStyle: normalizeCitationStyle(query('cite')),
+    languages: normalizeLanguages(query('lang')),
+  });
+
+/**
+ * Fold the layers into the settings the chain runs with.
+ *
+ * Later arguments win, but only where they carry a value that survived
+ * validation — so a user preference cannot blank out an operator's scraper URL
+ * by sending an empty string.
+ */
+export const resolveExtractionSettings = (
+  env: ExtractionEnv = process.env as ExtractionEnv,
+  ...overrides: Array<ClientExtractionOverrides | undefined | UserExtractionOverrides>
+): ExtractionSettings => {
+  let settings: ExtractionSettings = {
+    ...DEFAULT_EXTRACTION_SETTINGS,
+    ...defined(extractionSettingsFromEnv(env)),
+  };
+  for (const layer of overrides) {
+    if (layer) settings = { ...settings, ...normalizeOverrides(layer) };
+  }
+  return settings;
+};
+
+/** Settings minus every credential, for logging and the diagnostics tool. */
+export const redactExtractionSettings = (
+  settings: ExtractionSettings,
+): Omit<ExtractionSettings, 'scraperApiKey' | 'tavilyApiKey'> & {
+  scraperApiKey: boolean;
+  tavilyApiKey: boolean;
+} => {
+  const { scraperApiKey, tavilyApiKey, ...rest } = settings;
+  return { ...rest, scraperApiKey: !!scraperApiKey, tavilyApiKey: !!tavilyApiKey };
+};

--- a/packages-lobe/worker/routes/qwksearch/article.test.ts
+++ b/packages-lobe/worker/routes/qwksearch/article.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A cached row and the drizzle chain the GET handler walks over it.
+ *
+ * The handler makes two selects, and they are told apart by their argument: the
+ * article select takes no field list and ends in `.limit(1)`, the Q&A history
+ * select passes one and is awaited directly.
+ */
+let cachedRow: Record<string, unknown> | undefined;
+
+const db = {
+  insert: () => ({ values: async () => undefined }),
+  select: (fields?: unknown) => ({
+    from: () => ({
+      where: () =>
+        fields ? Promise.resolve([]) : { limit: async () => (cachedRow ? [cachedRow] : []) },
+    }),
+  }),
+  update: () => ({ set: () => ({ where: async () => undefined }) }),
+};
+
+vi.mock('../../qwksearch/db', () => ({ getQwkDB: () => db }));
+
+const { articleApp, restyleCite } = await import('./article');
+
+const get = (query: string) => articleApp.request(`/api/doc/article?${query}`);
+
+const row = {
+  author: 'Ada Lovelace',
+  author_cite: 'Lovelace, A.',
+  author_short: 'Lovelace',
+  author_type: 'single',
+  cite: 'Lovelace, A. (1990, Oct 1). <b>Notes</b>. <i>example.com</i>.',
+  date: '1990-10-01',
+  followUpQuestions: [],
+  html: '<p>body</p>',
+  source: 'example.com',
+  title: 'Notes',
+  url: 'https://example.com/notes',
+  word_count: 2,
+};
+
+beforeEach(() => {
+  cachedRow = { ...row };
+});
+
+describe('restyleCite', () => {
+  it('keeps the stored citation for APA', () => {
+    expect(restyleCite({ ...row, url: row.url }, 'apa').cite).toBe(row.cite);
+  });
+
+  it('rebuilds the citation from the cached columns for another style', () => {
+    const cite = restyleCite({ ...row, url: row.url }, 'mla').cite;
+    expect(cite).toContain('Lovelace, A. "<b>Notes</b>."');
+    expect(cite).toContain('1 Oct. 1990');
+  });
+});
+
+describe('GET /api/doc/article', () => {
+  it('serves the cached article with its stored citation by default', async () => {
+    const body = (await (await get('url=https://example.com/notes')).json()) as {
+      article: { cite: string };
+      cached: boolean;
+    };
+    expect(body.cached).toBe(true);
+    expect(body.article.cite).toBe(row.cite);
+  });
+
+  it('honours ?cite= on a cache hit rather than fragmenting the cache', async () => {
+    const body = (await (await get('url=https://example.com/notes&cite=chicago')).json()) as {
+      article: { cite: string };
+    };
+    expect(body.article.cite).toContain('October 1, 1990');
+  });
+
+  it('ignores an unrecognised ?cite= instead of failing the request', async () => {
+    const res = await get('url=https://example.com/notes&cite=harvard');
+    const body = (await res.json()) as { article: { cite: string } };
+    expect(res.status).toBe(200);
+    expect(body.article.cite).toBe(row.cite);
+  });
+
+  it('still refuses a url the chain cannot extract', async () => {
+    expect((await get('url=https://www.google.com/search?q=x')).status).toBe(400);
+  });
+
+  it('requires a url', async () => {
+    expect((await articleApp.request('/api/doc/article')).status).toBe(400);
+  });
+});

--- a/packages-lobe/worker/routes/qwksearch/article.ts
+++ b/packages-lobe/worker/routes/qwksearch/article.ts
@@ -11,11 +11,18 @@ import { Hono } from 'hono';
 
 import { getQwkDB } from '../../qwksearch/db';
 import {
+  buildCite,
   classifyUrl,
   extractArticle,
   type ExtractedArticle,
   isExtractableKind,
+  tiersForUrl,
 } from '../../qwksearch/extract';
+import {
+  type CitationStyle,
+  parseClientExtractionOverrides,
+  resolveExtractionSettings,
+} from '../../qwksearch/extractSettings';
 import { articleCache, articleQA } from '../../qwksearch/schema';
 
 interface CachedArticle extends ExtractedArticle {
@@ -37,6 +44,19 @@ const toResponseArticle = (row: typeof articleCache.$inferSelect): CachedArticle
   url: row.url,
   word_count: row.word_count || undefined,
 });
+
+/**
+ * Re-render a cached article's citation in the requested style.
+ *
+ * `articleCache` is keyed by URL alone and stores one `cite` string, written in
+ * whatever style produced it. Rather than fragmenting the cache per style, the
+ * response rebuilds the citation from the fields that *are* cached whenever a
+ * non-APA style is asked for. APA keeps the stored string, because that one
+ * came out of the extractor's name database and is better than anything the
+ * fallback builder can assemble from the columns.
+ */
+export const restyleCite = (article: CachedArticle, style: CitationStyle): CachedArticle =>
+  style === 'apa' ? article : { ...article, cite: buildCite(article, article.url || '', style) };
 
 export const articleApp = new Hono();
 
@@ -69,6 +89,15 @@ articleApp.get('/api/doc/article', async (c) => {
     return c.json({ error: 'URL is not an extractable article' }, 400);
   }
 
+  // Operator config (Worker vars and secrets) narrowed by the two request
+  // parameters that are safe to honour: `cite` and `lang`. Hosts, keys and the
+  // PDF OCR mode are deliberately not readable from the query string — see the
+  // module comment in `extractSettings.ts`.
+  const settings = resolveExtractionSettings(
+    process.env as Record<string, string | undefined>,
+    parseClientExtractionOverrides((name) => c.req.query(name)),
+  );
+
   try {
     const db = getQwkDB();
     const cached = await db.select().from(articleCache).where(eq(articleCache.url, url)).limit(1);
@@ -84,10 +113,16 @@ articleApp.get('/api/doc/article', async (c) => {
         .from(articleQA)
         .where(eq(articleQA.articleUrl, url));
 
-      return c.json({ article: { ...toResponseArticle(cached[0]), qaHistory }, cached: true });
+      return c.json({
+        article: {
+          ...restyleCite(toResponseArticle(cached[0]), settings.citationStyle),
+          qaHistory,
+        },
+        cached: true,
+      });
     }
 
-    const extracted = await extractArticle(url);
+    const extracted = await extractArticle(url, tiersForUrl(url, kind, settings));
     if (!extracted.html || extracted.error) {
       return c.json(
         { detail: extracted.error, error: 'Article extraction returned no content', url },

--- a/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
@@ -55,6 +55,7 @@ then LobeHub's tRPC/webapi/api, then the SPA catch-all.
 |---|---|---|---|---|
 | F1 | **Article extract side panel** — external links in chat open in a resizable right panel; citation, favorites, Q&A, follow-ups | `worker/routes/qwksearch/article.ts`, `articleAi.ts` | `src/features/QwkSearch/ArticlePanel/` (`ArticlePanel.tsx`, `store.ts`, `api.ts`, `useArticleLinkInterceptor.ts`) | D1 `articleCache`, `articleQA`, `favorites` |
 | F2 | **Extraction chain** — `extract-webpage` → Puppeteer scraper (8s deadline) → Tavily → `@lobechat/web-crawler`, routed per URL kind | `worker/qwksearch/extract.ts`, `worker/qwksearch/extractQwkSearch.ts` | — | writes through F1's cache |
+| F2a | **Extraction settings** — one resolved value behind F2's knobs: citation style, transcript languages, timeout, enabled tiers, render backend, PDF OCR mode | `worker/qwksearch/extractSettings.ts` | — | none (per-request) |
 | F3 | **Docs** (`/docs`) — Markdown research documents, autosaved, write/preview | `worker/routes/qwksearch/documents.ts` | `src/features/QwkSearch/Docs/` (`DocsWorkspace.tsx`, `DocsSidebar.tsx`, `DocsLayout.tsx`, `store.ts`) | D1 `documents` — the same table `apps/qwksearch-web` writes |
 | F4 | **Favorites** | `worker/routes/qwksearch/favorites.ts` | inside F1 | D1 `favorites` |
 | F5 | **QwkSearch search provider** — LobeHub's web-browsing tool fans out over QwkSearch's 100+ engines | `apps/server/src/services/search/impls/qwksearch/` | LobeHub's existing search portal UI | none (stateless proxy) |
@@ -105,6 +106,40 @@ GET /api/doc/article?url=…
 No upstream LobeHub file is edited for this. `extract.ts` and the new
 `extractQwkSearch.ts` both live under `worker/`; the only build-side change is
 *removing* the `linkedom` alias.
+
+### F2a — Extraction settings contract
+
+The chain used to read its configuration inline: `['en']` for transcript
+languages, an APA-shaped citation, `process.env.SCRAPER_URL` inside the tier
+that used it. `extractSettings.ts` replaces all of it with one resolved
+`ExtractionSettings`, folded out of three layers.
+
+```
+DEFAULT_EXTRACTION_SETTINGS          shipped behaviour
+  ← extractionSettingsFromEnv(env)   Worker vars + secrets   (operator)
+  ← UserExtractionOverrides          persisted preferences   (signed-in user)
+  ← ClientExtractionOverrides        ?cite= / ?lang=         (any caller)
+      ↓
+  tiersForUrl(url, kind, settings) → tiers bound to it, each tagged with `tierId`
+```
+
+| Concern | Behavior |
+|---|---|
+| Validation | Every value is normalized on the way in — language tags matched against a BCP-47 shape and capped at 5, numbers clamped, enums matched case-insensitively. A value that fails falls back to the layer below; nothing throws, because a bad preference must not become a 500 on an article fetch |
+| Layer asymmetry | `ClientExtractionOverrides` is a strict subset of `UserExtractionOverrides`, which is a strict subset of the settings. Hosts and credentials (`scraperUrl`, `scraperApiKey`, `tavilyApiKey`, `pdfProcessorUrl`, `proxy`) resolve **from the environment only** — a caller-supplied backend URL would make `/api/doc/article` an open request proxy and leak the configured bearer token to it |
+| `pdfProcessor` | Withheld from the client layer as well: `docling` OCRs every page, so selecting it is compute amplification rather than a preference |
+| Citation styles | `apa` (default, unchanged output), `mla`, `chicago`. The extractor emits APA only, so a non-APA style is rebuilt from `author_cite` / `title` / `source` / `date`; APA keeps the extractor's own string, which came from its 90k-name database |
+| Cache interaction | `articleCache` is keyed by URL and holds one `cite`. A non-APA request re-renders the citation from the cached columns instead of fragmenting the cache per style |
+| Tier selection | `settings.tiers` filters the per-kind chain and can legitimately empty it (`QWKSEARCH_EXTRACT_TIERS=scraper` + a PDF URL). The caller then gets the "no extraction tier configured" error rather than a tier the operator disabled |
+| Diagnostics | `redactExtractionSettings` returns the settings with each credential replaced by a boolean, so they can be logged or surfaced in the settings pane |
+
+Env vars, all optional and all defaulted: `QWKSEARCH_CITATION_STYLE`,
+`QWKSEARCH_EXTRACT_LANGUAGES`, `QWKSEARCH_EXTRACT_TIMEOUT`,
+`QWKSEARCH_EXTRACT_TIERS`, `QWKSEARCH_SCRAPER_DEADLINE_MS`,
+`QWKSEARCH_PDF_PROCESSOR`, `QWKSEARCH_PDF_PROCESSOR_URL`,
+`QWKSEARCH_EXTRACT_PROXY`, `QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP`. The existing
+`SCRAPER_URL`, `SCRAPER_API_KEY` and `TAVILY_API_KEY` keep their names, so no
+deployment needs to change.
 
 ### F5 — Search provider contract
 
@@ -162,6 +197,10 @@ Vars in `wrangler.jsonc` (both the default and `production` env):
 `APP_URL`, `DATABASE_DRIVER`, `DISABLE_REDIS`, `EMAIL_SERVICE_PROVIDER`,
 `SMTP_FROM`, `SCRAPER_URL`, `SEARCH_PROVIDERS`, `QWKSEARCH_SEARCH_URL`.
 
+Optional extraction vars, all defaulted, are listed under §F2a and in
+`packages-lobe/README.md`. Setting none of them reproduces the behavior the
+chain had before the settings layer existed.
+
 Secrets (`wrangler secret put`): `KEY_VAULTS_SECRET`, `AUTH_SECRET`,
 `DATABASE_URL` (when not using Hyperdrive), `S3_*`, `TAVILY_API_KEY`,
 `SCRAPER_API_KEY`, `QWKSEARCH_API_KEY`, per-provider model keys, `QSTASH_*`.
@@ -179,8 +218,9 @@ scoped stylesheet (`react-reason-editor/style.css`).
 ```bash
 cd packages-lobe
 
-# The extraction chain alone (35 cases: kind routing, tier order, field mapping)
-bunx vitest run worker/qwksearch/extract.test.ts worker/qwksearch/extractQwkSearch.test.ts
+# The extraction chain and its settings (62 cases: kind routing, tier order,
+# field mapping, citation styles, layer resolution and what the client may set)
+bunx vitest run worker/qwksearch
 
 # Worker, Cloudflare adapters, QwkSearch features, the search provider
 bunx vitest run worker src/features/QwkSearch \

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -24,7 +24,7 @@ Last updated: 2026-09-09.
 |---|---|
 | 0. Baseline — LobeHub builds and deploys on Workers | ✅ |
 | 1. Chat mode on the engine (staging) | 🚧 search and extraction wired; parity open |
-| 2. Settings as the single system of record | ⬜ |
+| 2. Settings as the single system of record | 🚧 extraction settings have a resolved backend; panes open |
 | 3. REASON docs inside the engine | ⬜ |
 | 4. Public cutover | 🔒 needs the license answer |
 | 5. Decommission + satellites + ops gaps | ⬜ |
@@ -106,13 +106,59 @@ Two things worth knowing before building on this:
 
 Follow-ups that are deliberately *not* in that change:
 
-- ⬜ **Per-user extraction settings.** Transcript language, citation style and
-  the render backend are hard-coded (`['en']`, APA-ish, `SCRAPER_URL`). They are
-  the substance of the Extraction pane in 2.2, so they land there.
-- ⬜ **PDF OCR modes.** `extract-pdf` supports in-process, hybrid and remote
-  Granite Docling processors; the engine takes the default slim path. Wiring the
-  remote processor URL needs a settings surface, so it also waits on 2.2.
+- ✅ **Per-user extraction settings — resolution layer.** Done in 1.5 below;
+  what remains is the UI that writes to it (2.2).
+- ✅ **PDF OCR modes.** `QWKSEARCH_PDF_PROCESSOR` /
+  `QWKSEARCH_PDF_PROCESSOR_URL` reach `extract-pdf` through 1.5.
 - ⬜ **Bundle budget in CI** (5.4) matters more now that the margin is ~2 MB.
+
+### 1.5 Extraction settings resolution ✅
+
+The extraction chain no longer hard-codes its knobs.
+`worker/qwksearch/extractSettings.ts` owns one `ExtractionSettings` value, and
+folds it out of three layers — shipped defaults, then Worker env, then
+per-request overrides — validating every value on the way in. `tiersForUrl`
+binds the resolved settings into each tier, so a tier no longer reaches for
+`process.env` itself.
+
+| Setting | Env var | Reaches |
+|---|---|---|
+| Citation style (`apa`/`mla`/`chicago`) | `QWKSEARCH_CITATION_STYLE` | `buildCite`, every tier |
+| Transcript languages | `QWKSEARCH_EXTRACT_LANGUAGES` | `extract-youtube` via `languages` |
+| Extractor timeout | `QWKSEARCH_EXTRACT_TIMEOUT` | `extract-webpage` `timeout` |
+| Enabled tiers, in order | `QWKSEARCH_EXTRACT_TIERS` | `tiersForUrl` |
+| Render backend + budget | `SCRAPER_URL`, `SCRAPER_API_KEY`, `QWKSEARCH_SCRAPER_DEADLINE_MS` | the Puppeteer tier |
+| PDF OCR mode + endpoint | `QWKSEARCH_PDF_PROCESSOR`, `QWKSEARCH_PDF_PROCESSOR_URL` | `extract-pdf` via `processor` |
+| Outbound proxy | `QWKSEARCH_EXTRACT_PROXY` | `extract-webpage` `proxy` |
+| Third-party reader fallback | `QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP` | `extract-webpage` |
+
+Three things worth knowing before building the pane on top of it:
+
+- **The client layer is deliberately narrower than the user layer.**
+  `GET /api/doc/article` honours `?cite=` and `?lang=` and nothing else. Every
+  other setting either names a host the Worker would then send a bearer token to
+  (`scraperUrl`, `pdfProcessorUrl`, `proxy`) or buys the caller compute
+  (`pdfProcessor=docling` OCRs every page). `ClientExtractionOverrides` is typed
+  to exclude them and `parseClientExtractionOverrides` never reads them.
+- **Citation style survives the cache.** `articleCache` is keyed by URL and holds
+  one `cite` string, so a non-APA request re-renders the citation from the cached
+  fields rather than fragmenting the cache per style. APA keeps the stored
+  string, which came out of the extractor's 90k-name database and beats anything
+  the fallback builder assembles from columns.
+- **An empty tier list is a real outcome.** `QWKSEARCH_EXTRACT_TIERS=scraper`
+  leaves a PDF URL with no viable tier, and the caller gets the "no extraction
+  tier configured" error rather than a tier the operator switched off.
+
+Follow-ups:
+
+- ⬜ **The user layer has no writer yet.** `UserExtractionOverrides` is the type
+  the Extraction pane (2.2) will persist to `src/store/user/slices/settings/`;
+  today only the env and query layers are populated.
+- ⬜ **MLA/Chicago only reach the fallback builder's fields.** The extractor's
+  own citation is APA, so a non-APA style is rebuilt from `author_cite`, `title`,
+  `source` and `date` — correct, but it loses the extractor's author-type
+  handling (organizations, two-author, more-than-two). Teaching
+  `extract-webpage` the other styles is the real fix.
 
 ### 1.4 Agent parity checklist ⬜
 
@@ -133,16 +179,23 @@ Reproduce today's chat-mode behavior on the engine and record each gap:
   to its engine equivalent: models → `Settings/provider` + `service-model`;
   mcpservers → `features/MCP/MCPSettings`; voice → `tts`; skills-memory →
   `skill` + `memory`; account/storage → `profile` / `storage`.
-- ⬜ **2.2 Add the two missing panes**, following the existing tab conventions
+- 🚧 **2.2 Add the two missing panes**, following the existing tab conventions
   (`src/features/Settings/<tab>/` + route segment + keys in
   `packages/locales/src/default/qwksearch.ts`): **Search & Sources** (engine and
   category selection, per-category defaults, time range, SearXNG URL — now that
   1.2 exists these map onto `QWKSEARCH_SEARCH_URL` and the category normalizer)
   and **Extraction** (citation style, transcript language, render backend,
   scraper/Tavily keys). Persist through `src/store/user/slices/settings/`.
-  Now that 1.3 exists, these have concrete sinks: transcript language is
-  `QwkSearchExtractOptions.languages`, the render backend is `SCRAPER_URL`, and
-  the PDF processor mode is `extract-pdf`'s. All three are hard-coded today.
+  The **Extraction** pane's backend is done (1.5): its fields are exactly
+  `UserExtractionOverrides` — citation style, transcript languages, PDF OCR mode,
+  extractor timeout, enabled tiers, third-party fallback. The pane serializes
+  that type and the request path folds it in; nothing further is needed
+  server-side. Note that the render backend and the scraper/Tavily keys are
+  **not** in that type on purpose — they stay Worker secrets (2.3), so the pane
+  shows them as read-only status, not inputs.
+  The **Search & Sources** pane still has no equivalent resolution layer; it
+  needs the same treatment `extractSettings.ts` gave extraction before it can be
+  built the same way.
 - ⬜ **2.3 Key migration.** Server env keys stay Worker secrets. Per-user keys
   live in `localStorage` today and have no server copy — announce a one-time
   re-entry into the engine's key vault; do not build a migrator.
@@ -224,12 +277,20 @@ Blocked on the LobeHub Community License answer, recorded in
 **Suggested next, in order** — all code-only, all testable without Cloudflare
 credentials:
 
-1. **5.4's bundle budget in CI.** The measurement now exists
-   (`bun run cf:budget`); what is missing is a workflow that runs it. That needs
-   a job that installs and builds `packages-lobe`, which no workflow does yet.
-2. **2.2's Extraction pane.** 1.3 gave it real settings to bind — transcript
-   language, PDF processor mode, render backend — that are hard-coded today.
-3. **2.1's settings map**, which 2.2 needs anyway and which is pure reading.
+1. **2.2's Extraction pane.** The seam is now fully specified: the pane's fields
+   are `UserExtractionOverrides` and the request path already folds that type in
+   (1.5). This is a UI-and-store change with no backend work left, which makes it
+   the cheapest remaining item with a user-visible result.
+2. **A `searchSettings.ts` for the Search & Sources pane**, mirroring
+   `extractSettings.ts`: one resolved value, layered defaults → env → user, with
+   the same rule that hosts and keys are environment-only. `QwkSearchImpl` reads
+   `QWKSEARCH_SEARCH_URL` and its category normalizer straight from env today,
+   the way the extraction tiers used to.
+3. **5.4's bundle budget in CI.** The measurement exists (`bun run cf:budget`);
+   what is missing is a workflow that runs it. That needs a job that installs and
+   builds `packages-lobe`, which no workflow does yet — a CI-minutes decision as
+   much as a code one, which is why it sits below the two above.
+4. **2.1's settings map**, which 2.2 needs anyway and which is pure reading.
 
 Then, for whichever you pick:
 


### PR DESCRIPTION
Continues the LobeHub-as-core-engine merge. #375 wired QwkSearch's extractors into the engine's article chain; this change gives that chain a configuration layer, which is the backend half of the Extraction settings pane (migration to-do § 2.2).

It also carries one **unrelated fix** — see "A production bug on `master`" below — because `Vitest` is red on the base branch and this PR cannot go green while it stands.

## The problem

Every knob in `worker/qwksearch/extract.ts` was a literal: `['en']` for transcript languages, an APA-shaped citation, `process.env.SCRAPER_URL` read inside the tier that used it, a 10-second extractor timeout. `extract-pdf`'s hybrid and Docling OCR modes were unreachable. That is fine with one caller, and wrong the moment a settings pane needs somewhere to write to.

## What changed

`worker/qwksearch/extractSettings.ts` (new) owns one `ExtractionSettings` value, folded out of three layers:

```
DEFAULT_EXTRACTION_SETTINGS          shipped behaviour
  ← extractionSettingsFromEnv(env)   Worker vars + secrets   (operator)
  ← UserExtractionOverrides          persisted preferences   (signed-in user)
  ← ClientExtractionOverrides        ?cite= / ?lang=         (any caller)
      ↓
  tiersForUrl(url, kind, settings) → tiers bound to it, each tagged with `tierId`
```

Every value is normalized on the way in — language tags matched against a BCP-47 shape and capped at 5, numbers clamped, enums matched case-insensitively. A value that fails validation falls back to the layer below rather than throwing, because a bad preference must not become a 500 on an article fetch. No tier reaches for `process.env` any more.

### The layers are deliberately asymmetric

`scraperUrl`, `scraperApiKey`, `tavilyApiKey`, `pdfProcessorUrl` and `proxy` resolve **from the environment only**. They name hosts the Worker will then send requests and bearer tokens to, so accepting them from a query parameter would turn `/api/doc/article` into an open request proxy and leak the configured keys to whatever host the caller chose. `ClientExtractionOverrides` is typed to exclude them and `parseClientExtractionOverrides` never reads them. `pdfProcessor` is withheld from the client layer too — `docling` OCRs every page, so selecting it is compute amplification rather than a preference.

`GET /api/doc/article` honours exactly two query parameters: `?cite=` and `?lang=`.

### Citation styles

MLA and Chicago alongside APA. APA output is byte-identical to before, and an APA request keeps the extractor's own citation, which comes out of its 90k-name database and beats anything the fallback builder assembles from columns. Another style is rebuilt from `author_cite` / `title` / `source` / `date`.

`articleCache` is keyed by URL and holds one `cite` string, so a non-APA request re-renders the citation from the cached columns rather than fragmenting the cache per style.

### New env vars

All optional, all defaulted — a deployment that sets none of them behaves exactly as before:

| Var | Default | Meaning |
| --- | --- | --- |
| `QWKSEARCH_CITATION_STYLE` | `apa` | `apa`, `mla` or `chicago` |
| `QWKSEARCH_EXTRACT_LANGUAGES` | `en` | preferred YouTube transcript languages (max 5) |
| `QWKSEARCH_EXTRACT_TIMEOUT` | `10` | `extract-webpage` timeout, seconds (1–60) |
| `QWKSEARCH_EXTRACT_TIERS` | all four | which tiers may run, in order |
| `QWKSEARCH_SCRAPER_DEADLINE_MS` | `8000` | Puppeteer render budget (1000–30000) |
| `PDF_PROCESSOR` | `frontend` | `extract-pdf` OCR mode: `frontend`, `hybrid`, `docling` |
| `PDF_PROCESSOR_URL` | — | remote docling-compatible processor |
| `QWKSEARCH_EXTRACT_PROXY` | — | outbound proxy for the extractor's fetches |
| `QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP` | `false` | third-party reader fallback |

`SCRAPER_URL`, `SCRAPER_API_KEY`, `TAVILY_API_KEY` and `PDF_PROCESSOR_URL` keep the names they already have on `master`.

## A production bug on `master` (commit `41e974b5`)

`lib/database/d1-session.ts` calls `requiresPrimary(request)`, which is **defined nowhere**. Every request through `runWithD1Session` — every request that touches D1 — throws `ReferenceError: requiresPrimary is not defined`. Live on `master` since #374, whose own Coverage run is a failure.

#374 landed two iterations of the same change on top of each other, and its test file has the same duplication: two tests send `/api/auth/callback/google` with mode `unconstrained` and expect opposite results. #374's commit message settles which it meant — *"ignoring both the client bookmark **and the `unconstrained` override**"* — so the auth pin belongs before the mode check, and the older contradictory test is removed. Nothing skipped or disabled. `cd apps/qwksearch-web && bunx vitest run` → **638 passed**.

Happy to split this into its own PR if you'd rather keep this one single-purpose.

## ⚠️ Needs a human decision (pre-existing, left alone)

Merging `master` in surfaced that **`extract.ts` contains two tier chains and only one of them runs** — the same double-landing pattern as the `d1-session` bug, from #375 rather than #374:

| | `tiersForUrl` (live) | `defaultTiersFor` (not wired) |
|---|---|---|
| article | `qwksearch → scraper → tavily → crawler` | `scraper → tavily → crawler` |
| youtube | `qwksearch` | `extractViaYouTube → scraper → tavily → crawler` |
| pdf | `qwksearch` | `extractViaPdf → tavily` |

`extractArticle` defaults to `tiersForUrl`, so `extractViaYouTube`, `extractViaPdf`, `loadCiteExtractor` and `articleViaCiteExtractor` have never been on a request path, and neither has the `PDF_PROCESSOR_URL` read inside `extractViaPdf`. §F2 of the integrations reference documents the live chain, not the unwired one. `master` also declared `export type ExtractionTier` **twice** — a duplicate-identifier error.

I fixed the duplicate declaration (the merge would not compile otherwise) and left the unwired code in place with a comment saying so, because the two chains are materially different products: the live one leads with `extract-webpage`'s own fetch, the unwired one leads with the Puppeteer render. Switching changes what *every* article extraction does.

**Please decide:** adopt `defaultTiersFor` (and rewrite §F2 to match), or delete it, the two tiers it names, and the two helpers. Tracked in the migration to-do § 1.3.

Both bugs would have been caught by a repo-wide type-check in CI (`TS2300` and `TS2304` respectively).

## Behavior worth flagging

`settings.tiers` can legitimately empty the chain — `QWKSEARCH_EXTRACT_TIERS=scraper` leaves a PDF URL with no viable tier. The caller then gets the existing "no extraction tier configured" error rather than a tier the operator switched off. That is intentional; the normalizer refuses to produce an empty tier list from a typo, so this only happens on a deliberate exclusion.

## Testing

- `worker/qwksearch/extractSettings.test.ts` (new, 18 cases): normalization, layer precedence, clamping, and that no override — even one casting past the type — can reach a host or a credential.
- `worker/routes/qwksearch/article.test.ts` (new, 7 cases): the route's cache-hit restyling, an unrecognised `?cite=` being ignored rather than failing, and the existing refusals.
- `worker/qwksearch/extract.test.ts`: updated for the tagged tiers, plus citation-style coverage.
- `bunx vitest run worker src/features/QwkSearch apps/server/src/services/search/impls/qwksearch` — **139 passed**, master's 27-case search suite included.
- `cd apps/qwksearch-web && bunx vitest run` — **638 passed** (the `Vitest` check's exact scope).
- `bun run check` on every file touched — lint clean.
- Type-check: the repo-wide `bun run check --type` did not finish in this environment (`tsgo` exceeded 25 min at ~14 GB RSS). A scoped `tsgo --noEmit` over `worker/qwksearch/**` and `worker/routes/qwksearch/**` reports **zero errors in any file this PR touches**.

`extract-pdf` is red here and on `master`; this PR changes no file under `packages/extract-pdf`. Undiagnosed — it runs on `bun test`, not Vitest.

## Merge resolution notes

Beyond the textual conflicts:

- **One name for the PDF processor.** #375 shipped `PDF_PROCESSOR_URL`; this branch had introduced `QWKSEARCH_PDF_PROCESSOR_URL` for the same endpoint. The settings layer adopts master's name.
- **A stale call site.** #375 renamed `articleFromHtml` → `articleFromHtmlViaCrawler`; the automatic merge left `articleFromRenderedHtml` and two tests calling the old name.
- **Orphaned test helpers.** #375's `articleHtml` / `longBody` are now used by the blocks that had been duplicating them inline.

## Docs

- **LobeHub Migration To-Do** — new § 1.5 with the settings table; § 2.2 marked as having no backend work left; the two-chains decision recorded under § 1.3.
- **LobeHub Integrations Reference** — new § F2a with the full contract.
- **`packages-lobe/README.md`** — the new vars and the client/server split.

## Remaining on this thread

- The Extraction pane itself (2.2) — its fields are exactly `UserExtractionOverrides`, and the request path already folds that type in.
- A `searchSettings.ts` mirroring this for the Search & Sources pane.
- MLA/Chicago currently lose the extractor's author-type handling (organizations, two-author, more-than-two), since only its APA branch knows about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYjNtWBxJh9Vf52c1Wdix6
