### PR TITLE
🐛 fix(d1): call the renamed requiresPrimary, so the site stops 500ing

### DIFF
--- a/apps/qwksearch-web/lib/database/d1-session.ts
+++ b/apps/qwksearch-web/lib/database/d1-session.ts
@@ -211,7 +211,7 @@ function resolveStart(request: Request, mode: D1SessionMode): string {
   if (mode === "primary") return FIRST_PRIMARY;
   // Before the `unconstrained` check on purpose: for auth traffic neither a
   // client bookmark nor the low-latency override is a strong enough guarantee.
-  if (needsPrimary(request)) return FIRST_PRIMARY;
+  if (requiresPrimary(request)) return FIRST_PRIMARY;
   if (mode === "unconstrained") return FIRST_UNCONSTRAINED;
 
   const bookmark = readClientBookmark(request);


### PR DESCRIPTION
Every request to `qwksearch-production` returns 500, the homepage included:

```
GET https://qwksearch.com/ → 500
```

## Cause

`apps/qwksearch-web/lib/database/d1-session.ts:214` calls a function that does not exist:

```ts
if (needsPrimary(request)) return FIRST_PRIMARY;   // ← defined nowhere
```

#382 renamed `needsPrimary` → `requiresPrimary` but left this one call site pointing at the old name.

That takes down the whole site because the Worker entry (`worker/index.ts`) wraps *every* request in `runWithD1Session(...)`, which calls `resolveStart()` before the request reaches a handler. So the first thing each request does is throw:

```
ReferenceError: needsPrimary is not defined
```

The only path that escapes it is `D1_SESSION_MODE=primary`, which returns on the line above; the default is `auto`.

Static assets kept serving — they come off the `ASSETS` binding without invoking the Worker — so the site looked half-alive while every SSR page and `/api/*` route was dead.

## Fix

One line: point the call at the function that exists.

## Testing

`lib/database/__tests__/d1-session.test.ts` already covers this. **17 of its 19 cases failed** with that exact `ReferenceError` before the change and all 19 pass after, so no new test is added — the suite simply was not run on #382 (`test-web-api.yml` triggers on `apps/qwksearch-web/**`, so those checks should have been red).

- `bunx vitest run lib/database/__tests__/d1-session.test.ts` → 19/19 passing
- Full `qwksearch-web` suite → 628/628 passing across 48 files

## Note on deploying

There is no workflow that ships the site (only `deploy-test-reports.yml`), so merging this does not fix production on its own — it needs a `bun run deploy` from `apps/qwksearch-web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxxBAT7nKfXsSeBYwWdmZx
