### PR TITLE
fix(build): let vinext resolve the native addons it must not bundle

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx open-ready next dev",
-    "prebuild": "cd ../../packages/extract-pdf && bun run build && cd ../shadcn-app-dock && bun run build && cd ../shadcn-settings && bun run build && cd ../react-weather-forecast && bun run build && cd ../trending-news-api && bun run build && cd ../chat-agent-toolkit && bun run build && cd ../use-voice-control && bun run build && cd ../research-agent-ui && bun run build && cd ../reason-editor-sidebar && bun run build && cd ../reason-editor && bun run build:lib",
+    "prebuild": "node ../../scripts/build-workspace-packages.mjs",
     "build": "vinext build",
     "deploy": "vinext deploy",
     "start": "next start",

--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -129,6 +129,10 @@
     "write-language": "workspace:*",
     "zod": "^4.5.4"
   },
+  "optionalDependencies": {
+    "@llamaindex/liteparse": "^2.14.4",
+    "@napi-rs/canvas": "^1.0.8"
+  },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.54.6",
     "@libsql/client": "^0.18.0",

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "mammoth": "^1.12.2",
       },
       "devDependencies": {
+        "@typescript/typescript6": "^6.0.2",
         "@vitest/coverage-v8": "^5.0.0",
         "@vitest/ui": "^5.0.0",
         "turbo": "^2.10.12",
@@ -385,7 +386,7 @@
     },
     "packages/extract-youtube": {
       "name": "extract-youtube",
-      "version": "1.0.264",
+      "version": "1.0.268",
       "bin": "dist/cli.js",
       "dependencies": {
         "fast-xml-parser": "^5.11.1",
@@ -421,7 +422,7 @@
     },
     "packages/html-renderer-api": {
       "name": "html-renderer-api",
-      "version": "1.0.148",
+      "version": "1.0.152",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.4.0",
       },
@@ -432,7 +433,7 @@
     },
     "packages/notebooklm-api-client": {
       "name": "notebooklm-api-client",
-      "version": "0.1.220",
+      "version": "0.1.224",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.4.0",
       },
