### PR TITLE
fix(sidebar): make the file tree's expand/collapse cycle reachable ev…

### DIFF
--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -3,9 +3,9 @@
  * @description Mobile-aware sidebar shell. Renders the toolbar and content
  * inside a Sheet on mobile and directly in the layout on desktop.
  */
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import type { DocumentTreeHandle } from './file-tree/filetree';
-import { expandToggleLabelFor, nextExpandLevel } from './file-tree/expandLevels';
+import { useExpandCycle } from './file-tree/useExpandCycle';
 import type { OutlineViewHandle } from './search/OutlineView';
 import type { AnyFileSource } from './app-types/fileSource';
 import type { SidebarProps } from './layout/sidebar/types';
@@ -72,24 +72,17 @@ export const Sidebar = ({
 
   const activeDocuments = useMemo(() => documents.filter(doc => !doc.isDeleted), [documents]);
 
-  // Expansion depth of the file tree, reported by the tree itself: 0 =
-  // fully collapsed, then 1, 2, 3... one folder level at a time up to the
-  // deepest nesting level, before wrapping back to collapsed. Sourcing it
-  // from the tree (rather than counting clicks) keeps the button honest
-  // when folders are opened by hand or restored from persisted state.
-  const [expandState, setExpandState] = useState({ level: 0, maxLevel: 0 });
-  const handleExpandStateChange = useCallback(
-    (next: { level: number; maxLevel: number }) => {
-      setExpandState((prev) =>
-        prev.level === next.level && prev.maxLevel === next.maxLevel ? prev : next,
-      );
-    },
-    [],
-  );
   // Track expand/collapse all state for outline
   const [outlineExpanded, setOutlineExpanded] = useState(true);
   // Ref for file tree
   const treeRef = useRef<DocumentTreeHandle>(null);
+
+  // Expansion depth of the file tree, reported by the tree itself: 0 = fully
+  // collapsed, then 1, 2, 3... one folder level at a time up to the deepest
+  // nesting level, before wrapping back to collapsed. The tree only reports
+  // in while it is mounted, so `canCycle` also tells the toolbar whether the
+  // Files panel is in this sidebar at all.
+  const expandCycle = useExpandCycle(treeRef);
   // Ref for outline view
   const outlineRef = useRef<OutlineViewHandle>(null);
 
@@ -118,27 +111,6 @@ export const Sidebar = ({
       onFileSourceChange?.(sourceId);
     }
   };
-
-  const handleToggleAllExpanded = () => {
-    const tree = treeRef.current;
-    if (!tree) return;
-    // Cycle from the level the tree is actually at (folders may have been
-    // expanded/collapsed by hand since the last click), not from a stale
-    // local counter.
-    const currentLevel = tree.getExpandLevel?.() ?? expandState.level;
-    const maxLevel = tree.getMaxExpandLevel?.() ?? expandState.maxLevel;
-    if (maxLevel === 0) return;
-    const nextLevel = nextExpandLevel(currentLevel, maxLevel);
-    if (nextLevel === 0) {
-      tree.collapseAll();
-    } else {
-      tree.expandToLevel(nextLevel);
-    }
-  };
-
-  const isFullyExpanded =
-    expandState.maxLevel > 0 && expandState.level >= expandState.maxLevel;
-  const expandToggleLabel = expandToggleLabelFor(expandState.level, expandState.maxLevel);
 
   const handleToggleOutlineExpanded = () => {
     const newState = !outlineExpanded;
@@ -179,10 +151,13 @@ export const Sidebar = ({
     activeFileSourceId,
     onFileSourceChange,
     onSourceSelect: handleSourceSelect,
-    allExpanded: isFullyExpanded,
-    expandToggleLabel,
+    allExpanded: expandCycle.isFullyExpanded,
+    expandToggleLabel: expandCycle.label,
+    // Without a mounted file tree the toggle has nothing to act on; the
+    // toolbar disables it rather than offering a click that does nothing.
+    expandToggleDisabled: !expandCycle.canCycle,
     outlineExpanded,
-    onToggleAllExpanded: handleToggleAllExpanded,
+    onToggleAllExpanded: expandCycle.toggle,
     onToggleOutlineExpanded: handleToggleOutlineExpanded,
     treeRef,
     outlineRef,
@@ -201,7 +176,7 @@ export const Sidebar = ({
   };
 
   const contentProps = {
-    onExpandStateChange: handleExpandStateChange,
+    onExpandStateChange: expandCycle.onExpandStateChange,
     onSetExpandedFolders,
     panels: leftPanels,
     persistenceKey: 'left',

--- a/packages/reason-editor-sidebar/src/SidebarContent.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarContent.tsx
@@ -38,10 +38,11 @@ import {
 } from './app-ui/dropdown-menu';
 import { SplitPane, Pane } from 'react-split-pane';
 import { usePersistence } from 'react-split-pane/persistence';
-import { X, XCircle, ArrowDownFromLine, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, FolderPlus, Folders, Trash2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb } from 'lucide-react';
+import { X, XCircle, ArrowDownFromLine, Edit2, RotateCcw, SplitSquareVertical, Loader2, Search, MessageSquare, FilePlus2, FolderPlus, Folders, Trash2, MessageSquarePlus, Link2, Tag, Sparkles, Lightbulb, ChevronsDownUp, ChevronsUpDown } from 'lucide-react';
 import './split-pane.css';
 
 import type { DocumentTreeHandle } from './file-tree/filetree';
+import { useExpandCycle } from './file-tree/useExpandCycle';
 
 /** Human-readable panel titles used in headers/empty states. */
 const PANEL_TITLES: Record<SidebarPanelType, string> = {
@@ -103,6 +104,16 @@ export const SidebarContent = ({
   const internalTreeRef = useRef<DocumentTreeHandle>(null);
   const internalOutlineRef = useRef<OutlineViewHandle>(null);
   const effectiveTreeRef = treeRef ?? internalTreeRef;
+  // The Files panel drives its own copy of the expand-level cycle so the
+  // control works wherever the panel is stacked, while still reporting the
+  // depth up to a host toolbar showing the same tree.
+  const expandCycle = useExpandCycle(effectiveTreeRef, onExpandStateChange);
+  // A host that hands in its own tree ref (the sidebar) also renders the
+  // cycle in its toolbar, so the panel header only shows its own control
+  // when nothing else is driving this tree — the right panel, which has no
+  // toolbar of its own. Same convention as the panel's other file actions,
+  // which the toolbar hides while the Files panel is showing them.
+  const showHeaderExpandToggle = !treeRef && expandCycle.canCycle;
   const effectiveOutlineRef = outlineRef ?? internalOutlineRef;
 
   const handleSelect = (id: string) => {
@@ -385,6 +396,24 @@ export const SidebarContent = ({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
+          {/*
+            * Steps the tree one folder level at a time and wraps back to
+            * collapsed. Hidden when the tree has no folders to cycle.
+            */}
+          {showHeaderExpandToggle && (
+            <button
+              className={panelHeaderButtonClass}
+              title={expandCycle.label}
+              aria-label={expandCycle.label}
+              onClick={expandCycle.toggle}
+            >
+              {expandCycle.isFullyExpanded ? (
+                <ChevronsDownUp className="h-3.5 w-3.5" />
+              ) : (
+                <ChevronsUpDown className="h-3.5 w-3.5" />
+              )}
+            </button>
+          )}
           {onFileManagerOpen && (
             <button
               className={panelHeaderButtonClass}
@@ -399,7 +428,7 @@ export const SidebarContent = ({
       <FileTree
         ref={effectiveTreeRef}
         documents={activeDocuments}
-        onExpandStateChange={onExpandStateChange}
+        onExpandStateChange={expandCycle.onExpandStateChange}
         onExpandedFoldersChange={onSetExpandedFolders}
         activeId={activeId}
         onSelect={handleSelect}

--- a/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
@@ -59,6 +59,12 @@ interface SidebarToolbarProps {
   allExpanded: boolean;
   /** Tooltip label describing what the expand-all toggle will do next (cycles by folder level). */
   expandToggleLabel: string;
+  /**
+   * Disables the expand-all toggle when there is no file tree behind it —
+   * the Files panel is turned off for this sidebar or lives in the other
+   * one — so the button doesn't advertise a cycle it cannot run.
+   */
+  expandToggleDisabled?: boolean;
   /** Whether all outline entries are currently expanded. */
   outlineExpanded: boolean;
   /** Steps the tree to its next expansion level (wraps to fully collapsed). */
@@ -117,6 +123,7 @@ export const SidebarToolbar = ({
   onSourceSelect,
   allExpanded,
   expandToggleLabel,
+  expandToggleDisabled = false,
   outlineExpanded,
   onToggleAllExpanded,
   onToggleOutlineExpanded,
@@ -282,7 +289,8 @@ export const SidebarToolbar = ({
                     size="sm"
                     onClick={onToggleAllExpanded}
                     aria-label={expandToggleLabel}
-                    className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                    disabled={expandToggleDisabled}
+                    className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent disabled:opacity-40"
                   >
                     {/* The icon shows the action the next click performs. */}
                     {allExpanded ? (
@@ -293,7 +301,7 @@ export const SidebarToolbar = ({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
-                  <p>{expandToggleLabel}</p>
+                  <p>{expandToggleDisabled ? 'No file tree in this sidebar' : expandToggleLabel}</p>
                 </TooltipContent>
               </Tooltip>
 

--- a/packages/reason-editor-sidebar/src/file-tree/index.ts
+++ b/packages/reason-editor-sidebar/src/file-tree/index.ts
@@ -8,3 +8,5 @@ export { FileTreeContextMenu } from "./FileTreeContextMenu";
 export { useFileTreeOperations } from "./useFileTreeOperations";
 export * from "./expandLevels";
 export * from "./documentUtils";
+export { useExpandCycle } from "./useExpandCycle";
+export type { ExpandCycle, ExpandState } from "./useExpandCycle";

--- a/packages/reason-editor-sidebar/src/file-tree/useExpandCycle.ts
+++ b/packages/reason-editor-sidebar/src/file-tree/useExpandCycle.ts
@@ -1,0 +1,93 @@
+/**
+ * @module file-tree/useExpandCycle
+ * @description Shared state and behaviour behind the file tree's
+ * "expand one folder level per click" toggle.
+ *
+ * The cycle used to live inline in {@link Sidebar}, which tied it to the left
+ * sidebar's toolbar. That left the toggle dead whenever the Files panel was
+ * not in that sidebar — turned off in the view menu, or moved to the right
+ * panel — because there was no mounted tree behind the ref, and it left the
+ * Files panel itself without any expand control of its own. Keeping the logic
+ * here lets both the toolbar and the Files panel header drive the same cycle,
+ * and lets each of them tell whether there is a tree to drive at all.
+ */
+import { useCallback, useState } from 'react';
+import type { RefObject } from 'react';
+
+import type { DocumentTreeHandle } from './filetree';
+import { expandToggleLabelFor, nextExpandLevel } from './expandLevels';
+
+/** Expansion depth of a file tree: `level` of `maxLevel` folder levels shown. */
+export interface ExpandState {
+  level: number;
+  maxLevel: number;
+}
+
+export interface ExpandCycle {
+  /** True while there is a mounted tree with at least one folder to cycle. */
+  canCycle: boolean;
+  /** True once every folder level is showing, so the next click collapses. */
+  isFullyExpanded: boolean;
+  /** Describes the action the next click performs, for tooltip and label. */
+  label: string;
+  /** Hand this to the tree's `onExpandStateChange`. */
+  onExpandStateChange: (next: ExpandState) => void;
+  /** The depth the tree last reported. */
+  state: ExpandState;
+  /** Steps one folder level deeper, wrapping back to fully collapsed. */
+  toggle: () => void;
+}
+
+const COLLAPSED: ExpandState = { level: 0, maxLevel: 0 };
+
+/**
+ * Drives the expand/collapse cycle of the tree behind `treeRef`.
+ *
+ * @param treeRef - Ref to the file tree being cycled. May be empty; the
+ *   returned `canCycle` is false until a tree with folders reports in.
+ * @param onStateChange - Optional passthrough, so a host that renders the
+ *   control somewhere else (the sidebar toolbar) can mirror the same depth.
+ */
+export function useExpandCycle(
+  treeRef: RefObject<DocumentTreeHandle | null>,
+  onStateChange?: (next: ExpandState) => void,
+): ExpandCycle {
+  // Sourced from the tree rather than counted from clicks, so the label stays
+  // honest when folders are opened by hand or restored from persisted state.
+  const [state, setState] = useState<ExpandState>(COLLAPSED);
+
+  const onExpandStateChange = useCallback(
+    (next: ExpandState) => {
+      setState((prev) =>
+        prev.level === next.level && prev.maxLevel === next.maxLevel ? prev : next,
+      );
+      onStateChange?.(next);
+    },
+    [onStateChange],
+  );
+
+  const toggle = useCallback(() => {
+    const tree = treeRef.current;
+    if (!tree) return;
+    // Read the live depth off the tree: folders may have been expanded or
+    // collapsed by hand since the last click, so a counter would drift.
+    const currentLevel = tree.getExpandLevel?.() ?? state.level;
+    const maxLevel = tree.getMaxExpandLevel?.() ?? state.maxLevel;
+    if (maxLevel === 0) return;
+    const next = nextExpandLevel(currentLevel, maxLevel);
+    if (next === 0) {
+      tree.collapseAll();
+    } else {
+      tree.expandToLevel(next);
+    }
+  }, [state.level, state.maxLevel, treeRef]);
+
+  return {
+    canCycle: state.maxLevel > 0,
+    isFullyExpanded: state.maxLevel > 0 && state.level >= state.maxLevel,
+    label: expandToggleLabelFor(state.level, state.maxLevel),
+    onExpandStateChange,
+    state,
+    toggle,
+  };
+}

--- a/packages/reason-editor-sidebar/test/file-tree/toolbarExpandCycle.test.tsx
+++ b/packages/reason-editor-sidebar/test/file-tree/toolbarExpandCycle.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Full-loop coverage for the file tree's expand/collapse level cycle as the
+ * user actually drives it: from the sidebar toolbar, and from the Files
+ * panel's own header.
+ *
+ * The FileTree unit tests only drive the imperative handle directly, so they
+ * miss the two ways the cycle reached the user broken — a toolbar button with
+ * no tree behind it (Files turned off for that sidebar, or moved to the right
+ * panel) that silently did nothing while advertising "Expand All", and a Files
+ * panel with no expand control of its own once it was not next to the toolbar.
+ */
+
+import { act, useCallback, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Sidebar } from '../../src/Sidebar';
+import { SidebarContent } from '../../src/SidebarContent';
+import type { Document } from '../../src/documents/DocumentTree';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const doc = (id: string, parentId: string | null, isFolder: boolean): Document => ({
+  id,
+  title: id,
+  content: '',
+  parentId,
+  isFolder,
+  isExpanded: false,
+});
+
+/**
+ * root
+ *  ├ a (folder) ─ a1 (folder) ─ a1x (folder) ─ deep (note)
+ *  ├ b (folder) ─ b1 (note)
+ *  └ c (note)
+ */
+const initialDocuments: Document[] = [
+  doc('a', null, true),
+  doc('a1', 'a', true),
+  doc('a1x', 'a1', true),
+  doc('deep', 'a1x', false),
+  doc('b', null, true),
+  doc('b1', 'b', false),
+  doc('c', null, false),
+];
+
+/** Persists the expanded set the way ReasonDocs' host state does. */
+function useHostDocuments() {
+  const [documents, setDocuments] = useState(initialDocuments);
+  const onSetExpandedFolders = useCallback((folderIds: string[]) => {
+    const expanded = new Set(folderIds);
+    setDocuments((docs) =>
+      docs.map((entry) =>
+        !!entry.isExpanded === expanded.has(entry.id)
+          ? entry
+          : { ...entry, isExpanded: expanded.has(entry.id) },
+      ),
+    );
+  }, []);
+  return { documents, onSetExpandedFolders };
+}
+
+/** Titles of the rows the tree currently draws, in order. */
+function rows() {
+  return Array.from(container.querySelectorAll('[role="treeitem"]')).map(
+    (node) => node.textContent,
+  );
+}
+
+/** The expand/collapse cycle control, found by the label it advertises. */
+function toggle(): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('button')).find((node) =>
+    /^(Expand|Collapse)/.test(node.getAttribute('aria-label') ?? ''),
+  );
+  if (!button) throw new Error('expand/collapse toggle not found');
+  return button as HTMLButtonElement;
+}
+
+function click() {
+  act(() => {
+    toggle().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+/** Walks the whole cycle: one level per click, then back to fully collapsed. */
+function expectCycleStepsThroughEveryLevel() {
+  expect(rows()).toEqual(['a', 'b', 'c']);
+  expect(toggle().getAttribute('aria-label')).toBe('Expand Level 1');
+
+  click();
+  expect(rows()).toEqual(['a', 'a1', 'b', 'b1', 'c']);
+  expect(toggle().getAttribute('aria-label')).toBe('Expand Level 2');
+
+  click();
+  expect(rows()).toEqual(['a', 'a1', 'a1x', 'b', 'b1', 'c']);
+  expect(toggle().getAttribute('aria-label')).toBe('Expand Level 3');
+
+  click();
+  expect(rows()).toEqual(['a', 'a1', 'a1x', 'deep', 'b', 'b1', 'c']);
+  expect(toggle().getAttribute('aria-label')).toBe('Collapse All');
+
+  click();
+  expect(rows()).toEqual(['a', 'b', 'c']);
+  expect(toggle().getAttribute('aria-label')).toBe('Expand Level 1');
+}
+
+function SidebarHost({ leftPanels }: { leftPanels: ('files' | 'openTabs')[] }) {
+  const { documents, onSetExpandedFolders } = useHostDocuments();
+  return (
+    <Sidebar
+      documents={documents}
+      activeId={null}
+      activeDocument={null}
+      onSelect={() => {}}
+      onAdd={() => {}}
+      onDelete={() => {}}
+      onDuplicate={() => {}}
+      onSetExpandedFolders={onSetExpandedFolders}
+      onMove={() => {}}
+      onRename={() => {}}
+      onSearchFocus={() => {}}
+      isOpen
+      onOpenChange={() => {}}
+      isMobile={false}
+      leftPanels={leftPanels}
+      onLeftPanelsChange={() => {}}
+      rightPanels={[]}
+      onRightPanelsChange={() => {}}
+      onRestore={() => {}}
+    />
+  );
+}
+
+describe('file tree expand-level cycle, as the user drives it', () => {
+  it('steps one folder level per toolbar click and wraps back to collapsed', () => {
+    act(() => root.render(<SidebarHost leftPanels={['files']} />));
+    expectCycleStepsThroughEveryLevel();
+  });
+
+  it('cycles from the Files panel header when the panel has no toolbar', () => {
+    // How the Files panel is rendered in the right panel: its own content,
+    // no sidebar toolbar, and no tree ref handed in from a host.
+    function RightPanelHost() {
+      const { documents, onSetExpandedFolders } = useHostDocuments();
+      return (
+        <SidebarContent
+          panels={['files']}
+          persistenceKey="right"
+          activeDocuments={documents}
+          activeId={null}
+          activeDocument={null}
+          headings={[]}
+          isMobile={false}
+          onSelect={() => {}}
+          onAdd={() => {}}
+          onDelete={() => {}}
+          onDuplicate={() => {}}
+          onMove={() => {}}
+          onRename={() => {}}
+          onSetExpandedFolders={onSetExpandedFolders}
+        />
+      );
+    }
+
+    act(() => root.render(<RightPanelHost />));
+    expectCycleStepsThroughEveryLevel();
+  });
+
+  it('disables the toolbar toggle when the files panel is not in this sidebar', () => {
+    act(() => root.render(<SidebarHost leftPanels={['openTabs']} />));
+
+    // The toolbar still renders (Open Tabs is showing), but there is no tree
+    // behind the toggle, so it must not offer a cycle it cannot run.
+    expect(toggle().disabled).toBe(true);
+  });
+});

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -396,6 +396,7 @@ const Index = ({
       onAdd={handleAdd}
       onDelete={state.handleDeleteDocument}
       onDuplicate={state.handleDuplicateDocument}
+      onSetExpandedFolders={state.handleSetExpandedFolders}
       onMove={state.handleMoveDocument}
       onManageTags={state.handleManageTags}
       onRename={(id: string, title: string) => state.handleUpdateDocument(id, { title })}

--- a/packages/reason-editor/src/editor/RightPanel.tsx
+++ b/packages/reason-editor/src/editor/RightPanel.tsx
@@ -45,6 +45,12 @@ interface RightPanelProps {
   onDelete: (id: string) => void;
   onDuplicate: (id: string) => void;
   onMove: (draggedId: string, targetId: string | null, position: 'before' | 'after' | 'child') => void;
+  /**
+   * Persists the file tree's expanded folders. Without it a Files panel
+   * stacked on this side keeps its expansion only in the tree's local state,
+   * so the next document change throws away a stepped expand/collapse.
+   */
+  onSetExpandedFolders?: (folderIds: string[]) => void;
   onManageTags?: (id: string) => void;
   onRename?: (id: string, newTitle: string) => void;
   headings: TocEntry[];
@@ -107,6 +113,7 @@ export function RightPanel({
   onAdd,
   onDelete,
   onDuplicate,
+  onSetExpandedFolders,
   onMove,
   onManageTags,
   onRename,
@@ -162,6 +169,7 @@ export function RightPanel({
           onAdd={onAdd}
           onDelete={onDelete}
           onDuplicate={onDuplicate}
+          onSetExpandedFolders={onSetExpandedFolders}
           onMove={onMove}
           onManageTags={onManageTags}
           onRename={onRename}


### PR DESCRIPTION
…erywhere

The file tree already stepped one folder level per click, but the only control for it was bolted to the left sidebar's toolbar, so it reached the user broken in two ways.

The toolbar's toggle renders whenever the Files *or* Open Tabs panel is on that side, but it drives the tree through a ref that is only filled while the Files panel is actually mounted there. With Files turned off in the view menu or moved to the right panel, the button stayed enabled and kept advertising "Expand All" while every click did nothing. And once Files was in the right panel it had no expand control at all, because that panel has no toolbar.

Pull the cycle out of Sidebar into a `useExpandCycle` hook so both the toolbar and the Files panel header can drive the same tree:

- The toolbar toggle now disables itself when no tree is reporting in, and says why, instead of offering a cycle it cannot run.
- The Files panel header grows its own cycle button, shown when no host toolbar is already driving that tree — the same convention the panel's other file actions follow. This is what makes the cycle work in the right panel.
- Thread `onSetExpandedFolders` through RightPanel so a Files panel stacked there persists its expansion too. Without it a stepped expand/collapse lived only in the tree's local state and the next document change threw it away, which is the bug that kept coming back on the left side.

Covered by a full-loop test that clicks the real control — from the toolbar and from the panel header — and walks every folder level and the wrap back to collapsed, with the host persisting each step the way ReasonDocs does. The existing tests only drove the imperative handle directly, so neither gap showed up in them.


Claude-Session: https://claude.ai/code/session_01ARq1yPGrwZiUA6Trnj294p