### PR TITLE
🐛 fix(ci): write the HTML test report where Wrangler looks for it

### DIFF
--- a/.github/workflows/deploy-test-reports.yml
+++ b/.github/workflows/deploy-test-reports.yml
@@ -27,6 +27,48 @@ jobs:
         run: bun run test:report
         continue-on-error: true
 
+      # The step above is allowed to fail so a red suite still publishes its
+      # report. What it must not do is leave `dist` missing: `wrangler deploy`
+      # treats an absent `assets.directory` as a hard error, so the run ends on
+      # a config error instead of on the test signal. Publish a placeholder
+      # rather than lose the deploy.
+      - name: Ensure a report exists to deploy
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -f apps/test-reports/dist/index.html ]; then
+            exit 0
+          fi
+          echo "::warning::Vitest wrote no HTML report; deploying a placeholder page."
+          mkdir -p apps/test-reports/dist
+          cat > apps/test-reports/dist/index.html <<HTML
+          <!doctype html>
+          <html lang="en">
+          <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Test report unavailable</title>
+          <style>
+          :root { color-scheme: light dark; }
+          body { margin: 0; min-height: 100vh; display: grid; place-items: center;
+                 font: 16px/1.6 system-ui, sans-serif; padding: 24px; }
+          main { max-width: 34rem; }
+          h1 { font-size: 1.25rem; margin: 0 0 .75rem; }
+          p { margin: 0 0 .75rem; opacity: .85; }
+          </style>
+          </head>
+          <body>
+          <main>
+          <h1>Test report unavailable</h1>
+          <p>The last run of the test suite ended before the HTML reporter could
+          write a report, so there is nothing to show here yet.</p>
+          <p><a href="$RUN_URL">Open the workflow run</a> for the full output.</p>
+          <p>Commit $GITHUB_SHA</p>
+          </main>
+          </body>
+          </html>
+          HTML
+
       - name: Deploy to Cloudflare Workers
         working-directory: apps/test-reports
         run: npx wrangler deploy

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ logs/
 /coverage/
 coverage/
 html/
+.vitest/
 test-report.junit.xml
 
 # Miscellaneous

--- a/apps/test-reports/package.json
+++ b/apps/test-reports/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "generate": "cd ../.. && vitest run --reporter=default --reporter=html --outputFile.html=apps/test-reports/dist/index.html",
-    "generate:coverage": "cd ../.. && vitest run --reporter=default --reporter=html --outputFile.html=apps/test-reports/dist/index.html --coverage",
+    "generate": "cd ../.. && VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run",
+    "generate:coverage": "cd ../.. && VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run --coverage",
     "preview": "wrangler dev",
     "deploy": "wrangler deploy"
   },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "build:editor": "turbo build --filter=react-reason-editor",
     "test": "vitest run",
     "test:ui": "vitest --ui",
-    "test:report": "vitest run --reporter=default --reporter=html --outputFile.html=apps/test-reports/dist/index.html",
-    "test:report:coverage": "vitest run --reporter=default --reporter=html --outputFile.html=apps/test-reports/dist/index.html --coverage",
+    "test:report": "VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run",
+    "test:report:coverage": "VITEST_HTML_REPORT_DIR=apps/test-reports/dist vitest run --coverage",
     "deploy:test-reports": "cd apps/test-reports && wrangler deploy"
   },
   "devDependencies": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,8 +13,25 @@ import { defineConfig } from 'vitest/config';
  * `domain-rank` and `extract-pdf` (bun test), `extract-youtube` (jest) and
  * `language-model-training` (pytest).
  */
