### PR TITLE
📝 docs(readme): correct and complete the package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,23 @@ bun i qwksearch-api-client
 - **extract-youtube** — A fast, no-browser, serverless-optimized YouTube transcript extractor that fetches subtitles and captions without requiring a headless browser. Supports multiple output formats (SRT, WebVTT) and runs on edge/serverless platforms.
   <a href="https://www.npmjs.com/package/extract-youtube"><img src="https://img.shields.io/npm/dm/extract-youtube.svg" alt="Monthly Downloads"></a>
 
-- **notebooklm-api-client** — Placeholder package for a future API client for Google's NotebookLM service.
+- **html-renderer-api** — A Cloudflare Worker that renders pages with Puppeteer via Browser Rendering. A Durable Object keeps the browser warm and persists cookies per session id, so pages behind a login or a Cloudflare challenge can be scraped, with Swagger UI and an OpenAPI spec on the worker itself.
+  <a href="https://www.npmjs.com/package/html-renderer-api"><img src="https://img.shields.io/npm/dm/html-renderer-api.svg" alt="Monthly Downloads"></a>
+
+- **notebooklm-api-client** — A Cloudflare Worker and on-demand Python container that drive Google's NotebookLM, which has no public API. One authenticated POST endpoint covers list/create/ask/summarize/delete, and a Puppeteer login flow captures the Google session for the container. The container sleeps after 5 minutes idle to conserve cost.
   <a href="https://www.npmjs.com/package/notebooklm-api-client"><img src="https://img.shields.io/npm/dm/notebooklm-api-client.svg" alt="Monthly Downloads"></a>
 
 - **qwksearch-api-client** — An auto-generated TypeScript API client for the QwkSearch platform, built from an OpenAPI specification. Provides typed fetch-based bindings for interacting with the QwkSearch backend API.
   <a href="https://www.npmjs.com/package/qwksearch-api-client"><img src="https://img.shields.io/npm/dm/qwksearch-api-client.svg" alt="Monthly Downloads"></a>
 
-- **reason-editor** — A formatted text editor built on Lexical (React) with a toolbar, documents manager, and note outlines. Includes drag-and-drop, collaborative editing via Yjs, file management, and rich UI components for a full-featured writing/research interface.
-  <a href="https://www.npmjs.com/package/reason-editor"><img src="https://img.shields.io/npm/dm/reason-editor.svg" alt="Monthly Downloads"></a>
+- **qwksearch-mcp-server** — An MCP server that exposes web search, page extraction and JavaScript rendering as tools over stdio, so any MCP client — Claude Desktop, Claude Code, or your own — can search and read the web through QwkSearch.
+  <a href="https://www.npmjs.com/package/qwksearch-mcp-server"><img src="https://img.shields.io/npm/dm/qwksearch-mcp-server.svg" alt="Monthly Downloads"></a>
+
+- **reason-editor** — A formatted text editor built on Tiptap and Plate (React), published as `react-reason-editor`, with a toolbar, documents manager, and note outlines. Ships 59 editor extensions on individual subpath exports, 21 locales, remappable shortcuts, drag-and-drop, and collaborative editing via Yjs.
+  <a href="https://www.npmjs.com/package/react-reason-editor"><img src="https://img.shields.io/npm/dm/react-reason-editor.svg" alt="Monthly Downloads"></a>
+
+- **reason-editor-sidebar** — The REASON editor's file/folder tree, open-tabs panel, outline and split-view menu as a standalone package, published as `react-reason-editor-sidebar`. Includes the file-source layer for local, SSH, S3, R2, B2, Google Docs and Turso backends.
+  <a href="https://www.npmjs.com/package/react-reason-editor-sidebar"><img src="https://img.shields.io/npm/dm/react-reason-editor-sidebar.svg" alt="Monthly Downloads"></a>
 
 - **render-url-to-html** — A collection of URL-to-HTML rendering strategies using Cloudflare Browser Rendering, Puppeteer with stealth plugins, and JSDOM. Fetches URLs and returns fully-rendered DOM as HTML, capable of bypassing bot-detection on JavaScript-rendered pages.
 
