### PR TITLE
Add badges, screenshot, and Claude skill to homepage

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,75 @@ already reached, and then went past by appending the `(merged)` marker.
 
 ## Completed
 
+## Homepage: the README's badges, a screenshot, and the Claude skill to copy
+
+**Status:** Completed
+**Source:** Direct request — "On the homepage feature the same badges as the
+readme", "To the homepage add skill to copy and also add screenshot", "add icon
+to docs in navbar. Don't show docs in nav when in docs already".
+**Branch:** `claude/grab-homepage-docs-navbar-ucd8l7`
+**PR:** Not created yet
+**Started:** 2026-09-09
+**Completed:** 2026-09-09
+
+### Goal
+The repo's front page sells the project — badges, a product shot, and the
+Claude Code skill that orients an agent in the monorepo. The homepage said
+none of it. Put the same three things on the marketing slab the homepage
+stacks below the workspace, and tidy the site links the dock carries.
+
+### Scope
+- `components/features/data.tsx` — `PROJECT_BADGES` (the README's wall, in the
+  README's order), `APP_SCREENSHOT`, and `CLAUDE_SKILL` (name, blurb, install
+  one-liner).
+- `components/features/FeaturesView.tsx` — a `BadgeWall` under the hero CTAs, a
+  `Screenshot` section between the hero and the demo video, and a
+  `ClaudeSkillSection` before the closing CTA.
+- `components/features/copy-command.tsx` — new: a command in a `<code>` box
+  with a copy button that reports success and failure.
+- `lib/config/site.ts` — the Docs site link now carries `BookOpen` rather than
+  a help circle.
+- `packages/research-agent-ui/src/lib/site-links.ts` (+ test) and
+  `app/CategoryDock.tsx` — the dock's Site Links menu drops the entry pointing
+  at the section already on screen.
+
+### Non-goals
+- **A second "Docs" button in the dock.** The dock's top-level `Docs` item is
+  the REASON workspace; a help-docs button beside it would put two entries
+  named "Docs" in one nav. The help docs stay in the Site Links menu.
+- **Checking the badge images into `public/`.** They are live status badges —
+  coverage, last commit, CI, npm version. A local copy would freeze them.
+- **Restating the README on the page.** Only the badges, the shot, and the
+  skill; the copy stays the page's own.
+
+### What changed
+The badge wall renders each badge at a uniform `h-5` — the README mixes `flat`
+and `for-the-badge` styles, which differ in height by a factor of two — and
+every badge carries its alt text as a `title`, since a shields.io image says
+nothing on hover. The `Docs` badge points at the site's own `/docs` rather than
+the README's API-docs URL, because on the site that route exists.
+
+`siteLinksForPath` hides a link only when it is genuinely where you are: the
+exact route or something nested under it (`/docs/guides/search` counts as
+`/docs`), never an external URL, never a link carrying a hash or query — the
+`/#downloads` entry opens the downloads dialog and is an action, not a
+destination — and `/` only on `/` itself.
+
+### Verification
+`bun install` cannot resolve `@cloudflare/vite-plugin@^1.43.0` in this
+environment, so `tsc` and `vitest` could not run. Instead every changed file
+was transpiled with `bun build --no-bundle` (all clean), and the ten cases in
+`site-links.test.ts` were executed directly against `siteLinksForPath` through
+`bun run` — all pass. The badge, screenshot and copy-command markup is
+unverified in a browser.
+
+### Remaining work
+- Run `bun run test` and the type check once dependencies install, and look at
+  the homepage in a browser.
+- If the intent behind "add icon to docs in navbar" was a top-level dock button
+  for the help docs rather than an icon on the existing Site Links entry, that
+  is a small follow-up — and it wants the REASON `Docs` item renamed first.
+
 ## Give the extraction chain's user layer somewhere to live
 
 **Status:** Completed

