### PR TITLE
🐛 fix(ci): build packages in dependency order when publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -146,12 +146,12 @@ jobs:
           # GitHub runs `run:` steps with `bash -e -o pipefail`, so simply not
           # writing `set -e` here does not disable errexit — `set -uo pipefail`
           # leaves it on. With errexit on, the first package whose publish fails
-          # kills the whole step: `chat-agent-toolkit` sorts first in
-          # `packages/*/`, so once its publish started returning npm E404 every
-          # later package stopped being evaluated at all and the whole workspace
-          # went unreleased. Turn errexit off explicitly; per-package outcomes
-          # are handled through $rc below, and the run still exits non-zero at
-          # the end if anything failed.
+          # kills the whole step: once the first package in the loop started
+          # returning npm E404 on publish, every later package stopped being
+          # evaluated at all and the whole workspace went unreleased. Turn
+          # errexit off explicitly; per-package outcomes are handled through
+          # $rc below, and the run still exits non-zero at the end if anything
+          # failed.
           set -uo pipefail
           set +e
 
@@ -161,7 +161,22 @@ jobs:
           unattempted_packages=""
           auth_broken=""
 
-          for dir in packages/*/; do
+          # Walk the workspace in dependency order rather than in shell-glob
+          # (alphabetical) order. bun links workspace packages into node_modules
+          # as symlinks, so a sibling that has not been built yet has no dist/
+          # and the `exports` -> `types` entries in its package.json point at
+          # files that do not exist. Alphabetically, `research-agent-ui` ran its
+          # declaration build before shadcn-app-dock, trending-news-api and
+          # use-voice-control were built, and tsc reported every import of them
+          # as "Cannot find module ... or its corresponding type declarations".
+          # Dependency order also means a sibling's `workspace:*` pin below is
+          # rewritten to the version that sibling just published, not the one it
+          # had before its bump.
+          build_order=$(node scripts/workspace-build-order.mjs)
+          echo "📋 Build order:"
+          echo "$build_order" | sed 's/^/   /'
+
+          for dir in $build_order; do
             pkg="${dir}package.json"
 
             if [ ! -f "$pkg" ]; then

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -39,6 +39,7 @@ jobs:
           - { flag: use-voice-control, dir: packages/use-voice-control }
           - { flag: user-help-docs, dir: packages/user-help-docs }
           - { flag: write-language, dir: packages/write-language }
+          - { flag: scripts, dir: scripts }
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/reason-editor/tsconfig.json
+++ b/packages/reason-editor/tsconfig.json
@@ -65,7 +65,8 @@
       "react-reason-editor/textdirection": ["./src/extensions/TextDirection/index.ts"],
       "react-reason-editor/textunderline": ["./src/extensions/TextUnderline/index.ts"],
       "react-reason-editor/twitter": ["./src/extensions/Twitter/index.ts"],
-      "react-reason-editor/video": ["./src/extensions/Video/index.ts"]
+      "react-reason-editor/video": ["./src/extensions/Video/index.ts"],
+      "react-reason-editor/wordcount": ["./src/extensions/WordCount/index.ts"]
     }
   },
   "include": ["src"]

--- a/packages/research-agent-ui/package.json
+++ b/packages/research-agent-ui/package.json
@@ -56,7 +56,7 @@
     "./dist/workspace.cjs"
   ],
   "scripts": {
-    "build": "vite build && (tsc --project tsconfig.build.json || true)",
+    "build": "vite build && tsc --project tsconfig.build.json",
     "build:cloudflare": "tsc src/cloudflare/worker.ts --outDir dist/cloudflare --declaration --module esnext --target esnext --lib esnext --moduleResolution node",
     "dev:cloudflare": "npm run build:cloudflare && wrangler dev --config wrangler.local.jsonc",
     "deploy:cloudflare": "npm run build:cloudflare && wrangler deploy --config wrangler.local.jsonc",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "qwksearch-scripts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Repository automation helpers invoked by the GitHub Actions workflows",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  }
+}

--- a/scripts/test/workspace-build-order.test.mjs
+++ b/scripts/test/workspace-build-order.test.mjs
@@ -1,0 +1,142 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  localDependencyGraph,
+  workspaceBuildOrder,
+} from '../workspace-build-order.mjs';
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..');
+
+/** Write a throwaway workspace and return its `packages` directory. */
+function fixture(manifests) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'build-order-'));
+  const packages = path.join(root, 'packages');
+  fs.mkdirSync(packages);
+
+  for (const [dir, pkg] of Object.entries(manifests)) {
+    fs.mkdirSync(path.join(packages, dir));
+    if (pkg === null) continue; // a directory with no package.json
+    fs.writeFileSync(
+      path.join(packages, dir, 'package.json'),
+      JSON.stringify(pkg),
+    );
+  }
+
+  return packages;
+}
+
+const tempRoots = [];
+function tempWorkspace(manifests) {
+  const packages = fixture(manifests);
+  tempRoots.push(path.dirname(packages));
+  return packages;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (tempRoots.length > 0) {
+    fs.rmSync(tempRoots.pop(), { force: true, recursive: true });
+  }
+});
+
+describe('workspaceBuildOrder', () => {
+  it('builds a package after every sibling it depends on', () => {
+    const packages = tempWorkspace({
+      // Alphabetically `app` sorts first, but it consumes both siblings.
+      app: { name: 'app', dependencies: { dock: 'workspace:*', voice: '^1.0.0' } },
+      dock: { name: 'dock', version: '0.1.0' },
+      voice: { name: 'voice', version: '1.2.0' },
+    });
+
+    expect(workspaceBuildOrder(packages)).toEqual([
+      `${packages}/dock/`,
+      `${packages}/voice/`,
+      `${packages}/app/`,
+    ]);
+  });
+
+  it('orders alphabetically when nothing depends on anything', () => {
+    const packages = tempWorkspace({
+      b: { name: 'b' },
+      a: { name: 'a' },
+      c: { name: 'c' },
+    });
+
+    expect(workspaceBuildOrder(packages)).toEqual([
+      `${packages}/a/`,
+      `${packages}/b/`,
+      `${packages}/c/`,
+    ]);
+  });
+
+  it('skips directories without a readable package.json', () => {
+    const packages = tempWorkspace({
+      broken: { name: undefined },
+      empty: null,
+      real: { name: 'real' },
+    });
+    fs.writeFileSync(path.join(packages, 'broken', 'package.json'), '{ not json');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(workspaceBuildOrder(packages)).toEqual([`${packages}/real/`]);
+  });
+
+  it('still emits every package when the graph has a cycle', () => {
+    const packages = tempWorkspace({
+      one: { name: 'one', dependencies: { two: 'workspace:*' } },
+      two: { name: 'two', dependencies: { one: 'workspace:*' } },
+    });
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(workspaceBuildOrder(packages)).toHaveLength(2);
+    expect(errors).toHaveBeenCalledWith(expect.stringContaining('cycle'));
+  });
+});
+
+describe('this workspace', () => {
+  // The regression: publishing walked `packages/*​/` alphabetically, so
+  // research-agent-ui was built before shadcn-app-dock, trending-news-api and
+  // use-voice-control, and tsc could not resolve their type declarations.
+  it('places every package after its local dependencies', () => {
+    const order = workspaceBuildOrder(path.join(repoRoot, 'packages')).map(
+      (dir) => path.basename(dir.replace(/\/$/, '')),
+    );
+    const graph = localDependencyGraph(
+      order.map((dir) => ({
+        dir,
+        pkg: JSON.parse(
+          fs.readFileSync(
+            path.join(repoRoot, 'packages', dir, 'package.json'),
+            'utf8',
+          ),
+        ),
+      })),
+    );
+
+    for (const [index, dir] of order.entries()) {
+      for (const dependency of graph.get(dir)) {
+        expect(
+          order.indexOf(dependency),
+          `${dir} must be built after ${dependency}`,
+        ).toBeLessThan(index);
+      }
+    }
+  });
+
+  it('builds research-agent-ui after the siblings whose types it imports', () => {
+    const order = workspaceBuildOrder(path.join(repoRoot, 'packages'));
+    const at = (dir) => order.indexOf(`${repoRoot}/packages/${dir}/`);
+
+    for (const sibling of [
+      'shadcn-app-dock',
+      'trending-news-api',
+      'use-voice-control',
+    ]) {
+      expect(at(sibling)).toBeGreaterThanOrEqual(0);
+      expect(at(sibling)).toBeLessThan(at('research-agent-ui'));
+    }
+  });
+});

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node', // plain Node scripts run by CI, no DOM involved
+    include: ['test/**/*.test.mjs'],
+    coverage: {
+      provider: 'v8',
+      include: ['*.mjs'],
+      reporter: ['text', 'json', 'html', 'lcov'],
+    },
+  },
+});

