### PR TITLE
Import useMainView hook from research-agent-ui

### DIFF
--- a/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
+++ b/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import dynamic from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { ChevronDown } from 'lucide-react';
-import { useChat } from 'research-agent-ui';
+import { useChat, useMainView } from 'research-agent-ui';
 
 import { ResearchWorkspaceView } from 'research-agent-ui/workspace';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
## Summary
Added import of the `useMainView` hook from the `research-agent-ui` package to the HomeScrollStack component.

## Changes
- Updated the import statement in `HomeScrollStack.tsx` to include `useMainView` alongside the existing `useChat` hook from `research-agent-ui`

## Notes
This change prepares the component to use the `useMainView` hook, though the actual implementation/usage of this hook is not included in this diff.

https://claude.ai/code/session_01DXvmXW2yJvP4LVkCR1zdo2