### PR TITLE
Add React Spinner component with 8 animation variants

### DIFF
--- a/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.stories.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.stories.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import RandomLoadingAnimation from './RandomLoadingAnimation';
+import Spinner from '../../ui/spinner';
 import {
   LOADING_ANIMATION_NAMES,
   QUANTUM_SPHERE_ANIMATION,
+  getSpinnerVariant,
   renderLoadingAnimation,
 } from './loading-animations';
 
 /**
  * `RandomLoadingAnimation` is the chat's "thinking" loader. Each mount picks a
- * different animation from the GRAB-URL spinner set (`grab-url/animations`)
- * plus the quantum orbital sphere, so a new one appears on every response.
+ * different animation from the GRAB-URL spinner set — the `grab-url/animations`
+ * SVGs and the eight `<Spinner>` variants — plus the quantum orbital sphere, so
+ * a new one appears on every response.
  */
 const meta: Meta<typeof RandomLoadingAnimation> = {
   title: 'ChatConversation/RandomLoadingAnimation',
@@ -36,24 +39,36 @@ export const Several: Story = {
   ),
 };
 
-/** Every SVG spinner in the pool, for reviewing the set as a whole. */
+/** Every spinner in the pool, for reviewing the set as a whole. */
 export const AllVariants: Story = {
   render: () => (
     <div className="flex flex-wrap gap-6">
       {LOADING_ANIMATION_NAMES.filter(
         (name) => name !== QUANTUM_SPHERE_ANIMATION,
-      ).map((name) => (
-        <figure key={name} className="flex flex-col items-center gap-2 w-32">
-          <div
-            dangerouslySetInnerHTML={{
-              __html: renderLoadingAnimation(name, 80),
-            }}
-          />
-          <figcaption className="text-xs text-muted-foreground">
-            {name}
-          </figcaption>
-        </figure>
-      ))}
+      ).map((name) => {
+        const variant = getSpinnerVariant(name);
+
+        return (
+          <figure key={name} className="flex flex-col items-center gap-2 w-32">
+            {variant ? (
+              <Spinner
+                variant={variant}
+                size={80}
+                className="text-muted-foreground"
+              />
+            ) : (
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: renderLoadingAnimation(name, 80),
+                }}
+              />
+            )}
+            <figcaption className="text-xs text-muted-foreground">
+              {name}
+            </figcaption>
+          </figure>
+        );
+      })}
     </div>
   ),
 };

--- a/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.tsx
+++ b/packages/research-agent-ui/src/components/ChatConversation/RandomLoadingAnimation.tsx
@@ -1,21 +1,24 @@
 /**
  * @fileoverview Chat "thinking" loader that shows a different animation every
  * time it mounts, picked at random from the GRAB-URL spinner set
- * (`grab-url/animations`) plus the quantum orbital sphere.
+ * (`grab-url/animations` plus the eight `<Spinner>` variants) and the quantum
+ * orbital sphere.
  */
 'use client';
 
 import { useEffect, useState } from 'react';
 import QuantumWaveOrbital from 'quantum-sphere-loading-icon/react';
 import { cn } from '../../lib/utils';