--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -14,6 +14,7 @@ import {
   PenLine,
   Search,
   Sparkles,
+  Terminal,
   X,
 } from "lucide-react";
 
@@ -30,18 +31,22 @@ import {
   SpotlightCard,
 } from "@/components/features/effects";
 import {
+  APP_SCREENSHOT,
+  CLAUDE_SKILL,
   COMPARISON_COLUMNS,
   COMPARISON_ROWS,
   ENGINE_NAMES,
   FEATURE_TABS,
   PIPELINE,
   PLATFORMS,
+  PROJECT_BADGES,
   PROVIDERS,
   SEARCH_CATEGORIES,
   STATS,
   faviconUrl,
   type ComparisonStatus,
 } from "@/components/features/data";
+import { CopyCommand } from "@/components/features/copy-command";
 import { config } from "@/lib/config/site";
 import { cn } from "@/lib/utils";
 
@@ -66,6 +71,47 @@ function SectionHeading({
         </p>
       )}
     </Reveal>
+  );
+}
+
+/**
+ * The README's badge wall. Uniform height rather than each badge's natural
+ * size — the row mixes `flat` and `for-the-badge` styles, which differ by a
+ * factor of two — and every badge carries its alt text as a tooltip, since a
+ * shields.io image says nothing on hover by itself.
+ */
+function BadgeWall() {
+  return (
+    <ul className="flex flex-wrap items-center justify-center gap-x-2 gap-y-2">
+      {PROJECT_BADGES.map((badge) => {
+        const image = (
+          <img
+            src={badge.src}
+            alt={badge.alt}
+            title={badge.alt}
+            loading="lazy"
+            className="h-5 w-auto"
+          />
+        );
+
+        return (
+          <li key={badge.alt} className="flex">
+            {badge.href ? (
+              <a
+                href={badge.href}
+                target={badge.href.startsWith("/") ? undefined : "_blank"}
+                rel="noopener noreferrer"
+                className="opacity-80 transition-opacity hover:opacity-100"
+              >
+                {image}
+              </a>
+            ) : (
+              image
+            )}
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 
@@ -118,6 +164,9 @@ function Hero() {
           </div>
         </Reveal>
 
+        <Reveal delay={300} className="mx-auto mt-10 max-w-3xl">
+          <BadgeWall />
+        </Reveal>
       </div>
 
       {/* Search engines QwkSearch queries, orbiting the index. Deliberately
@@ -146,6 +195,35 @@ function Hero() {
           </dl>
         </Reveal>
       </div>
+    </section>
+  );
+}
+
+/**
+ * The README's product shot. A plain <img> at the source's own aspect ratio:
+ * it's a remote asset the Worker's image optimizer won't proxy, and the
+ * intrinsic size is what keeps the frame from collapsing before it loads.
+ */
+function Screenshot() {
+  return (
+    <section className="relative px-4 pt-2 pb-6 sm:px-6 lg:px-8">
+      <Reveal className="mx-auto max-w-5xl">
+        <figure>
+          <div className="qs-border-beam relative isolate overflow-hidden rounded-3xl p-px">
+            <div className="bg-card/90 relative z-10 overflow-hidden rounded-[calc(1.5rem-1px)] border backdrop-blur-sm">
+              <img
+                src={APP_SCREENSHOT.src}
+                alt={APP_SCREENSHOT.alt}
+                loading="lazy"
+                className="block w-full"
+              />
+            </div>
+          </div>
+          <figcaption className="text-muted-foreground mt-3 text-center text-xs">
+            {APP_SCREENSHOT.caption}
+          </figcaption>
+        </figure>
+      </Reveal>
     </section>
   );
 }
@@ -612,6 +690,54 @@ function Platforms() {
   );
 }
 
+/**
+ * The Claude Code skill this repo ships, as a one-line copy. It is the same
+ * `.claude/skills/qwksearch-customize` Claude reads when working in this
+ * monorepo, so a fork starts with the same map of which package owns what.
+ */
+function ClaudeSkillSection() {
+  return (
+    <section className="relative px-4 py-16 sm:px-6 lg:px-8">
+      <SectionHeading
+        eyebrow="Fork it"
+        title={
+          <>
+            Hand your agent the{" "}
+            <span className="qs-shimmer-text bg-gradient-to-r from-sky-500 via-violet-500 to-sky-500 bg-clip-text text-transparent">
+              codebase map
+            </span>
+          </>
+        }
+        blurb="Drop this repo's Claude Code skill into your own setup, and Claude already knows which of the ~20 packages a change belongs in."
+      />
+
+      <Reveal className="mx-auto max-w-3xl">
+        <SpotlightCard className="bg-card/90 rounded-3xl border px-6 py-7 backdrop-blur-sm sm:px-8">
+          <div className="flex flex-wrap items-center gap-3">
+            <Pill>
+              <Terminal className="size-3.5" />
+              Claude Code skill
+            </Pill>
+            <code className="font-mono text-sm font-semibold">
+              {CLAUDE_SKILL.name}
+            </code>
+          </div>
+
+          <p className="text-muted-foreground mt-4 text-sm leading-relaxed text-pretty">
+            {CLAUDE_SKILL.blurb}
+          </p>
+
+          <CopyCommand
+            className="mt-5"
+            command={CLAUDE_SKILL.command}
+            label={`Copy the ${CLAUDE_SKILL.name} install command`}
+          />
+        </SpotlightCard>
+      </Reveal>
+    </section>
+  );
+}
+
 function ClosingCta() {
   return (
     <section className="relative px-4 pt-10 pb-28 sm:px-6 lg:px-8">
@@ -660,6 +786,7 @@ export function FeaturesView() {
   return (
     <div className="qs-features relative min-h-screen md:pl-20">
       <Hero />
+      <Screenshot />
       <VideoDemo />
       <EngineMarquee />
       <BentoGrid />
@@ -667,6 +794,7 @@ export function FeaturesView() {
       <Pipeline />
       <FeatureExplorer />
       <Platforms />
+      <ClaudeSkillSection />
       <ClosingCta />
     </div>
   );

--- a/apps/qwksearch-web/components/features/copy-command.tsx
+++ b/apps/qwksearch-web/components/features/copy-command.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import * as React from "react";
+import { Check, Copy } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * A shell one-liner with a copy button. Long commands wrap rather than scroll,
+ * so nothing is hidden on a phone, and the button reports what happened —
+ * `navigator.clipboard` is unavailable over plain HTTP and in some embedded
+ * webviews, and a button that silently did nothing is worse than one that says
+ * so.
+ */
+export function CopyCommand({
+  command,
+  className,
+  label = "Copy command",
+}: {
+  command: string;
+  className?: string;
+  /** Accessible name for the button, when the page has more than one. */
+  label?: string;
+}) {
+  const [state, setState] = React.useState<"idle" | "copied" | "failed">("idle");
+
+  React.useEffect(() => {
+    if (state === "idle") return;
+    const timer = setTimeout(() => setState("idle"), 2000);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setState("copied");
+    } catch {
+      setState("failed");
+    }
+  };
+
+  return (
+    <div className={cn("text-left", className)}>
+      <div className="bg-muted/60 flex items-start gap-3 rounded-xl border p-3">
+        <code className="min-w-0 flex-1 font-mono text-xs leading-relaxed break-all sm:text-sm">
+          {command}
+        </code>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={label}
+          title={label}
+          className="text-muted-foreground hover:text-foreground hover:bg-background focus-visible:ring-ring/50 shrink-0 rounded-lg border p-2 transition-colors focus-visible:ring-[3px] focus-visible:outline-none"
+        >
+          {state === "copied" ? (
+            <Check className="size-4 text-emerald-500" />
+          ) : (
+            <Copy className="size-4" />
+          )}
+        </button>
+      </div>
+      <p aria-live="polite" className="text-muted-foreground mt-2 text-xs">
+        {state === "copied"
+          ? "Copied to clipboard."
+          : state === "failed"
+            ? "Could not reach the clipboard — select the command above and copy it manually."
+            : " "}
+      </p>
+    </div>
+  );
+}

--- a/apps/qwksearch-web/components/features/data.tsx
+++ b/apps/qwksearch-web/components/features/data.tsx
@@ -646,3 +646,136 @@ export const PACKAGES: { name: string; blurb: string }[] = [
   { name: "shadcn-app-dock", blurb: "macOS-style dock with a shadcn theme switcher." },
   { name: "qwksearch-api-client", blurb: "Typed bindings generated from the OpenAPI spec." },
 ];
+
+export interface ProjectBadge {
+  /** Alt text, which doubles as the badge's tooltip and its React key. */
+  alt: string;
+  /** Badge image — shields.io, Zenodo, Codecov and friends. */
+  src: string;
+  /** Where the badge links; the plain tech-stack chips link nowhere. */
+  href?: string;
+}
+
+/**
+ * The README's badge wall, in the README's own order, so the homepage and the
+ * repo's front page say the same thing about the project. Rendered with plain
+ * <img> tags at a uniform height: every one of these is a remote SVG/PNG the
+ * Worker's image optimizer would not proxy anyway (see `faviconUrl`).
+ */
+export const PROJECT_BADGES: ProjectBadge[] = [
+  {
+    alt: "DOI",
+    src: "https://zenodo.org/badge/DOI/10.5281/zenodo.20951725.svg",
+    href: "https://doi.org/10.5281/zenodo.20951725",
+  },
+  {
+    alt: "Ask DeepWiki",
+    src: "https://deepwiki.com/badge.svg",
+    href: "https://deepwiki.com/OpenSourceAGI/qwksearch-research-agent",
+  },
+  {
+    alt: "Documentation",
+    src: "https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white",
+    href: "/docs",
+  },
+  {
+    alt: "API reference",
+    src: "https://img.shields.io/badge/API-blue?logo=fastapi&logoColor=white",
+    href: "https://qwksearch.com/api/docs",
+  },
+  {
+    alt: "YouTube",
+    src: "https://img.shields.io/badge/YouTube-red?style=for-the-badge&logo=youtube&logoColor=white",
+    href: "https://youtu.be/DzykBAdrw6s",
+  },
+  {
+    alt: "Deploy to Cloudflare Workers",
+    src: "https://deploy.workers.cloudflare.com/button",
+    href: "https://deploy.workers.cloudflare.com/?url=https://github.com/OpenSourceAGI/qwksearch-research-agent",
+  },
+  {
+    alt: "GitHub stars",
+    src: "https://img.shields.io/github/stars/vtempest/qwksearch-research-agent",
+    href: "https://github.com/OpenSourceAGI/qwksearch-research-agent/discussions",
+  },
+  {
+    alt: "NPM monthly downloads",
+    src: "https://img.shields.io/npm/dm/qwksearch-api-client.svg",
+    href: "https://www.npmjs.com/package/qwksearch-api-client",
+  },
+  {
+    alt: "Coverage",
+    src: "https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg",
+    href: "https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent",
+  },
+  {
+    alt: "Commit activity",
+    src: "https://img.shields.io/github/commit-activity/m/vtempest/qwksearch-research-agent",
+    href: "https://github.com/OpenSourceAGI/qwksearch-research-agent/graphs/contributors",
+  },
+  {
+    alt: "GitHub last commit",
+    src: "https://img.shields.io/github/last-commit/vtempest/qwksearch-research-agent.svg",
+    href: "https://github.com/OpenSourceAGI/qwksearch-research-agent/commits/master/",
+  },
+  {
+    alt: "Test status for master",
+    src: "https://github.com/OpenSourceAGI/qwksearch-research-agent/actions/workflows/test-web-api.yml/badge.svg",
+    href: "https://github.com/OpenSourceAGI/qwksearch-research-agent/actions/workflows/test-web-api.yml",
+  },
+  {
+    alt: "Uptime status",
+    src: "https://img.shields.io/badge/Uptime-Status-brightgreen?logo=uptimerobot&logoColor=white",
+    href: "https://stats.uptimerobot.com/wgqOZtDv0i",
+  },
+  {
+    alt: "npm version",
+    src: "https://img.shields.io/npm/v/qwksearch-api-client.svg",
+    href: "https://www.npmjs.com/package/qwksearch-api-client",
+  },
+  {
+    alt: "Join Discord",
+    src: "https://img.shields.io/discord/1110227955554209923.svg?label=Chat&logo=Discord&colorB=7289da&style=flat",
+    href: "https://discord.gg/SJdBqBz3tV",
+  },
+  {
+    alt: "PRs welcome",
+    src: "https://img.shields.io/badge/PRs-welcome-brightgreen.svg",
+    href: "https://github.com/OpenSourceAGI/qwksearch-research-agent/pulls",
+  },
+  {
+    alt: "Claude AI",
+    src: "https://img.shields.io/badge/Claude-D97757?logo=claude&logoColor=fff",
+  },
+  {
+    alt: "Cloudflare",
+    src: "https://img.shields.io/badge/Cloudflare-F38020?logo=Cloudflare&logoColor=white",
+  },
+  { alt: "Next.js", src: "https://img.shields.io/badge/Next.js-black" },
+  {
+    alt: "grab.js.org",
+    src: "https://i.imgur.com/n3uYGcI.png",
+    href: "https://grab.js.org",
+  },
+];
+
+/** The README's product shot, reused so both surfaces show the same app. */
+export const APP_SCREENSHOT = {
+  src: "https://i.imgur.com/ZMY9Xy7.png",
+  alt: "The QwkSearch workspace: a research chat with cited sources beside the REASON editor",
+  caption:
+    "Search, the extracted article with its cites, and the REASON editor — one screen.",
+};
+
+/**
+ * The Claude Code skill checked into `.claude/skills/`, offered here as a
+ * one-line copy so anyone forking the repo starts with the same orientation
+ * Claude gets: which package owns which surface.
+ */
+export const CLAUDE_SKILL = {
+  name: "qwksearch-customize",
+  blurb:
+    "Teaches Claude Code where every surface lives — the web app, the chat UI, the REASON editor, the extension, and the ~20 packages behind them — so a change lands in the right layer instead of being re-implemented in the wrong one.",
+  command:
+    "npx degit OpenSourceAGI/qwksearch-research-agent/.claude/skills/qwksearch-customize ~/.claude/skills/qwksearch-customize",
+};

--- a/apps/qwksearch-web/lib/config/site.ts
+++ b/apps/qwksearch-web/lib/config/site.ts
@@ -38,7 +38,9 @@ export const listFooterLinks: FooterLink[] = [
   {
     url: "/docs",
     text: "Docs",
-    icon: "HelpCircle",
+    // A book, not a help circle: this is the product's documentation, and the
+    // dock renders the icon beside the label where the distinction reads.
+    icon: "BookOpen",
   },
   {
     url: "https://www.linkedin.com/company/qwksearch/posts/",

--- a/packages/research-agent-ui/src/app/CategoryDock.tsx
+++ b/packages/research-agent-ui/src/app/CategoryDock.tsx
@@ -18,6 +18,7 @@ import {
 import { useSession } from "../hooks/useSession"
 import { useChat } from "../hooks/useChat"
 import { researchAgentUIConfig } from "../config"
+import { siteLinksForPath } from "../lib/site-links"
 import { useMainView } from "./MainViewProvider"
 import iconRead from "../icons/icon-read.svg"
 import iconConfigure from "../icons/icon-configure.svg"
@@ -45,6 +46,11 @@ export function CategoryDock() {
   ]
 
   const isOnResearch = pathname === "/" || pathname.startsWith("/c")
+
+  // A nav entry for the page you are already reading is dead weight — on
+  // /docs the "Docs" link led straight back to itself — so the current
+  // section drops out of the Site Links menu.
+  const siteLinks = siteLinksForPath(researchAgentUIConfig.footerLinks, pathname)
 
   const items: DockNavItem[] = [
     ...NAV_ITEMS.map(({ href, label, icon }) => ({
@@ -104,7 +110,7 @@ export function CategoryDock() {
                 <span className="text-sm">Site Links</span>
               </DropdownMenuSubTrigger>
               <DropdownMenuSubContent>
-                {researchAgentUIConfig.footerLinks.map(({ url, text, icon }) => {
+                {siteLinks.map(({ url, text, icon }) => {
                   const IconComponent = icon ? (LucideIcons as any)[icon] : null
                   const isExternal = url.startsWith("http")
                   return (

--- a/packages/research-agent-ui/src/lib/site-links.test.ts
+++ b/packages/research-agent-ui/src/lib/site-links.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { siteLinksForPath } from './site-links';
+
+const LINKS = [
+  { url: '/docs', text: 'Docs' },
+  { url: '/features', text: 'Features' },
+  { url: '/#downloads', text: 'Downloads' },
+  { url: 'https://discord.gg/SJdBqBz3tV', text: 'Support' },
+  { url: '/legal/privacy', text: 'Privacy' },
+];
+
+const texts = (pathname: string | null) =>
+  siteLinksForPath(LINKS, pathname).map((link) => link.text);
+
+describe('siteLinksForPath', () => {
+  it('keeps every link on a route none of them point at', () => {
+    expect(texts('/')).toEqual(['Docs', 'Features', 'Downloads', 'Support', 'Privacy']);
+  });
+
+  it('drops the docs link while the reader is in the docs', () => {
+    expect(texts('/docs')).not.toContain('Docs');
+    expect(texts('/docs/guides/search')).not.toContain('Docs');
+    expect(texts('/docs/')).not.toContain('Docs');
+  });
+
+  it('keeps the docs link on a route that merely starts with the same text', () => {
+    expect(texts('/docsearch')).toContain('Docs');
+  });
+
+  it('keeps hash links, which are actions rather than destinations', () => {
+    expect(texts('/')).toContain('Downloads');
+  });
+
+  it('keeps external links, which always lead away from the app', () => {
+    expect(texts('/')).toContain('Support');
+  });
+
+  it('drops only the nested route that is current', () => {
+    expect(texts('/legal/privacy')).toEqual(['Docs', 'Features', 'Downloads', 'Support']);
+    expect(texts('/legal')).toContain('Privacy');
+  });
+
+  it('returns every link when the route is unknown', () => {
+    expect(texts(null)).toHaveLength(LINKS.length);
+  });
+});

--- a/packages/research-agent-ui/src/lib/site-links.ts
+++ b/packages/research-agent-ui/src/lib/site-links.ts
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Which of the configured site links to offer on a given route.
+ *
+ * The dock carries the site links on every page, help docs included, so on
+ * `/docs` the "Docs" entry pointed at the page the reader was already on. A
+ * link to where you already are is dead weight in a nav, so the route the
+ * dock is currently showing drops out of the list.
+ */
+import type { FooterLink } from '../config';
+
+/**
+ * Whether `url` names the section `pathname` is inside — the route itself or
+ * anything nested under it, so `/docs/guides/search` counts as `/docs`.
+ *
+ * Only same-origin, path-only links can match:
+ *
+ * - An absolute URL (`https://…`) leaves the app, so it is never "here".
+ * - A link carrying a hash or a query (`/#downloads`) is an action rather than
+ *   a destination — that one opens the downloads dialog — and stays put.
+ * - `/` would otherwise match every route, so it is compared exactly.
+ */
+function isCurrentSection(url: string, pathname: string): boolean {
+  if (!url.startsWith('/') || url.includes('#') || url.includes('?')) return false;
+
+  const target = url.replace(/\/+$/, '') || '/';
+  const here = pathname.replace(/\/+$/, '') || '/';
+
+  return target === '/' ? here === '/' : here === target || here.startsWith(`${target}/`);
+}
+
+/**
+ * The site links worth showing from `pathname`: every configured link except
+ * one that leads back to the current page or its section.
+ */
+export function siteLinksForPath(links: FooterLink[], pathname: string | null): FooterLink[] {
+  if (!pathname) return links;
+  return links.filter((link) => !isCurrentSection(link.url, pathname));
+}


### PR DESCRIPTION
## Summary
Brings the README's badge wall, product screenshot, and Claude Code skill installation command to the homepage, ensuring the marketing site and repository front page present the same information about the project. Also improves the site navigation by hiding links to the current page section.

## Key Changes

### Homepage Content (`components/features/`)
- **New data exports** (`data.tsx`):
  - `PROJECT_BADGES`: Array of 18 badge objects (DOI, documentation, API, YouTube, deployment, GitHub stats, coverage, etc.) with alt text, image URLs, and optional links
  - `APP_SCREENSHOT`: Product shot with caption showing the QwkSearch workspace
  - `CLAUDE_SKILL`: Claude Code skill metadata including install command for the codebase map

- **New `BadgeWall` component** (`FeaturesView.tsx`):
  - Renders badges at uniform `h-5` height (README mixes `flat` and `for-the-badge` styles)
  - Each badge includes alt text as tooltip
  - Badges link to external resources or internal routes as configured
  - Positioned under hero CTAs with reveal animation

- **New `Screenshot` component** (`FeaturesView.tsx`):
  - Displays product shot with border beam effect
  - Includes figcaption with descriptive text
  - Positioned between hero and video demo sections

- **New `ClaudeSkillSection` component** (`FeaturesView.tsx`):
  - Showcases the Claude Code skill with description
  - Includes new `CopyCommand` component for one-liner installation
  - Positioned before closing CTA

- **New `CopyCommand` component** (`copy-command.tsx`):
  - Displays shell command in wrapped `<code>` block (no horizontal scroll on mobile)
  - Copy button with visual feedback (Check icon on success)
  - Reports success/failure states with accessible messaging
  - Gracefully handles clipboard API unavailability

### Navigation Improvements
- **New `siteLinksForPath` utility** (`packages/research-agent-ui/src/lib/site-links.ts`):
  - Filters site links to hide entries pointing to the current page section
  - Only matches same-origin path-only links (ignores external URLs, hash/query links)
  - Treats `/` specially to avoid matching all routes
  - Includes comprehensive test suite with 6 test cases

- **Updated `CategoryDock`** (`packages/research-agent-ui/src/app/CategoryDock.tsx`):
  - Integrates `siteLinksForPath` to filter Site Links menu based on current pathname
  - Prevents "Docs" link from appearing when user is already in `/docs` section

- **Icon update** (`apps/qwksearch-web/lib/config/site.ts`):
  - Changed Docs link icon from `HelpCircle` to `BookOpen` for better semantic clarity

## Implementation Details
- Badges are remote SVG/PNG assets (not proxied by image optimizer) to preserve live status indicators
- Uniform badge height achieved via CSS class despite mixed style formats in shields.io
- `CopyCommand` wraps text with `break-all` to prevent overflow on mobile devices
- Route matching in `siteLinksForPath` normalizes trailing slashes and handles edge cases (root path, nested routes)
- All new components use existing design system (Reveal animations, SpotlightCard, Pill components)

https://claude.ai/code/session_018P4c87AEqn7npBpALtsKdK