### PR TITLE
Raise the quality of REASON's AI writing tools

### DIFF
--- a/packages/reason-editor/src/components/Bubble/RichTextBubbleText.tsx
+++ b/packages/reason-editor/src/components/Bubble/RichTextBubbleText.tsx
@@ -4,12 +4,13 @@
 
 import { TextSelection } from '@tiptap/pm/state';
 import { BubbleMenu } from '@tiptap/react/menus';
-import { Check } from 'lucide-react';
+import { Check, Sparkles } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
 import { ActionButton } from '@/components';
 import { IconComponent } from '@/components/icons';
 import { Popover, PopoverContent, PopoverTrigger, Separator } from '@/components/ui';
+import { getAiState, isAiEnabled } from '@/extensions/Ai';
 import { RichTextBold } from '@/extensions/Bold';
 import { RichTextCode } from '@/extensions/Code';
 import { RichTextColor } from '@/extensions/Color';
@@ -117,9 +118,32 @@ function ParagraphFormat() {
   );
 }
 
+/**
+ * "Ask AI" trigger for the selection bubble — the shortest path from
+ * highlighting text to rewriting it. Renders nothing when the Ai extension is
+ * not registered, so the bubble is unchanged for editors without it.
+ */
+function AskAiButton() {
+  const editor = useEditorInstance();
+
+  if (!isAiEnabled(editor)) return null;
+
+  return (
+    <ActionButton
+      action={() => editor.commands.openAiMenu()}
+      shortcutKeys={['mod', 'J']}
+      tooltip='Ask AI'
+    >
+      <Sparkles className='richtext-size-4 richtext-text-violet-600' />
+    </ActionButton>
+  );
+}
+
 function DefaultButtonBubble() {
   return (
     <>
+      <AskAiButton />
+
       <ParagraphFormat />
 
       <Separator
@@ -160,6 +184,12 @@ export function RichTextBubbleText({ buttonBubble }: RichTextBubbleTextProps) {
 
     // check content select length is not empty
     if ($from.pos === to) {
+      return false;
+    }
+
+    // The AI panel anchors to the same selection; showing both stacks two
+    // floating surfaces on top of each other.
+    if (getAiState(editor.view.state)?.panel.status !== 'closed') {
       return false;
     }
 

--- a/packages/reason-editor/src/editor-views/components/Toolbar.tsx
+++ b/packages/reason-editor/src/editor-views/components/Toolbar.tsx
@@ -58,6 +58,7 @@ import { RichTextZoom } from '@/extensions/Zoom/components/RichTextZoom';
 import { RichTextPagination } from '@/extensions/Pagination/components/RichTextPagination';
 import { RichTextTableOfContentsPanel } from '@/extensions/TableOfContents';
 import { RichTextHarper } from '@/extensions/Harper';
+import { RichTextAi } from '@/extensions/Ai';
 import { RichTextDrawio } from '@/extensions/Drawio';
 import { getReadAloudText, useReadAloudState } from '@/extensions/ReadAloud';
 import {
@@ -1352,6 +1353,9 @@ export const RichTextToolbar = ({
         <RichTextItalic />
         <RichTextUnderline />
         <RichTextHighlight />
+
+        {/* AI writing assistant — renders nothing when the Ai extension is off */}
+        <RichTextAi />
 
         {/* ≡ — Block format */}
         <div className="dropdown-container">

--- a/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
+++ b/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
@@ -62,7 +62,12 @@ import { Twitter } from 'react-reason-editor/twitter';
 import { Video } from 'react-reason-editor/video';
 import { WordCount } from 'react-reason-editor/wordcount';
 
-import { Ai } from '@/extensions/Ai';
+import {
+  Ai,
+  buildAiUserPrompt,
+  createStreamingCompletion,
+  mockAiCompletion,
+} from '@/extensions/Ai';
 import { Comment } from '@/extensions/Comment';
 import { Drawio } from '@/extensions/Drawio';
 import { Harper } from '@/extensions/Harper';
@@ -136,6 +141,37 @@ const demoBase64Upload = (file: File) => {
     }, 300);
   });
 };
+
+/**
+ * Default endpoint the AI writing assistant posts to. It matches the
+ * `{ text, prompt } -> { rewrittenText }` contract the QwkSearch web app
+ * serves at `/api/agent/rewrite`, which is where this editor is mounted.
+ * Hosts without that route point the setting at their own (or clear it) —
+ * an empty value falls back to the offline demo transform rather than
+ * failing every action.
+ */
+const DEFAULT_AI_ENDPOINT = '/api/agent/rewrite';
+
+/**
+ * Builds the extension's `getCompletion`. The request carries the whole
+ * instruction — the system rules, the surrounding context window and the text
+ * to act on — as one prompt, so a plain rewrite route needs no changes to
+ * serve every command in the menu.
+ */
+const createAiCompletion = (endpoint: string) =>
+  endpoint
+    ? createStreamingCompletion({
+        endpoint,
+        body: (request) => ({
+          // `prompt` carries the real instruction; `text` is the field such
+          // routes validate as non-empty, so the generate commands (which run
+          // with no selection) fall back to their context and instruction.
+          text: request.selectedText || request.documentText || request.instruction,
+          prompt: `${request.systemPrompt}\n\n${buildAiUserPrompt(request)}`,
+          command: request.commandId,
+        }),
+      })
+    : mockAiCompletion;
 
 // ─── Registry ────────────────────────────────────────────────────────────────
 
@@ -686,10 +722,29 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
     label: 'AI Writing',
     description: 'Ask AI anything: rewrite, expand, shorten, or fix selected text with an inline diff review.',
     category: 'Collaboration',
-    // Ships with an offline demo completion so the menu works out of the box;
-    // host apps override it with a real model via `Ai.configure({ getCompletion })`.
     defaultEnabled: true,
-    create: () => Ai,
+    settings: [
+      {
+        key: 'endpoint',
+        label: 'Completion endpoint',
+        type: 'text',
+        default: DEFAULT_AI_ENDPOINT,
+        placeholder: DEFAULT_AI_ENDPOINT,
+        help: 'POST target for AI actions. Clear it to use the offline demo transform instead of a model.',
+      },
+      {
+        key: 'contextChars',
+        label: 'Document context (characters)',
+        type: 'number',
+        default: 4000,
+        help: 'How much text around the selection is sent as context. 0 sends none.',
+      },
+    ],
+    create: (s) =>
+      Ai.configure({
+        getCompletion: createAiCompletion(String(s.endpoint ?? '').trim()),
+        contextChars: Number.isFinite(Number(s.contextChars)) ? Number(s.contextChars) : 4000,
+      }),
   },
 
   // ── Discoverable extras (off by default) ──

--- a/packages/reason-editor/src/extensions/Ai/Ai.ts
+++ b/packages/reason-editor/src/extensions/Ai/Ai.ts
@@ -9,6 +9,12 @@
  * package) and rebuilt on Tiptap/ProseMirror: a decoration-driven plugin
  * (state machine + diff rendering) in place of Slate's editor transforms,
  * following the same shape as this package's `Harper` extension.
+ *
+ * Three rules shape the behaviour here, all of them about not damaging the
+ * document: nothing is written until the user accepts; what is written is the
+ * sanitised, Markdown-aware content the review panel showed, not the raw model
+ * response; and the request only ever carries a bounded window of the document
+ * so a long file cannot silently blow up the call.
  */
 
 import { type Editor, Extension } from '@tiptap/core';
@@ -18,7 +24,10 @@ import type { Mapping } from '@tiptap/pm/transform';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 
 import { DEFAULT_AI_COMMANDS } from './commands';
+import { completionToContent } from './lib/completionToContent';
 import { mockAiCompletion } from './lib/mockCompletion';
