### PR TITLE
Record #393 in the trackers, and what CI does and does not cover

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -107,6 +107,17 @@ server and not in `api.ts` fails it.
       (missing `electron` types and similar), pre-existing and untouched here.
 
 ### Notes for the next run
+- **PRs in this repo auto-merge.** `auto-merge-claude.yml` merged #393 about ten
+  seconds after it opened, before its own checks finished — so a PR is the
+  delivery, not a review checkpoint, and any commit pushed after it lands needs
+  its own PR against the new `master`.
+- **CI cannot see `packages-lobe`.** It is outside the root workspace graph, so
+  no job installs, builds or tests it; a green run says nothing about a change
+  made there. The Coverage workflow was also already red on the base commit
+  `f10e1091` for six packages (`extract-youtube`, `extract-pdf`, `qwksearch-web`,
+  `shadcn-settings`, `search-web-api`, `chat-agent-toolkit`), so check the same
+  job on the base before treating a failure as yours. Both findings are written
+  up in the to-do under "What CI will and will not tell you".
 - **`pnpm install --ignore-scripts` in `packages-lobe` works here**, takes a few
   minutes and ~3 GB, and is what a `src/` change needs. Earlier runs recorded a
   scratch-vitest recipe for `worker/`-only changes; the to-do now says to prefer

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ the core engine but the elements of qwksearch are then added". Picked up the
 LobeHub Migration To-Do's own #1 suggested next: 2.2's Extraction pane, which
 1.6 had just unblocked by giving the resolver's user layer an API.
 **Branch:** `claude/magical-bohr-cg4yml`
-**PR:** Not created yet
+**PR:** #393
 **Started:** 2026-09-09
 **Completed:** 2026-09-09
 

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -243,7 +243,7 @@ Follow-ups:
 - ✅ **`languages` is capped at five and `tiers` at the four known ids**; the
   pane reads both bounds out of `options` and never repeats them.
 
-### 1.7 Extraction settings pane ✅
+### 1.7 Extraction settings pane ✅ (#393)
 
 2.2's Extraction half, shipped. `/settings/extraction` is a form over the one
 JSON document 1.6 serves, and the first QwkSearch surface to live *inside*

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -479,3 +479,26 @@ Then, for whichever you pick:
    touching `src/` needs the real install.
 4. Update this page's status and add the seam to the integrations reference in
    the same change.
+
+## What CI will and will not tell you
+
+Two things about this repo's CI are worth knowing before you read a red check
+on a `packages-lobe` change, both observed on #393:
+
+- **Nothing in CI builds or tests `packages-lobe`.** The root `workspaces` are
+  `packages/*`, `packages/render-url-to-html/*` and `apps/*`; `packages-lobe` is
+  a separate pnpm workspace outside that graph, so no job installs it. A green
+  run says nothing about a change made there, and a red one is almost certainly
+  not yours. Your own `bunx vitest run` under `packages-lobe` is the only
+  signal — which is why 5.4's "bundle budget in CI" needs a whole new job.
+- **The Coverage workflow is already red on `master`.** On `f10e1091` six jobs
+  failed before any of this work existed: `extract-youtube`, `extract-pdf`,
+  `qwksearch-web`, `shadcn-settings`, `search-web-api` and
+  `chat-agent-toolkit`. Check the same job on the base commit before treating a
+  failure as yours.
+
+Also: **PRs here auto-merge.** `.github/workflows/auto-merge-claude.yml` merged
+#393 about ten seconds after it was opened, before its own checks finished. So
+the PR is the delivery, not a review checkpoint — get the change right before
+opening it, and expect any follow-up commit pushed afterwards to need its own
+PR against the new `master`.


### PR DESCRIPTION
Follow-up to #393, which auto-merged about ten seconds after it opened — before this bookkeeping could ride along on the same branch. Docs only; no source changes.

## Two commits

**Record #393 against the pane's tracker entries.** The TODO entry still said `PR: Not created yet` and §1.7 of the migration to-do carried no PR link. Both now point at #393.

**Write down what this repo's CI does and does not cover.** Two findings from #393 that each cost real time to establish and neither of which is visible from the workflow files alone:

- **Nothing in CI builds or tests `packages-lobe`.** The root `workspaces` are `packages/*`, `packages/render-url-to-html/*` and `apps/*`; `packages-lobe` is a separate pnpm workspace outside that graph, so no job installs it. A green run says nothing about a change made there, and a red one is almost certainly unrelated. This is also why §5.4's "bundle budget in CI" needs a whole new job rather than a step added to an existing one.
- **The Coverage workflow was already red on `master`.** On `f10e1091` — the commit #393 branched from — six jobs failed before any of that work existed: `extract-youtube`, `extract-pdf`, `qwksearch-web`, `shadcn-settings`, `search-web-api`, `chat-agent-toolkit`. So a red job on a future PR needs checking against the same job on the base commit before it is treated as the PR's. ([Base run](https://github.com/OpenSourceAGI/qwksearch-research-agent/actions/runs/34356564089) · [#393's run](https://github.com/OpenSourceAGI/qwksearch-research-agent/actions/runs/34379961327), whose only completed failure was `extract-pdf` — one of the six.)

Plus a note that `auto-merge-claude.yml` merges PRs seconds after opening, before their checks finish, so a PR here is the delivery rather than a review checkpoint — and any commit pushed after one lands needs its own PR against the new `master`, which is what this one is.

## Not addressed

Those six red Coverage jobs are left alone. They are pre-existing, none is in code #393 touched, and repairing six unrelated packages is its own change rather than something to widen a docs PR with. Worth flagging that while they stay red the Coverage workflow gives no usable signal on any PR.

## Verification

Three Markdown/MDX files, no code. `packages/user-help-docs`' own docs-wiring suite covers content edits like these, and its job passed on the base commit; nothing in the diff adds, removes or renames a doc page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVM83Qmfk3EDLeqEo1BykK

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVM83Qmfk3EDLeqEo1BykK)_