+import Spinner from '../../ui/spinner';
 import {
   QUANTUM_SPHERE_ANIMATION,
   getRandomLoadingAnimation,
+  getSpinnerVariant,
   renderLoadingAnimation,
 } from './loading-animations';
 
 interface RandomLoadingAnimationProps {
-  /** Width and height of the SVG spinners, in pixels. */
+  /** Width and height of the spinners, in pixels. */
   size?: number;
   /** Extra classes for the centering wrapper. */
   className?: string;
@@ -40,6 +43,8 @@ const RandomLoadingAnimation = ({
     setAnimation(getRandomLoadingAnimation());
   }, []);
 
+  const spinnerVariant = animation ? getSpinnerVariant(animation) : undefined;
+
   return (
     <div
       role="status"
@@ -48,6 +53,12 @@ const RandomLoadingAnimation = ({
     >
       {animation === QUANTUM_SPHERE_ANIMATION ? (
         <QuantumWaveOrbital autoRandomize={true} />
+      ) : spinnerVariant ? (
+        <Spinner
+          variant={spinnerVariant}
+          size={size}
+          className="text-muted-foreground"
+        />
       ) : animation ? (
         <div
           className="flex items-center justify-center"

--- a/packages/research-agent-ui/src/components/ChatConversation/loading-animations.ts
+++ b/packages/research-agent-ui/src/components/ChatConversation/loading-animations.ts
@@ -1,12 +1,14 @@
 /**
  * @fileoverview Registry and random picker for the chat's "thinking" loader.
  *
- * The animated SVG spinners ship with `grab-url/animations` (the
- * `loading-animations` package of the GRAB-URL monorepo) and the quantum
- * orbital sphere ships with `quantum-sphere-loading-icon`. Both are pulled
- * into one pool so the chat can show a different loader on every response.
+ * Three sources feed one pool so the chat can show a different loader on every
+ * response: the animated SVG spinners from `grab-url/animations` (the
+ * `loading-animations` package of the GRAB-URL monorepo), the eight
+ * {@link Spinner} variants from the same set (React, drawn in `currentColor`),
+ * and the quantum orbital sphere from `quantum-sphere-loading-icon`.
  */
 import * as grabUrlAnimations from 'grab-url/animations';
+import { SPINNER_VARIANTS, type SpinnerVariant } from '../../ui/spinner';
 
 /** Options accepted by every `grab-url/animations` spinner factory. */
 export interface LoadingAnimationOptions {
@@ -31,6 +33,25 @@ export type SvgLoadingAnimation = (options?: LoadingAnimationOptions) => string;
  */
 export const QUANTUM_SPHERE_ANIMATION = 'quantumSphere';
 
+/** Marks the pool names that a {@link Spinner} variant renders. */
+export const SPINNER_ANIMATION_PREFIX = 'spinner:';
+
+/**
+ * The `grab-url/animations` spinners that are SVG twins of a {@link Spinner}
+ * variant. They are dropped from the pool so upgrading `grab-url` adds new
+ * looks to the rotation rather than a second copy of the eight below.
+ */
+const SPINNER_SVG_TWINS = new Set([
+  'loadingSpokes',
+  'loadingCircleNotch',
+  'loadingPinwheel',
+  'loadingCircleTrack',
+  'loadingDotsBounce',
+  'loadingPulseRing',
+  'loadingEqualizerBars',
+  'loadingInfiniteDash',
+]);
+
 /**
  * Every animated SVG spinner exported by `grab-url/animations`, keyed by its
  * export name. Read off the module namespace rather than listed by hand, so
@@ -40,13 +61,21 @@ export const SVG_LOADING_ANIMATIONS: Record<string, SvgLoadingAnimation> =
   Object.fromEntries(
     Object.entries(grabUrlAnimations as Record<string, unknown>).filter(
       ([name, factory]) =>
-        typeof factory === 'function' && name.startsWith('loading'),
+        typeof factory === 'function' &&
+        name.startsWith('loading') &&
+        !SPINNER_SVG_TWINS.has(name),
     ),
   ) as Record<string, SvgLoadingAnimation>;
+
+/** The eight {@link Spinner} variants, as pool names. */
+export const SPINNER_LOADING_ANIMATIONS: string[] = SPINNER_VARIANTS.map(
+  (variant) => `${SPINNER_ANIMATION_PREFIX}${variant}`,
+);
 
 /** Every loader the chat can show, sorted so the order is deterministic. */
 export const LOADING_ANIMATION_NAMES: string[] = [
   QUANTUM_SPHERE_ANIMATION,
+  ...SPINNER_LOADING_ANIMATIONS,
   ...Object.keys(SVG_LOADING_ANIMATIONS).sort(),
 ];
 
@@ -63,6 +92,19 @@ export function getRandomLoadingAnimation(): string {
   const pool = choices.length > 0 ? choices : LOADING_ANIMATION_NAMES;
   lastPicked = pool[Math.floor(Math.random() * pool.length)];
   return lastPicked;
+}
+
+/**
+ * Reads the {@link Spinner} variant a pool name stands for.
+ *
+ * @param name - A name from {@link LOADING_ANIMATION_NAMES}
+ * @returns {SpinnerVariant | undefined} The variant, or `undefined` when the
+ *   name is not a spinner pick
+ */
+export function getSpinnerVariant(name: string): SpinnerVariant | undefined {
+  if (!name.startsWith(SPINNER_ANIMATION_PREFIX)) return undefined;
+  const variant = name.slice(SPINNER_ANIMATION_PREFIX.length);
+  return SPINNER_VARIANTS.find((candidate) => candidate === variant);
 }
 
 /**

--- a/packages/research-agent-ui/src/ui/spinner.stories.tsx
+++ b/packages/research-agent-ui/src/ui/spinner.stories.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Spinner, { SPINNER_VARIANTS } from './spinner';
+
+/**
+ * `Spinner` is the shadcn/ui-style loading component from the GRAB-URL
+ * loading-animations set. It draws in `currentColor`, so a `text-*` class
+ * restyles it, and sizes off a single `size` prop.
+ */
+const meta: Meta<typeof Spinner> = {
+  title: 'UI/Spinner',
+  component: Spinner,
+  args: { size: 48 },
+  argTypes: {
+    variant: { control: 'select', options: [...SPINNER_VARIANTS] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Spinner>;
+
+/** The rotating spokes, drawn at the default size. */
+export const Default: Story = { args: { size: 24 } };
+
+/** All eight variants side by side. */
+export const AllVariants: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-6 text-muted-foreground">
+      {SPINNER_VARIANTS.map((variant) => (
+        <figure key={variant} className="flex flex-col items-center gap-2 w-28">
+          <Spinner {...args} variant={variant} />
+          <figcaption className="text-xs">{variant}</figcaption>
+        </figure>
+      ))}
+    </div>
+  ),
+};
+
+/** Recolored by the surrounding text color. */
+export const Colored: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-6">
+      <Spinner {...args} variant="circle" className="text-primary" />
+      <Spinner {...args} variant="bars" className="text-blue-500" />
+      <Spinner {...args} variant="ring" className="text-emerald-500" />
+    </div>
+  ),
+};

--- a/packages/research-agent-ui/src/ui/spinner.tsx
+++ b/packages/research-agent-ui/src/ui/spinner.tsx
@@ -1,0 +1,236 @@
+/**
+ * @fileoverview `Spinner` — the shadcn/ui-style loading component from the
+ * GRAB-URL loading-animations set, with eight variants. Every variant draws
+ * with `currentColor` and sizes off a single `size` prop, so a text-color
+ * utility class is all it takes to restyle one.
+ */
+'use client';
+
+import * as React from 'react';
+import { cn } from '../lib/utils';
+
+/** Every look `Spinner` can draw. */
+export const SPINNER_VARIANTS = [
+  'default',
+  'circle',
+  'pinwheel',
+  'circle-filled',
+  'ellipsis',
+  'ring',
+  'bars',
+  'infinite',
+] as const;
+
+/** One of the eight names in {@link SPINNER_VARIANTS}. */
+export type SpinnerVariant = (typeof SPINNER_VARIANTS)[number];
+
+export interface SpinnerProps
+  extends Omit<React.SVGProps<SVGSVGElement>, 'width' | 'height'> {
+  /** Which animation to draw. Defaults to the rotating spokes. */
+  variant?: SpinnerVariant;
+  /** Width and height in pixels. */
+  size?: number;
+}
+
+/** The lemniscate the `infinite` variant traces. */
+const INFINITY_LOOP =
+  'M12 12c-2-2.67-4-4-6-4a4 4 0 1 0 0 8c2 0 4-1.33 6-4Zm0 0c2 2.67 4 4 6 4a4 4 0 0 0 0-8c-2 0-4 1.33-6 4Z';
+
+/**
+ * Spins a group about the middle of the 24×24 viewBox. `transform-box` is set
+ * explicitly because an SVG child's default box is the element's own bounds in
+ * older engines, which would swing an arc around its own centre instead.
+ */
+const SPIN_ABOUT_CENTRE: React.CSSProperties = {
+  transformBox: 'view-box',
+  transformOrigin: 'center',
+};
+
+/** The eight spokes of the default variant, drawn faintest last so it reads as rotating. */
+const SPOKES: Array<[number, number, number, number]> = [
+  [12, 2, 12, 6],
+  [16.24, 7.76, 19.07, 4.93],
+  [18, 12, 22, 12],
+  [16.24, 16.24, 19.07, 19.07],
+  [12, 18, 12, 22],
+  [4.93, 19.07, 7.76, 16.24],
+  [2, 12, 6, 12],
+  [4.93, 4.93, 7.76, 7.76],
+];
+
+/**
+ * Draws the body of one variant inside the shared 24×24 viewBox.
+ *
+ * @param variant - Which look to draw
+ * @returns {React.ReactNode} The variant's SVG children
+ */
+const renderVariant = (variant: SpinnerVariant): React.ReactNode => {
+  switch (variant) {
+    case 'circle':
+      return (
+        <g className="animate-spin" style={SPIN_ABOUT_CENTRE}>
+          <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+        </g>
+      );
+
+    case 'pinwheel':
+      return (
+        <g className="animate-spin" style={SPIN_ABOUT_CENTRE}>
+          <path d="M22 12a1 1 0 0 1-10 0 1 1 0 0 0-10 0" />
+          <path d="M7 20.7a1 1 0 1 1 5-8.7 1 1 0 1 0 5-8.6" />
+          <path d="M7 3.3a1 1 0 1 1 5 8.6 1 1 0 1 0 5 8.6" />
+          <circle cx="12" cy="12" r="10" />
+        </g>
+      );
+
+    case 'circle-filled':
+      return (
+        <>
+          <circle cx="12" cy="12" r="9" opacity="0.2" />
+          <g className="animate-spin" style={SPIN_ABOUT_CENTRE}>
+            <path d="M21 12a9 9 0 0 0-9-9" />
+          </g>
+        </>
+      );
+
+    case 'ellipsis':
+      return (
+        <g fill="currentColor" stroke="none">
+          {[4, 12, 20].map((cx, index) => (
+            <circle key={cx} cx={cx} cy="12" r="2.5">
+              <animate
+                attributeName="cy"
+                values="12;7.5;12"
+                keyTimes="0;0.5;1"
+                dur="1.2s"
+                begin={`${index * 0.16}s`}
+                repeatCount="indefinite"
+              />
+            </circle>
+          ))}
+        </g>
+      );
+
+    case 'ring':
+      return (
+        <>
+          {[0, -0.8].map((begin) => (
+            <circle key={begin} cx="12" cy="12" r="2">
+              <animate
+                attributeName="r"
+                values="2;11"
+                dur="1.6s"
+                begin={`${begin}s`}
+                repeatCount="indefinite"
+              />
+              <animate
+                attributeName="opacity"
+                values="1;0"
+                dur="1.6s"
+                begin={`${begin}s`}
+                repeatCount="indefinite"
+              />
+            </circle>
+          ))}
+        </>
+      );
+
+    case 'bars':
+      return (
+        <g fill="currentColor" stroke="none">
+          {[2.5, 10, 17.5].map((x, index) => (
+            <rect key={x} x={x} y="8" width="4" height="8" rx="1.5">
+              <animate
+                attributeName="height"
+                values="8;18;8"
+                keyTimes="0;0.5;1"
+                dur="1.1s"
+                begin={`${index * 0.18}s`}
+                repeatCount="indefinite"
+              />
+              <animate
+                attributeName="y"
+                values="8;3;8"
+                keyTimes="0;0.5;1"
+                dur="1.1s"
+                begin={`${index * 0.18}s`}
+                repeatCount="indefinite"
+              />
+            </rect>
+          ))}
+        </g>
+      );
+
+    case 'infinite':
+      return (
+        <>
+          <path d={INFINITY_LOOP} opacity="0.2" />
+          {/* `pathLength` normalises the loop to 100 units, so the dash and its
+              travel are expressed as percentages rather than measured lengths. */}
+          <path d={INFINITY_LOOP} pathLength="100" strokeDasharray="25 75">
+            <animate
+              attributeName="stroke-dashoffset"
+              values="100;0"
+              dur="1.5s"
+              repeatCount="indefinite"
+            />
+          </path>
+        </>
+      );
+
+    default:
+      return (
+        <g className="animate-spin" style={SPIN_ABOUT_CENTRE}>
+          {SPOKES.map(([x1, y1, x2, y2], index) => (
+            <line
+              key={`${x1}-${y1}`}
+              x1={x1}
+              y1={y1}
+              x2={x2}
+              y2={y2}
+              opacity={1 - index * 0.1}
+            />
+          ))}
+        </g>
+      );
+  }
+};
+
+/**
+ * One loading animation, drawn in the current text color.
+ *
+ * @example
+ * ```tsx
+ * <Spinner />
+ * <Spinner variant="circle" size={48} />
+ * <Spinner variant="bars" className="text-primary" />
+ * ```
+ *
+ * @returns {JSX.Element} The rendered spinner
+ */
+const Spinner = ({
+  variant = 'default',
+  size = 24,
+  className,
+  ...props
+}: SpinnerProps) => (
+  <svg
+    aria-hidden="true"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    width={size}
+    height={size}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={cn('shrink-0', className)}
+    {...props}
+  >
+    {renderVariant(variant)}
+  </svg>
+);
+
+export default Spinner;
+export { Spinner };

--- a/packages/research-agent-ui/test/loadingAnimations.test.ts
+++ b/packages/research-agent-ui/test/loadingAnimations.test.ts
@@ -1,15 +1,20 @@
 /**
  * @fileoverview Unit tests for the chat loader pool: the spinner registry read
- * off `grab-url/animations`, the random picker, and SVG rendering.
+ * off `grab-url/animations`, the `<Spinner>` variants folded in beside it, the
+ * random picker, and SVG rendering.
  */
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
     LOADING_ANIMATION_NAMES,
     QUANTUM_SPHERE_ANIMATION,
+    SPINNER_ANIMATION_PREFIX,
+    SPINNER_LOADING_ANIMATIONS,
     SVG_LOADING_ANIMATIONS,
     getRandomLoadingAnimation,
+    getSpinnerVariant,
     renderLoadingAnimation,
 } from '../src/components/ChatConversation/loading-animations';
+import { SPINNER_VARIANTS } from '../src/ui/spinner';
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -27,13 +32,52 @@ describe('SVG_LOADING_ANIMATIONS', () => {
             ),
         ).toBe(true);
     });
+
+    it('drops the SVG twins of the <Spinner> variants', () => {
+        expect(Object.keys(SVG_LOADING_ANIMATIONS)).not.toContain('loadingSpokes');
+        expect(Object.keys(SVG_LOADING_ANIMATIONS)).not.toContain(
+            'loadingEqualizerBars',
+        );
+    });
+});
+
+describe('SPINNER_LOADING_ANIMATIONS', () => {
+    it('names every <Spinner> variant with the spinner prefix', () => {
+        expect(SPINNER_LOADING_ANIMATIONS).toHaveLength(SPINNER_VARIANTS.length);
+        expect(
+            SPINNER_LOADING_ANIMATIONS.every((name) =>
+                name.startsWith(SPINNER_ANIMATION_PREFIX),
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('getSpinnerVariant', () => {
+    it('reads the variant back out of a spinner pool name', () => {
+        for (const variant of SPINNER_VARIANTS) {
+            expect(getSpinnerVariant(`${SPINNER_ANIMATION_PREFIX}${variant}`)).toBe(
+                variant,
+            );
+        }
+    });
+
+    it('returns undefined for anything that is not a spinner pick', () => {
+        expect(getSpinnerVariant(QUANTUM_SPHERE_ANIMATION)).toBeUndefined();
+        expect(getSpinnerVariant('loadingSpinner')).toBeUndefined();
+        expect(getSpinnerVariant(`${SPINNER_ANIMATION_PREFIX}nope`)).toBeUndefined();
+    });
 });
 
 describe('LOADING_ANIMATION_NAMES', () => {
-    it('includes the quantum sphere alongside every SVG spinner', () => {
+    it('includes the quantum sphere and every spinner, SVG and React alike', () => {
         expect(LOADING_ANIMATION_NAMES).toContain(QUANTUM_SPHERE_ANIMATION);
+        expect(LOADING_ANIMATION_NAMES).toEqual(
+            expect.arrayContaining(SPINNER_LOADING_ANIMATIONS),
+        );
         expect(LOADING_ANIMATION_NAMES).toHaveLength(
-            Object.keys(SVG_LOADING_ANIMATIONS).length + 1,
+            Object.keys(SVG_LOADING_ANIMATIONS).length +
+                SPINNER_LOADING_ANIMATIONS.length +
+                1,
         );
     });
 
@@ -93,8 +137,9 @@ describe('renderLoadingAnimation', () => {
         expect(svg).toContain('height="64px"');
     });
 
-    it('returns an empty string for an unknown name', () => {
+    it('returns an empty string for a name it does not render', () => {
         expect(renderLoadingAnimation('nope', 64)).toBe('');
         expect(renderLoadingAnimation(QUANTUM_SPHERE_ANIMATION, 64)).toBe('');
+        expect(renderLoadingAnimation(SPINNER_LOADING_ANIMATIONS[0], 64)).toBe('');
     });
 });

--- a/packages/research-agent-ui/test/randomLoadingAnimation.test.tsx
+++ b/packages/research-agent-ui/test/randomLoadingAnimation.test.tsx
@@ -1,16 +1,18 @@
 /**
  * @fileoverview Render tests for the chat's randomized "thinking" loader:
- * that it mounts an SVG spinner, mounts the quantum sphere when that is the
- * pick, and exposes a status role for screen readers.
+ * that it mounts an SVG spinner, a `<Spinner>` variant, or the quantum sphere
+ * depending on the pick, and exposes a status role for screen readers.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import RandomLoadingAnimation from '../src/components/ChatConversation/RandomLoadingAnimation';
 import {
     QUANTUM_SPHERE_ANIMATION,
+    SPINNER_ANIMATION_PREFIX,
     SVG_LOADING_ANIMATIONS,
     getRandomLoadingAnimation,
 } from '../src/components/ChatConversation/loading-animations';
+import { SPINNER_VARIANTS } from '../src/ui/spinner';
 
 // The picker is random by design, so stub it to force each branch.
 vi.mock('../src/components/ChatConversation/loading-animations', async (importOriginal) => ({
@@ -46,6 +48,26 @@ describe('RandomLoadingAnimation', () => {
         // loadingSpinner is the multi-colour rotating dial.
         expect(container.innerHTML).toContain('animateTransform');
     });
+
+    it.each(SPINNER_VARIANTS)(
+        'renders the %s <Spinner> variant when that is the pick',
+        (variant) => {
+            pick(`${SPINNER_ANIMATION_PREFIX}${variant}`);
+
+            const { container } = render(<RandomLoadingAnimation size={48} />);
+
+            const svg = container.querySelector('svg');
+            expect(svg).toBeTruthy();
+            expect(svg?.getAttribute('width')).toBe('48');
+            // Spinner draws in the surrounding text colour rather than a fixed hex.
+            expect(svg?.getAttribute('stroke')).toBe('currentColor');
+            // Every variant animates, by CSS rotation or by SMIL.
+            expect(
+                container.innerHTML.includes('animate-spin') ||
+                    container.innerHTML.includes('<animate'),
+            ).toBe(true);
+        },
+    );
 
     it('renders the quantum sphere when that is the pick', () => {
         pick(QUANTUM_SPHERE_ANIMATION);


### PR DESCRIPTION
## Summary
Introduces a new `Spinner` React component from the GRAB-URL loading-animations set, integrating it into the chat's loading animation pool alongside existing SVG spinners and the quantum sphere.

## Key Changes

- **New `Spinner` component** (`packages/research-agent-ui/src/ui/spinner.tsx`):
  - Eight animation variants: `default`, `circle`, `pinwheel`, `circle-filled`, `ellipsis`, `ring`, `bars`, `infinite`
  - Draws in `currentColor` for easy recoloring via text color utilities
  - Single `size` prop for consistent sizing
  - Uses CSS animations (`animate-spin`) and SMIL `<animate>` elements depending on variant

- **Updated loading animation registry** (`loading-animations.ts`):
  - Added `SPINNER_ANIMATION_PREFIX` (`'spinner:'`) to namespace Spinner variants in the pool
  - Created `SPINNER_LOADING_ANIMATIONS` array mapping all 8 variants to pool names
  - Added `getSpinnerVariant()` function to extract variant from pool name
  - Filtered out SVG twins (`loadingSpokes`, `loadingEqualizerBars`, etc.) from `SVG_LOADING_ANIMATIONS` to avoid duplicate animations in rotation
  - Integrated Spinner variants into `LOADING_ANIMATION_NAMES` pool

- **Updated `RandomLoadingAnimation` component**:
  - Now renders `<Spinner>` components when a spinner variant is picked
  - Falls back to SVG rendering for non-spinner animations
  - Updated to use `getSpinnerVariant()` to determine which renderer to use

- **Added Storybook stories**:
  - New `spinner.stories.tsx` showcasing all variants, default size, and color customization
  - Updated `RandomLoadingAnimation.stories.tsx` to display both React and SVG spinners in the pool

- **Comprehensive test coverage**:
  - Tests for `SPINNER_LOADING_ANIMATIONS` pool naming
  - Tests for `getSpinnerVariant()` variant extraction
  - Tests for SVG twin filtering
  - Render tests for each Spinner variant in `RandomLoadingAnimation`
  - Updated pool size assertions to account for new variants

## Implementation Details

- Spinner variants use a shared 24×24 viewBox with `transformBox: 'view-box'` for proper rotation centering
- SVG twins are explicitly filtered to prevent duplicate animations when upgrading `grab-url/animations`
- The component is marked as `'use client'` for Next.js compatibility
- All animations respect the surrounding text color via `currentColor` stroke/fill

https://claude.ai/code/session_01JFFHgVJ5bCKNUZMt6tVq9o