--- a/scripts/workspace-build-order.mjs
+++ b/scripts/workspace-build-order.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+/**
+ * Order the workspace's package directories so that every package comes after
+ * each sibling it depends on.
+ *
+ * The npm publish workflow used to walk `packages/*​/`, i.e. shell-glob
+ * (alphabetical) order, which has nothing to do with the dependency graph.
+ * `bun install` links workspace packages into `node_modules` as symlinks, so a
+ * sibling that has not been built yet has no `dist/` and the `exports` ->
+ * `types` entries in its package.json point at files that do not exist. That
+ * made `research-agent-ui` (13th alphabetically) fail its declaration build on
+ * the three siblings that sort after it:
+ *
+ *   Cannot find module 'shadcn-app-dock' or its corresponding type declarations.
+ *   Cannot find module 'trending-news-api' or its corresponding type declarations.
+ *   Cannot find module 'use-voice-control/client' ...
+ *
+ * Usage: node scripts/workspace-build-order.mjs [rootDir]
+ *   rootDir defaults to `packages`. Prints one directory per line, with a
+ *   trailing slash, e.g. `packages/domain-rank/`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Read every `<root>/<dir>/package.json` that exists.
+ *
+ * @param {string} root
+ * @returns {{ dir: string, pkg: Record<string, any> }[]}
+ */
+export function readWorkspacePackages(root) {
+  const packages = [];
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const manifest = path.join(root, entry.name, 'package.json');
+    if (!fs.existsSync(manifest)) continue;
+
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    } catch (error) {
+      console.error(`Skipping ${manifest}: ${error.message}`);
+      continue;
+    }
+    if (!pkg.name) continue;
+
+    packages.push({ dir: entry.name, pkg });
+  }
+
+  return packages;
+}
+
+/**
+ * Map each package directory to the sibling directories it depends on.
+ *
+ * Local edges are keyed by package *name*, not by the version range: bun links
+ * a sibling into node_modules whenever the name matches a workspace package, so
+ * `"use-voice-control": "^0.1.37"` resolves to the local copy exactly like
+ * `"workspace:*"` does, and needs building just the same.
+ *
+ * @param {{ dir: string, pkg: Record<string, any> }[]} packages
+ * @returns {Map<string, Set<string>>}
+ */
+export function localDependencyGraph(packages) {
+  const dirByName = new Map(packages.map(({ dir, pkg }) => [pkg.name, dir]));
+  const graph = new Map();
+
+  for (const { dir, pkg } of packages) {
+    const local = new Set();
+    for (const field of [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+    ]) {
+      for (const name of Object.keys(pkg[field] ?? {})) {
+        const depDir = dirByName.get(name);
+        if (depDir && depDir !== dir) local.add(depDir);
+      }
+    }
+    graph.set(dir, local);
+  }
+
+  return graph;
+}
+
+/**
+ * Topologically sort the workspace, alphabetically within each ready set so the
+ * order is stable across runs and stays close to the old one where the graph
+ * allows it.
+ *
+ * @param {string} [root]
+ * @returns {string[]} directories, e.g. `['packages/domain-rank/', ...]`
+ */
+export function workspaceBuildOrder(root = 'packages') {
+  const packages = readWorkspacePackages(root);
+  const dependencies = localDependencyGraph(packages);
+
+  const pending = packages.map(({ dir }) => dir).sort();
+  const built = new Set();
+  const order = [];
+
+  while (pending.length > 0) {
+    const ready = pending.findIndex((dir) =>
+      [...dependencies.get(dir)].every((dep) => built.has(dep)),
+    );
+
+    // A dependency cycle leaves nothing ready. No order can be right, so take
+    // the alphabetically first entry and keep going: everything still gets
+    // built and published, and the cycle is reported on stderr where it shows
+    // up in the job log.
+    if (ready === -1) {
+      console.error(
+        `Dependency cycle involving ${pending[0]} — falling back to alphabetical order for it`,
+      );
+    }
+
+    const [dir] = pending.splice(ready === -1 ? 0 : ready, 1);
+    built.add(dir);
+    order.push(`${root}/${dir}/`);
+  }
+
+  return order;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  console.log(workspaceBuildOrder(process.argv[2]).join('\n'));
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       'packages/use-voice-control',
       'packages/user-help-docs',
       'packages/write-language',
+      'scripts',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
The publish job walked `packages/*/`, i.e. shell-glob (alphabetical) order, which has nothing to do with the dependency graph. `bun install` links workspace packages into node_modules as symlinks, so a sibling that has not been built yet has no `dist/` and the `exports` -> `types` entries in its package.json point at files that do not exist. Any package built before its siblings therefore failed to resolve their declarations:

  research-agent-ui (13th alphabetically)
    Cannot find module 'shadcn-app-dock' or its corresponding type declarations.  (x2)
    Cannot find module 'trending-news-api' or its corresponding type declarations.
    Cannot find module 'use-voice-control/react' ...
    Cannot find module 'use-voice-control/client' ...
  react-reason-editor
    Cannot find module 'use-voice-control/client' ...  (x4, plus /react)
  extract-webpage
    Cannot find module 'extract-youtube' ...

11 of the workspace's local dependency edges pointed the wrong way under alphabetical order. Add `scripts/workspace-build-order.mjs`, which topologically sorts `packages/*` over local dependency edges (keyed by package name, so `"use-voice-control": "^0.1.37"` counts as local exactly like `workspace:*`), breaking ties alphabetically so the order stays stable. The publish loop iterates that instead of the glob. As a side effect the `workspace:*` -> `^<version>` pinning now sees a sibling's version after its publish bump rather than before it.

Two things the reordering does not cover:

- `react-reason-editor/wordcount` is a self-reference, so no build order can satisfy it. Every other `react-reason-editor/*` subpath is mapped in the package's tsconfig `paths` (matching the resolver in its vite config); wordcount was missing, and resolution fell through to the not-yet-written dist entry. Map it too.
- research-agent-ui's build ended in `(tsc ... || true)`, which swallowed exactly these errors and published a tarball with broken declarations instead of tripping the workflow's "build failed, don't publish" path. Drop the `|| true` now that the build is clean.

Verified locally on the full workspace: in glob order the builds reproduce all 12 errors in the three packages above; in dependency order all 20 packages build with zero TypeScript errors. `scripts/test` locks the invariant — every package ordered after its local dependencies, and research-agent-ui after the three siblings whose types it imports — and runs in the coverage matrix.


Claude-Session: https://claude.ai/code/session_01HWbDUjW2zo2EMpR497ZawU