@@ -144,7 +153,21 @@ bun i qwksearch-api-client
 - **shadcn-app-dock** — A prop-driven, macOS-style category dock React component with icon magnification on hover and a built-in shadcn theme switcher. Uses Framer Motion for animations and integrates with next-themes for light/dark mode toggling.
   <a href="https://www.npmjs.com/package/shadcn-app-dock"><img src="https://img.shields.io/npm/dm/shadcn-app-dock.svg" alt="Monthly Downloads"></a>
 
+- **shadcn-settings** — A schema-driven settings form renderer built on shadcn/ui. Feed it plain-data field declarations and value/commit callbacks and it renders string, password, textarea, select and switch controls in card, inline or ghost layouts, with custom field types supplied as renderers.
+  <a href="https://www.npmjs.com/package/shadcn-settings"><img src="https://img.shields.io/npm/dm/shadcn-settings.svg" alt="Monthly Downloads"></a>
+
 - **language-model-training** — A from-scratch GPT-style transformer implementation built on Tinygrad that trains a next-word-prediction language model with a full Wikipedia pipeline. Ships with a FastAPI control API, Docker Compose orchestration, and a Next.js dashboard for monitoring training jobs.
+
+- **trending-news-api** — A React trending-news widget backed by Wikipedia's daily pageviews joined to The News API through a bundled Cloudflare Worker proxy, with a 10-minute client cache.
+  <a href="https://www.npmjs.com/package/trending-news-api"><img src="https://img.shields.io/npm/dm/trending-news-api.svg" alt="Monthly Downloads"></a>
+
+- **react-weather-forecast** — A React weather forecast widget using Open-Meteo, published as `use-weather-forecast`. Resolves the viewer's location from explicit coordinates, a bundled Cloudflare geo Worker, or IP geolocation.
+  <a href="https://www.npmjs.com/package/use-weather-forecast"><img src="https://img.shields.io/npm/dm/use-weather-forecast.svg" alt="Monthly Downloads"></a>
+
+- **use-voice-control** — React voice control with speech transcription, vocalization and interruption (STT/TTS/VAD), plus a CLI that reads Markdown and text files aloud to audio files.
+  <a href="https://www.npmjs.com/package/use-voice-control"><img src="https://img.shields.io/npm/dm/use-voice-control.svg" alt="Monthly Downloads"></a>
+
+- **user-help-docs** — The user-facing help documentation served at `/docs` in the web app via Fumadocs. Content is inlined at build time so the docs run on Cloudflare Workers, where there is no filesystem to scan.
 
 - **write-language** — A multi-provider language generation toolkit using the Vercel AI SDK that generates text responses via 10+ LLM providers including OpenAI, Anthropic, Google, Groq, and more. Provides a unified interface for streaming and non-streaming text generation.
   <a href="https://www.npmjs.com/package/write-language"><img src="https://img.shields.io/npm/dm/write-language.svg" alt="Monthly Downloads"></a>

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -16,14 +16,23 @@
 - **extract-youtube** — A fast, no-browser, serverless-optimized YouTube transcript extractor that fetches subtitles and captions without requiring a headless browser. Supports multiple output formats (SRT, WebVTT) and runs on edge/serverless platforms.
   <a href="https://www.npmjs.com/package/extract-youtube"><img src="https://img.shields.io/npm/dm/extract-youtube.svg" alt="Monthly Downloads"></a>
 
-- **notebooklm-api-client** — Placeholder package for a future API client for Google's NotebookLM service.
+- **html-renderer-api** — A Cloudflare Worker that renders pages with Puppeteer via Browser Rendering. A Durable Object keeps the browser warm and persists cookies per session id, so pages behind a login or a Cloudflare challenge can be scraped, with Swagger UI and an OpenAPI spec on the worker itself.
+  <a href="https://www.npmjs.com/package/html-renderer-api"><img src="https://img.shields.io/npm/dm/html-renderer-api.svg" alt="Monthly Downloads"></a>
+
+- **notebooklm-api-client** — A Cloudflare Worker and on-demand Python container that drive Google's NotebookLM, which has no public API. One authenticated POST endpoint covers list/create/ask/summarize/delete, and a Puppeteer login flow captures the Google session for the container. The container sleeps after 5 minutes idle to conserve cost.
   <a href="https://www.npmjs.com/package/notebooklm-api-client"><img src="https://img.shields.io/npm/dm/notebooklm-api-client.svg" alt="Monthly Downloads"></a>
 
 - **qwksearch-api-client** — An auto-generated TypeScript API client for the QwkSearch platform, built from an OpenAPI specification. Provides typed fetch-based bindings for interacting with the QwkSearch backend API.
   <a href="https://www.npmjs.com/package/qwksearch-api-client"><img src="https://img.shields.io/npm/dm/qwksearch-api-client.svg" alt="Monthly Downloads"></a>
 