+
+/**
+ * Vitest 5's HTML reporter ignores `outputFile` and writes `<outputDir>/index.html`
+ * plus its UI bundle, where `outputDir` is a *reporter option* defaulting to
+ * `.vitest`. A reporter named on the command line (`--reporter=html`) is
+ * constructed without options and would silently keep that default, which is how
+ * `apps/test-reports/dist` came to be missing at deploy time -- so the reporter
+ * and its destination both have to be declared here.
+ *
+ * The report stays opt-in so a plain `vitest run` does not pay for copying the UI
+ * bundle; `test:report` sets this to the directory Wrangler deploys.
+ */
+const htmlReportDir = process.env.VITEST_HTML_REPORT_DIR;
+
 export default defineConfig({
   test: {
+    reporters: htmlReportDir
+      ? ['default', ['html', { outputDir: htmlReportDir }]]
+      : ['default'],
     projects: [
       'apps/collaboration-server',
       'apps/qwk-vscode-ext',


### PR DESCRIPTION
## The failure

Every `Test Reports` run has ended the same way:

```
✘ [ERROR] The directory specified by the "assets.directory" field in your configuration file does not exist:

  /home/runner/work/qwksearch-research-agent/qwksearch-research-agent/apps/test-reports/dist
```

## Root cause

The suite ran to completion and the reporter announced `Report is generated` — yet `dist` was never created. Vitest 5's HTML reporter **dropped `outputFile` support**. It now takes an `outputDir` *reporter option*, defaults it to `.vitest`, and writes `<outputDir>/index.html` plus its UI bundle there:

```js
this.reporterDir = resolve(this.ctx.config.root, this.options.outputDir || ".vitest");
```

So `--outputFile.html=apps/test-reports/dist/index.html` was parsed, ignored, and the entire report landed in `.vitest/`. The line directly above the Wrangler error said so all along:

```
 HTML  Report is generated
       You can run npx vite preview --outDir .vitest to see the test results.
```

A reporter named on the command line is constructed *without* options, so `--reporter=html` cannot carry the destination either — the reporter and its `outputDir` have to be declared together in config.

## The fix

**Report destination.** `vitest.config.ts` now declares the reporters, with `outputDir` read from `VITEST_HTML_REPORT_DIR`. The report stays opt-in, so a plain `vitest run` still skips it and the cost of copying the UI bundle:

```ts
reporters: htmlReportDir
  ? ['default', ['html', { outputDir: htmlReportDir }]]
  : ['default'],
```

`test:report`, `test:report:coverage` and the two `apps/test-reports` `generate` scripts set that variable to the directory the Worker deploys.

**Deploy resilience.** The test step is deliberately `continue-on-error` so a red suite still publishes its report — but a run that dies before the reporter writes anything left `dist` absent, and Wrangler treats a missing `assets.directory` as a hard error. The job then ended on a config error with the test signal nowhere in sight. A guard step now writes a placeholder page linking back to the workflow run, so the deploy survives and the real failure stays legible.

**Housekeeping.** `.vitest/` is now gitignored; Vitest 5 creates it by default.

## Verification

Against `vitest@5.0.0` / `@vitest/ui@5.0.0` in an isolated scratch project:

| Check | Result |
| --- | --- |
| Old invocation (`--outputFile.html=out/dist/index.html`) | Reproduces the bug exactly — `out/dist` missing, report in `.vitest/` |
| New invocation with `VITEST_HTML_REPORT_DIR=out/dist` | `out/dist/index.html` + `out/dist/ui/`, no stray `.vitest/` |
| **Failing** suite (the CI case — exit 1) | Report still written in full |
| No env var set | No report, no `.vitest/` — plain `vitest run` unaffected |
| `wrangler deploy --dry-run` on the real report | `Read 8 files from the assets directory` |
| `wrangler deploy --dry-run` on the placeholder | `Read 1 file from the assets directory` |

The guard step's heredoc was extracted from the parsed YAML and executed both ways: it leaves an existing report untouched and expands `$RUN_URL` / `$GITHUB_SHA` correctly into the placeholder. The `reporters` ternary was type-checked under `--strict` to confirm the tuple form survives contextual typing.

Note that the suite itself is red on `master` (52 failing tests across 23 files) for reasons unrelated to this change — that is precisely the state the report is meant to publish, and it now will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HopyMuEY4FXdAaNQPFa7Z5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HopyMuEY4FXdAaNQPFa7Z5)_