### PR TITLE
✅ test(qwksearch-web): fix the config route suite and cover six more …

### DIFF
--- a/apps/qwksearch-web/app/api/__tests__/helpers/fake-db.ts
+++ b/apps/qwksearch-web/app/api/__tests__/helpers/fake-db.ts
@@ -51,6 +51,7 @@ const CHAIN_METHODS = [
   'leftJoin',
   'onConflictDoNothing',
   'onConflictDoUpdate',
+  'execute',
 ] as const;
 
 export interface FakeDb {

--- a/apps/qwksearch-web/app/api/admin/freekeys/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/admin/freekeys/__tests__/route.test.ts
@@ -1,0 +1,466 @@
+/**
+ * @fileoverview Route tests for the admin free-key diagnostics endpoint.
+ * It reports where each provider key is visible, masks the keys themselves,
+ * lists the free models the database knows about, and live-tests them —
+ * either one representative model per provider (summary mode) or every free
+ * model for a named provider (`?testAll=`).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/lib/auth/admin', () => ({ assertAdmin: vi.fn() }))
+vi.mock('@/lib/auth/session', () => ({ getSession: vi.fn() }))
+vi.mock('chat-agent-toolkit/config/environment-variables', () => ({ getEnv: vi.fn() }))
+vi.mock('chat-agent-toolkit/models/registry', () => ({ default: vi.fn() }))
+vi.mock('chat-agent-toolkit/config/language-models-database', () => ({
+  LANGUAGE_MODELS: [
+    {
+      provider: 'NVIDIA',
+      models: [
+        { id: 'nv/free-a', name: 'Free A', free: true, type: 'text-generation', contextLength: 8000 },
+        { id: 'nv/free-b', name: 'Free B', free: true, type: 'text', contextLength: 4000 },
+        { id: 'nv/paid', name: 'Paid', free: false, type: 'text-generation', contextLength: 8000 },
+        { id: 'nv/free-image', name: 'Image', free: true, type: 'image', contextLength: 0 },
+      ],
+    },
+    {
+      provider: 'OpenRouter',
+      models: [
+        { id: 'or/other', name: 'Other', free: true, type: 'text', contextLength: 1000 },
+        {
+          id: 'meta-llama/llama-3.3-70b-instruct:free',
+          name: 'Llama 3.3',
+          free: true,
+          type: 'text-generation',
+          contextLength: 128000,
+        },
+      ],
+    },
+    {
+      provider: 'AnyAPI',
+      models: [
+        { id: 'any/other', name: 'Other', free: true, type: 'text', contextLength: 1000 },
+        { id: 'deepseek/deepseek-v3:free', name: 'DeepSeek', free: true, type: 'text', contextLength: 64000 },
+      ],
+    },
+  ],
+}))
+
+import { assertAdmin } from '@/lib/auth/admin'
+import { getSession } from '@/lib/auth/session'
+import { getEnv } from 'chat-agent-toolkit/config/environment-variables'
+import ModelRegistry from 'chat-agent-toolkit/models/registry'
+import { GET } from '../route'
+
+const mockAssertAdmin = assertAdmin as unknown as ReturnType<typeof vi.fn>
+const mockGetSession = getSession as unknown as ReturnType<typeof vi.fn>
+const mockGetEnv = getEnv as unknown as ReturnType<typeof vi.fn>
+const mockRegistry = ModelRegistry as unknown as ReturnType<typeof vi.fn>
+
+const getActiveProviders = vi.fn()
+
+/**
+ * Stand the mocked registry up as a constructor — the route calls
+ * `new ModelRegistry()`, which needs a `function` implementation.
+ */
+function stubRegistry() {
+  mockRegistry.mockImplementation(function () {
+    return { getActiveProviders }
+  })
+}
+
+/** Serves the given env map to the route, and undefined for anything else. */
+function env(values: Record<string, string | undefined>) {
+  mockGetEnv.mockImplementation((key: string) => values[key])
+}
+
+/** The minimal NextRequest shape this route reads: a query string. */
+function request(query = '') {
+  const url = new URL(`http://localhost/api/admin/freekeys${query}`)
+  return { url: url.toString(), nextUrl: url } as any
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+/** A successful chat-completion response. */
+const chatOk = () => new Response('{}', { status: 200 })
+/** A `/models` listing response. */
+const modelsListing = (ids: string[]) =>
+  new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), { status: 200 })
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  stubRegistry()
+  mockAssertAdmin.mockResolvedValue(null)
+  mockGetSession.mockResolvedValue(null)
+  getActiveProviders.mockResolvedValue([])
+  env({})
+  fetchMock = vi.fn().mockResolvedValue(chatOk())
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+describe('GET /api/admin/freekeys authorization', () => {
+  it('returns the guard response for a non-admin without doing any work', async () => {
+    mockAssertAdmin.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 }),
+    )
+
+    const res = await GET(request())
+
+    expect(res.status).toBe(403)
+    expect(mockGetEnv).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/admin/freekeys summary mode', () => {
+  it('lists only the free text models for each provider', async () => {
+    const body = await (await GET(request())).json()
+
+    // The paid model and the image model are both filtered out.
+    expect(body.nvidia.freeModelCount).toBe(2)
+    expect(body.nvidia.freeModels.map((m: { id: string }) => m.id)).toEqual([
+      'nv/free-a',
+      'nv/free-b',
+    ])
+  })
+
+  it('reports each free model with its name and context length', async () => {
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.freeModels[0]).toEqual({
+      id: 'nv/free-a',
+      name: 'Free A',
+      contextLength: 8000,
+    })
+  })
+
+  it('reports a key as unconfigured and skips its live test when unset', async () => {
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.keyConfigured).toBe(false)
+    expect(body.nvidia.keyMasked).toBeNull()
+    expect(body.nvidia.liveTest).toEqual({ skipped: true, reason: 'no API key' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('masks a long key to its first eight and last four characters', async () => {
+    env({ NVIDIA_API_KEY: 'nvapi-abcdefghijklmnop' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.keyConfigured).toBe(true)
+    expect(body.nvidia.keyMasked).toBe('nvapi-ab...mnop')
+    expect(body.nvidia.keyMasked).not.toContain('cdefghijkl')
+  })
+
+  it('masks a short key to its first four characters only', async () => {
+    env({ NVIDIA_API_KEY: 'short-key' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.keyMasked).toBe('shor...')
+  })
+
+  it('falls back to the documented base URLs when none are configured', async () => {
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.baseUrl).toBe('https://integrate.api.nvidia.com/v1')
+    expect(body.openrouter.baseUrl).toBe('https://openrouter.ai/api/v1')
+    expect(body.anyapi.baseUrl).toBe('https://api.anyapi.ai/v1')
+  })
+
+  it('honours a configured base URL override', async () => {
+    env({ NVIDIA_BASE_URL: 'https://nvidia.internal/v1' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.baseUrl).toBe('https://nvidia.internal/v1')
+  })
+
+  it('live-tests the first free model when the key is set', async () => {
+    env({ NVIDIA_API_KEY: 'nvapi-key' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.liveTest).toMatchObject({ model: 'nv/free-a', ok: true, status: 200 })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://integrate.api.nvidia.com/v1/chat/completions')
+    expect(init.headers.Authorization).toBe('Bearer nvapi-key')
+    expect(JSON.parse(init.body)).toMatchObject({ model: 'nv/free-a', max_tokens: 5, stream: false })
+  })
+
+  it('prefers the known-good Llama model for the OpenRouter probe', async () => {
+    env({ OPENROUTER_API_KEY: 'or-key' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.openrouter.liveTest.model).toBe('meta-llama/llama-3.3-70b-instruct:free')
+  })
+
+  it('prefers the known-good DeepSeek model for the AnyAPI probe', async () => {
+    env({ ANYAPI_API_KEY: 'any-key' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.anyapi.liveTest.model).toBe('deepseek/deepseek-v3:free')
+  })
+
+  it('sends the OpenRouter attribution headers, and only to OpenRouter', async () => {
+    env({ OPENROUTER_API_KEY: 'or-key', NVIDIA_API_KEY: 'nv-key' })
+
+    await GET(request())
+
+    const orCall = fetchMock.mock.calls.find(([url]) => String(url).includes('openrouter.ai'))
+    const nvCall = fetchMock.mock.calls.find(([url]) => String(url).includes('nvidia.com'))
+    expect(orCall?.[1].headers['X-Title']).toBe('QwkSearch')
+    expect(nvCall?.[1].headers).not.toHaveProperty('X-Title')
+  })
+
+  it('reports a failed live test with its status and a truncated body', async () => {
+    env({ NVIDIA_API_KEY: 'nvapi-key' })
+    fetchMock.mockResolvedValue(new Response('x'.repeat(500), { status: 429 }))
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.liveTest).toMatchObject({ ok: false, status: 429 })
+    expect(body.nvidia.liveTest.error).toHaveLength(200)
+  })
+
+  it('reports a network failure as a not-ok live test carrying the message', async () => {
+    env({ NVIDIA_API_KEY: 'nvapi-key' })
+    fetchMock.mockRejectedValue(new Error('connection reset'))
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.liveTest).toMatchObject({ ok: false, error: 'connection reset' })
+  })
+
+  it('reports which env sources a key is visible through', async () => {
+    vi.stubEnv('NVIDIA_API_KEY', 'from-process-env')
+    env({ NVIDIA_API_KEY: 'from-process-env' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.key).toMatchObject({
+      set: true,
+      sources: { processEnv: true, cloudflareEnv: false },
+    })
+  })
+
+  it('reports a key that no env source exposes as unset', async () => {
+    const body = await (await GET(request())).json()
+
+    expect(body.nvidia.key).toEqual({
+      set: false,
+      masked: null,
+      sources: { cloudflareEnv: false, processEnv: false },
+    })
+  })
+
+  it('reports the provider list guests actually receive', async () => {
+    getActiveProviders.mockResolvedValue([
+      { name: 'NVIDIA', type: 'nvidia', chatModels: [{ key: 'a' }, { key: 'b' }] },
+    ])
+
+    const body = await (await GET(request())).json()
+
+    expect(body.guestProviders.providers).toEqual([
+      { name: 'NVIDIA', type: 'nvidia', modelCount: 2 },
+    ])
+    expect(body.guestProviders.error).toBeNull()
+  })
+
+  it('reports a registry failure instead of failing the whole diagnostic', async () => {
+    getActiveProviders.mockRejectedValue(new Error('registry unavailable'))
+
+    const res = await GET(request())
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.guestProviders.providers).toEqual([])
+    expect(body.guestProviders.error).toBe('registry unavailable')
+  })
+
+  it('mirrors which providers will load for guests', async () => {
+    env({ OPENROUTER_API_KEY: 'or-key' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.guestLogic).toMatchObject({
+      openrouterKeySet: true,
+      openrouterWillBeLoaded: true,
+      nvidiaWillBeLoaded: false,
+      anyapiWillBeLoaded: false,
+    })
+  })
+
+  it('reports an anonymous request as signed out', async () => {
+    const body = await (await GET(request())).json()
+
+    expect(body.auth.session).toEqual({ signedIn: false })
+  })
+
+  it('reports the signed-in identity of the calling request', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'user-1', email: 'ada@example.com' } })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.auth.session).toEqual({
+      signedIn: true,
+      userId: 'user-1',
+      email: 'ada@example.com',
+    })
+  })
+
+  it('reports a session lookup failure without failing the diagnostic', async () => {
+    mockGetSession.mockRejectedValue(new Error('cookie decode failed'))
+
+    const body = await (await GET(request())).json()
+
+    expect(body.auth.session).toEqual({ signedIn: false, error: 'cookie decode failed' })
+  })
+
+  it('warns that a missing BETTER_AUTH_SECRET invalidates sessions on restart', async () => {
+    const body = await (await GET(request())).json()
+
+    expect(body.auth.betterAuthSecretSet).toBe(false)
+    expect(body.auth.note).toMatch(/BETTER_AUTH_SECRET is not set/)
+  })
+
+  it('confirms sessions survive restarts once the secret is set', async () => {
+    env({ BETTER_AUTH_SECRET: 'a-secret', GOOGLE_CLIENT_ID: 'id', GOOGLE_CLIENT_SECRET: 'secret' })
+
+    const body = await (await GET(request())).json()
+
+    expect(body.auth.betterAuthSecretSet).toBe(true)
+    expect(body.auth.googleOAuthConfigured).toBe(true)
+    expect(body.auth.note).toMatch(/will survive worker restarts/i)
+  })
+
+  it('never leaks a raw key into the response', async () => {
+    env({
+      NVIDIA_API_KEY: 'nvapi-supersecretvalue',
+      OPENROUTER_API_KEY: 'or-supersecretvalue',
+      ANYAPI_API_KEY: 'any-supersecretvalue',
+    })
+
+    const raw = await (await GET(request())).text()
+
+    expect(raw).not.toContain('nvapi-supersecretvalue')
+    expect(raw).not.toContain('or-supersecretvalue')
+    expect(raw).not.toContain('any-supersecretvalue')
+  })
+})
+
+describe('GET /api/admin/freekeys?testAll', () => {
+  it('tests only the named provider', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key', OPENROUTER_API_KEY: 'or-key' })
+
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    expect(Object.keys(body)).toEqual(['nvidia'])
+  })
+
+  it('tests every provider for testAll=all', async () => {
+    const body = await (await GET(request('?testAll=all'))).json()
+
+    expect(Object.keys(body).sort()).toEqual(['anyapi', 'nvidia', 'openrouter'])
+  })
+
+  it('reports a missing key instead of testing', async () => {
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    expect(body.nvidia).toEqual({ error: 'NVIDIA_API_KEY not set' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('live-tests every free model for the provider', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key' })
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/models') ? modelsListing(['nv/free-a', 'nv/free-b']) : chatOk(),
+    )
+
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    expect(body.nvidia.upstreamModelsFetched).toBe(true)
+    expect(body.nvidia.results).toHaveLength(2)
+    expect(body.nvidia.results.every((r: { ok: boolean }) => r.ok)).toBe(true)
+  })
+
+  it('skips the live call for a model the provider no longer lists', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key' })
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/models') ? modelsListing(['nv/free-a']) : chatOk(),
+    )
+
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    const dropped = body.nvidia.results.find((r: { model: string }) => r.model === 'nv/free-b')
+    expect(dropped).toMatchObject({
+      ok: false,
+      existsUpstream: false,
+      error: 'model not listed by provider /models endpoint',
+      ms: 0,
+    })
+    // Only the listed model reached /chat/completions.
+    const chatCalls = fetchMock.mock.calls.filter(([u]) => String(u).endsWith('/chat/completions'))
+    expect(chatCalls).toHaveLength(1)
+  })
+
+  it('still tests every model when the upstream listing is unavailable', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key' })
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/models') ? new Response('nope', { status: 500 }) : chatOk(),
+    )
+
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    expect(body.nvidia.upstreamModelsFetched).toBe(false)
+    expect(body.nvidia.results).toHaveLength(2)
+    expect(body.nvidia.results[0].existsUpstream).toBeUndefined()
+  })
+
+  it('treats an empty upstream listing as unavailable rather than as "no models exist"', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key' })
+    fetchMock.mockImplementation(async (url: string) =>
+      String(url).endsWith('/models') ? modelsListing([]) : chatOk(),
+    )
+
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    expect(body.nvidia.upstreamModelsFetched).toBe(false)
+    expect(body.nvidia.results.every((r: { ok: boolean }) => r.ok)).toBe(true)
+  })
+
+  it('records a per-model failure without aborting the run', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key' })
+    fetchMock.mockImplementation(async (url: string, init: RequestInit = {}) => {
+      if (String(url).endsWith('/models')) return modelsListing(['nv/free-a', 'nv/free-b'])
+      return JSON.parse(String(init.body)).model === 'nv/free-a'
+        ? new Response('rate limited', { status: 429 })
+        : chatOk()
+    })
+
+    const body = await (await GET(request('?testAll=nvidia'))).json()
+
+    const byModel = Object.fromEntries(
+      body.nvidia.results.map((r: { model: string }) => [r.model, r]),
+    )
+    expect(byModel['nv/free-a']).toMatchObject({ ok: false, status: 429 })
+    expect(byModel['nv/free-b']).toMatchObject({ ok: true })
+  })
+
+  it('ignores an unrecognised testAll value', async () => {
+    env({ NVIDIA_API_KEY: 'nv-key' })
+
+    const body = await (await GET(request('?testAll=bogus'))).json()
+
+    expect(body).toEqual({})
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/qwksearch-web/app/api/auth/providers/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/auth/providers/__tests__/route.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Route tests for the OAuth provider discovery endpoint the
+ * sign-in page uses to decide which social buttons to render. A provider is
+ * only advertised when both halves of its credential pair are configured,
+ * and Google additionally has to not be the placeholder from `.env.example`.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/config/env', () => ({ getEnv: vi.fn() }))
+
+import { getEnv } from '@/lib/config/env'
+import { GET } from '../route'
+
+const mockGetEnv = getEnv as unknown as ReturnType<typeof vi.fn>
+
+const GOOGLE_PLACEHOLDER_ID = 'your-google-client-id.apps.googleusercontent.com'
+const GOOGLE_PLACEHOLDER_SECRET = 'your-google-client-secret'
+
+/** Serves the given env map to the route, and undefined for anything else. */
+function env(values: Record<string, string | undefined>) {
+  mockGetEnv.mockImplementation((key: string) => values[key])
+}
+
+const providers = async () => (await (await GET()).json()).providers as string[]
+
+const ALL_CONFIGURED = {
+  GOOGLE_CLIENT_ID: 'real-google-id',
+  GOOGLE_CLIENT_SECRET: 'real-google-secret',
+  AUTH_DISCORD_ID: 'discord-id',
+  AUTH_DISCORD_SECRET: 'discord-secret',
+  AUTH_LINKEDIN_ID: 'linkedin-id',
+  AUTH_LINKEDIN_SECRET: 'linkedin-secret',
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/auth/providers', () => {
+  it('advertises nothing when no provider is configured', async () => {
+    env({})
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('advertises every configured provider', async () => {
+    env(ALL_CONFIGURED)
+
+    expect(await providers()).toEqual(['google', 'discord', 'linkedin'])
+  })
+
+  it('advertises Google when both halves are real', async () => {
+    env({ GOOGLE_CLIENT_ID: 'real-google-id', GOOGLE_CLIENT_SECRET: 'real-google-secret' })
+
+    expect(await providers()).toEqual(['google'])
+  })
+
+  it('hides Google when only the client id is set', async () => {
+    env({ GOOGLE_CLIENT_ID: 'real-google-id' })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('hides Google when only the client secret is set', async () => {
+    env({ GOOGLE_CLIENT_SECRET: 'real-google-secret' })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('hides Google when the client id is still the example placeholder', async () => {
+    env({ GOOGLE_CLIENT_ID: GOOGLE_PLACEHOLDER_ID, GOOGLE_CLIENT_SECRET: 'real-google-secret' })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('hides Google when the client secret is still the example placeholder', async () => {
+    env({ GOOGLE_CLIENT_ID: 'real-google-id', GOOGLE_CLIENT_SECRET: GOOGLE_PLACEHOLDER_SECRET })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('hides a provider whose credentials are empty strings', async () => {
+    env({ AUTH_DISCORD_ID: '', AUTH_DISCORD_SECRET: '' })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('advertises Discord independently of the others', async () => {
+    env({ AUTH_DISCORD_ID: 'discord-id', AUTH_DISCORD_SECRET: 'discord-secret' })
+
+    expect(await providers()).toEqual(['discord'])
+  })
+
+  it('hides Discord when only one half is set', async () => {
+    env({ AUTH_DISCORD_ID: 'discord-id' })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('advertises LinkedIn independently of the others', async () => {
+    env({ AUTH_LINKEDIN_ID: 'linkedin-id', AUTH_LINKEDIN_SECRET: 'linkedin-secret' })
+
+    expect(await providers()).toEqual(['linkedin'])
+  })
+
+  it('hides LinkedIn when only one half is set', async () => {
+    env({ AUTH_LINKEDIN_SECRET: 'linkedin-secret' })
+
+    expect(await providers()).toEqual([])
+  })
+
+  it('answers with JSON under a providers key', async () => {
+    env(ALL_CONFIGURED)
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ providers: ['google', 'discord', 'linkedin'] })
+  })
+})

--- a/apps/qwksearch-web/app/api/config/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/config/__tests__/route.test.ts
@@ -24,9 +24,7 @@ vi.mock('@/lib/config', () => ({
 }))
 
 vi.mock('chat-agent-toolkit/models/registry', () => ({
-  default: vi.fn().mockImplementation(() => ({
-    getActiveProviders: vi.fn().mockResolvedValue([]),
-  })),
+  default: vi.fn(),
 }))
 
 vi.mock('@/lib/config/env', () => ({
@@ -52,6 +50,16 @@ const mockUpdateConfig = configManager.updateConfig as ReturnType<typeof vi.fn>
 const mockGetEnv = getEnv as ReturnType<typeof vi.fn>
 const mockModelRegistry = ModelRegistry as unknown as ReturnType<typeof vi.fn>
 
+/**
+ * Point the mocked ModelRegistry constructor at a fixed set of active
+ * providers. Uses a `function` implementation so `new ModelRegistry()` works.
+ */
+function stubModelRegistry(providers: unknown[]) {
+  mockModelRegistry.mockImplementation(function () {
+    return { getActiveProviders: vi.fn().mockResolvedValue(providers) }
+  })
+}
+
 const baseConfig = () => ({
   modelProviders: [],
   search: { tavilyApiKey: '' },
@@ -63,10 +71,11 @@ beforeEach(() => {
   mockGetUIConfigSections.mockReturnValue([])
   mockGetEnv.mockReturnValue(undefined)
   // restoreMocks (vitest config) wipes the factory implementation before each
-  // test, so re-establish the default ModelRegistry behavior here.
-  mockModelRegistry.mockImplementation(() => ({
-    getActiveProviders: vi.fn().mockResolvedValue([]),
-  }))
+  // test, so re-establish the default ModelRegistry behavior here. The route
+  // calls `new ModelRegistry()`, and vitest only lets a mock stand in for a
+  // constructor when its implementation is a `function` (an arrow throws
+  // "is not a constructor"), so keep these implementations non-arrow.
+  stubModelRegistry([])
   // null = authorized; tests for the guard override this per-case.
   ;(assertAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(null)
 })
@@ -93,11 +102,7 @@ describe('GET /api/config', () => {
       modelProviders: [{ id: 'openai', chatModels: [] }],
       search: { tavilyApiKey: '' },
     })
-    mockModelRegistry.mockImplementation(() => ({
-      getActiveProviders: vi.fn().mockResolvedValue([
-        { id: 'openai', chatModels: [{ key: 'gpt-4o' }] },
-      ]),
-    }))
+    stubModelRegistry([{ id: 'openai', chatModels: [{ key: 'gpt-4o' }] }])
 
     const res = await GET(makeRequest())
     const data = await res.json()

--- a/apps/qwksearch-web/app/api/search/engines/__tests__/engine-admin.test.ts
+++ b/apps/qwksearch-web/app/api/search/engines/__tests__/engine-admin.test.ts
@@ -1,0 +1,224 @@
+/**
+ * @fileoverview Route tests for the two engine administration endpoints:
+ * `/status`, which reads and writes the enabled-engine list in the config,
+ * and `/test`, which probes each named engine with a throwaway query.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/config', () => ({
+  default: { getConfig: vi.fn(), updateConfig: vi.fn() },
+}))
+
+vi.mock('search-web-api/search/search-query-executor.js', () => ({
+  Search: vi.fn(),
+}))
+
+import configManager from '@/lib/config'
+import { Search } from 'search-web-api/search/search-query-executor.js'
+import { jsonRequest } from '../../../__tests__/helpers/fake-db'
+import { GET as GET_STATUS, POST as POST_STATUS } from '../status/route'
+import { POST as POST_TEST } from '../test/route'
+
+const mockGetConfig = configManager.getConfig as unknown as ReturnType<typeof vi.fn>
+const mockUpdateConfig = configManager.updateConfig as unknown as ReturnType<typeof vi.fn>
+const mockSearch = Search as unknown as ReturnType<typeof vi.fn>
+
+const search = vi.fn()
+
+/**
+ * Stand the mocked `Search` class up as a constructor. The implementation
+ * has to be a `function` — an arrow implementation makes `new Search()`
+ * throw "is not a constructor".
+ */
+function stubSearch() {
+  mockSearch.mockImplementation(function () {
+    return { search }
+  })
+}
+
+const statusRequest = (body: unknown) =>
+  POST_STATUS(jsonRequest('http://localhost/api/search/engines/status', 'POST', body))
+const testRequest = (body: unknown) =>
+  POST_TEST(jsonRequest('http://localhost/api/search/engines/test', 'POST', body))
+
+/** A POST whose body is not valid JSON, to drive the outer catch. */
+const brokenBodyRequest = (url: string) =>
+  new Request(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{oops',
+  }) as any
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  stubSearch()
+  search.mockResolvedValue([{ title: 'a result' }])
+})
+
+describe('GET /api/search/engines/status', () => {
+  it('returns the enabled engines from the config', async () => {
+    mockGetConfig.mockReturnValue(['google', 'brave'])
+
+    const res = await GET_STATUS()
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ enabledEngines: ['google', 'brave'] })
+    expect(mockGetConfig).toHaveBeenCalledWith('search.enabledEngines', [])
+  })
+
+  it('returns an empty list when nothing is enabled yet', async () => {
+    mockGetConfig.mockReturnValue([])
+
+    expect(await (await GET_STATUS()).json()).toEqual({ enabledEngines: [] })
+  })
+
+  it('500s when the config read throws', async () => {
+    mockGetConfig.mockImplementation(() => {
+      throw new Error('config unreadable')
+    })
+
+    const res = await GET_STATUS()
+
+    expect(res.status).toBe(500)
+    expect((await res.json()).message).toBe('Failed to fetch engine status')
+  })
+})
+
+describe('POST /api/search/engines/status', () => {
+  it('persists the submitted engine list', async () => {
+    const res = await statusRequest({ enabledEngines: ['google', 'ddg'] })
+
+    expect(res.status).toBe(200)
+    expect(mockUpdateConfig).toHaveBeenCalledWith('search.enabledEngines', ['google', 'ddg'])
+    expect((await res.json()).message).toBe('Engine status updated')
+  })
+
+  it('accepts an empty list, disabling every engine', async () => {
+    const res = await statusRequest({ enabledEngines: [] })
+
+    expect(res.status).toBe(200)
+    expect(mockUpdateConfig).toHaveBeenCalledWith('search.enabledEngines', [])
+  })
+
+  it('400s when enabledEngines is not an array', async () => {
+    const res = await statusRequest({ enabledEngines: 'google' })
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toBe('enabledEngines must be an array')
+    expect(mockUpdateConfig).not.toHaveBeenCalled()
+  })
+
+  it('400s when enabledEngines is missing', async () => {
+    const res = await statusRequest({})
+
+    expect(res.status).toBe(400)
+    expect(mockUpdateConfig).not.toHaveBeenCalled()
+  })
+
+  it('500s when the config write throws', async () => {
+    mockUpdateConfig.mockImplementation(() => {
+      throw new Error('read-only config')
+    })
+
+    const res = await statusRequest({ enabledEngines: ['google'] })
+
+    expect(res.status).toBe(500)
+    expect((await res.json()).message).toBe('Failed to update engine status')
+  })
+
+  it('500s on an unparseable body', async () => {
+    const res = await POST_STATUS(brokenBodyRequest('http://localhost/api/search/engines/status'))
+
+    expect(res.status).toBe(500)
+  })
+})
+
+describe('POST /api/search/engines/test', () => {
+  it('reports an engine that returns results as working', async () => {
+    const res = await testRequest({ engines: ['google'] })
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ results: { google: { working: true } } })
+  })
+
+  it('probes each engine by name with a one-page throwaway query', async () => {
+    await testRequest({ engines: ['google'] })
+
+    expect(search).toHaveBeenCalledWith('test', 1, ['google'])
+  })
+
+  it('reports an engine that returns nothing as not working', async () => {
+    search.mockResolvedValue([])
+
+    const { results } = await (await testRequest({ engines: ['google'] })).json()
+
+    expect(results.google).toEqual({ working: false })
+  })
+
+  it('reports a non-array result as not working', async () => {
+    search.mockResolvedValue(null)
+
+    const { results } = await (await testRequest({ engines: ['google'] })).json()
+
+    expect(results.google).toEqual({ working: false })
+  })
+
+  it('records the failure message for an engine that throws', async () => {
+    search.mockRejectedValue(new Error('403 from upstream'))
+
+    const { results } = await (await testRequest({ engines: ['google'] })).json()
+
+    expect(results.google).toEqual({ working: false, error: '403 from upstream' })
+  })
+
+  it('labels a non-Error rejection as an unknown error', async () => {
+    search.mockRejectedValue('just a string')
+
+    const { results } = await (await testRequest({ engines: ['google'] })).json()
+
+    expect(results.google).toEqual({ working: false, error: 'Unknown error' })
+  })
+
+  it('keeps probing the remaining engines after one fails', async () => {
+    search
+      .mockRejectedValueOnce(new Error('down'))
+      .mockResolvedValueOnce([{ title: 'a result' }])
+
+    const { results } = await (await testRequest({ engines: ['broken', 'google'] })).json()
+
+    expect(results).toEqual({
+      broken: { working: false, error: 'down' },
+      google: { working: true },
+    })
+  })
+
+  it('400s when engines is missing', async () => {
+    const res = await testRequest({})
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toBe('engines array is required')
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it('400s on an empty engines array', async () => {
+    const res = await testRequest({ engines: [] })
+
+    expect(res.status).toBe(400)
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it('400s when engines is not an array', async () => {
+    const res = await testRequest({ engines: 'google' })
+
+    expect(res.status).toBe(400)
+    expect(search).not.toHaveBeenCalled()
+  })
+
+  it('500s on an unparseable body', async () => {
+    const res = await POST_TEST(brokenBodyRequest('http://localhost/api/search/engines/test'))
+
+    expect(res.status).toBe(500)
+    expect((await res.json()).message).toBe('Failed to test engines')
+  })
+})

--- a/apps/qwksearch-web/app/api/user/__tests__/route.test.ts
+++ b/apps/qwksearch-web/app/api/user/__tests__/route.test.ts
@@ -1,0 +1,404 @@
+/**
+ * @fileoverview Route tests for the account endpoints: the profile
+ * (read / update / delete), the password change, and the storage quota
+ * readout. All three are session-gated.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/auth/session', () => ({ getSession: vi.fn(), getUserId: vi.fn() }))
+vi.mock('@/lib/database', () => ({ getDB: vi.fn() }))
+vi.mock('@/lib/auth', () => ({ initAuth: vi.fn() }))
+vi.mock('next/headers', () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }))
+vi.mock('@/lib/storage/quota', () => ({ getUserStorageStats: vi.fn() }))
+
+import { getSession, getUserId } from '@/lib/auth/session'
+import { getDB } from '@/lib/database'
+import { initAuth } from '@/lib/auth'
+import { getUserStorageStats } from '@/lib/storage/quota'
+import { createFakeDb, jsonRequest, type FakeDb } from '../../__tests__/helpers/fake-db'
+import { GET, PATCH, DELETE } from '../route'
+import { POST as CHANGE_PASSWORD } from '../password/route'
+import { GET as GET_STORAGE } from '../storage/route'
+
+const mockGetSession = getSession as unknown as ReturnType<typeof vi.fn>
+const mockGetUserId = getUserId as unknown as ReturnType<typeof vi.fn>
+const mockGetDB = getDB as unknown as ReturnType<typeof vi.fn>
+const mockInitAuth = initAuth as unknown as ReturnType<typeof vi.fn>
+const mockStorageStats = getUserStorageStats as unknown as ReturnType<typeof vi.fn>
+
+const deleteUser = vi.fn()
+const changePassword = vi.fn()
+
+const storedUser = (overrides: Record<string, unknown> = {}) => ({
+  id: 'user-1',
+  name: 'Ada',
+  email: 'ada@example.com',
+  image: null,
+  apiKey: 'qwk_existing',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+})
+
+function setup(options: Parameters<typeof createFakeDb>[0] = {}): FakeDb {
+  const db = createFakeDb(options)
+  mockGetDB.mockReturnValue(db)
+  mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+  mockGetUserId.mockResolvedValue('user-1')
+  return db
+}
+
+const patch = (body: unknown) => PATCH(jsonRequest('http://localhost/api/user', 'PATCH', body))
+const changePasswordRequest = (body: unknown) =>
+  CHANGE_PASSWORD(jsonRequest('http://localhost/api/user/password', 'POST', body))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  mockInitAuth.mockResolvedValue({ api: { deleteUser, changePassword } })
+  deleteUser.mockResolvedValue({ success: true })
+  changePassword.mockResolvedValue({})
+})
+
+describe('GET /api/user', () => {
+  it('401s without a session', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    const res = await GET()
+
+    expect(res.status).toBe(401)
+    expect((await res.json()).message).toBe('Unauthorized')
+  })
+
+  it('returns the stored profile', async () => {
+    setup({ select: [storedUser()] })
+
+    const res = await GET()
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toMatchObject({ id: 'user-1', name: 'Ada', email: 'ada@example.com' })
+  })
+
+  it('404s when the session user has no row', async () => {
+    setup({ select: [] })
+
+    const res = await GET()
+
+    expect(res.status).toBe(404)
+    expect((await res.json()).message).toBe('User not found')
+  })
+
+  it('mints and persists an API key when the profile has none', async () => {
+    const db = setup({ select: [storedUser({ apiKey: null })] })
+
+    const res = await GET()
+
+    const body = await res.json()
+    expect(body.apiKey).toMatch(/^qwk_[0-9a-f]{32}$/)
+    // The freshly minted key is written back, not just returned.
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update.apiKey).toBe(body.apiKey)
+  })
+
+  it('leaves an existing API key alone', async () => {
+    const db = setup({ select: [storedUser({ apiKey: 'qwk_existing' })] })
+
+    const res = await GET()
+
+    expect((await res.json()).apiKey).toBe('qwk_existing')
+    expect(db.calls.update).toBeUndefined()
+  })
+})
+
+describe('PATCH /api/user', () => {
+  it('401s without a session', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    const res = await patch({ name: 'Ada' })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('updates the name', async () => {
+    const db = setup()
+
+    const res = await patch({ name: 'Grace' })
+
+    expect(res.status).toBe(200)
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update.name).toBe('Grace')
+    expect(update.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('rejects a name longer than 32 characters', async () => {
+    const db = setup()
+
+    const res = await patch({ name: 'x'.repeat(33) })
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toMatch(/32 characters/)
+    expect(db.calls.update).toBeUndefined()
+  })
+
+  it('accepts a name of exactly 32 characters', async () => {
+    const db = setup()
+
+    const res = await patch({ name: 'x'.repeat(32) })
+
+    expect(res.status).toBe(200)
+    expect(db.calls.update).toHaveLength(1)
+  })
+
+  it('rejects a non-string name', async () => {
+    const db = setup()
+
+    const res = await patch({ name: 42 })
+
+    expect(res.status).toBe(400)
+    expect(db.calls.update).toBeUndefined()
+  })
+
+  it('rejects a malformed email', async () => {
+    const db = setup()
+
+    const res = await patch({ email: 'not-an-email' })
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toMatch(/valid email/)
+    expect(db.calls.update).toBeUndefined()
+  })
+
+  it('updates a well-formed email', async () => {
+    const db = setup()
+
+    const res = await patch({ email: 'grace@example.com' })
+
+    expect(res.status).toBe(200)
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update.email).toBe('grace@example.com')
+  })
+
+  it('updates the avatar image', async () => {
+    const db = setup()
+
+    await patch({ image: 'https://cdn.example.com/a.png' })
+
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update.image).toBe('https://cdn.example.com/a.png')
+  })
+
+  it('clears the avatar when image is explicitly null', async () => {
+    const db = setup()
+
+    await patch({ image: null })
+
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update).toHaveProperty('image', null)
+  })
+
+  it('regenerates the API key on request', async () => {
+    const db = setup()
+
+    const res = await patch({ regenerateApiKey: true })
+
+    expect(res.status).toBe(200)
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update.apiKey).toMatch(/^qwk_[0-9a-f]{32}$/)
+  })
+
+  it('leaves the API key alone when regeneration is not requested', async () => {
+    const db = setup()
+
+    await patch({ name: 'Grace' })
+
+    const [update] = db.calls.set[0] as [Record<string, unknown>]
+    expect(update).not.toHaveProperty('apiKey')
+  })
+
+  it('touches only updatedAt for an empty body', async () => {
+    const db = setup()
+
+    const res = await patch({})
+
+    expect(res.status).toBe(200)
+    expect(Object.keys(db.calls.set[0][0] as object)).toEqual(['updatedAt'])
+  })
+})
+
+describe('DELETE /api/user', () => {
+  it('401s without a session', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    const res = await DELETE()
+
+    expect(res.status).toBe(401)
+  })
+
+  it('deletes the account through better-auth', async () => {
+    setup()
+
+    const res = await DELETE()
+
+    expect(res.status).toBe(200)
+    expect(deleteUser).toHaveBeenCalledTimes(1)
+    expect((await res.json()).message).toMatch(/deleted successfully/i)
+  })
+
+  it('400s with the auth message when better-auth reports failure', async () => {
+    setup()
+    deleteUser.mockResolvedValue({ success: false, message: 'Re-authenticate first.' })
+
+    const res = await DELETE()
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toBe('Re-authenticate first.')
+  })
+
+  it('surfaces a client-side auth error message on a 403', async () => {
+    setup()
+    deleteUser.mockRejectedValue(Object.assign(new Error('Not allowed'), { status: 403 }))
+
+    const res = await DELETE()
+
+    expect(res.status).toBe(500)
+    expect((await res.json()).message).toBe('Not allowed')
+  })
+
+  it('hides the detail of an unexpected server error', async () => {
+    setup()
+    deleteUser.mockRejectedValue(new Error('postgres exploded at 10.0.0.4'))
+
+    const res = await DELETE()
+
+    expect(res.status).toBe(500)
+    expect((await res.json()).message).toBe('Failed to delete account.')
+  })
+})
+
+describe('POST /api/user/password', () => {
+  it('401s without a session', async () => {
+    mockGetSession.mockResolvedValue(null)
+
+    const res = await changePasswordRequest({ currentPassword: 'a', newPassword: 'longenough' })
+
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects a new password shorter than 8 characters', async () => {
+    setup()
+
+    const res = await changePasswordRequest({ currentPassword: 'old', newPassword: 'short' })
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toMatch(/at least 8 characters/)
+    expect(changePassword).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing new password', async () => {
+    setup()
+
+    const res = await changePasswordRequest({ currentPassword: 'old' })
+
+    expect(res.status).toBe(400)
+    expect(changePassword).not.toHaveBeenCalled()
+  })
+
+  it('accepts a new password of exactly 8 characters', async () => {
+    setup()
+
+    const res = await changePasswordRequest({ currentPassword: 'old', newPassword: '12345678' })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('changes the password without revoking the other sessions', async () => {
+    setup()
+
+    const res = await changePasswordRequest({ currentPassword: 'old', newPassword: 'new-password' })
+
+    expect(res.status).toBe(200)
+    expect(changePassword).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: { currentPassword: 'old', newPassword: 'new-password', revokeOtherSessions: false },
+      }),
+    )
+  })
+
+  it('400s with the auth error when the current password is wrong', async () => {
+    setup()
+    changePassword.mockRejectedValue(new Error('Invalid password'))
+
+    const res = await changePasswordRequest({ currentPassword: 'wrong', newPassword: 'new-password' })
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toBe('Invalid password')
+  })
+
+  it('falls back to a generic message when the auth error has none', async () => {
+    setup()
+    changePassword.mockRejectedValue({})
+
+    const res = await changePasswordRequest({ currentPassword: 'old', newPassword: 'new-password' })
+
+    expect(res.status).toBe(400)
+    expect((await res.json()).message).toBe('Failed to change password.')
+  })
+})
+
+describe('GET /api/user/storage', () => {
+  it('401s without a session', async () => {
+    mockGetUserId.mockResolvedValue(null)
+
+    const res = await GET_STORAGE()
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the raw byte figures alongside rounded megabytes', async () => {
+    setup()
+    mockStorageStats.mockResolvedValue({
+      used: 5 * 1024 * 1024,
+      quota: 20 * 1024 * 1024,
+      remaining: 15 * 1024 * 1024,
+      allowed: true,
+    })
+
+    const res = await GET_STORAGE()
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      used: 5242880,
+      quota: 20971520,
+      remaining: 15728640,
+      allowed: true,
+      usedMB: 5,
+      quotaMB: 20,
+      remainingMB: 15,
+      percentage: 25,
+    })
+  })
+
+  it('reports 100 percent for a full quota', async () => {
+    setup()
+    mockStorageStats.mockResolvedValue({
+      used: 1024,
+      quota: 1024,
+      remaining: 0,
+      allowed: false,
+    })
+
+    const { percentage, allowed } = await (await GET_STORAGE()).json()
+
+    expect(percentage).toBe(100)
+    expect(allowed).toBe(false)
+  })
+
+  it('500s when the quota lookup fails', async () => {
+    setup()
+    mockStorageStats.mockRejectedValue(new Error('db down'))
+
+    const res = await GET_STORAGE()
+
+    expect(res.status).toBe(500)
+    expect((await res.json()).message).toBe('Failed to fetch storage stats')
+  })
+})

--- a/apps/qwksearch-web/lib/__tests__/cors.test.ts
+++ b/apps/qwksearch-web/lib/__tests__/cors.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @fileoverview Tests for the CORS allowlist wrapper used by the public
+ * agent API routes. The allowlist is baked in at module load from
+ * NODE_ENV, so under vitest (NODE_ENV=test) the localhost dev origins
+ * are part of it alongside the debate-ai.com production origins.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { withCors, corsPreflight } from '../cors'
+
+const ALLOWED = 'https://debate-ai.com'
+const ALLOWED_WWW = 'https://www.debate-ai.com'
+const DENIED = 'https://evil.example.com'
+
+/** A request carrying (or omitting) an Origin header. */
+function request(origin?: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers)
+  if (origin) headers.set('origin', origin)
+  return new Request('http://localhost/api/agent/search', { ...init, headers })
+}
+
+describe('withCors', () => {
+  it('adds the allow-origin header for an allowlisted origin', async () => {
+    const handler = withCors(async () => Response.json({ ok: true }))
+
+    const res = await handler(request(ALLOWED))
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED)
+    expect(res.headers.get('Vary')).toContain('Origin')
+  })
+
+  it('allows the www variant of the production origin', async () => {
+    const handler = withCors(async () => Response.json({ ok: true }))
+
+    const res = await handler(request(ALLOWED_WWW))
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED_WWW)
+  })
+
+  it('allows the localhost dev origins outside production', async () => {
+    const handler = withCors(async () => Response.json({ ok: true }))
+
+    const res = await handler(request('http://localhost:3000'))
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000')
+  })
+
+  it('returns the handler response untouched for an origin off the list', async () => {
+    const original = Response.json({ ok: true })
+    const handler = withCors(async () => original)
+
+    const res = await handler(request(DENIED))
+
+    expect(res).toBe(original)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('passes same-origin requests (no Origin header) straight through', async () => {
+    const original = Response.json({ ok: true })
+    const handler = withCors(async () => original)
+
+    const res = await handler(request())
+
+    expect(res).toBe(original)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  it('tolerates a minimal request mock with no headers property', async () => {
+    const original = Response.json({ ok: true })
+    const handler = withCors(async () => original)
+
+    const res = await handler({ url: 'http://localhost/api/agent/search' } as unknown as Request)
+
+    expect(res).toBe(original)
+  })
+
+  it('preserves status, statusText and the handler body', async () => {
+    const handler = withCors(async () =>
+      new Response('rate limited', { status: 429, statusText: 'Too Many Requests' }),
+    )
+
+    const res = await handler(request(ALLOWED))
+
+    expect(res.status).toBe(429)
+    expect(res.statusText).toBe('Too Many Requests')
+    expect(await res.text()).toBe('rate limited')
+  })
+
+  it('keeps the headers the handler already set', async () => {
+    const handler = withCors(async () =>
+      new Response('data: hi\n\n', { headers: { 'Content-Type': 'text/event-stream' } }),
+    )
+
+    const res = await handler(request(ALLOWED))
+
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream')
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED)
+  })
+
+  it('appends to a Vary header the handler already set instead of replacing it', async () => {
+    const handler = withCors(async () =>
+      new Response(null, { headers: { Vary: 'Accept-Encoding' } }),
+    )
+
+    const res = await handler(request(ALLOWED))
+
+    const vary = res.headers.get('Vary') ?? ''
+    expect(vary).toContain('Accept-Encoding')
+    expect(vary).toContain('Origin')
+  })
+
+  it('forwards the request and extra route args to the wrapped handler', async () => {
+    const inner = vi.fn(async () => Response.json({ ok: true }))
+    const handler = withCors(inner)
+    const req = request(ALLOWED)
+    const ctx = { params: Promise.resolve({ id: 'abc' }) }
+
+    await handler(req, ctx)
+
+    expect(inner).toHaveBeenCalledWith(req, ctx)
+  })
+
+  it('supports a synchronous handler', async () => {
+    const handler = withCors(() => Response.json({ ok: true }))
+
+    const res = await handler(request(ALLOWED))
+
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED)
+  })
+
+  it('lets a handler rejection propagate', async () => {
+    const handler = withCors(async () => {
+      throw new Error('boom')
+    })
+
+    await expect(handler(request(ALLOWED))).rejects.toThrow('boom')
+  })
+})
+
+describe('corsPreflight', () => {
+  it('answers an allowlisted preflight with the permitted methods and headers', () => {
+    const res = corsPreflight(request(ALLOWED, { method: 'OPTIONS' }))
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ALLOWED)
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, OPTIONS')
+    expect(res.headers.get('Access-Control-Allow-Headers')).toBe('Content-Type, Authorization')
+    expect(res.headers.get('Vary')).toBe('Origin')
+  })
+
+  it('answers a non-allowlisted preflight with a bare 204', () => {
+    const res = corsPreflight(request(DENIED, { method: 'OPTIONS' }))
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBeNull()
+  })
+
+  it('answers a preflight with no Origin header with a bare 204', () => {
+    const res = corsPreflight(request(undefined, { method: 'OPTIONS' }))
+
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})

--- a/apps/qwksearch-web/lib/chat/__tests__/history.test.ts
+++ b/apps/qwksearch-web/lib/chat/__tests__/history.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @fileoverview Tests for `handleHistorySave`, which persists a human message
+ * and its parent chat, and branches the conversation when a prior message is
+ * re-sent.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/database', () => ({ getDB: vi.fn() }))
+
+import { createFakeDb, type FakeDb } from '../../../app/api/__tests__/helpers/fake-db'
+import { handleHistorySave } from '../history'
+import type { Message } from '../schemas'
+
+type Db = Parameters<typeof handleHistorySave>[5]
+
+const message = (overrides: Partial<Message> = {}): Message =>
+  ({
+    chatId: 'chat-1',
+    content: 'What is quantum computing?',
+    messageId: 'msg-1',
+    ...overrides,
+  }) as Message
+
+/**
+ * A fake db seeded with the relational lookups `handleHistorySave` makes:
+ * the parent chat, then the human message.
+ */
+function fakeDb(seed: { chat?: unknown; message?: unknown } = {}): FakeDb {
+  return createFakeDb({
+    query: {
+      chats: { findFirst: seed.chat },
+      messages: { findFirst: seed.message },
+    },
+  })
+}
+
+const save = (db: FakeDb | undefined, userId: string | null, msg = message(), humanId = 'msg-1') =>
+  handleHistorySave(msg, humanId, 'webSearch', [], userId, db as unknown as Db)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+describe('handleHistorySave', () => {
+  it('writes nothing for a guest (no userId)', async () => {
+    const db = fakeDb()
+
+    await save(db, null)
+
+    expect(db.calls).toEqual({})
+  })
+
+  it('writes nothing when the database is unavailable', async () => {
+    await expect(save(undefined, 'user-1')).resolves.toBeUndefined()
+  })
+
+  it('creates the chat and inserts the message when neither exists', async () => {
+    const db = fakeDb()
+
+    await save(db, 'user-1')
+
+    expect(db.calls.insert).toHaveLength(2)
+    const [chatValues] = db.calls.values[0] as [Record<string, unknown>]
+    expect(chatValues).toMatchObject({
+      id: 'chat-1',
+      title: 'What is quantum computing?',
+      focusMode: 'webSearch',
+      userId: 'user-1',
+      thinkingTimeLimit: 0,
+    })
+  })
+
+  it('guards the new-chat insert against a concurrent duplicate', async () => {
+    const db = fakeDb()
+
+    await save(db, 'user-1')
+
+    expect(db.calls.onConflictDoNothing).toHaveLength(1)
+  })
+
+  it('records the caller-supplied thinking time limit on a new chat', async () => {
+    const db = fakeDb()
+
+    await handleHistorySave(message(), 'msg-1', 'webSearch', [], 'user-1', db as unknown as Db, 45)
+
+    const [chatValues] = db.calls.values[0] as [Record<string, unknown>]
+    expect(chatValues.thinkingTimeLimit).toBe(45)
+  })
+
+  it('inserts the human message with the human message id, not the message id', async () => {
+    const db = fakeDb()
+
+    await save(db, 'user-1', message({ messageId: 'client-generated' }), 'human-42')
+
+    const [messageValues] = db.calls.values[1] as [Record<string, unknown>]
+    expect(messageValues).toMatchObject({
+      messageId: 'human-42',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      role: 'user',
+      content: 'What is quantum computing?',
+    })
+  })
+
+  it('skips the chat insert when the chat already belongs to this user', async () => {
+    const db = fakeDb({ chat: { id: 'chat-1', userId: 'user-1' } })
+
+    await save(db, 'user-1')
+
+    // One insert only — the message; the chat is already there.
+    expect(db.calls.insert).toHaveLength(1)
+    const [messageValues] = db.calls.values[0] as [Record<string, unknown>]
+    expect(messageValues).toMatchObject({ messageId: 'msg-1' })
+  })
+
+  it('refuses to touch a chat id owned by another account', async () => {
+    const db = fakeDb({ chat: { id: 'chat-1', userId: 'someone-else' } })
+
+    await save(db, 'user-1')
+
+    expect(db.calls.insert).toBeUndefined()
+    expect(db.calls.delete).toBeUndefined()
+  })
+
+  it('branches the conversation when the human message is re-sent', async () => {
+    const db = fakeDb({
+      chat: { id: 'chat-1', userId: 'user-1' },
+      message: { id: 7, messageId: 'msg-1' },
+    })
+
+    await save(db, 'user-1')
+
+    // Re-send deletes the later messages instead of inserting a duplicate.
+    expect(db.calls.insert).toBeUndefined()
+    expect(db.calls.delete).toHaveLength(1)
+    expect(db.calls.where).toHaveLength(1)
+  })
+
+  it('creates a missing chat even when the human message already exists', async () => {
+    const db = fakeDb({ message: { id: 7, messageId: 'msg-1' } })
+
+    await save(db, 'user-1')
+
+    expect(db.calls.insert).toHaveLength(1)
+    expect(db.calls.delete).toHaveLength(1)
+  })
+
+  it('stores createdAt as an ISO string', async () => {
+    const db = fakeDb()
+
+    await save(db, 'user-1')
+
+    const [chatValues] = db.calls.values[0] as [Record<string, unknown>]
+    const [messageValues] = db.calls.values[1] as [Record<string, unknown>]
+    expect(() => new Date(chatValues.createdAt as string).toISOString()).not.toThrow()
+    expect(typeof chatValues.createdAt).toBe('string')
+    expect(typeof messageValues.createdAt).toBe('string')
+  })
+})


### PR DESCRIPTION
…surfaces

The `/api/config` GET tests failed under vitest 5 because the route does `new ModelRegistry()` while the test stubbed the constructor with an arrow implementation, which is not constructable — every GET fell into the catch and returned a 500. Stub it with a `function` implementation instead, via a small `stubModelRegistry` helper, and note the constraint where it bites.

Then add tests for six untested surfaces, chosen for having real branching worth pinning down:

- `lib/cors.ts` — the origin allowlist, header pass-through, `Vary` appending, and preflight answers.
- `lib/chat/history.ts` — new-chat creation, the re-send branch that deletes later messages, the guest and no-db short-circuits, and the guard against a chat id owned by another account.
- `/api/user` plus `/api/user/password` and `/api/user/storage` — the session gates, name and email validation, API key minting and regeneration, account deletion, and the quota readout.
- `/api/auth/providers` — a provider is advertised only when both halves of its credential pair are set, and Google only when it is not the `.env.example` placeholder.
- `/api/search/engines/status` and `/test` — config read/write, array validation, and per-engine probe results including partial failure.
- `/api/admin/freekeys` — the admin gate, key masking (asserting no raw key reaches the response), env-source reporting, and `?testAll=` with its upstream-listing skip.

`execute` joins the fake-db chain methods so `history.ts`, which ends its chains with `.execute()`, can use the shared double.

Suite goes from 637 to 763 passing tests across 55 files. Each new file was mutation-checked against the source it covers.


Claude-Session: https://claude.ai/code/session_01UqrtpTXFtxEm4utNJT5YkV