-- **reason-editor** — A formatted text editor built on Lexical (React) with a toolbar, documents manager, and note outlines. Includes drag-and-drop, collaborative editing via Yjs, file management, and rich UI components for a full-featured writing/research interface.
-  <a href="https://www.npmjs.com/package/reason-editor"><img src="https://img.shields.io/npm/dm/reason-editor.svg" alt="Monthly Downloads"></a>
+- **qwksearch-mcp-server** — An MCP server that exposes web search, page extraction and JavaScript rendering as tools over stdio, so any MCP client — Claude Desktop, Claude Code, or your own — can search and read the web through QwkSearch.
+  <a href="https://www.npmjs.com/package/qwksearch-mcp-server"><img src="https://img.shields.io/npm/dm/qwksearch-mcp-server.svg" alt="Monthly Downloads"></a>
+
+- **reason-editor** — A formatted text editor built on Tiptap and Plate (React), published as `react-reason-editor`, with a toolbar, documents manager, and note outlines. Ships 59 editor extensions on individual subpath exports, 21 locales, remappable shortcuts, drag-and-drop, and collaborative editing via Yjs.
+  <a href="https://www.npmjs.com/package/react-reason-editor"><img src="https://img.shields.io/npm/dm/react-reason-editor.svg" alt="Monthly Downloads"></a>
+
+- **reason-editor-sidebar** — The REASON editor's file/folder tree, open-tabs panel, outline and split-view menu as a standalone package, published as `react-reason-editor-sidebar`. Includes the file-source layer for local, SSH, S3, R2, B2, Google Docs and Turso backends.
+  <a href="https://www.npmjs.com/package/react-reason-editor-sidebar"><img src="https://img.shields.io/npm/dm/react-reason-editor-sidebar.svg" alt="Monthly Downloads"></a>
 
 - **render-url-to-html** — A collection of URL-to-HTML rendering strategies using Cloudflare Browser Rendering, Puppeteer with stealth plugins, and JSDOM. Fetches URLs and returns fully-rendered DOM as HTML, capable of bypassing bot-detection on JavaScript-rendered pages.
 
@@ -38,7 +47,21 @@
 - **shadcn-app-dock** — A prop-driven, macOS-style category dock React component with icon magnification on hover and a built-in shadcn theme switcher. Uses Framer Motion for animations and integrates with next-themes for light/dark mode toggling.
   <a href="https://www.npmjs.com/package/shadcn-app-dock"><img src="https://img.shields.io/npm/dm/shadcn-app-dock.svg" alt="Monthly Downloads"></a>
 
+- **shadcn-settings** — A schema-driven settings form renderer built on shadcn/ui. Feed it plain-data field declarations and value/commit callbacks and it renders string, password, textarea, select and switch controls in card, inline or ghost layouts, with custom field types supplied as renderers.
+  <a href="https://www.npmjs.com/package/shadcn-settings"><img src="https://img.shields.io/npm/dm/shadcn-settings.svg" alt="Monthly Downloads"></a>
+
 - **language-model-training** — A from-scratch GPT-style transformer implementation built on Tinygrad that trains a next-word-prediction language model with a full Wikipedia pipeline. Ships with a FastAPI control API, Docker Compose orchestration, and a Next.js dashboard for monitoring training jobs.
