### PR TITLE
Use grab-url in the weather widget and repeat failed geo lookups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -249,7 +249,7 @@
     },
     "packages/chat-agent-toolkit": {
       "name": "chat-agent-toolkit",
-      "version": "1.2.291",
+      "version": "1.2.296",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.50",
         "@ai-sdk/google": "^4.0.65",
@@ -297,7 +297,7 @@
     },
     "packages/domain-rank": {
       "name": "domain-rank",
-      "version": "0.1.281",
+      "version": "0.1.286",
       "dependencies": {
         "fuse.js": "^7.5.0",
         "grab-url": "^1.6.22",
@@ -316,7 +316,7 @@
     },
     "packages/extract-pdf": {
       "name": "extract-pdf",
-      "version": "0.1.276",
+      "version": "0.1.280",
       "dependencies": {
         "grab-url": "^1.6.22",
       },
@@ -341,7 +341,7 @@
     },
     "packages/extract-webpage": {
       "name": "extract-webpage",
-      "version": "1.2.286",
+      "version": "1.2.291",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "ai": "^7.0.94",
@@ -390,8 +390,10 @@
     },
     "packages/extract-youtube": {
       "name": "extract-youtube",
-      "version": "1.0.279",
-      "bin": "dist/cli.js",
+      "version": "1.0.284",
+      "bin": {
+        "extract-youtube": "dist/cli.js",
+      },
       "dependencies": {
         "fast-xml-parser": "^5.11.1",
         "grab-url": "^1.6.22",
@@ -426,7 +428,7 @@
     },
     "packages/html-renderer-api": {
       "name": "html-renderer-api",
-      "version": "1.0.163",
+      "version": "1.0.168",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.4.0",
       },
@@ -437,7 +439,7 @@
     },
     "packages/notebooklm-api-client": {
       "name": "notebooklm-api-client",
-      "version": "0.1.235",
+      "version": "0.1.240",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.4.0",
       },
@@ -451,7 +453,7 @@
     },
     "packages/qwksearch-api-client": {
       "name": "qwksearch-api-client",
-      "version": "0.9.234",
+      "version": "0.9.238",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -465,7 +467,7 @@
     },
     "packages/qwksearch-mcp-server": {
       "name": "qwksearch-mcp-server",
-      "version": "1.0.127",
+      "version": "1.0.132",
       "bin": {
         "qwksearch-mcp": "./bin/qwksearch-mcp.ts",
       },
@@ -482,7 +484,10 @@
     },
     "packages/react-weather-forecast": {
       "name": "use-weather-forecast",
-      "version": "0.1.105",
+      "version": "0.1.110",
+      "dependencies": {
+        "grab-url": "^1.6.22",
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260908.1",
         "@testing-library/react": "^16.3.3",
@@ -505,7 +510,7 @@
     },
     "packages/reason-editor": {
       "name": "react-reason-editor",
-      "version": "1.0.93",
+      "version": "1.0.98",
       "dependencies": {
         "@ariakit/react": "^0.4.39",
         "@emoji-mart/data": "1.2.1",
@@ -713,7 +718,7 @@
     },
     "packages/reason-editor-sidebar": {
       "name": "react-reason-editor-sidebar",
-      "version": "0.1.11",
+      "version": "0.1.15",
       "dependencies": {
         "@headless-tree/core": "^1.7.0",
         "@headless-tree/react": "^1.7.0",
@@ -842,7 +847,7 @@
     },
     "packages/research-agent-ui": {
       "name": "research-agent-ui",
-      "version": "0.1.160",
+      "version": "0.1.165",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -924,7 +929,7 @@
     },
     "packages/search-web-api": {
       "name": "search-web-api",
-      "version": "1.0.144",
+      "version": "1.0.148",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@scalar/hono-api-reference": "^0.12.1",
@@ -944,7 +949,7 @@
     },
     "packages/shadcn-app-dock": {
       "name": "shadcn-app-dock",
-      "version": "0.1.142",
+      "version": "0.1.146",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-slot": "^1.3.3",
@@ -977,7 +982,7 @@
     },
     "packages/shadcn-settings": {
       "name": "shadcn-settings",
-      "version": "0.1.19",
+      "version": "0.1.24",
       "dependencies": {
         "@radix-ui/react-select": "^2.3.7",
         "@radix-ui/react-switch": "^1.3.7",
@@ -1006,7 +1011,7 @@
     },
     "packages/trending-news-api": {
       "name": "trending-news-api",
-      "version": "0.1.19",
+      "version": "0.1.24",
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260908.1",
         "@testing-library/react": "^16.3.3",
@@ -1029,9 +1034,9 @@
     },
     "packages/use-voice-control": {
       "name": "use-voice-control",
-      "version": "0.1.101",
+      "version": "0.1.105",
       "bin": {
-        "use-voice-control": "./bin/use-voice-control.mjs",
+        "use-voice-control": "bin/use-voice-control.mjs",
       },
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
@@ -1089,7 +1094,7 @@
     },
     "packages/write-language": {
       "name": "write-language",
-      "version": "0.1.161",
+      "version": "0.1.166",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^5.0.78",
         "@ai-sdk/anthropic": "^4.0.50",

--- a/packages/react-weather-forecast/README.md
+++ b/packages/react-weather-forecast/README.md
@@ -72,6 +72,10 @@ This package no longer uses ipinfo.io. Instead:
   no mixed-content issues, though ipapi.co's free tier is rate-limited (1,000
   requests/day) — deploy the worker and pass `geoEndpoint` for higher-volume or
   production use.
+- A failed lookup is **repeated** before it throws: `getClientLocation` tries three
+  times by default, waiting 500ms, then 1s, so a single rate-limited or cold-start
+  response doesn't take the whole forecast down. Tune it with the third argument:
+  `getClientLocation(geoEndpoint, ip, { attempts: 5, retryDelay: 250 })`.
 
 ### Deploying the geo worker
 
@@ -96,3 +100,6 @@ in non-browser environments (SSR) or when `localStorage` is unavailable/full.
 
 - Open-Meteo powers the forecast data.
 - Cloudflare's `request.cf` and ipapi.co power IP geolocation (see above).
+- HTTP requests go through [`grab-url`](https://www.npmjs.com/package/grab-url), the
+  repo-wide client, rather than raw `fetch`. It is the package's only runtime
+  dependency.

--- a/packages/react-weather-forecast/package.json
+++ b/packages/react-weather-forecast/package.json
@@ -21,6 +21,9 @@
   },
   "files": ["dist", "README.md", "LICENSE"],
   "sideEffects": false,
+  "dependencies": {
+    "grab-url": "^1.6.22"
+  },
   "peerDependencies": {
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19"

--- a/packages/react-weather-forecast/src/api/forecast.ts
+++ b/packages/react-weather-forecast/src/api/forecast.ts
@@ -1,6 +1,7 @@
 import type { WeatherForecastData, WeatherForecastOptions, WeatherLocation } from '../types';
 import { getWeatherIcon } from '../weatherCodes';
 import { getClientLocation } from './geolocation';
+import { grabJson } from './http';
 import { readCachedForecast, writeCachedForecast } from '../lib/cache';
 
 function buildUrl(latitude: number, longitude: number, options: WeatherForecastOptions) {
@@ -62,13 +63,10 @@ export async function getWeatherForecast(
   const cached = readCachedForecast<WeatherForecastData>(url);
   if (cached) return cached;
 
-  const response = await fetch(url, { headers: { 'Content-Type': 'application/json' } });
-
-  if (!response.ok) {
-    throw new Error(`Weather request failed: ${response.status} ${response.statusText}`);
-  }
-
-  const data = await response.json();
+  const data = await grabJson<any>(url, 'Weather request', {
+    headers: { 'Content-Type': 'application/json' },
+    retryAttempts: 1,
+  });
 
   if (!data?.current || !data?.hourly || !data?.daily) {
     throw new Error('Invalid weather response');

--- a/packages/react-weather-forecast/src/api/geolocation.ts
+++ b/packages/react-weather-forecast/src/api/geolocation.ts
@@ -1,6 +1,23 @@
 import type { WeatherLocation } from '../types';
+import { grabJson } from './http';
 
 const DEFAULT_IP_API_URL = 'https://ipapi.co';
+
+/**
+ * ipapi.co's free tier rate-limits by IP and answers a 200 carrying
+ * `{ error: true, reason: 'RateLimited' }`, and a geo worker can drop a
+ * request while it cold-starts. Both clear on their own, so the lookup is
+ * repeated before the error reaches the caller.
+ */
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+export type GeolocationOptions = {
+  /** default=3 How many times the lookup is tried before the error is thrown. */
+  attempts?: number;
+  /** default=500 Milliseconds to wait before the second try; each further wait grows by that much. */
+  retryDelay?: number;
+};
 
 type IpApiResponse = {
   city?: string;
@@ -22,30 +39,25 @@ type GeoWorkerResponse = {
   longitude?: number | string;
 };
 
-export async function getClientLocation(geoEndpoint?: string, ip?: string): Promise<WeatherLocation> {
-  if (geoEndpoint) {
-    const url = ip ? `${geoEndpoint}?ip=${encodeURIComponent(ip)}` : geoEndpoint;
-    const res = await fetch(url);
-    if (!res.ok) throw new Error(`Geolocation worker lookup failed: ${res.status}`);
-    const data: GeoWorkerResponse = await res.json();
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-    return {
-      city: data.city,
-      region: data.region,
-      country: data.country,
-      timezone: data.timezone,
-      latitude: Number(data.latitude),
-      longitude: Number(data.longitude),
-    };
-  }
+async function lookupViaWorker(geoEndpoint: string, ip?: string): Promise<WeatherLocation> {
+  const url = ip ? `${geoEndpoint}?ip=${encodeURIComponent(ip)}` : geoEndpoint;
+  const data = await grabJson<GeoWorkerResponse>(url, 'Geolocation worker lookup');
 
-  const res = await fetch(`${DEFAULT_IP_API_URL}/${ip ? `${encodeURIComponent(ip)}/` : ''}json/`);
-  if (!res.ok) throw new Error(`ipapi.co lookup failed: ${res.status}`);
-  const data: IpApiResponse = await res.json();
+  return {
+    city: data.city,
+    region: data.region,
+    country: data.country,
+    timezone: data.timezone,
+    latitude: Number(data.latitude),
+    longitude: Number(data.longitude),
+  };
+}
 
-  if (data.error) {
-    throw new Error(`ipapi.co lookup failed: ${data.reason ?? 'unknown error'}`);
-  }
+async function lookupViaIpApi(ip?: string): Promise<WeatherLocation> {
+  const url = `${DEFAULT_IP_API_URL}/${ip ? `${encodeURIComponent(ip)}/` : ''}json/`;
+  const data = await grabJson<IpApiResponse>(url, 'ipapi.co lookup');
 
   return {
     city: data.city,
@@ -55,4 +67,38 @@ export async function getClientLocation(geoEndpoint?: string, ip?: string): Prom
     latitude: Number(data.latitude),
     longitude: Number(data.longitude),
   };
+}
+
+/**
+ * Resolve the caller's location, either from a deployed geo worker or from
+ * ipapi.co directly.
+ *
+ * A failed lookup is repeated with a growing delay and only the last error is
+ * thrown, so a single rate-limited or cold-started response no longer takes
+ * the whole forecast down with it.
+ *
+ * @param geoEndpoint URL of a deployed geo worker; omit to use ipapi.co.
+ * @param ip Look up this IP instead of the caller's own.
+ * @param options How often to repeat the lookup, and how long to wait between tries.
+ */
+export async function getClientLocation(
+  geoEndpoint?: string,
+  ip?: string,
+  options: GeolocationOptions = {}
+): Promise<WeatherLocation> {
+  const attempts = Math.max(1, Math.trunc(options.attempts ?? DEFAULT_ATTEMPTS));
+  const retryDelay = Math.max(0, options.retryDelay ?? DEFAULT_RETRY_DELAY_MS);
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return geoEndpoint ? await lookupViaWorker(geoEndpoint, ip) : await lookupViaIpApi(ip);
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts && retryDelay > 0) await wait(retryDelay * attempt);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }

--- a/packages/react-weather-forecast/src/api/http.ts
+++ b/packages/react-weather-forecast/src/api/http.ts
@@ -1,0 +1,66 @@
+import grab from 'grab-url';
+
+/**
+ * Shared JSON transport for the package's upstreams (the geo worker, ipapi.co
+ * and Open-Meteo).
+ *
+ * `grab-url` is the HTTP client used across this repo: it parses the JSON,
+ * applies a timeout and can repeat a failed request itself. Unlike `fetch` it
+ * resolves rather than rejects when a request fails, handing back the message
+ * on `.error`, so every call site has to inspect the payload -- that check
+ * lives here so the callers can just `await` a typed body.
+ */
+export type GrabJsonOptions = {
+  headers?: Record<string, string>;
+  /** default=0 Times grab-url repeats a request that failed at the transport level. */
+  retryAttempts?: number;
+  /** default=15 Seconds before the request is aborted. */
+  timeout?: number;
+};
+
+/**
+ * Both upstreams can answer HTTP 200 with an error flag instead of data:
+ * ipapi.co does it for rate limits, Open-Meteo for a malformed query.
+ */
+type ErrorPayload = { error?: boolean | string; reason?: string };
+
+/**
+ * grab-url reports a failed request as `HTTP error: 429 Too Many Requests`.
+ * That prefix is noise once the message is nested under `<label> failed:`,
+ * so drop it and keep the status.
+ */
+function describeFailure(error: string): string {
+  return error.replace(/^HTTP error:\s*/i, '').trim() || 'unknown error';
+}
+
+/**
+ * Request a JSON body, throwing a labelled error for any failure.
+ *
+ * @param url Full URL to request.
+ * @param label Prefix for the thrown message, e.g. `ipapi.co lookup`.
+ * @param options Transport options passed through to grab-url.
+ */
+export async function grabJson<T>(
+  url: string,
+  label: string,
+  options: GrabJsonOptions = {}
+): Promise<T> {
+  const { headers, retryAttempts = 0, timeout = 15 } = options;
+
+  const data = (await grab(url, { headers, retryAttempts, timeout })) as
+    | (T & ErrorPayload)
+    | null
+    | undefined;
+
+  if (typeof data?.error === 'string') {
+    throw new Error(`${label} failed: ${describeFailure(data.error)}`);
+  }
+
+  if (data?.error === true) {
+    throw new Error(`${label} failed: ${data.reason ?? 'unknown error'}`);
+  }
+
+  if (!data) throw new Error(`${label} failed: empty response`);
+
+  return data as T;
+}

--- a/packages/react-weather-forecast/test/forecast.test.ts
+++ b/packages/react-weather-forecast/test/forecast.test.ts
@@ -1,6 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { getWeatherForecast } from '../src/api/forecast';
 import { clearWeatherForecastCache } from '../src/lib/cache';
+import grab from 'grab-url';
+
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
 
 /** A minimal but complete Open-Meteo response shape. */
 function openMeteoResponse(overrides: Record<string, unknown> = {}) {
@@ -36,25 +40,20 @@ function openMeteoResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function mockFetch(payload: unknown, init: { ok?: boolean; status?: number; statusText?: string } = {}) {
-  const fetchMock = vi.fn(async () => ({
-    ok: init.ok ?? true,
-    status: init.status ?? 200,
-    statusText: init.statusText ?? 'OK',
-    json: async () => payload,
-  }));
-  vi.stubGlobal('fetch', fetchMock);
-  return fetchMock;
+/** grab-url resolves with the parsed body, or with `{ error }` when a request failed. */
+function mockFetch(payload: unknown) {
+  mockGrab.mockResolvedValue(payload as never);
+  return mockGrab;
 }
 
-function requestedUrl(fetchMock: ReturnType<typeof mockFetch>, call = 0): URL {
+function requestedUrl(fetchMock: typeof mockGrab, call = 0): URL {
   return new URL(fetchMock.mock.calls[call][0] as unknown as string);
 }
 
 describe('getWeatherForecast', () => {
   beforeEach(() => {
     clearWeatherForecastCache();
-    vi.unstubAllGlobals();
+    vi.resetAllMocks();
   });
 
   it('queries Open-Meteo with the supplied coordinates', async () => {
@@ -103,18 +102,12 @@ describe('getWeatherForecast', () => {
   });
 
   it('resolves the location by IP when no coordinates are given', async () => {
-    const fetchMock = vi.fn(async (input: string) => {
+    const fetchMock = mockGrab.mockImplementation(async (input: string) => {
       if (input.includes('ipapi.co')) {
-        return {
-          ok: true,
-          status: 200,
-          statusText: 'OK',
-          json: async () => ({ city: 'Austin', country_name: 'United States', latitude: 30.27, longitude: -97.74 }),
-        };
+        return { city: 'Austin', country_name: 'United States', latitude: 30.27, longitude: -97.74 };
       }
-      return { ok: true, status: 200, statusText: 'OK', json: async () => openMeteoResponse() };
+      return openMeteoResponse();
     });
-    vi.stubGlobal('fetch', fetchMock);
 
     const result = await getWeatherForecast();
 
@@ -215,10 +208,18 @@ describe('getWeatherForecast', () => {
   });
 
   it('throws with status and status text on a failed request', async () => {
-    mockFetch(null, { ok: false, status: 503, statusText: 'Service Unavailable' });
+    mockFetch({ error: 'HTTP error: 503 Service Unavailable' });
 
     await expect(getWeatherForecast({ latitude: 1, longitude: 2 })).rejects.toThrow(
       'Weather request failed: 503 Service Unavailable'
+    );
+  });
+
+  it('throws with the reason when Open-Meteo answers 200 with an error flag', async () => {
+    mockFetch({ error: true, reason: 'Cannot initialize WeatherVariable from invalid String value' });
+
+    await expect(getWeatherForecast({ latitude: 1, longitude: 2 })).rejects.toThrow(
+      'Weather request failed: Cannot initialize WeatherVariable from invalid String value'
     );
   });
 

--- a/packages/react-weather-forecast/test/geolocation.test.ts
+++ b/packages/react-weather-forecast/test/geolocation.test.ts
@@ -1,24 +1,27 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
 import { getClientLocation } from '../src/api/geolocation';
+import grab from 'grab-url';
 
-function mockFetch(response: unknown, init: { ok?: boolean; status?: number } = {}) {
-  const fetchMock = vi.fn(async () => ({
-    ok: init.ok ?? true,
-    status: init.status ?? 200,
-    json: async () => response,
-  }));
-  vi.stubGlobal('fetch', fetchMock);
-  return fetchMock;
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
+
+/** grab-url resolves with the parsed body, or with `{ error }` when a request failed. */
+function grabResolves(...responses: unknown[]) {
+  for (const response of responses) mockGrab.mockResolvedValueOnce(response as never);
+  return mockGrab;
 }
+
+/** No delay between tries: the repeat behaviour is what is under test, not the backoff. */
+const noDelay = { retryDelay: 0 };
 
 describe('getClientLocation', () => {
   beforeEach(() => {
-    vi.unstubAllGlobals();
+    vi.resetAllMocks();
   });
 
   describe('via the bundled geo worker', () => {
     it('requests the endpoint and normalizes the payload', async () => {
-      const fetchMock = mockFetch({
+      grabResolves({
         city: 'Austin',
         region: 'Texas',
         country: 'United States',
@@ -29,7 +32,7 @@ describe('getClientLocation', () => {
 
       const location = await getClientLocation('https://geo.example.workers.dev');
 
-      expect(fetchMock).toHaveBeenCalledWith('https://geo.example.workers.dev');
+      expect(mockGrab.mock.calls[0][0]).toBe('https://geo.example.workers.dev');
       expect(location).toEqual({
         city: 'Austin',
         region: 'Texas',
@@ -41,7 +44,7 @@ describe('getClientLocation', () => {
     });
 
     it('coerces string coordinates to numbers', async () => {
-      mockFetch({ latitude: '30.27', longitude: '-97.74' });
+      grabResolves({ latitude: '30.27', longitude: '-97.74' });
 
       const location = await getClientLocation('https://geo.example.workers.dev');
 
@@ -50,25 +53,25 @@ describe('getClientLocation', () => {
     });
 
     it('passes an explicit IP through as a URL-encoded query param', async () => {
-      const fetchMock = mockFetch({ latitude: 1, longitude: 2 });
+      grabResolves({ latitude: 1, longitude: 2 });
 
       await getClientLocation('https://geo.example.workers.dev', '8.8.8.8');
 
-      expect(fetchMock).toHaveBeenCalledWith('https://geo.example.workers.dev?ip=8.8.8.8');
+      expect(mockGrab.mock.calls[0][0]).toBe('https://geo.example.workers.dev?ip=8.8.8.8');
     });
 
     it('throws with the status code when the worker errors', async () => {
-      mockFetch({}, { ok: false, status: 502 });
+      grabResolves({ error: 'HTTP error: 502 Bad Gateway' });
 
-      await expect(getClientLocation('https://geo.example.workers.dev')).rejects.toThrow(
-        'Geolocation worker lookup failed: 502'
-      );
+      await expect(
+        getClientLocation('https://geo.example.workers.dev', undefined, { attempts: 1 })
+      ).rejects.toThrow('Geolocation worker lookup failed: 502 Bad Gateway');
     });
   });
 
   describe('via ipapi.co (default)', () => {
     it('hits the json endpoint and maps country_name to country', async () => {
-      const fetchMock = mockFetch({
+      grabResolves({
         city: 'Berlin',
         region: 'Berlin',
         country_name: 'Germany',
@@ -79,7 +82,7 @@ describe('getClientLocation', () => {
 
       const location = await getClientLocation();
 
-      expect(fetchMock).toHaveBeenCalledWith('https://ipapi.co/json/');
+      expect(mockGrab.mock.calls[0][0]).toBe('https://ipapi.co/json/');
       expect(location).toEqual({
         city: 'Berlin',
         region: 'Berlin',
@@ -91,29 +94,102 @@ describe('getClientLocation', () => {
     });
 
     it('scopes the lookup to an explicit IP', async () => {
-      const fetchMock = mockFetch({ latitude: 1, longitude: 2 });
+      grabResolves({ latitude: 1, longitude: 2 });
 
       await getClientLocation(undefined, '1.1.1.1');
 
-      expect(fetchMock).toHaveBeenCalledWith('https://ipapi.co/1.1.1.1/json/');
+      expect(mockGrab.mock.calls[0][0]).toBe('https://ipapi.co/1.1.1.1/json/');
     });
 
-    it('throws on a non-ok response', async () => {
-      mockFetch({}, { ok: false, status: 429 });
+    it('throws on a failed request', async () => {
+      grabResolves({ error: 'HTTP error: 429 Too Many Requests' });
 
-      await expect(getClientLocation()).rejects.toThrow('ipapi.co lookup failed: 429');
+      await expect(getClientLocation(undefined, undefined, { attempts: 1 })).rejects.toThrow(
+        'ipapi.co lookup failed: 429 Too Many Requests'
+      );
     });
 
     it('throws on a 200 response carrying an error flag', async () => {
-      mockFetch({ error: true, reason: 'RateLimited' });
+      grabResolves({ error: true, reason: 'RateLimited' });
 
-      await expect(getClientLocation()).rejects.toThrow('ipapi.co lookup failed: RateLimited');
+      await expect(getClientLocation(undefined, undefined, { attempts: 1 })).rejects.toThrow(
+        'ipapi.co lookup failed: RateLimited'
+      );
     });
 
     it('falls back to a generic message when no reason is given', async () => {
-      mockFetch({ error: true });
+      grabResolves({ error: true });
 
-      await expect(getClientLocation()).rejects.toThrow('ipapi.co lookup failed: unknown error');
+      await expect(getClientLocation(undefined, undefined, { attempts: 1 })).rejects.toThrow(
+        'ipapi.co lookup failed: unknown error'
+      );
+    });
+
+    it('throws when the response is empty', async () => {
+      grabResolves(null);
+
+      await expect(getClientLocation(undefined, undefined, { attempts: 1 })).rejects.toThrow(
+        'ipapi.co lookup failed: empty response'
+      );
+    });
+  });
+
+  describe('repeating a failed lookup', () => {
+    it('retries a rate-limited lookup and returns the first good response', async () => {
+      grabResolves(
+        { error: true, reason: 'RateLimited' },
+        { city: 'Austin', latitude: 30.27, longitude: -97.74 }
+      );
+
+      const location = await getClientLocation(undefined, undefined, noDelay);
+
+      expect(mockGrab).toHaveBeenCalledTimes(2);
+      expect(location.city).toBe('Austin');
+    });
+
+    it('repeats the lookup three times by default before giving up', async () => {
+      mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
+
+      await expect(getClientLocation(undefined, undefined, noDelay)).rejects.toThrow(
+        'ipapi.co lookup failed: RateLimited'
+      );
+      expect(mockGrab).toHaveBeenCalledTimes(3);
+    });
+
+    it('honours a custom attempt count', async () => {
+      mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
+
+      await expect(
+        getClientLocation(undefined, undefined, { attempts: 5, retryDelay: 0 })
+      ).rejects.toThrow('ipapi.co lookup failed: RateLimited');
+      expect(mockGrab).toHaveBeenCalledTimes(5);
+    });
+
+    it('repeats a worker lookup too', async () => {
+      grabResolves({ error: 'HTTP error: 502 Bad Gateway' }, { latitude: 1, longitude: 2 });
+
+      const location = await getClientLocation('https://geo.example.workers.dev', undefined, noDelay);
+
+      expect(mockGrab).toHaveBeenCalledTimes(2);
+      expect(location.latitude).toBe(1);
+    });
+
+    it('waits between tries when a delay is configured', async () => {
+      grabResolves({ error: true, reason: 'RateLimited' }, { latitude: 1, longitude: 2 });
+
+      const start = Date.now();
+      await getClientLocation(undefined, undefined, { retryDelay: 20 });
+
+      expect(Date.now() - start).toBeGreaterThanOrEqual(20);
+      expect(mockGrab).toHaveBeenCalledTimes(2);
+    });
+
+    it('never repeats a lookup that succeeded', async () => {
+      grabResolves({ latitude: 1, longitude: 2 });
+
+      await getClientLocation(undefined, undefined, noDelay);
+
+      expect(mockGrab).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/react-weather-forecast/tsup.config.ts
+++ b/packages/react-weather-forecast/tsup.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   splitting: false,
-  external: ['react', 'react-dom'],
+  external: ['react', 'react-dom', 'grab-url'],
 });

--- a/skills/ask-weather-forecast/SKILL.md
+++ b/skills/ask-weather-forecast/SKILL.md
@@ -34,6 +34,11 @@ Option 3 is the default and is the usual source of trouble: ipapi.co rate-limits
 and calling it from the client exposes the visitor to a third party. Deploy the worker
 (`bun run worker:deploy`) and pass `geoEndpoint` for anything real.
 
+Either lookup is repeated before it throws — `getClientLocation(geoEndpoint, ip,
+{ attempts, retryDelay })`, 3 tries with a 500ms, then 1s wait by default — because
+ipapi.co answers a rate limit as HTTP 200 with `{ error: true, reason: 'RateLimited' }`
+and a worker can drop a request while it cold-starts. Only the last error is thrown.
+
 ## Options and shapes
 
 | Option | Default | Meaning |
@@ -76,7 +81,7 @@ falls back to the browser's zone when the string is missing or invalid.
 | --- | --- |
 | The package isn't found as `react-weather-forecast` | The npm name is `use-weather-forecast`. |
 | Wrong city, or the datacenter's location | IP geolocation resolved the server or a VPN exit. Pass explicit coordinates, or use `geoEndpoint` so Cloudflare's edge geo is used. |
-| `ipapi.co lookup failed: …` | Rate-limited or blocked. Deploy the geo worker and set `geoEndpoint`. |
+| `ipapi.co lookup failed: …` | Rate-limited or blocked, and every repeat failed too. Deploy the geo worker and set `geoEndpoint`. |
 | `Geolocation worker lookup failed: <status>` | The endpoint is wrong or not deployed. |
 | `Invalid weather response` | Open-Meteo replied without `current`/`hourly`/`daily` — usually invalid coordinates (only one of lat/lon given, so the pair was ignored). |
 | Stale data after changing units | Different units → different URL → different cache key, but an unchanged URL keeps its 30-minute entry. `clearWeatherForecastCache()`. |


### PR DESCRIPTION
## What changed

**`grab-url` replaces raw `fetch`** in `packages/react-weather-forecast` (published as `use-weather-forecast`), matching the rest of the repo. Both HTTP calls — the geo lookup and the Open-Meteo forecast — go through a new `src/api/http.ts` helper:

```ts
const data = await grabJson<IpApiResponse>(url, 'ipapi.co lookup');
```

`grab-url` parses the JSON, applies a timeout and resolves with `{ error: "HTTP error: 429 …" }` instead of rejecting, so the payload check lives in one place. The helper strips grab-url's `HTTP error: ` prefix, so the thrown messages keep their existing shape (`ipapi.co lookup failed: 429 Too Many Requests`, `Weather request failed: 503 Service Unavailable`).

**A failed geo lookup now repeats instead of throwing on the first response.** ipapi.co's free tier answers a rate limit with HTTP 200 and `{ error: true, reason: 'RateLimited' }`, which the old code turned straight into

```ts
throw new Error(`ipapi.co lookup failed: ${data.reason ?? 'unknown error'}`);
```

taking the whole forecast down with it. `getClientLocation` now retries — 3 tries by default, waiting 500ms then 1s — and throws only the last error. Both the worker and the ipapi.co path retry, and it's tunable through a new optional third argument:

```ts
getClientLocation(geoEndpoint, ip, { attempts: 5, retryDelay: 250 })
```

The signature stays backwards compatible; existing callers get the defaults.

## Notes

- `grab-url@^1.6.22` is now the package's only runtime dependency, and is marked external in `tsup.config.ts` so it isn't bundled into `dist`. Its heavier deps (linkedom, chalk, cli-*) live in the CLI bundle only — the ESM library path pulls nothing extra into a browser bundle.
- `worker/geo-worker.ts` stays on native `fetch`: it runs on Cloudflare Workers, isn't part of the published npm files, and its inbound handler must be `fetch`.
- README and `skills/ask-weather-forecast/SKILL.md` document the retry behaviour and the client change.

## Testing

- `bun run test` in `packages/react-weather-forecast` — 92 passed (7 files). Tests mock the `grab-url` module the way `search-web-api` does, and new cases cover the repeat behaviour, a custom attempt count, worker-path retries, the backoff wait, and Open-Meteo's own 200-with-error-flag response.
- `bun run typecheck` — clean.
- `bun run build` — tsup + `tsc -p tsconfig.build.json` succeed; `grab-url` is left as an import in both the ESM and CJS output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZCx6iUrkzJ6KM8gXsbrbC

---
_Generated by [Claude Code](https://claude.ai/code/session_01AZCx6iUrkzJ6KM8gXsbrbC)_