+import { AI_SYSTEM_PROMPT, buildAiInstruction, clampContext } from './lib/prompt';
+import { sanitizeCompletion } from './lib/sanitizeCompletion';
 
 import type {
   AiCommandDefinition,
@@ -29,7 +38,8 @@ import type {
 } from './types';
 
 export * from './types';
-export { DEFAULT_AI_COMMANDS } from './commands';
+export { DEFAULT_AI_COMMANDS, DEFAULT_AI_LANGUAGES, AI_COMMAND_GROUP_LABELS } from './commands';
+export { AI_SYSTEM_PROMPT } from './lib/prompt';
 
 export interface AiOptions {
   /** Quick commands offered in the "Ask AI anything…" menu. */
@@ -37,9 +47,21 @@ export interface AiOptions {
   /**
    * Runs a completion for an instruction. Defaults to an offline demo
    * transform; host apps should supply a real implementation, the same way
-   * `Image`/`Video` take an `upload` callback.
+   * `Image`/`Video` take an `upload` callback. See `createStreamingCompletion`
+   * for a ready-made fetch/stream implementation.
    */
   getCompletion: AiCompletionFn;
+  /**
+   * System message sent with every request. Constrains the model to return
+   * only the replacement text — override to add house style or domain rules.
+   */
+  systemPrompt: string;
+  /**
+   * How much surrounding document text (in characters) is sent as context.
+   * The window is taken from around the selection, so the nearest text is
+   * what survives the clamp. Set to `0` to send no context at all.
+   */
+  contextChars: number;
   /** Class applied to the (still-present) original text while a replacement is reviewed. */
   removedClass: string;
   /** Class applied to the streamed/suggested text widget. */
@@ -61,9 +83,18 @@ interface AiPluginState {
 
 type AiMeta =
   | { type: 'open-menu'; from: number; to: number }
-  | { type: 'set-loading'; from: number; to: number; commandLabel: string; instruction: string }
+  | {
+      type: 'set-loading';
+      from: number;
+      to: number;
+      commandId: string;
+      commandLabel: string;
+      instruction: string;
+      option?: string;
+    }
   | { type: 'set-suggestion'; suggestion: AiSuggestion; commandLabel: string }
   | { type: 'set-error'; from: number; to: number; commandLabel: string; message: string }
+  | { type: 'settle' }
   | { type: 'close' };
 
 export const aiPluginKey = new PluginKey<AiPluginState>('ai');
@@ -79,6 +110,11 @@ export function getAiOptions(editor: Editor): AiOptions | undefined {
     | undefined;
 }
 
+/** Whether the Ai extension is registered on this editor, for hosts that render its controls conditionally. */
+export function isAiEnabled(editor: Editor | null | undefined): boolean {
+  return !!editor && typeof (editor.commands as any).openAiMenu === 'function';
+}
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     ai: {
@@ -86,15 +122,17 @@ declare module '@tiptap/core' {
       openAiMenu: () => ReturnType;
       /** Close the menu and discard any pending suggestion without touching the document. */
       closeAiMenu: () => ReturnType;
-      /** Run one of `options.commands` against the menu's range. */
-      runAiCommand: (commandId: string) => ReturnType;
+      /** Run one of `options.commands` against the menu's range, optionally with a submenu choice. */
+      runAiCommand: (commandId: string, option?: string) => ReturnType;
       /** Run a free-form instruction typed into the menu's input. */
       submitAiPrompt: (instruction: string) => ReturnType;
+      /** Abort an in-flight completion and return to the command menu. */
+      stopAiGeneration: () => ReturnType;
       /** Replace the original range with the suggestion (or insert it, when there was no selection). */
       acceptAiSuggestion: () => ReturnType;
       /** Discard the suggestion, leaving the document untouched. */
       discardAiSuggestion: () => ReturnType;
-      /** Keep the original text and insert the suggestion as a new paragraph below it. */
+      /** Keep the original text and insert the suggestion as a new block below it. */
       insertAiSuggestionBelow: () => ReturnType;
       /** Re-run the last instruction against its original range. */
       retryAiSuggestion: () => ReturnType;
@@ -183,19 +221,38 @@ function buildDecorations(doc: ProseMirrorNode, panel: AiPanelState, options: Ai
   return DecorationSet.empty;
 }
 
+/**
+ * The document text sent as context: a window centred on the range rather than
+ * the whole document, so cost and latency stay bounded on a long file.
+ */
+function readContextWindow(doc: ProseMirrorNode, from: number, to: number, budget: number): string {
+  if (budget <= 0) return '';
+
+  // Read a generous span either side, then clamp precisely by characters:
+  // positions and characters are not 1:1 once nodes are involved.
+  const span = budget + 200;
+  const before = doc.textBetween(Math.max(0, from - span), from, '\n');
+  const after = doc.textBetween(to, Math.min(doc.content.size, to + span), '\n');
+
+  const half = Math.floor(budget / 2);
+  const head = clampContext(before, half);
+  const tail = after.length > budget - head.length ? `${after.slice(0, budget - head.length)}…` : after;
+
+  return `${head}${head && tail ? '\n' : ''}${tail}`.trim();
+}
+
 async function runAiRequest(
   editor: Editor,
   options: AiOptions,
   storage: AiStorage,
-  instruction: string,
-  commandLabel: string,
+  request: { instruction: string; commandId: string; commandLabel: string; option?: string },
   from: number,
   to: number
 ) {
   const { view } = editor;
   const doc = editor.state.doc;
   const selectedText = from === to ? '' : doc.textBetween(from, to, '\n');
-  const documentText = doc.textBetween(0, doc.content.size, '\n');
+  const documentText = readContextWindow(doc, from, to, options.contextChars);
   const mode: AiSuggestion['mode'] = selectedText ? 'replace' : 'insert';
 
   storage.abortController?.abort();
@@ -208,28 +265,57 @@ async function runAiRequest(
       type: 'set-loading',
       from,
       to,
-      commandLabel,
-      instruction,
+      commandId: request.commandId,
+      commandLabel: request.commandLabel,
+      instruction: request.instruction,
+      option: request.option,
     } satisfies AiMeta)
   );
 
   const dispatchSuggestion = (text: string, isStreaming: boolean) => {
     if (token !== storage.requestToken || editor.isDestroyed) return;
+    const suggestedText = sanitizeCompletion(text, { streaming: isStreaming });
     editor.view.dispatch(
       editor.view.state.tr.setMeta(aiPluginKey, {
         type: 'set-suggestion',
-        commandLabel,
-        suggestion: { from, to, originalText: selectedText, suggestedText: text, mode, isStreaming },
+        commandLabel: request.commandLabel,
+        suggestion: { from, to, originalText: selectedText, suggestedText, mode, isStreaming },
       } satisfies AiMeta)
     );
   };
 
   try {
     const result = await options.getCompletion(
-      { instruction, selectedText, documentText },
+      {
+        instruction: request.instruction,
+        selectedText,
+        documentText,
+        commandId: request.commandId,
+        commandLabel: request.commandLabel,
+        option: request.option,
+        systemPrompt: options.systemPrompt,
+        mode,
+      },
       (chunk) => dispatchSuggestion(chunk, true),
       controller.signal
     );
+
+    if (token !== storage.requestToken || editor.isDestroyed) return;
+
+    const finalText = sanitizeCompletion(result);
+    if (!finalText) {
+      editor.view.dispatch(
+        editor.view.state.tr.setMeta(aiPluginKey, {
+          type: 'set-error',
+          from,
+          to,
+          commandLabel: request.commandLabel,
+          message: 'The model returned an empty response.',
+        } satisfies AiMeta)
+      );
+      return;
+    }
+
     dispatchSuggestion(result, false);
   } catch (error) {
     if (controller.signal.aborted || token !== storage.requestToken || editor.isDestroyed) return;
@@ -238,7 +324,7 @@ async function runAiRequest(
         type: 'set-error',
         from,
         to,
-        commandLabel,
+        commandLabel: request.commandLabel,
         message: error instanceof Error ? error.message : 'Something went wrong.',
       } satisfies AiMeta)
     );
@@ -252,6 +338,8 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
     return {
       commands: DEFAULT_AI_COMMANDS,
       getCompletion: mockAiCompletion,
+      systemPrompt: AI_SYSTEM_PROMPT,
+      contextChars: 4000,
       removedClass: 'ai-removed-text',
       insertedClass: 'ai-suggested-text',
       loadingClass: 'ai-loading-indicator',
@@ -276,10 +364,18 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
   },
 
   addCommands() {
+    /** Cancels any in-flight request so a late chunk cannot revive a closed panel. */
+    const cancelInFlight = () => {
+      this.storage.abortController?.abort();
+      this.storage.abortController = null;
+      this.storage.requestToken += 1;
+    };
+
     return {
       openAiMenu:
         () =>
         ({ state, dispatch }) => {
+          cancelInFlight();
           const { from, to } = state.selection;
           if (dispatch) {
             dispatch(state.tr.setMeta(aiPluginKey, { type: 'open-menu', from, to } satisfies AiMeta));
@@ -290,23 +386,63 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
       closeAiMenu:
         () =>
         ({ state, dispatch }) => {
-          this.storage.abortController?.abort();
-          this.storage.requestToken += 1;
+          cancelInFlight();
           if (dispatch) {
             dispatch(state.tr.setMeta(aiPluginKey, { type: 'close' } satisfies AiMeta));
           }
           return true;
         },
 
+      stopAiGeneration:
+        () =>
+        ({ state, dispatch }) => {
+          const panel = getAiState(state)?.panel;
+          if (!panel || (panel.status !== 'loading' && panel.status !== 'reviewing')) return false;
+          if (panel.status === 'reviewing' && !panel.suggestion.isStreaming) return false;
+
+          cancelInFlight();
+          if (!dispatch) return true;
+
+          // Text already streamed in is worth keeping: settle it so the user
+          // can accept the partial result. With nothing yet to review, fall
+          // back to the command list.
+          if (panel.status === 'reviewing') {
+            dispatch(state.tr.setMeta(aiPluginKey, { type: 'settle' } satisfies AiMeta));
+          } else {
+            const { from, to } = getPanelRange(panel, state.selection);
+            dispatch(state.tr.setMeta(aiPluginKey, { type: 'open-menu', from, to } satisfies AiMeta));
+          }
+          return true;
+        },
+
       runAiCommand:
-        (commandId: string) =>
+        (commandId: string, option?: string) =>
         ({ state, editor }) => {
           const command = this.options.commands.find((c) => c.id === commandId);
           if (!command) return false;
 
           const panel = getAiState(state)?.panel ?? { status: 'closed' as const };
           const { from, to } = getPanelRange(panel, state.selection);
-          void runAiRequest(editor as Editor, this.options, this.storage, command.prompt, command.label, from, to);
+
+          // A command that rewrites a selection has nothing to act on when the
+          // caret is collapsed; running it anyway produces a confident answer
+          // about nothing, so refuse instead.
+          if (command.requiresSelection !== false && from === to) return false;
+          if (command.options?.length && !option) return false;
+
+          void runAiRequest(
+            editor as Editor,
+            this.options,
+            this.storage,
+            {
+              instruction: buildAiInstruction(command, option),
+              commandId: command.id,
+              commandLabel: option ? `${command.label} → ${option}` : command.label,
+              option,
+            },
+            from,
+            to
+          );
           return true;
         },
 
@@ -318,7 +454,14 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
 
           const panel = getAiState(state)?.panel ?? { status: 'closed' as const };
           const { from, to } = getPanelRange(panel, state.selection);
-          void runAiRequest(editor as Editor, this.options, this.storage, trimmed, 'Custom', from, to);
+          void runAiRequest(
+            editor as Editor,
+            this.options,
+            this.storage,
+            { instruction: trimmed, commandId: 'custom', commandLabel: 'Custom' },
+            from,
+            to
+          );
           return true;
         },
 
@@ -331,8 +474,12 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
             editor as Editor,
             this.options,
             this.storage,
-            last.instruction,
-            last.commandLabel,
+            {
+              instruction: last.instruction,
+              commandId: last.commandId,
+              commandLabel: last.commandLabel,
+              option: last.option,
+            },
             last.from,
             last.to
           );
@@ -341,23 +488,30 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
 
       acceptAiSuggestion:
         () =>
-        ({ state, dispatch, tr }) => {
+        ({ state, chain }) => {
           const panel = getAiState(state)?.panel;
           if (!panel || panel.status !== 'reviewing' || panel.suggestion.isStreaming) return false;
 
           const { from, to, suggestedText } = panel.suggestion;
-          tr.insertText(suggestedText, from, to);
-          tr.setMeta(aiPluginKey, { type: 'close' } satisfies AiMeta);
+          const { content } = completionToContent(suggestedText);
+          if (!content) return false;
 
-          if (dispatch) dispatch(tr);
-          return true;
+          cancelInFlight();
+          return chain()
+            .insertContentAt({ from, to }, content, {
+              parseOptions: { preserveWhitespace: false },
+            })
+            .command(({ tr }) => {
+              tr.setMeta(aiPluginKey, { type: 'close' } satisfies AiMeta);
+              return true;
+            })
+            .run();
         },
 
       discardAiSuggestion:
         () =>
         ({ state, dispatch }) => {
-          this.storage.abortController?.abort();
-          this.storage.requestToken += 1;
+          cancelInFlight();
           if (dispatch) {
             dispatch(state.tr.setMeta(aiPluginKey, { type: 'close' } satisfies AiMeta));
           }
@@ -366,21 +520,27 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
 
       insertAiSuggestionBelow:
         () =>
-        ({ state, dispatch, tr }) => {
+        ({ state, chain }) => {
           const panel = getAiState(state)?.panel;
           if (!panel || panel.status !== 'reviewing' || panel.suggestion.isStreaming) return false;
 
           const { to, suggestedText } = panel.suggestion;
-          const $to = tr.doc.resolve(Math.min(to, tr.doc.content.size));
-          const blockEnd = $to.end($to.depth);
+          const { content } = completionToContent(suggestedText);
+          if (!content) return false;
 
-          const paragraphType = state.schema.nodes.paragraph;
-          const node = paragraphType.create(null, suggestedText ? state.schema.text(suggestedText) : undefined);
-          tr.insert(blockEnd, node);
-          tr.setMeta(aiPluginKey, { type: 'close' } satisfies AiMeta);
+          // Insert after the block the suggestion ends in, so the original text
+          // is left exactly as it was rather than being split around the result.
+          const $to = state.doc.resolve(Math.min(to, state.doc.content.size));
+          const insertAt = $to.depth > 0 ? $to.after($to.depth) : $to.pos;
 
-          if (dispatch) dispatch(tr);
-          return true;
+          cancelInFlight();
+          return chain()
+            .insertContentAt(insertAt, content, { parseOptions: { preserveWhitespace: false } })
+            .command(({ tr }) => {
+              tr.setMeta(aiPluginKey, { type: 'close' } satisfies AiMeta);
+              return true;
+            })
+            .run();
         },
     };
   },
@@ -413,7 +573,9 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
                   panel = { status: 'loading', from: meta.from, to: meta.to, commandLabel: meta.commandLabel };
                   lastRequest = {
                     instruction: meta.instruction,
+                    commandId: meta.commandId,
                     commandLabel: meta.commandLabel,
+                    option: meta.option,
                     from: meta.from,
                     to: meta.to,
                   };
@@ -429,6 +591,11 @@ export const Ai = Extension.create<AiOptions, AiStorage>({
                     commandLabel: meta.commandLabel,
                     message: meta.message,
                   };
+                  break;
+                case 'settle':
+                  if (panel.status === 'reviewing') {
+                    panel = { ...panel, suggestion: { ...panel.suggestion, isStreaming: false } };
+                  }
                   break;
                 case 'close':
                   panel = { status: 'closed' };

--- a/packages/reason-editor/src/extensions/Ai/README.md
+++ b/packages/reason-editor/src/extensions/Ai/README.md
@@ -1,0 +1,89 @@
+# Ai — writing assistant
+
+Streams a model's suggestion for the current selection (or the caret), shows it
+as an inline red/green diff, and writes nothing to the document until the user
+accepts it.
+
+## Entry points
+
+| Trigger | Where |
+| --- | --- |
+| `AI` button | main toolbar (`RichTextAi`) |
+| ✨ Ask AI | selection bubble menu |
+| `⌘/Ctrl + J` | keyboard, anywhere in the editor |
+| `/ai` | slash-command menu |
+
+All four open the same floating panel (`AiMenu`): a filterable command palette
+plus a free-form prompt box. Typing filters the commands; `↑`/`↓` and `Enter`
+run one, `Enter` on an empty highlight submits the typed prompt instead.
+
+## Review flow
+
+Nothing is applied automatically. While the answer streams the panel shows it
+with a **Stop** control (stopping keeps what has already arrived), and once it
+settles the actions are **Replace selection** (`⌘/Ctrl + Enter`), **Insert
+below**, **Try again**, **Copy** and **Discard**.
+
+## Wiring a real model
+
+The extension ships with an offline demo transform so the menu works with no
+backend. Point it at a real one with `getCompletion`:
+
+```ts
+import { Ai, createStreamingCompletion } from 'react-reason-editor/ai';
+
+Ai.configure({
+  getCompletion: createStreamingCompletion({ endpoint: '/api/ai' }),
+  // How much text around the selection is sent as context. 0 sends none.
+  contextChars: 4000,
+});
+```
+
+`createStreamingCompletion` handles a plain text stream, an OpenAI-compatible
+SSE stream, and a single JSON object (`{ rewrittenText }`, `{ text }`,
+`{ choices: [...] }`), and surfaces a JSON `error` body as the message shown in
+the panel. For anything else, implement `AiCompletionFn` directly — it is
+called with the instruction, the selection, a clamped context window, the
+command id and a `systemPrompt`, plus an `AbortSignal` that fires when the user
+cancels.
+
+In this repo the plugin registry defaults the endpoint to the QwkSearch web
+app's `/api/agent/rewrite`; it is editable (and clearable, to fall back to the
+demo transform) under Settings → Plugins → AI Writing.
+
+## What the extension guarantees about the output
+
+- The response is sanitised before it is shown or applied: chat preambles
+  ("Sure — here's a tighter version:"), code fences wrapping the whole answer,
+  and quotes around the whole answer are removed, and blank-line runs are
+  collapsed. The same clean-up runs on every streamed chunk, so the preview and
+  the accepted text always match.
+- Markdown structure in the answer (lists, headings, emphasis, tables) is
+  converted to real nodes on accept, so "Key takeaways" produces a bullet list
+  rather than literal `- ` characters. A single-line rewrite is inserted as
+  plain text so the marks already on the range survive.
+- Commands that rewrite a selection are hidden — and refuse to run — when the
+  caret is collapsed, so they never answer confidently about nothing.
+
+## Customising the commands
+
+```ts
+Ai.configure({
+  commands: [
+    ...DEFAULT_AI_COMMANDS,
+    {
+      id: 'cut-card',
+      label: 'Cut this evidence',
+      description: 'Condense into a debate card',
+      icon: Scissors,
+      group: 'transform',
+      prompt:
+        'Condense this evidence into a debate card. Preserve exact quotations and identify the claim and the warrant. Do not invent citations.',
+    },
+  ],
+});
+```
+
+`group` places the command under a menu heading (`edit`, `tone`, `transform`,
+`generate`), `requiresSelection: false` makes it available at a bare caret, and
+`options` turns it into a submenu (that is how Translate picks its language).

--- a/packages/reason-editor/src/extensions/Ai/commands.ts
+++ b/packages/reason-editor/src/extensions/Ai/commands.ts
@@ -1,55 +1,235 @@
 /**
  * Default quick-commands shown in the Ai extension's "Ask AI anything…"
- * menu. Ported from the writing-assistant command set in the old
- * `packages/reason-editor/ai` (Plate.js) source. Overridable via
+ * menu and in the toolbar's AI dropdown. Overridable via
  * `Ai.configure({ commands })`.
+ *
+ * Prompt wording matters more than it looks: every prompt names the unit it
+ * operates on ("the text"), states what must be preserved, and — for anything
+ * that reshapes the content — says what the output should be, so the model
+ * returns a drop-in replacement rather than a commentary on one. The shared
+ * "return only the replacement" framing lives in `lib/prompt.ts` and is sent
+ * as the system message, so it is not repeated in each prompt here.
  */
 
-import { CheckCheck, Feather, Minus, Plus, SmilePlus, Sparkles } from 'lucide-react';
+import {
+  ArrowRightLeft,
+  Baby,
+  Briefcase,
+  CheckCheck,
+  Coffee,
+  Feather,
+  FileText,
+  Languages,
+  ListChecks,
+  ListTree,
+  Minus,
+  PenLine,
+  Plus,
+  Quote,
+  SmilePlus,
+  Sparkles,
+  WandSparkles,
+} from 'lucide-react';
 
-import type { AiCommandDefinition } from './types';
+import type { AiCommandDefinition, AiCommandOption } from './types';
+
+/** Target languages offered by the Translate command. */
+export const DEFAULT_AI_LANGUAGES: AiCommandOption[] = [
+  { id: 'en', label: 'English' },
+  { id: 'es', label: 'Spanish' },
+  { id: 'fr', label: 'French' },
+  { id: 'de', label: 'German' },
+  { id: 'pt', label: 'Portuguese' },
+  { id: 'it', label: 'Italian' },
+  { id: 'zh', label: 'Chinese (Simplified)' },
+  { id: 'ja', label: 'Japanese' },
+  { id: 'ko', label: 'Korean' },
+  { id: 'hi', label: 'Hindi' },
+  { id: 'ar', label: 'Arabic' },
+  { id: 'ru', label: 'Russian' },
+];
 
 export const DEFAULT_AI_COMMANDS: AiCommandDefinition[] = [
+  // ── Edit: same content, better prose ──
   {
     id: 'improve',
     label: 'Improve writing',
-    description: 'Rewrite for clarity and flow',
+    description: 'Clearer, tighter, same meaning',
     icon: Sparkles,
-    prompt: 'Improve the writing quality of the selected text while preserving its original meaning and tone.',
-  },
-  {
-    id: 'emojify',
-    label: 'Emojify',
-    description: 'Add relevant emoji',
-    icon: SmilePlus,
-    prompt: 'Add relevant emoji throughout the selected text without changing the wording.',
-  },
-  {
-    id: 'longer',
-    label: 'Make longer',
-    description: 'Expand with more detail',
-    icon: Plus,
-    prompt: 'Expand the selected text with more detail and supporting context while keeping the same tone.',
-  },
-  {
-    id: 'shorter',
-    label: 'Make shorter',
-    description: 'Trim to the essentials',
-    icon: Minus,
-    prompt: 'Make the selected text more concise, removing redundancy while preserving all key points.',
+    group: 'edit',
+    prompt:
+      'Improve the clarity, flow and word choice of the text. Keep the author\'s meaning, voice, facts and level of formality exactly as they are, and keep roughly the same length.',
   },
   {
     id: 'fix',
     label: 'Fix spelling & grammar',
     description: 'Correct mistakes only',
     icon: CheckCheck,
-    prompt: 'Fix all spelling and grammar mistakes in the selected text without changing its meaning or style.',
+    group: 'edit',
+    prompt:
+      'Correct spelling, grammar, punctuation and obvious typos in the text. Change nothing else: keep the original wording, sentence structure, tone and formatting. If the text is already correct, return it unchanged.',
+  },
+  {
+    id: 'shorter',
+    label: 'Make shorter',
+    description: 'Trim to the essentials',
+    icon: Minus,
+    group: 'edit',
+    prompt:
+      'Rewrite the text roughly half as long. Cut redundancy, filler and hedging, but keep every claim, figure, name and qualifier that carries meaning.',
+  },
+  {
+    id: 'longer',
+    label: 'Make longer',
+    description: 'Expand with more detail',
+    icon: Plus,
+    group: 'edit',
+    prompt:
+      'Expand the text with useful detail, explanation and structure, staying on the same topic and in the same voice. Do not invent facts, statistics, quotations or sources — expand only on what the text already implies.',
   },
   {
     id: 'simplify',
     label: 'Simplify language',
     description: 'Plainer words, shorter sentences',
     icon: Feather,
-    prompt: 'Simplify the language of the selected text so it is easier to understand, using plainer words and shorter sentences.',
+    group: 'edit',
+    prompt:
+      'Rewrite the text in plain, direct language: common words, shorter sentences, active voice. Keep all of the original meaning, including any technical terms that have no plain equivalent.',
+  },
+  {
+    id: 'rephrase',
+    label: 'Rephrase',
+    description: 'Same point, fresh wording',
+    icon: ArrowRightLeft,
+    group: 'edit',
+    prompt:
+      'Rewrite the text with different wording and sentence structure while preserving its meaning, tone and approximate length. Avoid reusing the original phrasing.',
+  },
+
+  // ── Tone ──
+  {
+    id: 'professional',
+    label: 'Professional tone',
+    description: 'Polished and businesslike',
+    icon: Briefcase,
+    group: 'tone',
+    prompt:
+      'Rewrite the text in a polished, professional tone: precise, courteous, free of slang and exclamation marks. Do not change the meaning or add new claims.',
+  },
+  {
+    id: 'casual',
+    label: 'Casual tone',
+    description: 'Relaxed and conversational',
+    icon: Coffee,
+    group: 'tone',
+    prompt:
+      'Rewrite the text in a relaxed, conversational tone, as if explaining it to a colleague. Keep it clear and keep the meaning unchanged; do not add jokes or filler.',
+  },
+  {
+    id: 'confident',
+    label: 'More confident',
+    description: 'Drop the hedging',
+    icon: PenLine,
+    group: 'tone',
+    prompt:
+      'Rewrite the text so it reads more decisively: remove hedges such as "maybe", "I think" and "sort of", and use active voice. Keep any genuine uncertainty that the text explicitly states.',
+  },
+  {
+    id: 'emojify',
+    label: 'Emojify',
+    description: 'Add relevant emoji',
+    icon: SmilePlus,
+    group: 'tone',
+    prompt:
+      'Add a small number of relevant emoji to the text, at most one per sentence. Do not change any of the wording.',
+  },
+
+  // ── Transform: reshape the selection into something else ──
+  {
+    id: 'summarize',
+    label: 'Summarize',
+    description: 'Condense into a short paragraph',
+    icon: FileText,
+    group: 'transform',
+    prompt:
+      'Summarize the text in one short paragraph that captures its main point and the reasoning behind it. Use only information present in the text.',
+  },
+  {
+    id: 'key-points',
+    label: 'Key takeaways',
+    description: 'Turn it into a bullet list',
+    icon: ListTree,
+    group: 'transform',
+    prompt:
+      'Rewrite the text as a list of the key takeaways, one per line, each starting with "- ". Keep each line to a single sentence and use only information present in the text.',
+  },
+  {
+    id: 'action-items',
+    label: 'Extract action items',
+    description: 'Who does what, next',
+    icon: ListChecks,
+    group: 'transform',
+    prompt:
+      'List the concrete action items implied by the text, one per line, each starting with "- " and written as an imperative with the owner named when the text names one. If the text contains no action items, return "- No action items.".',
+  },
+  {
+    id: 'explain',
+    label: 'Explain this',
+    description: 'Plain-English explanation',
+    icon: Baby,
+    group: 'transform',
+    prompt:
+      'Explain what the text means in plain English, in one short paragraph a non-expert can follow. Explain the text; do not rewrite or evaluate it.',
+  },
+  {
+    id: 'translate',
+    label: 'Translate',
+    description: 'Into another language',
+    icon: Languages,
+    group: 'transform',
+    options: DEFAULT_AI_LANGUAGES,
+    prompt:
+      'Translate the text accurately, preserving tone, formatting, line breaks, names, URLs, code and numbers. Target language:',
+  },
+
+  // ── Generate: works from the caret, no selection needed ──
+  {
+    id: 'continue',
+    label: 'Continue writing',
+    description: 'Pick up where the text stops',
+    icon: WandSparkles,
+    group: 'generate',
+    requiresSelection: false,
+    prompt:
+      'Continue the document from where it stops, in the same voice, tense and formatting. Write one or two paragraphs that follow naturally. Do not repeat what has already been written and do not invent sources or statistics.',
+  },
+  {
+    id: 'outline',
+    label: 'Draft an outline',
+    description: 'Headings for this document',
+    icon: ListTree,
+    group: 'generate',
+    requiresSelection: false,
+    prompt:
+      'Draft a working outline for this document, one heading per line, each starting with "- ". Base it on what the document is already about.',
+  },
+  {
+    id: 'counterpoint',
+    label: 'Counterpoint',
+    description: 'The strongest objection',
+    icon: Quote,
+    group: 'transform',
+    prompt:
+      'State the strongest good-faith objection to the argument in the text, in one short paragraph. Name the assumption it challenges. Do not invent evidence, sources or statistics.',
   },
 ];
+
+/** Order the menu renders groups in, with the heading shown above each. */
+export const AI_COMMAND_GROUP_LABELS: Record<string, string> = {
+  edit: 'Edit',
+  tone: 'Tone',
+  transform: 'Transform',
+  generate: 'Generate',
+};
+
+export const AI_COMMAND_GROUP_ORDER = ['edit', 'tone', 'transform', 'generate'] as const;

--- a/packages/reason-editor/src/extensions/Ai/components/AiMenu.tsx
+++ b/packages/reason-editor/src/extensions/Ai/components/AiMenu.tsx
@@ -1,11 +1,12 @@
 /**
  * Floating "Ask AI anything…" panel for the Ai extension. Reads the
  * extension's ProseMirror plugin state (menu / loading / reviewing / error)
- * and renders the matching UI: the quick-command list, a streaming spinner,
- * the accept/discard/insert-below/try-again review controls, or an error
- * with a retry action. Positioned with `@floating-ui/dom` and rendered
- * through a portal so it floats above the editor regardless of scroll
- * containers, the same approach `SlashCommand` uses for its own popup.
+ * and renders the matching UI: the filterable quick-command list, a streaming
+ * indicator with a Stop control, the accept/insert-below/try-again/discard
+ * review controls over a preview of the result, or an error with a retry
+ * action. Positioned with `@floating-ui/dom` and rendered through a portal so
+ * it floats above the editor regardless of scroll containers, the same
+ * approach `SlashCommand` uses for its own popup.
  *
  * Styled with hand-written `.ai-menu*` classes (see `src/styles/ProseMirror.scss`)
  * rather than Tailwind utilities: this component ships inside the published
@@ -15,7 +16,17 @@
 
 import { computePosition, flip, offset, shift } from '@floating-ui/dom';
 import { posToDOMRect, useEditorState } from '@tiptap/react';
-import { Check, CornerDownRight, Loader2, RotateCcw, Sparkles, X } from 'lucide-react';
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  CornerDownRight,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+  Square,
+  X,
+} from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -23,6 +34,8 @@ import { useEditorInstance } from '@/store/editor';
 import { useEditableEditor } from '@/store/store';
 
 import { getAiOptions, getAiState } from '../Ai';
+import { AI_COMMAND_GROUP_LABELS } from '../commands';
+import { commandsForSelection, groupCommands } from '../lib/prompt';
 
 import type { AiCommandDefinition, AiPanelState } from '../types';
 
@@ -33,14 +46,16 @@ function MenuRow({
   label,
   onClick,
   disabled,
+  title,
 }: {
   icon: React.ComponentType<{ className?: string }>;
   label: string;
   onClick: () => void;
   disabled?: boolean;
+  title?: string;
 }) {
   return (
-    <button type="button" disabled={disabled} onClick={onClick} className="ai-menu-row">
+    <button type="button" disabled={disabled} onClick={onClick} title={title} className="ai-menu-row">
       <Icon className="ai-menu-row-icon" />
       {label}
     </button>
@@ -53,6 +68,9 @@ export function AiMenu() {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [prompt, setPrompt] = useState('');
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const [submenu, setSubmenu] = useState<AiCommandDefinition | null>(null);
+  const [copied, setCopied] = useState(false);
   const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
 
   const panel = useEditorState({
@@ -67,15 +85,43 @@ export function AiMenu() {
   }, [panel]);
 
   const isOpen = panel.status !== 'closed';
+  const hasSelection = !!range && range.to > range.from;
+  const selectionLength = range ? range.to - range.from : 0;
+
+  const commands: AiCommandDefinition[] = editor ? (getAiOptions(editor)?.commands ?? []) : [];
+
+  // Typing filters the command list, so the input doubles as a palette rather
+  // than only ever being a free-form prompt box.
+  const query = prompt.trim().toLowerCase();
+  const visibleCommands = useMemo(() => {
+    const available = commandsForSelection(commands, hasSelection);
+    if (!query) return available;
+    return available.filter((command) =>
+      `${command.label} ${command.description ?? ''}`.toLowerCase().includes(query)
+    );
+    // `commands` is a stable options array; `query`/`hasSelection` drive this.
+  }, [commands, query, hasSelection]);
+
+  const sections = useMemo(() => groupCommands(visibleCommands), [visibleCommands]);
 
   // Reset and focus the input each time the menu opens fresh.
   useEffect(() => {
     if (panel.status === 'menu') {
-      setPrompt('');
       const raf = requestAnimationFrame(() => inputRef.current?.focus());
       return () => cancelAnimationFrame(raf);
     }
+    if (panel.status === 'closed') {
+      setPrompt('');
+      setSubmenu(null);
+      setActiveIndex(-1);
+      setCopied(false);
+    }
   }, [panel.status]);
+
+  // A filtered-out highlight would run the wrong command on Enter.
+  useEffect(() => {
+    setActiveIndex((index) => (index >= visibleCommands.length ? visibleCommands.length - 1 : index));
+  }, [visibleCommands.length]);
 
   // Keep the panel anchored to its range as the document/viewport changes.
   useEffect(() => {
@@ -117,7 +163,23 @@ export function AiMenu() {
       }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') editor.commands.closeAiMenu();
+      if (event.key === 'Escape') {
+        if (submenu) {
+          setSubmenu(null);
+          return;
+        }
+        editor.commands.closeAiMenu();
+        return;
+      }
+
+      // Cmd/Ctrl+Enter accepts a settled suggestion from anywhere in the panel.
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        const state = getAiState(editor.state)?.panel;
+        if (state?.status === 'reviewing' && !state.suggestion.isStreaming) {
+          event.preventDefault();
+          editor.commands.acceptAiSuggestion();
+        }
+      }
     };
 
     document.addEventListener('mousedown', handlePointerDown);
@@ -126,15 +188,50 @@ export function AiMenu() {
       document.removeEventListener('mousedown', handlePointerDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isOpen, editor]);
+  }, [isOpen, editor, submenu]);
 
   if (!editable || !editor || !isOpen || !position) return null;
 
-  const commands: AiCommandDefinition[] = getAiOptions(editor)?.commands ?? [];
+  const runCommand = (command: AiCommandDefinition) => {
+    if (command.options?.length) {
+      setSubmenu(command);
+      return;
+    }
+    editor.commands.runAiCommand(command.id);
+  };
 
-  const submitPrompt = () => {
-    if (!prompt.trim()) return;
-    editor.commands.submitAiPrompt(prompt);
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index) => (visibleCommands.length ? (index + 1) % visibleCommands.length : -1));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        visibleCommands.length ? (index <= 0 ? visibleCommands.length - 1 : index - 1) : -1
+      );
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const highlighted = activeIndex >= 0 ? visibleCommands[activeIndex] : undefined;
+      if (highlighted) {
+        runCommand(highlighted);
+        return;
+      }
+      if (prompt.trim()) editor.commands.submitAiPrompt(prompt);
+    }
+  };
+
+  const copyResult = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can be denied; the result is still visible to select.
+    }
   };
 
   return createPortal(
@@ -150,70 +247,145 @@ export function AiMenu() {
         <input
           ref={inputRef}
           value={prompt}
-          onChange={(event) => setPrompt(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              submitPrompt();
-            }
+          onChange={(event) => {
+            setPrompt(event.target.value);
+            setActiveIndex(event.target.value.trim() ? 0 : -1);
           }}
-          placeholder="Ask AI anything…"
+          onKeyDown={onInputKeyDown}
+          placeholder={hasSelection ? 'Ask AI to change the selection…' : 'Ask AI anything…'}
           className="ai-menu-input"
+          aria-label="Ask AI"
         />
       </div>
 
-      {panel.status === 'menu' && (
+      {panel.status === 'menu' && submenu && (
         <div className="ai-menu-commands">
-          {commands.map((command) => (
+          <button type="button" className="ai-menu-row" onClick={() => setSubmenu(null)}>
+            <ArrowLeft className="ai-menu-row-icon" />
+            {submenu.label}
+          </button>
+          {submenu.options?.map((option) => (
             <button
-              key={command.id}
+              key={option.id}
               type="button"
-              onClick={() => editor.commands.runAiCommand(command.id)}
               className="ai-menu-command"
+              onClick={() => {
+                setSubmenu(null);
+                editor.commands.runAiCommand(submenu.id, option.label);
+              }}
             >
-              <command.icon className="ai-menu-row-icon" />
               <span className="ai-menu-command-text">
-                <span className="ai-menu-command-label">{command.label}</span>
-                {command.description && (
-                  <span className="ai-menu-command-description">{command.description}</span>
-                )}
+                <span className="ai-menu-command-label">{option.label}</span>
               </span>
             </button>
           ))}
         </div>
       )}
 
+      {panel.status === 'menu' && !submenu && (
+        <>
+          <div className="ai-menu-hint">
+            {hasSelection
+              ? `${selectionLength.toLocaleString()} characters selected`
+              : 'Nothing selected — select text for rewrite actions'}
+          </div>
+          <div className="ai-menu-commands">
+            {sections.length === 0 && <div className="ai-menu-empty">No matching actions</div>}
+            {sections.map((section) => (
+              <div key={section.group}>
+                <div className="ai-menu-group-label">{AI_COMMAND_GROUP_LABELS[section.group]}</div>
+                {section.commands.map((command) => {
+                  const index = visibleCommands.indexOf(command);
+                  return (
+                    <button
+                      key={command.id}
+                      type="button"
+                      data-active={index === activeIndex ? 'true' : undefined}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onClick={() => runCommand(command)}
+                      className="ai-menu-command"
+                    >
+                      <command.icon className="ai-menu-row-icon" />
+                      <span className="ai-menu-command-text">
+                        <span className="ai-menu-command-label">{command.label}</span>
+                        {command.description && (
+                          <span className="ai-menu-command-description">{command.description}</span>
+                        )}
+                      </span>
+                      {command.options?.length ? <span className="ai-menu-command-more">›</span> : null}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
       {panel.status === 'loading' && (
         <div className="ai-menu-loading">
           <Loader2 className="ai-menu-row-icon ai-menu-spin" />
-          {panel.commandLabel === 'Custom' ? 'Generating…' : `${panel.commandLabel}…`}
+          <span className="ai-menu-loading-label">
+            {panel.commandLabel === 'Custom' ? 'Generating…' : `${panel.commandLabel}…`}
+          </span>
+          <button type="button" className="ai-menu-stop" onClick={() => editor.commands.stopAiGeneration()}>
+            <Square className="ai-menu-row-icon" />
+            Stop
+          </button>
         </div>
       )}
 
       {panel.status === 'error' && (
         <div className="ai-menu-error">
           <p className="ai-menu-error-message">{panel.message}</p>
-          <MenuRow icon={RotateCcw} label="Try again" onClick={() => editor.commands.retryAiSuggestion()} />
+          <div className="ai-menu-review">
+            <MenuRow icon={RotateCcw} label="Try again" onClick={() => editor.commands.retryAiSuggestion()} />
+            <MenuRow icon={X} label="Dismiss" onClick={() => editor.commands.closeAiMenu()} />
+          </div>
         </div>
       )}
 
       {panel.status === 'reviewing' && (
-        <div className="ai-menu-review">
-          <MenuRow
-            icon={Check}
-            label="Accept"
-            disabled={panel.suggestion.isStreaming}
-            onClick={() => editor.commands.acceptAiSuggestion()}
-          />
-          <MenuRow icon={X} label="Discard" onClick={() => editor.commands.discardAiSuggestion()} />
-          <MenuRow
-            icon={CornerDownRight}
-            label="Insert below"
-            disabled={panel.suggestion.isStreaming}
-            onClick={() => editor.commands.insertAiSuggestionBelow()}
-          />
-          <MenuRow icon={RotateCcw} label="Try again" onClick={() => editor.commands.retryAiSuggestion()} />
-        </div>
+        <>
+          <div className="ai-menu-preview" aria-live="polite">
+            {panel.suggestion.suggestedText || '…'}
+          </div>
+          {panel.suggestion.isStreaming ? (
+            <div className="ai-menu-loading">
+              <Loader2 className="ai-menu-row-icon ai-menu-spin" />
+              <span className="ai-menu-loading-label">{panel.commandLabel}…</span>
+              <button
+                type="button"
+                className="ai-menu-stop"
+                onClick={() => editor.commands.stopAiGeneration()}
+              >
+                <Square className="ai-menu-row-icon" />
+                Stop
+              </button>
+            </div>
+          ) : (
+            <div className="ai-menu-review">
+              <MenuRow
+                icon={Check}
+                label={panel.suggestion.mode === 'replace' ? 'Replace selection' : 'Insert'}
+                title="⌘/Ctrl + Enter"
+                onClick={() => editor.commands.acceptAiSuggestion()}
+              />
+              <MenuRow
+                icon={CornerDownRight}
+                label="Insert below"
+                onClick={() => editor.commands.insertAiSuggestionBelow()}
+              />
+              <MenuRow icon={RotateCcw} label="Try again" onClick={() => editor.commands.retryAiSuggestion()} />
+              <MenuRow
+                icon={Copy}
+                label={copied ? 'Copied' : 'Copy'}
+                onClick={() => copyResult(panel.suggestion.suggestedText)}
+              />
+              <MenuRow icon={X} label="Discard" onClick={() => editor.commands.discardAiSuggestion()} />
+            </div>
+          )}
+        </>
       )}
     </div>,
     document.body

--- a/packages/reason-editor/src/extensions/Ai/components/RichTextAi.tsx
+++ b/packages/reason-editor/src/extensions/Ai/components/RichTextAi.tsx
@@ -1,0 +1,244 @@
+/**
+ * Toolbar control (React) for the Ai extension: a single "AI" button that
+ * opens the writing-assistant actions — the same commands the floating
+ * "Ask AI anything…" menu offers, reachable without first learning the
+ * ⌘J shortcut or the `/ai` slash command.
+ *
+ * Running a command from here hands off to the extension, so the streamed
+ * result is still reviewed as an inline diff next to the text it changes;
+ * this control is an entry point, not a second implementation of the flow.
+ *
+ * Like `AiMenu` it is styled with plain `.ai-menu*` / `.ai-toolbar*` classes
+ * (see `src/styles/ProseMirror.scss`) rather than Tailwind utilities, because
+ * it ships inside the published extension bundle and must not depend on the
+ * host app's Tailwind config.
+ */
+
+import { computePosition, flip, offset, shift } from '@floating-ui/dom';
+import { useEditorState } from '@tiptap/react';
+import { ArrowLeft, ChevronDown, Loader2, Sparkles } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { useTiptapEditor } from '@/store/editor';
+
+import { getAiOptions, getAiState, isAiEnabled } from '../Ai';
+import { AI_COMMAND_GROUP_LABELS } from '../commands';
+import { commandsForSelection, groupCommands } from '../lib/prompt';
+
+import type { Editor } from '@tiptap/core';
+import type { AiCommandDefinition } from '../types';
+
+export interface RichTextAiProps {
+  /** Editor to act on. Falls back to the one from Tiptap context. */
+  editor?: Editor | null;
+  /** Label shown next to the icon. Pass `''` for an icon-only button. */
+  label?: string;
+}
+
+/**
+ * Renders nothing when the Ai extension is not registered on the editor, so
+ * hosts can drop it into a toolbar unconditionally.
+ */
+export function RichTextAi({ editor: providedEditor, label = 'AI' }: RichTextAiProps) {
+  const { editor } = useTiptapEditor(providedEditor);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [submenu, setSubmenu] = useState<AiCommandDefinition | null>(null);
+  const [position, setPosition] = useState<{ x: number; y: number } | null>(null);
+
+  const { hasSelection, isBusy } = useEditorState({
+    editor,
+    selector: ({ editor: e }) => {
+      if (!e) return { hasSelection: false, isBusy: false };
+      const status = getAiState(e.state)?.panel.status;
+      return {
+        hasSelection: !e.state.selection.empty,
+        isBusy: status === 'loading' || status === 'reviewing',
+      };
+    },
+  }) ?? { hasSelection: false, isBusy: false };
+
+  const commands = editor ? (getAiOptions(editor)?.commands ?? []) : [];
+  const sections = useMemo(
+    () => groupCommands(commandsForSelection(commands, hasSelection)),
+    [commands, hasSelection]
+  );
+
+  // Anchor the dropdown under the button and keep it there while scrolling.
+  useEffect(() => {
+    if (!open || !buttonRef.current || !panelRef.current) return;
+
+    const anchor = buttonRef.current;
+    const update = () => {
+      if (!panelRef.current) return;
+      computePosition(anchor, panelRef.current, {
+        placement: 'bottom-start',
+        strategy: 'fixed',
+        middleware: [offset(6), flip(), shift({ padding: 8 })],
+      }).then(({ x, y }) => setPosition({ x, y }));
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [open, sections.length, submenu]);
+
+  useEffect(() => {
+    if (!open) {
+      setSubmenu(null);
+      setPosition(null);
+      return;
+    }
+
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node;
+      if (panelRef.current?.contains(target) || buttonRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [open]);
+
+  if (!isAiEnabled(editor)) return null;
+
+  const run = (command: AiCommandDefinition, option?: string) => {
+    if (command.options?.length && !option) {
+      setSubmenu(command);
+      return;
+    }
+    setOpen(false);
+    // Focus first: the command reads the live selection, and clicking the
+    // toolbar can otherwise leave the editor without a resolved selection.
+    editor?.chain().focus().run();
+    editor?.commands.runAiCommand(command.id, option);
+  };
+
+  const askAnything = () => {
+    setOpen(false);
+    editor?.chain().focus().run();
+    editor?.commands.openAiMenu();
+  };
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        title="AI writing assistant (Ctrl/⌘ + J)"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-state={open ? 'open' : 'closed'}
+        className="ai-toolbar-button"
+        onMouseDown={(event) => event.preventDefault()}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {isBusy ? (
+          <Loader2 className="ai-toolbar-icon ai-menu-spin" />
+        ) : (
+          <Sparkles className="ai-toolbar-icon" />
+        )}
+        {label && <span className="ai-toolbar-label">{label}</span>}
+        <ChevronDown className="ai-toolbar-chevron" />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={panelRef}
+            role="menu"
+            aria-label="AI actions"
+            className="ai-menu ai-toolbar-menu"
+            style={{
+              position: 'fixed',
+              top: position?.y ?? -9999,
+              left: position?.x ?? -9999,
+              visibility: position ? 'visible' : 'hidden',
+              zIndex: 60,
+            }}
+          >
+            {submenu ? (
+              <div className="ai-menu-commands">
+                <button type="button" className="ai-menu-row" onClick={() => setSubmenu(null)}>
+                  <ArrowLeft className="ai-menu-row-icon" />
+                  {submenu.label}
+                </button>
+                {submenu.options?.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    className="ai-menu-command"
+                    onClick={() => run(submenu, option.label)}
+                  >
+                    <span className="ai-menu-command-text">
+                      <span className="ai-menu-command-label">{option.label}</span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <>
+                <button type="button" className="ai-menu-command ai-menu-ask" onClick={askAnything}>
+                  <Sparkles className="ai-menu-row-icon" />
+                  <span className="ai-menu-command-text">
+                    <span className="ai-menu-command-label">Ask AI anything…</span>
+                    <span className="ai-menu-command-description">Write your own instruction</span>
+                  </span>
+                  <span className="ai-menu-command-shortcut">⌘J</span>
+                </button>
+
+                <div className="ai-menu-hint">
+                  {hasSelection
+                    ? 'Runs on the selected text'
+                    : 'Select text to rewrite it, or generate from the caret'}
+                </div>
+
+                <div className="ai-menu-commands">
+                  {sections.map((section) => (
+                    <div key={section.group}>
+                      <div className="ai-menu-group-label">
+                        {AI_COMMAND_GROUP_LABELS[section.group]}
+                      </div>
+                      {section.commands.map((command) => (
+                        <button
+                          key={command.id}
+                          type="button"
+                          className="ai-menu-command"
+                          onClick={() => run(command)}
+                        >
+                          <command.icon className="ai-menu-row-icon" />
+                          <span className="ai-menu-command-text">
+                            <span className="ai-menu-command-label">{command.label}</span>
+                            {command.description && (
+                              <span className="ai-menu-command-description">{command.description}</span>
+                            )}
+                          </span>
+                          {command.options?.length ? (
+                            <span className="ai-menu-command-more">›</span>
+                          ) : null}
+                        </button>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/packages/reason-editor/src/extensions/Ai/index.ts
+++ b/packages/reason-editor/src/extensions/Ai/index.ts
@@ -1,9 +1,22 @@
 /**
- * Entry point for the Ai extension that re-exports the extension and its
- * React components. Lets the app import the AI writing assistant from a
- * single, stable module path.
+ * Entry point for the Ai extension that re-exports the extension, its React
+ * components, and the helpers host apps need to wire a real model in. Lets
+ * the app import the AI writing assistant from a single, stable module path.
  */
 
 export * from './Ai';
 export * from './components/AiMenu';
+export * from './components/RichTextAi';
 export { mockAiCompletion } from './lib/mockCompletion';
+export { createStreamingCompletion } from './lib/createStreamingCompletion';
+export type { StreamingCompletionOptions } from './lib/createStreamingCompletion';
+export {
+  buildAiInstruction,
+  buildAiUserPrompt,
+  clampContext,
+  commandRequiresSelection,
+  commandsForSelection,
+  groupCommands,
+} from './lib/prompt';
+export { sanitizeCompletion } from './lib/sanitizeCompletion';
+export { completionToContent, completionToHtml, needsRichInsert } from './lib/completionToContent';

--- a/packages/reason-editor/src/extensions/Ai/lib/completionToContent.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/completionToContent.ts
@@ -1,0 +1,70 @@
+/**
+ * Turns a sanitised completion into content the editor can insert.
+ *
+ * Models answer in Markdown even when nobody asked: "Key takeaways" comes back
+ * as `- ` lines, "Draft an outline" as `## ` headings, emphasis as `**bold**`.
+ * Inserting that as plain text writes the punctuation into the document and
+ * loses the structure, so the same `marked` conversion the MarkdownPaste
+ * extension uses on pasted text is applied here before accepting.
+ *
+ * Text with no Markdown structure and no paragraph breaks is left as plain
+ * text, so a simple rewrite keeps the marks (bold, links, highlights) that
+ * were already on the replaced range.
+ */
+
+import { marked } from 'marked';
+
+/** Structural Markdown — the patterns worth converting rather than inserting literally. */
+const BLOCK_MARKDOWN_RE = [
+  /^#{1,6}\s+/m, // headings
+  /^\s*[-*+]\s+\S/m, // bullet lists
+  /^\s*\d+\.\s+\S/m, // ordered lists
+  /^\s*>\s+\S/m, // blockquotes
+  /^\s*[-*]\s+\[[ xX]\]/m, // task lists
+  /^\|.+\|\s*$/m, // tables
+  /^\s*(?:---|\*\*\*)\s*$/m, // horizontal rules
+];
+
+/** Inline Markdown that is only worth converting when it is unambiguous. */
+const INLINE_MARKDOWN_RE = [
+  /\*\*[^\s*][^*]*\*\*/, // bold
+  /\[[^\]]+\]\([^)\s]+\)/, // links
+  /`[^`\n]+`/, // inline code
+];
+
+/** Whether the completion carries formatting that should become real nodes. */
+export function hasMarkdownStructure(text: string): boolean {
+  return (
+    BLOCK_MARKDOWN_RE.some((re) => re.test(text)) || INLINE_MARKDOWN_RE.some((re) => re.test(text))
+  );
+}
+
+/**
+ * Whether the completion should be inserted as HTML rather than plain text:
+ * either it carries Markdown structure, or it spans more than one paragraph
+ * (which as plain text would collapse into one block with literal newlines).
+ */
+export function needsRichInsert(text: string): boolean {
+  return hasMarkdownStructure(text) || /\n/.test(text.trim());
+}
+
+/**
+ * Renders a completion to HTML for `insertContentAt`. `<thead>`/`<tbody>` are
+ * dropped for the same reason MarkdownPaste drops them: the editor's table
+ * schema has no node for them, so ProseMirror would discard the rows inside.
+ */
+export function completionToHtml(text: string): string {
+  const html = marked.parse(text, { gfm: true, breaks: true, async: false }) as string;
+  return html.replace(/<\/?(thead|tbody)>/g, '');
+}
+
+/**
+ * The content to hand `insertContentAt`, plus whether it is HTML. Plain-text
+ * results are returned untouched so simple rewrites keep the existing marks.
+ */
+export function completionToContent(text: string): { content: string; isHtml: boolean } {
+  const trimmed = text.trim();
+  if (!trimmed) return { content: '', isHtml: false };
+  if (!needsRichInsert(trimmed)) return { content: trimmed, isHtml: false };
+  return { content: completionToHtml(trimmed), isHtml: true };
+}

--- a/packages/reason-editor/src/extensions/Ai/lib/createStreamingCompletion.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/createStreamingCompletion.ts
@@ -1,0 +1,183 @@
+/**
+ * A ready-made `getCompletion` for host apps: POSTs the request to an
+ * endpoint and streams the response back into the editor.
+ *
+ * The extension ships with an offline mock so the menu works out of the box,
+ * but every real deployment needs the same twenty lines of fetch-and-decode
+ * glue — including the parts that are easy to get wrong (aborting on cancel,
+ * surfacing a JSON error body instead of "failed to fetch", handling both a
+ * plain text stream and a Server-Sent Events stream). This provides them.
+ *
+ * @example
+ * ```ts
+ * Ai.configure({
+ *   getCompletion: createStreamingCompletion({ endpoint: '/api/ai' }),
+ * });
+ * ```
+ */
+
+import type { AiCompletionFn, AiCompletionRequest } from '../types';
+
+export interface StreamingCompletionOptions {
+  /** URL the completion is POSTed to. Defaults to `/api/ai`. */
+  endpoint?: string;
+  /** Extra request headers (auth, workspace id, …). */
+  headers?: HeadersInit | (() => HeadersInit);
+  /**
+   * Builds the JSON body. Defaults to sending the whole
+   * {@link AiCompletionRequest} — instruction, selection, context window,
+   * command id and the system prompt — so the route can prompt as it likes.
+   */
+  body?: (request: AiCompletionRequest) => unknown;
+  /**
+   * Response format. `auto` (the default) detects Server-Sent Events from the
+   * `Content-Type` header or a leading `data:` line and otherwise treats the
+   * body as a plain text stream.
+   */
+  format?: 'auto' | 'text' | 'sse';
+  /**
+   * Pulls the text out of one parsed payload — an SSE event, or the whole body
+   * for a non-streaming JSON response. Defaults to the OpenAI-compatible
+   * shapes (`choices[0].delta.content`, `choices[0].text`, `delta`, `text`,
+   * `content`, `rewrittenText`, or a bare string).
+   */
+  parseEvent?: (payload: unknown) => string;
+}
+
+/** Reads the delta from the common OpenAI-compatible event shapes. */
+function defaultParseEvent(payload: unknown): string {
+  if (typeof payload === 'string') return payload;
+  if (!payload || typeof payload !== 'object') return '';
+
+  const data = payload as Record<string, any>;
+  const choice = Array.isArray(data.choices) ? data.choices[0] : undefined;
+
+  const candidates = [
+    choice?.delta?.content,
+    choice?.text,
+    data.delta,
+    data.text,
+    data.content,
+    data.rewrittenText,
+    data.completion,
+  ];
+
+  return candidates.find((value) => typeof value === 'string') ?? '';
+}
+
+/** Turns a failed response into an Error carrying the server's own message when it sent one. */
+async function toError(response: Response): Promise<Error> {
+  const fallback = `AI request failed (${response.status} ${response.statusText || 'error'}).`;
+  try {
+    const body: any = await response.json();
+    const message = body?.error?.message ?? body?.error ?? body?.message;
+    return new Error(typeof message === 'string' && message ? message : fallback);
+  } catch {
+    return new Error(fallback);
+  }
+}
+
+export function createStreamingCompletion(
+  options: StreamingCompletionOptions = {}
+): AiCompletionFn {
+  const {
+    endpoint = '/api/ai',
+    headers,
+    body = (request: AiCompletionRequest) => request,
+    format = 'auto',
+    parseEvent = defaultParseEvent,
+  } = options;
+
+  return async (request, onChunk, signal) => {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      signal,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(typeof headers === 'function' ? headers() : headers),
+      },
+      body: JSON.stringify(body(request)),
+    });
+
+    if (!response.ok) throw await toError(response);
+
+    // A route that answers with one JSON object rather than a stream — the
+    // shape most "rewrite this text" endpoints ship with. Reported as a single
+    // chunk so the review panel behaves identically either way.
+    if (response.headers.get('content-type')?.includes('application/json')) {
+      const text = parseEvent(await response.json());
+      if (text) onChunk(text);
+      return text;
+    }
+
+    if (!response.body) return (await response.text()) ?? '';
+
+    const isSse =
+      format === 'sse' ||
+      (format === 'auto' && !!response.headers.get('content-type')?.includes('text/event-stream'));
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let accumulated = '';
+    let buffer = '';
+    let sse = isSse;
+    let sniffed = format !== 'auto' || isSse;
+
+    const flushSseLines = (final: boolean) => {
+      const lines = buffer.split('\n');
+      // Without a trailing newline the last line may still be partial.
+      buffer = final ? '' : (lines.pop() ?? '');
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+
+        const payload = trimmed.slice(5).trim();
+        if (!payload || payload === '[DONE]') continue;
+
+        let delta = '';
+        try {
+          delta = parseEvent(JSON.parse(payload));
+        } catch {
+          delta = payload;
+        }
+
+        if (delta) {
+          accumulated += delta;
+          onChunk(accumulated);
+        }
+      }
+    };
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const text = decoder.decode(value, { stream: true });
+
+      if (!sniffed) {
+        sse = /^\s*(?:data:|event:)/.test(text);
+        sniffed = true;
+      }
+
+      if (sse) {
+        buffer += text;
+        flushSseLines(false);
+      } else if (text) {
+        accumulated += text;
+        onChunk(accumulated);
+      }
+    }
+
+    const tail = decoder.decode();
+    if (sse) {
+      buffer += tail;
+      flushSseLines(true);
+    } else if (tail) {
+      accumulated += tail;
+      onChunk(accumulated);
+    }
+
+    return accumulated;
+  };
+}

--- a/packages/reason-editor/src/extensions/Ai/lib/mockCompletion.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/mockCompletion.ts
@@ -23,15 +23,19 @@ function wait(ms: number, signal: AbortSignal) {
   });
 }
 
-function transform(instruction: string, selectedText: string): string {
-  const lower = instruction.toLowerCase();
+function transform(commandId: string, instruction: string, selectedText: string): string {
+  const lower = `${commandId} ${instruction}`.toLowerCase();
   const text = selectedText.trim();
 
   if (!text) {
-    return `${instruction.trim() || 'New content'}.`;
+    // Nothing selected: the generate commands ask for fresh content.
+    if (lower.includes('outline')) {
+      return '- Background\n- What changed\n- Why it matters\n- Next steps';
+    }
+    return `${instruction.trim() || 'New content'}\n\n(Offline demo response — configure Ai.configure({ getCompletion }) to use a real model.)`;
   }
   if (lower.includes('emoji')) {
-    return `${text} ✨📝`;
+    return `${text} \u2728\ud83d\udcdd`;
   }
   if (lower.includes('shorter') || lower.includes('concise')) {
     const words = text.split(/\s+/);
@@ -40,6 +44,14 @@ function transform(instruction: string, selectedText: string): string {
   }
   if (lower.includes('longer') || lower.includes('expand')) {
     return `${text} In other words, this point matters because it clarifies the reader's understanding and adds useful context.`;
+  }
+  if (lower.includes('key-points') || lower.includes('action-items') || lower.includes('takeaway')) {
+    return text
+      .split(/(?<=[.!?])\s+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((s) => `- ${s.replace(/[.!?]$/, '')}`)
+      .join('\n');
   }
   if (lower.includes('simplify')) {
     return text
@@ -55,15 +67,17 @@ function transform(instruction: string, selectedText: string): string {
 }
 
 export const mockAiCompletion: AiCompletionFn = async (request, onChunk, signal) => {
-  const full = transform(request.instruction, request.selectedText);
-  const words = full.split(' ');
+  const full = transform(request.commandId, request.instruction, request.selectedText);
+  // Split on whitespace but keep it, so multi-line demo output (lists,
+  // paragraphs) streams with its line breaks intact.
+  const chunks = full.split(/(\s+)/).filter(Boolean);
 
   let acc = '';
-  for (let i = 0; i < words.length; i++) {
+  for (const chunk of chunks) {
     if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-    acc += (i === 0 ? '' : ' ') + words[i];
+    acc += chunk;
     onChunk(acc);
-    await wait(35, signal);
+    if (chunk.trim()) await wait(35, signal);
   }
 
   return acc;

--- a/packages/reason-editor/src/extensions/Ai/lib/prompt.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/prompt.ts
@@ -1,0 +1,98 @@
+/**
+ * Prompt construction and command resolution for the Ai extension.
+ *
+ * Everything here is pure so it can be unit-tested without an editor: the
+ * system message that keeps completions paste-ready, how a command plus an
+ * optional submenu choice becomes one instruction, and which commands are
+ * offered for the current selection.
+ */
+
+import { AI_COMMAND_GROUP_ORDER } from '../commands';
+
+import type { AiCommandDefinition, AiCommandGroup, AiSuggestionMode } from '../types';
+
+/**
+ * System message sent with every request. It exists because a chat-tuned model
+ * left to itself answers *about* the edit ("Sure! Here's a tighter version:")
+ * — and in an editor that preamble is what lands in the document.
+ */
+export const AI_SYSTEM_PROMPT = [
+  'You are a writing assistant inside a rich-text editor.',
+  'Return only the text that should appear in the document — nothing else.',
+  'Never add a preamble, sign-off, explanation, or commentary about what you changed.',
+  'Never wrap the answer in Markdown code fences or quotation marks unless the original text was itself fenced or quoted.',
+  'Preserve the original language of the text unless asked to translate.',
+  'Preserve quotations, citations, URLs, code, numbers and proper nouns exactly, unless the instruction is explicitly about changing them.',
+  'Never invent facts, statistics, sources, citations or links.',
+  'Match the surrounding formatting: plain paragraphs separated by blank lines, and one item per line for lists.',
+].join('\n');
+
+/** Whether a command needs a non-empty selection (the default for everything that rewrites text). */
+export function commandRequiresSelection(command: AiCommandDefinition): boolean {
+  return command.requiresSelection !== false;
+}
+
+/**
+ * Commands offered for the current selection state: with the caret collapsed,
+ * the rewrite commands are hidden rather than left to misfire on no input.
+ */
+export function commandsForSelection(
+  commands: AiCommandDefinition[],
+  hasSelection: boolean
+): AiCommandDefinition[] {
+  return hasSelection ? commands : commands.filter((c) => !commandRequiresSelection(c));
+}
+
+/** Groups commands for rendering, in `AI_COMMAND_GROUP_ORDER`, dropping empty groups. */
+export function groupCommands(
+  commands: AiCommandDefinition[]
+): { group: AiCommandGroup; commands: AiCommandDefinition[] }[] {
+  return AI_COMMAND_GROUP_ORDER.map((group) => ({
+    group: group as AiCommandGroup,
+    commands: commands.filter((command) => (command.group ?? 'edit') === group),
+  })).filter((section) => section.commands.length > 0);
+}
+
+/** Joins a command's prompt with the submenu choice it was run with, if any. */
+export function buildAiInstruction(command: AiCommandDefinition, option?: string): string {
+  const prompt = command.prompt.trim();
+  if (!option) return prompt;
+  return prompt.endsWith(':') ? `${prompt} ${option}.` : `${prompt} (${option})`;
+}
+
+/**
+ * Trims a context window to `max` characters, cutting from the start so the
+ * text nearest the selection — the part that actually informs the completion —
+ * is what survives.
+ */
+export function clampContext(text: string, max: number): string {
+  if (max <= 0) return '';
+  if (text.length <= max) return text;
+  return `…${text.slice(text.length - max)}`;
+}
+
+/**
+ * Renders the request as a single user message, for completion functions that
+ * only take one string (a plain `/api/ai` route, an OpenAI-compatible
+ * endpoint). Sent alongside {@link AI_SYSTEM_PROMPT}.
+ */
+export function buildAiUserPrompt(request: {
+  instruction: string;
+  selectedText: string;
+  documentText: string;
+  mode: AiSuggestionMode;
+}): string {
+  const sections = [`Instruction:\n${request.instruction}`];
+
+  if (request.documentText.trim()) {
+    sections.push(`Surrounding document (context only, do not rewrite):\n${request.documentText}`);
+  }
+
+  sections.push(
+    request.mode === 'replace'
+      ? `Text to act on:\n${request.selectedText}`
+      : 'No text is selected. Write new content for the caret position, using the context above.'
+  );
+
+  return sections.join('\n\n');
+}

--- a/packages/reason-editor/src/extensions/Ai/lib/sanitizeCompletion.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/sanitizeCompletion.ts
@@ -1,0 +1,111 @@
+/**
+ * Cleans a model response into text that is safe to paste into the document.
+ *
+ * The system prompt asks for a bare replacement, but chat-tuned models still
+ * lead with "Sure — here's a tighter version:", wrap prose in ```code fences,
+ * or quote the whole answer. Accepting a suggestion writes it into the user's
+ * document verbatim, so the response is normalised on the way in — while it
+ * streams as well as at the end, so the review diff shows what accepting will
+ * actually produce.
+ *
+ * Every step is conservative: it only strips a wrapper when the whole response
+ * is wrapped, so a genuinely fenced or quoted answer keeps its markers.
+ */
+
+/**
+ * Assistant lead-ins, matched only at the very start and only when the line
+ * ends in a colon — "Here is why this matters." is content, "Here is the
+ * revised text:" is not.
+ */
+const PREAMBLE_RE =
+  /^(?:sure|certainly|of course|absolutely|got it|okay|ok|here(?:'|’)?s|here is|here are|below is|i(?:'|’)?ve|i have)\b[^\n:]{0,120}:[ \t]*\r?\n+/i;
+
+/** A single-line preamble followed by the answer on the same line, e.g. `Rewritten: …`. */
+const INLINE_PREAMBLE_RE =
+  /^(?:sure|certainly|of course|absolutely|got it|okay|ok)[,!.]?[ \t]*/i;
+
+/** Opening fence, with or without a language tag. */
+const OPENING_FENCE_RE = /^[ \t]*(?:```|~~~)[^\n]*\r?\n/;
+/** Closing fence at the end of the response. */
+const CLOSING_FENCE_RE = /\r?\n[ \t]*(?:```|~~~)[ \t]*$/;
+
+/**
+ * Removes a fence that wraps the *entire* response. While streaming, the
+ * closing fence has not arrived yet, so an opening fence alone is dropped too.
+ */
+export function stripCodeFences(text: string): string {
+  if (!OPENING_FENCE_RE.test(text)) return text;
+
+  const withoutOpening = text.replace(OPENING_FENCE_RE, '');
+  // A second fence in the middle means the response is genuinely multi-block
+  // code; leave it alone rather than mangling half of it.
+  const inner = withoutOpening.replace(CLOSING_FENCE_RE, '');
+  if (/(?:^|\n)[ \t]*(?:```|~~~)/.test(inner)) return text;
+
+  return inner;
+}
+
+/** Removes a leading "Sure, here's the rewrite:" style lead-in. */
+export function stripPreamble(text: string): string {
+  const withoutBlock = text.replace(PREAMBLE_RE, '');
+  if (withoutBlock !== text) return withoutBlock;
+  return text.replace(INLINE_PREAMBLE_RE, '');
+}
+
+/** Removes quotation marks that wrap the whole response and nothing else. */
+export function stripWrappingQuotes(text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.length < 2) return text;
+
+  const pairs: [string, string][] = [
+    ['"', '"'],
+    ['“', '”'],
+    ["'", "'"],
+    ['‘', '’'],
+  ];
+
+  for (const [open, close] of pairs) {
+    if (!trimmed.startsWith(open) || !trimmed.endsWith(close)) continue;
+    const inner = trimmed.slice(open.length, trimmed.length - close.length);
+    // Only unwrap when the marks really are a wrapper — not when the text
+    // happens to open and close with separate quotations.
+    if (!inner.includes(close)) return inner;
+  }
+
+  return text;
+}
+
+/** Collapses the runs of blank lines models like to emit, and trims trailing space. */
+export function normalizeWhitespace(text: string): string {
+  return text
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+export interface SanitizeOptions {
+  /**
+   * True while chunks are still arriving. Trailing whitespace is meaningful
+   * mid-stream (the next chunk continues the word), so it is preserved; the
+   * final pass trims it.
+   */
+  streaming?: boolean;
+}
+
+/**
+ * Runs the full clean-up. Idempotent, so it can be applied to every streamed
+ * chunk and again to the final text without compounding.
+ */
+export function sanitizeCompletion(text: string, { streaming = false }: SanitizeOptions = {}): string {
+  if (!text) return '';
+
+  let out = normalizeWhitespace(text);
+  out = stripPreamble(out);
+  out = stripCodeFences(out);
+  // Only unwrap quotes once the response has settled: mid-stream the closing
+  // mark has not arrived, so unwrapping early makes the preview flicker.
+  if (!streaming) out = stripWrappingQuotes(out);
+  out = out.replace(/^\n+/, '');
+
+  return streaming ? out.replace(/[ \t]+$/, ' ').replace(/^[ \t]+/, '') : out.trim();
+}

--- a/packages/reason-editor/src/extensions/Ai/types.ts
+++ b/packages/reason-editor/src/extensions/Ai/types.ts
@@ -7,6 +7,17 @@
 
 import type { ComponentType } from 'react';
 
+/** Section a command is listed under in the menu. Purely presentational grouping. */
+export type AiCommandGroup = 'edit' | 'tone' | 'transform' | 'generate';
+
+/** One choice offered by a command that needs an argument (e.g. a target language). */
+export interface AiCommandOption {
+  /** Stable identifier, also used as the React key. */
+  id: string;
+  /** Label shown in the submenu. */
+  label: string;
+}
+
 /** A single quick-action offered in the "Ask AI anything…" command list. */
 export interface AiCommandDefinition {
   /** Stable identifier, also used as the React key. */
@@ -17,6 +28,20 @@ export interface AiCommandDefinition {
   description?: string;
   /** `lucide-react` icon component rendered next to the label. */
   icon: ComponentType<{ className?: string }>;
+  /** Section the command is listed under. Defaults to `edit`. */
+  group?: AiCommandGroup;
+  /**
+   * Whether the command only makes sense with text selected. Commands that
+   * rewrite the selection are hidden (rather than silently misfiring on an
+   * empty selection) when the caret is collapsed. Defaults to `true`.
+   */
+  requiresSelection?: boolean;
+  /**
+   * Choices the command needs before it can run — rendered as a submenu.
+   * The picked option's `label` is appended to `prompt` and passed to the
+   * completion function as `request.option`.
+   */
+  options?: AiCommandOption[];
   /**
    * Instruction sent to the completion function as `request.instruction`.
    * The selection (or, when nothing is selected, an empty string) is passed
@@ -32,8 +57,26 @@ export interface AiCompletionRequest {
   instruction: string;
   /** The selected text the instruction should act on. Empty when generating fresh content. */
   selectedText: string;
-  /** Plain-text of the whole document, for context. */
+  /**
+   * Plain text around the selection, for context. Clamped to a bounded window
+   * (see `AiOptions.contextChars`) so a long document does not blow up the
+   * request — never assume it is the whole document.
+   */
   documentText: string;
+  /** `id` of the quick command that ran, or `'custom'` for a free-form prompt. */
+  commandId: string;
+  /** Human label of the command that ran, for logging/telemetry. */
+  commandLabel: string;
+  /** The submenu choice the command was run with (e.g. `'Spanish'`), when it has options. */
+  option?: string;
+  /**
+   * A ready-to-use system message that constrains the model to return only the
+   * replacement text — no preamble, no Markdown fences. Pass it straight
+   * through to the provider; the editor sanitises the response either way.
+   */
+  systemPrompt: string;
+  /** `replace` when the result will swap the selection, `insert` when it will be added at the caret. */
+  mode: AiSuggestionMode;
 }
 
 /**
@@ -49,14 +92,16 @@ export type AiCompletionFn = (
   signal: AbortSignal
 ) => Promise<string>;
 
+/** `replace` swaps `[from, to]` on accept; `insert` adds the text at the caret. */
+export type AiSuggestionMode = 'replace' | 'insert';
+
 /** A suggestion currently being reviewed: either a replacement for a selection or a fresh insertion at the cursor. */
 export interface AiSuggestion {
   from: number;
   to: number;
   originalText: string;
   suggestedText: string;
-  /** `replace` swaps `[from, to]` on accept; `insert` adds a new block below on accept. */
-  mode: 'replace' | 'insert';
+  mode: AiSuggestionMode;
   /** True while text is still streaming in; accept/insert-below are disabled until it settles. */
   isStreaming: boolean;
 }
@@ -64,7 +109,9 @@ export interface AiSuggestion {
 /** The last request that ran, kept around so "Try again" can be re-issued without retyping. */
 export interface AiLastRequest {
   instruction: string;
+  commandId: string;
   commandLabel: string;
+  option?: string;
   from: number;
   to: number;
 }

--- a/packages/reason-editor/src/styles/ProseMirror.scss
+++ b/packages/reason-editor/src/styles/ProseMirror.scss
@@ -329,14 +329,20 @@
   }
 }
 
-/* Ai extension: floating "Ask AI anything…" menu */
+/* Ai extension: floating "Ask AI anything…" menu, and the toolbar's AI
+   dropdown, which reuses the same shell.
+
+   Colours come from the `--richtext-*` aliases declared in `global.scss`, so
+   the panel follows the host's light/dark theme instead of the hard-coded
+   white it used to paint regardless. */
 .ai-menu {
   width: 320px;
+  max-width: calc(100vw - 16px);
   overflow: hidden;
   border-radius: 8px;
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
-  color: #111827;
+  border: 1px solid var(--richtext-border, #e5e7eb);
+  background: var(--richtext-popover, #ffffff);
+  color: var(--richtext-popover-foreground, #111827);
   box-shadow: 0 6px 20px rgb(15 23 42 / 12%);
   font-size: 13px;
 }
@@ -346,14 +352,14 @@
   align-items: center;
   gap: 8px;
   padding: 8px 10px;
-  border-bottom: 1px solid #e5e7eb;
+  border-bottom: 1px solid var(--richtext-border, #e5e7eb);
 }
 
 .ai-menu-input-icon {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  color: #9ca3af;
+  color: var(--richtext-muted-foreground, #9ca3af);
 }
 
 .ai-menu-input {
@@ -362,11 +368,32 @@
   background: transparent;
   outline: none;
   font-size: 13px;
-  color: #111827;
+  color: inherit;
 }
 
 .ai-menu-input::placeholder {
-  color: #9ca3af;
+  color: var(--richtext-muted-foreground, #9ca3af);
+}
+
+.ai-menu-hint {
+  padding: 6px 12px 0;
+  color: var(--richtext-muted-foreground, #9ca3af);
+  font-size: 11px;
+}
+
+.ai-menu-group-label {
+  padding: 6px 8px 2px;
+  color: var(--richtext-muted-foreground, #9ca3af);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.ai-menu-empty {
+  padding: 10px 8px;
+  color: var(--richtext-muted-foreground, #9ca3af);
+  font-size: 12px;
 }
 
 .ai-menu-commands,
@@ -386,15 +413,16 @@
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: #111827;
+  color: inherit;
   font-size: 13px;
   text-align: left;
   cursor: pointer;
 }
 
 .ai-menu-command:hover,
+.ai-menu-command[data-active='true'],
 .ai-menu-row:hover:not(:disabled) {
-  background: #f3f4f6;
+  background: var(--richtext-accent, #f3f4f6);
 }
 
 .ai-menu-row:disabled {
@@ -406,7 +434,7 @@
   width: 16px;
   height: 16px;
   flex-shrink: 0;
-  color: #6b7280;
+  color: var(--richtext-muted-foreground, #6b7280);
 }
 
 .ai-menu-command-text {
@@ -424,10 +452,38 @@
 
 .ai-menu-command-description {
   overflow: hidden;
-  color: #9ca3af;
+  color: var(--richtext-muted-foreground, #9ca3af);
   font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.ai-menu-command-more,
+.ai-menu-command-shortcut {
+  flex-shrink: 0;
+  color: var(--richtext-muted-foreground, #9ca3af);
+  font-size: 11px;
+}
+
+/* Ask-AI row sits above the command groups, separated from them. */
+.ai-menu-ask {
+  border-bottom: 1px solid var(--richtext-border, #e5e7eb);
+  border-radius: 0;
+  padding: 8px 12px;
+}
+
+/* Streamed result, mirrored in the panel so a long suggestion stays readable
+   even when the inline diff runs off the bottom of the viewport. */
+.ai-menu-preview {
+  max-height: 180px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--richtext-border, #e5e7eb);
+  color: inherit;
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .ai-menu-loading,
@@ -436,13 +492,39 @@
   align-items: center;
   gap: 8px;
   padding: 10px;
-  color: #6b7280;
+  color: var(--richtext-muted-foreground, #6b7280);
   font-size: 13px;
+}
+
+.ai-menu-loading-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-menu-stop {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border: 1px solid var(--richtext-border, #e5e7eb);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.ai-menu-stop:hover {
+  background: var(--richtext-accent, #f3f4f6);
 }
 
 .ai-menu-error {
   flex-direction: column;
   align-items: stretch;
+  padding-bottom: 0;
 }
 
 .ai-menu-error-message {
@@ -461,4 +543,46 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+/* Ai extension: toolbar entry point */
+.ai-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 4px 6px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--richtext-foreground, #4b5563);
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.ai-toolbar-button:hover,
+.ai-toolbar-button[data-state='open'] {
+  background: var(--richtext-accent, #f3f4f6);
+}
+
+.ai-toolbar-icon {
+  width: 16px;
+  height: 16px;
+  color: #7c3aed;
+}
+
+.ai-toolbar-label {
+  font-size: 13px;
+}
+
+.ai-toolbar-chevron {
+  width: 10px;
+  height: 10px;
+  opacity: 0.4;
+}
+
+.ai-toolbar-menu {
+  width: 300px;
 }

--- a/packages/reason-editor/test/ai-completion.test.ts
+++ b/packages/reason-editor/test/ai-completion.test.ts
@@ -1,0 +1,308 @@
+/**
+ * The pure half of the Ai extension: turning a model response into text that
+ * is safe to write into a document (no chat preamble, no stray code fence),
+ * deciding whether that text should be inserted as rich content, building the
+ * instruction a command sends, and the fetch/stream glue host apps wire up.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_AI_COMMANDS } from '../src/extensions/Ai/commands';
+import { createStreamingCompletion } from '../src/extensions/Ai/lib/createStreamingCompletion';
+import {
+  completionToContent,
+  hasMarkdownStructure,
+  needsRichInsert,
+} from '../src/extensions/Ai/lib/completionToContent';
+import {
+  buildAiInstruction,
+  buildAiUserPrompt,
+  clampContext,
+  commandsForSelection,
+  groupCommands,
+} from '../src/extensions/Ai/lib/prompt';
+import { sanitizeCompletion } from '../src/extensions/Ai/lib/sanitizeCompletion';
+
+import type { AiCompletionRequest } from '../src/extensions/Ai/types';
+
+describe('sanitizeCompletion', () => {
+  it('drops a "here is the rewrite:" preamble', () => {
+    expect(sanitizeCompletion("Sure! Here's a tighter version:\n\nThe cat sat.")).toBe(
+      'The cat sat.'
+    );
+  });
+
+  it('drops a bare acknowledgement prefix on the same line', () => {
+    expect(sanitizeCompletion('Sure, the cat sat.')).toBe('the cat sat.');
+  });
+
+  it('keeps a sentence that merely starts like a preamble', () => {
+    const text = 'Here is why the migration matters.';
+    expect(sanitizeCompletion(text)).toBe(text);
+  });
+
+  it('unwraps a code fence that wraps the whole answer', () => {
+    expect(sanitizeCompletion('```markdown\n# Title\n\nBody.\n```')).toBe('# Title\n\nBody.');
+  });
+
+  it('leaves a genuinely multi-block code answer alone', () => {
+    const text = '```ts\nconst a = 1;\n```\n\nand\n\n```ts\nconst b = 2;\n```';
+    expect(sanitizeCompletion(text)).toBe(text);
+  });
+
+  it('unwraps quotes around the whole answer but not internal quotations', () => {
+    expect(sanitizeCompletion('"The cat sat."')).toBe('The cat sat.');
+    expect(sanitizeCompletion('He said "no" and left.')).toBe('He said "no" and left.');
+  });
+
+  it('leaves the closing quote alone while the response is still streaming', () => {
+    expect(sanitizeCompletion('"The cat sat."', { streaming: true })).toBe('"The cat sat."');
+  });
+
+  it('collapses runs of blank lines and trailing spaces', () => {
+    expect(sanitizeCompletion('One.   \n\n\n\nTwo.')).toBe('One.\n\nTwo.');
+  });
+
+  it('is idempotent, so it can run on every streamed chunk', () => {
+    const once = sanitizeCompletion("Here's the result:\n\n```\nHello\n```");
+    expect(sanitizeCompletion(once)).toBe(once);
+    expect(once).toBe('Hello');
+  });
+
+  it('returns an empty string for an empty response', () => {
+    expect(sanitizeCompletion('')).toBe('');
+    expect(sanitizeCompletion('   \n  ')).toBe('');
+  });
+});
+
+describe('completionToContent', () => {
+  it('keeps a single-line rewrite as plain text, so existing marks survive', () => {
+    expect(completionToContent('A tighter sentence.')).toEqual({
+      content: 'A tighter sentence.',
+      isHtml: false,
+    });
+  });
+
+  it('converts a bullet list into real list markup', () => {
+    const { content, isHtml } = completionToContent('- First\n- Second');
+    expect(isHtml).toBe(true);
+    expect(content).toContain('<ul>');
+    expect(content).toContain('<li>');
+  });
+
+  it('treats multi-paragraph text as rich content rather than one block', () => {
+    expect(needsRichInsert('One.\n\nTwo.')).toBe(true);
+    expect(completionToContent('One.\n\nTwo.').isHtml).toBe(true);
+  });
+
+  it('does not mistake a hyphenated sentence for a list', () => {
+    expect(hasMarkdownStructure('A well-known result.')).toBe(false);
+  });
+
+  it('strips table wrappers the editor schema has no node for', () => {
+    const { content } = completionToContent('| a | b |\n| --- | --- |\n| 1 | 2 |');
+    expect(content).toContain('<table>');
+    expect(content).not.toContain('<tbody>');
+  });
+});
+
+describe('command resolution', () => {
+  it('hides selection-only commands when nothing is selected', () => {
+    const available = commandsForSelection(DEFAULT_AI_COMMANDS, false);
+    expect(available.length).toBeGreaterThan(0);
+    expect(available.every((command) => command.requiresSelection === false)).toBe(true);
+    expect(available.map((c) => c.id)).toContain('continue');
+    expect(available.map((c) => c.id)).not.toContain('improve');
+  });
+
+  it('offers every command once there is a selection', () => {
+    expect(commandsForSelection(DEFAULT_AI_COMMANDS, true)).toHaveLength(DEFAULT_AI_COMMANDS.length);
+  });
+
+  it('groups commands in menu order and drops empty groups', () => {
+    const sections = groupCommands(commandsForSelection(DEFAULT_AI_COMMANDS, false));
+    expect(sections.every((section) => section.commands.length > 0)).toBe(true);
+    expect(sections.map((section) => section.group)).toEqual(['generate']);
+  });
+
+  it('appends a submenu choice to a prompt that ends in a colon', () => {
+    const translate = DEFAULT_AI_COMMANDS.find((command) => command.id === 'translate')!;
+    expect(buildAiInstruction(translate, 'Spanish')).toMatch(/Target language: Spanish\.$/);
+  });
+
+  it('parenthesises a choice for a prompt that does not end in a colon', () => {
+    const improve = DEFAULT_AI_COMMANDS.find((command) => command.id === 'improve')!;
+    expect(buildAiInstruction(improve, 'British English')).toMatch(/\(British English\)$/);
+  });
+
+  it('gives every default command a unique id and a prompt', () => {
+    const ids = DEFAULT_AI_COMMANDS.map((command) => command.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(DEFAULT_AI_COMMANDS.every((command) => command.prompt.trim().length > 20)).toBe(true);
+  });
+});
+
+describe('clampContext', () => {
+  it('keeps the text nearest the selection when the window overflows', () => {
+    const clamped = clampContext('abcdefghij', 4);
+    expect(clamped).toBe('…ghij');
+  });
+
+  it('passes short context through untouched', () => {
+    expect(clampContext('abc', 10)).toBe('abc');
+  });
+
+  it('drops context entirely at a zero budget', () => {
+    expect(clampContext('abc', 0)).toBe('');
+  });
+});
+
+describe('buildAiUserPrompt', () => {
+  it('names the text to act on when replacing a selection', () => {
+    const prompt = buildAiUserPrompt({
+      instruction: 'Fix grammar.',
+      selectedText: 'the cat sat',
+      documentText: 'Some context.',
+      mode: 'replace',
+    });
+    expect(prompt).toContain('Instruction:\nFix grammar.');
+    expect(prompt).toContain('Text to act on:\nthe cat sat');
+    expect(prompt).toContain('Some context.');
+  });
+
+  it('says there is no selection when generating at the caret', () => {
+    const prompt = buildAiUserPrompt({
+      instruction: 'Continue.',
+      selectedText: '',
+      documentText: '',
+      mode: 'insert',
+    });
+    expect(prompt).toContain('No text is selected');
+  });
+});
+
+/** Builds a `Response` whose body streams the given chunks. */
+function streamingResponse(chunks: string[], headers: Record<string, string> = {}) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200, headers });
+}
+
+const REQUEST: AiCompletionRequest = {
+  instruction: 'Improve this.',
+  selectedText: 'the cat sat',
+  documentText: '',
+  commandId: 'improve',
+  commandLabel: 'Improve writing',
+  systemPrompt: 'system',
+  mode: 'replace',
+};
+
+describe('createStreamingCompletion', () => {
+  it('accumulates a plain text stream and reports each step', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => streamingResponse(['The cat ', 'sat down.'])));
+
+    const chunks: string[] = [];
+    const result = await createStreamingCompletion()(REQUEST, (text) => chunks.push(text), new AbortController().signal);
+
+    expect(result).toBe('The cat sat down.');
+    expect(chunks).toEqual(['The cat ', 'The cat sat down.']);
+  });
+
+  it('decodes an OpenAI-style SSE stream, ignoring [DONE]', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        streamingResponse(
+          [
+            'data: {"choices":[{"delta":{"content":"The cat "}}]}\n\n',
+            'data: {"choices":[{"delta":{"content":"sat."}}]}\n\ndata: [DONE]\n\n',
+          ],
+          { 'content-type': 'text/event-stream' }
+        )
+      )
+    );
+
+    const result = await createStreamingCompletion()(REQUEST, () => {}, new AbortController().signal);
+    expect(result).toBe('The cat sat.');
+  });
+
+  it('reassembles an SSE event split across two network chunks', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        streamingResponse(['data: {"choices":[{"delta":{"con', 'tent":"Whole."}}]}\n\n'], {
+          'content-type': 'text/event-stream',
+        })
+      )
+    );
+
+    const result = await createStreamingCompletion()(REQUEST, () => {}, new AbortController().signal);
+    expect(result).toBe('Whole.');
+  });
+
+  it('accepts a plain JSON rewrite response as a single chunk', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ rewrittenText: 'The cat rested.' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+      )
+    );
+
+    const chunks: string[] = [];
+    const result = await createStreamingCompletion()(
+      REQUEST,
+      (text) => chunks.push(text),
+      new AbortController().signal
+    );
+
+    expect(result).toBe('The cat rested.');
+    expect(chunks).toEqual(['The cat rested.']);
+  });
+
+  it('surfaces the server error message rather than a bare status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: 'Rate limit reached.' }), {
+            status: 429,
+            headers: { 'content-type': 'application/json' },
+          })
+      )
+    );
+
+    await expect(
+      createStreamingCompletion()(REQUEST, () => {}, new AbortController().signal)
+    ).rejects.toThrow('Rate limit reached.');
+  });
+
+  it('posts the whole request to the configured endpoint', async () => {
+    const fetchMock = vi.fn(async () => streamingResponse(['ok']));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await createStreamingCompletion({ endpoint: '/api/write', headers: { 'X-Test': '1' } })(
+      REQUEST,
+      () => {},
+      new AbortController().signal
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/write');
+    expect((init.headers as Record<string, string>)['X-Test']).toBe('1');
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      commandId: 'improve',
+      instruction: 'Improve this.',
+      systemPrompt: 'system',
+    });
+  });
+});

--- a/packages/reason-editor/test/ai-extension.test.ts
+++ b/packages/reason-editor/test/ai-extension.test.ts
@@ -1,0 +1,301 @@
+/**
+ * The Ai extension's document-facing behaviour: what it refuses to run, what
+ * the completion function is handed, and — the part that matters most — what
+ * actually lands in the document when a suggestion is accepted.
+ */
+
+import { Editor } from '@tiptap/core';
+import { BulletList } from '@tiptap/extension-bullet-list';
+import { Document } from '@tiptap/extension-document';
+import { ListItem } from '@tiptap/extension-list-item';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import { Text } from '@tiptap/extension-text';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Ai, getAiState } from '../src/extensions/Ai';
+
+import type { AiCompletionFn, AiCompletionRequest } from '../src/extensions/Ai/types';
+
+let editor: Editor | null = null;
+
+afterEach(() => {
+  editor?.destroy();
+  editor = null;
+});
+
+/** A completion that resolves immediately with `text`, recording what it was asked. */
+function stubCompletion(text: string) {
+  const seen: AiCompletionRequest[] = [];
+  const fn: AiCompletionFn = async (request, onChunk) => {
+    seen.push(request);
+    onChunk(text);
+    return text;
+  };
+  return { fn, seen };
+}
+
+function createEditor(content: string, getCompletion: AiCompletionFn, options = {}) {
+  editor = new Editor({
+    extensions: [
+      Document,
+      Paragraph,
+      Text,
+      BulletList,
+      ListItem,
+      Ai.configure({ getCompletion, ...options }),
+    ],
+    content,
+  });
+  return editor;
+}
+
+/** Lets the completion promise and its dispatched transactions settle. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/** Selects the given document positions. */
+function select(instance: Editor, from: number, to: number) {
+  instance.commands.setTextSelection({ from, to });
+}
+
+describe('running a command', () => {
+  it('refuses a rewrite command when nothing is selected', async () => {
+    const { fn, seen } = stubCompletion('rewritten');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    instance.commands.setTextSelection(3);
+    expect(instance.commands.runAiCommand('improve')).toBe(false);
+
+    await settle();
+    expect(seen).toHaveLength(0);
+    expect(getAiState(instance.state)?.panel.status).toBe('closed');
+  });
+
+  it('runs a generate command with no selection', async () => {
+    const { fn, seen } = stubCompletion('A new paragraph.');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    instance.commands.setTextSelection(3);
+    expect(instance.commands.runAiCommand('continue')).toBe(true);
+
+    await settle();
+    expect(seen[0]?.mode).toBe('insert');
+    expect(seen[0]?.selectedText).toBe('');
+  });
+
+  it('waits for a submenu choice before running a command that needs one', () => {
+    const { fn } = stubCompletion('Hola.');
+    const instance = createEditor('<p>Hello.</p>', fn);
+
+    select(instance, 1, 6);
+    expect(instance.commands.runAiCommand('translate')).toBe(false);
+    expect(instance.commands.runAiCommand('translate', 'Spanish')).toBe(true);
+  });
+
+  it('passes the selection, the command id and the system prompt to the completion', async () => {
+    const { fn, seen } = stubCompletion('The cat rested.');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(seen[0]).toMatchObject({
+      commandId: 'improve',
+      commandLabel: 'Improve writing',
+      selectedText: 'The cat sat.',
+      mode: 'replace',
+    });
+    expect(seen[0]?.systemPrompt).toContain('Return only the text');
+  });
+
+  it('clamps the document context to the configured budget', async () => {
+    const { fn, seen } = stubCompletion('short');
+    const long = 'word '.repeat(400);
+    const instance = createEditor(`<p>${long}</p><p>Target sentence.</p>`, fn, {
+      contextChars: 120,
+    });
+
+    const end = instance.state.doc.content.size - 1;
+    select(instance, end - 16, end);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(seen[0]?.documentText.length).toBeLessThanOrEqual(130);
+    expect(seen[0]?.documentText.length).toBeGreaterThan(0);
+  });
+
+  it('sends no context at all at a zero budget', async () => {
+    const { fn, seen } = stubCompletion('short');
+    const instance = createEditor('<p>The cat sat.</p>', fn, { contextChars: 0 });
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(seen[0]?.documentText).toBe('');
+  });
+});
+
+describe('reviewing and accepting', () => {
+  it('leaves the document untouched until the suggestion is accepted', async () => {
+    const { fn } = stubCompletion('The cat rested.');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(instance.getText()).toBe('The cat sat.');
+    expect(getAiState(instance.state)?.panel.status).toBe('reviewing');
+  });
+
+  it('replaces the selection on accept and closes the panel', async () => {
+    const { fn } = stubCompletion('The cat rested.');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(instance.commands.acceptAiSuggestion()).toBe(true);
+    expect(instance.getText()).toBe('The cat rested.');
+    expect(getAiState(instance.state)?.panel.status).toBe('closed');
+  });
+
+  it('strips a chat preamble and code fence before anything reaches the document', async () => {
+    const { fn } = stubCompletion("Sure! Here's the rewrite:\n\n```\nThe cat rested.\n```");
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+    instance.commands.acceptAiSuggestion();
+
+    expect(instance.getText()).toBe('The cat rested.');
+  });
+
+  it('writes a multi-paragraph answer as real paragraphs', async () => {
+    const { fn } = stubCompletion('First para.\n\nSecond para.');
+    const instance = createEditor('<p>Old.</p>', fn);
+
+    select(instance, 1, 5);
+    instance.commands.runAiCommand('longer');
+    await settle();
+    instance.commands.acceptAiSuggestion();
+
+    expect(instance.getJSON().content).toHaveLength(2);
+    expect(instance.getHTML()).not.toContain('First para.\n');
+  });
+
+  it('writes a bullet answer as a real list rather than literal dashes', async () => {
+    const { fn } = stubCompletion('- First point\n- Second point');
+    const instance = createEditor('<p>Old.</p>', fn);
+
+    select(instance, 1, 5);
+    instance.commands.runAiCommand('key-points');
+    await settle();
+    instance.commands.acceptAiSuggestion();
+
+    expect(instance.getHTML()).toContain('<ul>');
+    expect(instance.getText()).not.toContain('- First point');
+  });
+
+  it('keeps the original text when inserting below', async () => {
+    const { fn } = stubCompletion('An added thought.');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(instance.commands.insertAiSuggestionBelow()).toBe(true);
+    expect(instance.getText()).toContain('The cat sat.');
+    expect(instance.getText()).toContain('An added thought.');
+    expect(instance.getJSON().content).toHaveLength(2);
+  });
+
+  it('discards without touching the document', async () => {
+    const { fn } = stubCompletion('Something else.');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+    instance.commands.discardAiSuggestion();
+
+    expect(instance.getText()).toBe('The cat sat.');
+    expect(getAiState(instance.state)?.panel.status).toBe('closed');
+  });
+
+  it('reports an empty model response as an error instead of an empty suggestion', async () => {
+    const { fn } = stubCompletion('   ');
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    const panel = getAiState(instance.state)?.panel;
+    expect(panel?.status).toBe('error');
+  });
+
+  it('surfaces a failed completion as an error the user can retry', async () => {
+    const fn: AiCompletionFn = async () => {
+      throw new Error('Rate limit reached.');
+    };
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    const panel = getAiState(instance.state)?.panel;
+    expect(panel?.status).toBe('error');
+    expect(panel && 'message' in panel && panel.message).toBe('Rate limit reached.');
+  });
+});
+
+describe('cancelling', () => {
+  it('keeps what already streamed when generation is stopped', async () => {
+    let resolveRequest: (() => void) | undefined;
+    const fn: AiCompletionFn = (request, onChunk) => {
+      onChunk('Partial resu');
+      return new Promise<string>((resolve) => {
+        resolveRequest = () => resolve('Partial result.');
+      });
+    };
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    expect(instance.commands.stopAiGeneration()).toBe(true);
+    const panel = getAiState(instance.state)?.panel;
+    expect(panel?.status).toBe('reviewing');
+    expect(panel && 'suggestion' in panel && panel.suggestion.isStreaming).toBe(false);
+    expect(panel && 'suggestion' in panel && panel.suggestion.suggestedText).toBe('Partial resu');
+
+    // A late resolution from the cancelled request must not revive the panel.
+    resolveRequest?.();
+    await settle();
+    expect(getAiState(instance.state)?.panel.status).toBe('reviewing');
+  });
+
+  it('aborts the request when the menu is closed', async () => {
+    const aborted = vi.fn();
+    const fn: AiCompletionFn = (request, onChunk, signal) => {
+      signal.addEventListener('abort', aborted);
+      return new Promise<string>(() => {});
+    };
+    const instance = createEditor('<p>The cat sat.</p>', fn);
+
+    select(instance, 1, 13);
+    instance.commands.runAiCommand('improve');
+    await settle();
+
+    instance.commands.closeAiMenu();
+    expect(aborted).toHaveBeenCalled();
+    expect(getAiState(instance.state)?.panel.status).toBe('closed');
+  });
+});