@@ -446,7 +447,7 @@
     },
     "packages/qwksearch-api-client": {
       "name": "qwksearch-api-client",
-      "version": "0.9.224",
+      "version": "0.9.227",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -460,7 +461,7 @@
     },
     "packages/qwksearch-mcp-server": {
       "name": "qwksearch-mcp-server",
-      "version": "1.0.112",
+      "version": "1.0.116",
       "bin": {
         "qwksearch-mcp": "./bin/qwksearch-mcp.ts",
       },
@@ -697,7 +698,7 @@
         "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.3.3",
         "tailwindcss-animate": "^1.0.7",
-        "tailwindcss3": "npm:tailwindcss@^4.3.3",
+        "tailwindcss3": "npm:tailwindcss@^3.4.17",
         "terser": "^5.51.2",
         "typescript": "^7.0.2",
         "unplugin-dts": "1.1.0",
@@ -919,7 +920,7 @@
     },
     "packages/search-web-api": {
       "name": "search-web-api",
-      "version": "1.0.131",
+      "version": "1.0.135",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@scalar/hono-api-reference": "^0.12.1",
@@ -3050,6 +3051,8 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
 
+    "@typescript/old": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
     "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
@@ -3089,6 +3092,8 @@
     "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
 
     "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "@typescript/typescript6": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "@udecode/cn": ["@udecode/cn@52.3.4", "", { "dependencies": { "@udecode/react-utils": "52.3.4", "react-compiler-runtime": "^1.0.0" }, "peerDependencies": { "class-variance-authority": ">=0.7.0", "react": ">=18.0.0", "react-dom": ">=18.0.0", "tailwind-merge": ">=2.2.0" } }, "sha512-mf+vcfWl1N3Vo5lqiX79zggiun0ftbue0/DMoWfQiZrym64nxJ7emfOMm8Hb5MI0MoTEncg2Zvr7ntoIgrMN8g=="],
 
@@ -3283,6 +3288,8 @@
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
@@ -3481,6 +3488,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
@@ -3856,6 +3865,8 @@
 
     "devtools-protocol": ["devtools-protocol@0.0.1299070", "", {}, "sha512-+qtL3eX50qsJ7c+qVyagqi7AWMoQCBGNfoyJZMwm/NSXVqLYbuitrWEEIzxfUmTNy7//Xe8yhMmQ+elj3uAqSg=="],
 
+    "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
+
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "diff-match-patch-ts": ["diff-match-patch-ts@0.6.0", "", {}, "sha512-U0uPIJ+wJqgaBoVw2MFSFpGIk7q3mJJ+/sehbxDZFv4Gx6a1GOmrsSLmxVDDrGtRL4Q9de084aa5lVpCHn+eUw=="],
@@ -3865,6 +3876,8 @@
     "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
 
     "direction": ["direction@1.0.4", "", { "bin": { "direction": "cli.js" } }, "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="],
+
+    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dnd-core": ["dnd-core@16.0.1", "", { "dependencies": { "@react-dnd/asap": "^5.0.1", "@react-dnd/invariant": "^4.0.1", "redux": "^4.2.0" } }, "sha512-HK294sl7tbw6F6IeuK16YSBUoorvHpY8RHO+9yFfaJyCDVb6n7PRcezrOEOa2SBCqiYpemh5Jx20ZcjKdFAVng=="],
 
@@ -5152,6 +5165,8 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "object-is": ["object-is@1.1.6", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1" } }, "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q=="],
@@ -5338,7 +5353,13 @@
 
     "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
 
+    "postcss-import": ["postcss-import@15.1.0", "", { "dependencies": { "postcss-value-parser": "^4.0.0", "read-cache": "^1.0.0", "resolve": "^1.1.7" }, "peerDependencies": { "postcss": "^8.0.0" } }, "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew=="],
+
+    "postcss-js": ["postcss-js@4.1.0", "", { "dependencies": { "camelcase-css": "^2.0.1" }, "peerDependencies": { "postcss": "^8.4.21" } }, "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw=="],
+
     "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
     "postcss-replace": ["postcss-replace@2.0.1", "", { "dependencies": { "kind-of": "^6.0.3", "object-path": "^0.11.8" }, "peerDependencies": { "postcss": "^8.4" } }, "sha512-T83GVovCkBQkFCTmuid0B2bWNu/O0Bh/HDMeEGFC62EwMvVBLZQFYM7iBbcGT48QDXSNSX6e/X1Q7/Syh5NFng=="],
 
@@ -5561,6 +5582,8 @@
     "react-tweet": ["react-tweet@3.3.1", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog=="],
 
     "reactjs-signal": ["reactjs-signal@2.0.6", "", { "dependencies": { "alien-signals": "^3.2.0" }, "peerDependencies": { "react": ">=18" } }, "sha512-SG7BpeS+P99xRnZvkWYlrArpTRi2cs8uA8oBIraSjjpfMH/E5wpan6bGCgaJelkgqyzlp9nhf/wHvnJG0SeOPA=="],
+
+    "read-cache": ["read-cache@1.0.2", "", {}, "sha512-/peqiBB/n07gQGLsWaHho3WfvUyRscw0gYTsEFMhrIe/nWLkYaf5SbKYjGYqtRV3aPwykJgF2VEMo1ac4bnsGA=="],
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -5932,7 +5955,7 @@
 
     "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
 
-    "tailwindcss3": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
+    "tailwindcss3": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -6922,8 +6945,6 @@
 
     "expect/jest-util": ["jest-util@30.5.1", "", { "dependencies": { "@jest/types": "30.5.1", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.3" } }, "sha512-yKuxmNy2rSbTXw+3SIPanJo+nV4/BS1p26v44IYBFMsswSQySfMMcPHErnOncda7i9HEz0q605rIhSTBVgrZTg=="],
 
-    "extract-webpage/qwksearch-api-client": ["qwksearch-api-client@0.9.225", "", {}, "sha512-qu8voxkkMai0A73LqGPP3QwKhPO6k73SFlgzvP7mn1iNd9y1zq28WNVkHLUnz99Cqql6Oc7jDX+qSWF2/i80UA=="],
-
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -7212,6 +7233,8 @@
 
     "pbkdf2/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
+
     "prebuild-install/tar-fs": ["tar-fs@2.1.5", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
@@ -7350,6 +7373,10 @@
 
     "swagger-jsdoc/yaml": ["yaml@2.0.0-1", "", {}, "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="],
 
+    "tailwindcss3/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "tailwindcss3/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
+
     "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "test-exclude/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
@@ -7451,8 +7478,6 @@
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "write-language/qwksearch-api-client": ["qwksearch-api-client@0.9.225", "", {}, "sha512-qu8voxkkMai0A73LqGPP3QwKhPO6k73SFlgzvP7mn1iNd9y1zq28WNVkHLUnz99Cqql6Oc7jDX+qSWF2/i80UA=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
@@ -8356,6 +8381,10 @@
 
     "stream-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
+    "tailwindcss3/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "tailwindcss3/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
     "test-exclude/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
     "tough-cookie/tldts/tldts-core": ["tldts-core@7.4.10", "", {}, "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw=="],
@@ -8917,6 +8946,8 @@
     "research-agent-ui/use-voice-control/lucide-react/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
+
+    "tailwindcss3/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "test-exclude/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,10 @@
         "wait-on": "^9.1.0",
         "wrangler": "^4.130.0",
       },
+      "optionalDependencies": {
+        "@llamaindex/liteparse": "^2.14.4",
+        "@napi-rs/canvas": "^1.0.8",
+      },
     },
     "apps/test-reports": {
       "name": "test-reports",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "deploy:test-reports": "cd apps/test-reports && wrangler deploy"
   },
   "devDependencies": {
+    "@typescript/typescript6": "^6.0.2",
     "@vitest/coverage-v8": "^5.0.0",
     "@vitest/ui": "^5.0.0",
     "turbo": "^2.10.12",

--- a/packages/domain-rank/tsconfig.build.json
+++ b/packages/domain-rank/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    // TypeScript 7 no longer infers the common source directory (TS5011).
+    "rootDir": "./src",
     "declaration": true,
     "declarationDir": "./dist",
     "emitDeclarationOnly": true,

--- a/packages/react-weather-forecast/package.json
+++ b/packages/react-weather-forecast/package.json
@@ -41,7 +41,7 @@
     "wrangler": "^4.130.0"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/packages/react-weather-forecast/tsconfig.build.json
+++ b/packages/react-weather-forecast/tsconfig.build.json
@@ -9,5 +9,5 @@
     "declarationDir": "./dist"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "vite.config.ts"]
+  "exclude": ["node_modules", "dist", "tsup.config.ts"]
 }

--- a/packages/react-weather-forecast/tsup.config.ts
+++ b/packages/react-weather-forecast/tsup.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
-  dts: true,
+  // Declarations come from `tsc -p tsconfig.build.json` (see the build
+  // script). tsup bundles rollup-plugin-dts built against TypeScript 5,
+  // which throws `Cannot read properties of undefined (reading
+  // 'useCaseSensitiveFileNames')` on the TypeScript 7 this repo installs.
+  dts: false,
   clean: true,
   sourcemap: true,
   splitting: false,

--- a/packages/reason-editor-sidebar/src/types/styles.d.ts
+++ b/packages/reason-editor-sidebar/src/types/styles.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Ambient declarations for the stylesheets this package imports for their side
+ * effects. Vite turns such an import into a bundled `<style>`; TypeScript 7
+ * refuses one without a declaration:
+ *
+ *   error TS2882: Cannot find module or type declarations for side-effect
+ *   import of './filemanager.css'.
+ */
+
+declare module '*.css';
+declare module '*.scss';

--- a/packages/reason-editor/package.json
+++ b/packages/reason-editor/package.json
@@ -978,7 +978,7 @@
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.3.3",
     "tailwindcss-animate": "^1.0.7",
-    "tailwindcss3": "npm:tailwindcss@^4.3.3",
+    "tailwindcss3": "npm:tailwindcss@^3.4.17",
     "terser": "^5.51.2",
     "typescript": "^7.0.2",
     "unplugin-dts": "1.1.0",

--- a/packages/research-agent-ui/tsconfig.build.json
+++ b/packages/research-agent-ui/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    // TypeScript 7 no longer infers the common source directory (TS5011).
+    "rootDir": "./src",
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationDir": "./dist"

--- a/packages/shadcn-app-dock/tsconfig.build.json
+++ b/packages/shadcn-app-dock/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    // TypeScript 7 no longer infers the common source directory (TS5011).
+    "rootDir": "./src",
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationDir": "./dist"

--- a/packages/shadcn-settings/tsconfig.build.json
+++ b/packages/shadcn-settings/tsconfig.build.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
+    // TypeScript 7 no longer infers the common source directory (TS5011).
+    "rootDir": "./src",
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationDir": "./dist"

--- a/packages/trending-news-api/package.json
+++ b/packages/trending-news-api/package.json
@@ -41,7 +41,7 @@
     "wrangler": "^4.130.0"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && tsc --project tsconfig.build.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/packages/trending-news-api/tsconfig.build.json
+++ b/packages/trending-news-api/tsconfig.build.json
@@ -9,5 +9,5 @@
     "declarationDir": "./dist"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "vite.config.ts"]
+  "exclude": ["node_modules", "dist", "tsup.config.ts"]
 }

--- a/packages/trending-news-api/tsup.config.ts
+++ b/packages/trending-news-api/tsup.config.ts
@@ -3,7 +3,11 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
-  dts: true,
+  // Declarations come from `tsc -p tsconfig.build.json` (see the build
+  // script). tsup bundles rollup-plugin-dts built against TypeScript 5,
+  // which throws `Cannot read properties of undefined (reading
+  // 'useCaseSensitiveFileNames')` on the TypeScript 7 this repo installs.
+  dts: false,
   clean: true,
   sourcemap: true,
   splitting: false,

--- a/scripts/build-workspace-packages.mjs
+++ b/scripts/build-workspace-packages.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Build every `packages/*` that has a `build` script, in dependency order.
+ *
+ * `apps/qwksearch-web` consumes its siblings through their built `dist/`, and
+ * its `prebuild` used to name them in a hand-written `cd ... && bun run build`
+ * chain. That chain listed `research-agent-ui` *before* `reason-editor` and
+ * `reason-editor-sidebar`, two packages whose types it imports, so its
+ * declaration build could not resolve them:
+ *
+ *   src/workspace/ResearchWorkspaceView.tsx: Cannot find module
+ *   'react-reason-editor/reason-docs' or its corresponding type declarations.
+ *
+ * `bun install` links siblings into node_modules as symlinks, so one that has
+ * not been built yet has no `dist/` and its `exports` -> `types` entries point
+ * at files that do not exist. The npm publish workflow hit the same wall and
+ * fixed it with `workspace-build-order.mjs` (see #386); this reuses that same
+ * topological order rather than keeping a second hand-maintained list in sync.
+ *
+ * Turbo would also order these correctly from `turbo.json`'s
+ * `dependsOn: ["^build"]`, but its graph counts a dependency as internal only
+ * when the declared range matches the workspace copy. `research-agent-ui` asks
+ * for `use-voice-control: ^0.1.95` while the workspace sits at 0.1.93, so
+ * turbo treats it as an ordinary registry dependency and never builds it.
+ * `workspaceBuildOrder` keys local edges by package *name*, which is why it
+ * covers that case and turbo does not.
+ *
+ * Usage: node scripts/build-workspace-packages.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { workspaceBuildOrder } from './workspace-build-order.mjs';
+
+/** Repository root, one level up from `scripts/`. */
+export const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * The subset of {@link workspaceBuildOrder} that defines a `build` script,
+ * in the same order. Packages without one (e.g. `qwksearch-api-client`, whose
+ * `dist` is committed) are skipped rather than failing the run.
+ *
+ * @param {string} root
+ * @returns {string[]} directories relative to the repository root
+ */
+export function buildablePackages(root = 'packages') {
+  return workspaceBuildOrder(path.join(repoRoot, root)).map((dir) => path.join(root, path.basename(path.normalize(dir)))).filter((dir) => {
+    const manifest = path.join(repoRoot, dir, 'package.json');
+    if (!fs.existsSync(manifest)) return false;
+
+    return Boolean(JSON.parse(fs.readFileSync(manifest, 'utf8')).scripts?.build);
+  });
+}
+
+function main() {
+  const dirs = buildablePackages();
+
+  console.log(`Building ${dirs.length} workspace packages in dependency order:`);
+  for (const dir of dirs) console.log(`   ${dir}`);
+
+  for (const dir of dirs) {
+    console.log(`\n▶ ${dir}`);
+    const result = spawnSync('bun', ['run', 'build'], {
+      cwd: path.join(repoRoot, dir),
+      stdio: 'inherit',
+    });
+
+    if (result.status !== 0) {
+      console.error(`\n✗ ${dir} failed with exit code ${result.status}`);
+      process.exit(result.status ?? 1);
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) main();

--- a/scripts/test/build-workspace-packages.test.mjs
+++ b/scripts/test/build-workspace-packages.test.mjs
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { buildablePackages, repoRoot } from '../build-workspace-packages.mjs';
+
+const order = buildablePackages();
+
+/** Position of a package directory in the build order, or -1. */
+function at(name) {
+  return order.indexOf(path.join('packages', name));
+}
+
+describe('buildablePackages', () => {
+  it('only lists packages that define a build script', () => {
+    for (const dir of order) {
+      const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, dir, 'package.json'), 'utf8'));
+
+      expect(pkg.scripts?.build, dir).toBeTruthy();
+    }
+  });
+
+  it('skips packages without one', () => {
+    // `qwksearch-api-client` ships a committed `dist` and has no `build`
+    // script; naming it in a build chain would fail the run.
+    expect(at('qwksearch-api-client')).toBe(-1);
+  });
+
+  it('builds research-agent-ui after every sibling whose types it imports', () => {
+    // The hand-written prebuild chain this replaced put research-agent-ui
+    // before the two editor packages, so its declaration build could not
+    // resolve `react-reason-editor/*` or `react-reason-editor-sidebar`.
+    const ui = at('research-agent-ui');
+    expect(ui).toBeGreaterThan(-1);
+
+    for (const dependency of ['reason-editor', 'reason-editor-sidebar', 'chat-agent-toolkit']) {
+      expect(at(dependency), dependency).toBeGreaterThan(-1);
+      expect(at(dependency), dependency).toBeLessThan(ui);
+    }
+  });
+
+  it('includes use-voice-control, which turbo skips', () => {
+    // research-agent-ui asks for `^0.1.95` while the workspace copy is 0.1.93,
+    // so turbo does not count it as an internal dependency. The build order is
+    // keyed by package name, so it does.
+    expect(at('use-voice-control')).toBeGreaterThan(-1);
+    expect(at('use-voice-control')).toBeLessThan(at('research-agent-ui'));
+  });
+});


### PR DESCRIPTION
Follow-up to #391, which cleared the six breaks that stopped `bun run build` before it ever reached this one.

## The failure

With those cleared, `vinext build` now runs all five phases and then dies on the last step, before any output is emitted:

```
Error: Failed to resolve required runtime dependency
"@llamaindex/liteparse" for standalone output
    at copyPackageAndRuntimeDeps (vinext/dist/build/standalone.js:80)
```

`next.config.mjs` sets `output: "standalone"`, so vinext walks the bundle's runtime dependencies and copies each one. `@llamaindex/liteparse` and `@napi-rs/canvas` are on that list because `vite.config.ts` marks them external — deliberately, since they ship native napi addons workerd cannot load, and nothing in this app opts into the `extract-pdf` code paths that lazily import them.

## Why extract-pdf's `optionalDependencies` didn't cover it

`packages/extract-pdf` already declares both optional. vinext takes the optional flag for a **top-level** entry from the consuming app's own manifest:

```js
const rootOptional = new Set(Object.keys(rootPkg.optionalDependencies ?? {}));
...
if (!packageJsonPath) { if (entry.optional) continue; throw ... }
```

This app declared no `optionalDependencies`, so both arrived non-optional — and bun's isolated linker leaves them reachable only under `packages/extract-pdf/node_modules`, unresolvable from the app root.

## The fix

Declaring them in `apps/qwksearch-web` fixes it twice over:

1. They now resolve **from the app directory**, so `resolvePackageJsonPath` succeeds and the throw cannot be reached at all.
2. On a platform with no prebuilt binary for them, the optional flag makes vinext skip rather than fail.

## Verification

Both conditions checked directly against the code path in `standalone.js`:

| | `require.resolve` from `apps/qwksearch-web` |
|---|---|
| before | `MODULE_NOT_FOUND` → vinext throws |
| after `bun install` | resolves, and bun links both into `apps/qwksearch-web/node_modules` |

This break is **not new** — it reproduces identically on unmodified master, behind the six failures that stopped the build before it got this far. I confirmed that earlier in the session by running `vinext build` against master's code, where it failed at the same line.

Full-build re-verification with this change applied was still running when I stopped it; the resolution check above is what actually determines the outcome of that step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UiwhGaLEfTxeQTFr15B8f

---
_Generated by [Claude Code](https://claude.ai/code/session_014UiwhGaLEfTxeQTFr15B8f)_