+
+- **trending-news-api** — A React trending-news widget backed by Wikipedia's daily pageviews joined to The News API through a bundled Cloudflare Worker proxy, with a 10-minute client cache.
+  <a href="https://www.npmjs.com/package/trending-news-api"><img src="https://img.shields.io/npm/dm/trending-news-api.svg" alt="Monthly Downloads"></a>
+
+- **react-weather-forecast** — A React weather forecast widget using Open-Meteo, published as `use-weather-forecast`. Resolves the viewer's location from explicit coordinates, a bundled Cloudflare geo Worker, or IP geolocation.
+  <a href="https://www.npmjs.com/package/use-weather-forecast"><img src="https://img.shields.io/npm/dm/use-weather-forecast.svg" alt="Monthly Downloads"></a>
+
+- **use-voice-control** — React voice control with speech transcription, vocalization and interruption (STT/TTS/VAD), plus a CLI that reads Markdown and text files aloud to audio files.
+  <a href="https://www.npmjs.com/package/use-voice-control"><img src="https://img.shields.io/npm/dm/use-voice-control.svg" alt="Monthly Downloads"></a>
+
+- **user-help-docs** — The user-facing help documentation served at `/docs` in the web app via Fumadocs. Content is inlined at build time so the docs run on Cloudflare Workers, where there is no filesystem to scan.
 
 - **write-language** — A multi-provider language generation toolkit using the Vercel AI SDK that generates text responses via 10+ LLM providers including OpenAI, Anthropic, Google, Groq, and more. Provides a unified interface for streaming and non-streaming text generation.
   <a href="https://www.npmjs.com/package/write-language"><img src="https://img.shields.io/npm/dm/write-language.svg" alt="Monthly Downloads"></a>


### PR DESCRIPTION
Follow-up to #402. While writing the per-package skills against each package's source, three kinds of drift showed up in the package list — which lives twice, identically, in `README.md` and `packages/readme.md`. Both copies are updated together here.

## Wrong descriptions

- **`reason-editor`** was described as *"built on Lexical (React)"*. It is **Tiptap and Plate** — 44 `@tiptap/*` and 32 `@platejs/*` dependencies, and `ReasonDocs`' `editorEngine` prop defaults to `'plate'`, with `'tiptap'` kept as the control version for the features not yet ported.
- **`notebooklm-api-client`** was described as *"Placeholder package for a future API client"*. It is a working Cloudflare Worker plus an on-demand Python container: one authenticated POST endpoint covering `list`/`create`/`ask`/`summarize`/`delete`, and a Puppeteer Google sign-in flow that captures cookies and localStorage for the container. The container sleeps after 5 minutes idle.

## Broken npm badge

`reason-editor`'s badge pointed at `npmjs.com/package/reason-editor`, which 404s — the package publishes as **`react-reason-editor`**. Every badge target in the list now returns 200 from the registry, and the three packages whose directory name differs from their published name (`reason-editor`, `reason-editor-sidebar`, `react-weather-forecast`) say so in their description.

## Eight missing packages

The list covered 15 of the repo's 23 packages. Added, each described from its source:

| Package | Summary |
| --- | --- |
| `html-renderer-api` | Cloudflare Worker rendering pages with Puppeteer; Durable Object browser pool, per-session cookie persistence, Swagger/OpenAPI |
| `qwksearch-mcp-server` | Search, extraction and JS rendering as MCP tools over stdio |
| `reason-editor-sidebar` | The editor's file tree, open tabs, outline and split-view menu; file sources for local/SSH/S3/R2/B2/Google Docs/Turso |
| `shadcn-settings` | Schema-driven settings form renderer on shadcn/ui |
| `trending-news-api` | Trending widget over Wikipedia pageviews × The News API, via a Worker proxy |
| `react-weather-forecast` | Open-Meteo widget with a bundled Cloudflare geo Worker |
| `use-voice-control` | STT/TTS/VAD hooks plus a read-aloud CLI |
| `user-help-docs` | The Fumadocs `/docs` site (private — no badge) |

## Notes

- Docs only — no code, config or dependency changes.
- The branch was restarted from `master` after #402 merged, so this contains one commit on top of current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016GnF2Xa4LGZZwNJiggTtEn


---
_Generated by [Claude Code](https://claude.ai/code/session_016GnF2Xa4LGZZwNJiggTtEn)_