### PR DESCRIPTION
The Ai extension had no toolbar entry point, a six-item command list, and wrote the model's raw response into the document. This reworks it around what actually reaches the page.

Entry points
- New `RichTextAi` toolbar control: an AI button with the commands grouped by intent, a Translate submenu, a busy indicator, and an "Ask AI anything…" row. Renders nothing when the extension is not registered.
- "Ask AI" added to the selection bubble menu, which now yields while the AI panel is open instead of stacking two floating surfaces.

Output quality
- Responses are sanitised before they are previewed or applied: chat preambles, code fences wrapping the whole answer, and quotes around the whole answer are stripped, blank-line runs collapsed. The same pass runs on each streamed chunk, so the preview matches what accepting writes.
- Markdown in the answer becomes real nodes on accept (lists, headings, tables), so "Key takeaways" no longer inserts literal "- " characters; single-line rewrites stay plain text so existing marks survive.
- Requests carry a bounded context window around the selection instead of the whole document, plus a system prompt, command id and mode.

Commands and review flow
- 19 commands across Edit / Tone / Transform / Generate, with prompts that state what to preserve and forbid invented sources; commands that rewrite a selection are hidden and refuse to run at a collapsed caret.
- The panel is now a filterable palette (type to filter, arrows to move), shows a preview of the streamed result, and adds Stop (keeping what already arrived), Copy, Dismiss, and ⌘/Ctrl+Enter to accept.
- Panel colours follow the host theme instead of painting white in dark mode.

Wiring
- New `createStreamingCompletion` helper handles text streams, SSE, and single-JSON routes, and surfaces a server error body as the panel message.
- The plugin registry now points the assistant at the app's real `/api/agent/rewrite` by default, with the endpoint and context budget editable in plugin settings; clearing the endpoint falls back to the offline demo transform.

Tests: 49 new cases covering sanitisation, Markdown conversion, command resolution, the fetch/stream glue, and the extension's document behaviour.


Claude-Session: https://claude.ai/code/session_01F3sBzex1vTKvJC4DzLvGUK