### PR TITLE
✅ test(extract-pdf): serve the URL fixture locally instead of fetching africau.edu

### DIFF
--- a/packages/extract-pdf/test/pdf-to-html.test.ts
+++ b/packages/extract-pdf/test/pdf-to-html.test.ts
@@ -1,8 +1,38 @@
-import { describe, it, expect } from "bun:test";
+import { afterAll, beforeAll, describe, it, expect } from "bun:test";
 import { convertPDFToHTML } from "../src/pdf-to-html";
 import { minimalPDFBuffer } from "./helpers/minimal-pdf";
 
 const TIMEOUT = 30_000;
+
+/**
+ * Serves the fixture PDF from localhost for the URL case below.
+ *
+ * That test used to fetch https://www.africau.edu/images/default/sample.pdf.
+ * The host now answers 403, so an unrelated third party going down turned the
+ * whole extract-pdf suite red on every branch. Serving our own bytes still
+ * drives the real URL branch of `convertPDFToHTML` — `grab()` fetches it as an
+ * arraybuffer and the result goes through the same parser — without depending
+ * on anything outside the repo.
+ */
+let pdfServer: ReturnType<typeof Bun.serve>;
+let pdfUrl: string;
+
+beforeAll(() => {
+  const pdf = minimalPDFBuffer();
+
+  // Port 0 asks the OS for a free port, so parallel test files cannot collide.
+  pdfServer = Bun.serve({
+    port: 0,
+    fetch: () =>
+      new Response(pdf, { headers: { "content-type": "application/pdf" } }),
+  });
+
+  pdfUrl = `http://localhost:${pdfServer.port}/sample.pdf`;
+});
+
+afterAll(() => {
+  pdfServer?.stop(true);
+});
 
 describe("convertPDFToHTML", () => {
   it("returns html and format fields from a buffer", async () => {
@@ -43,9 +73,13 @@ describe("convertPDFToHTML", () => {
   }, TIMEOUT);
 
   it("accepts a PDF by URL", async () => {
-    const url = "https://www.africau.edu/images/default/sample.pdf";
-    const result = (await convertPDFToHTML(url)) as any;
+    const result = (await convertPDFToHTML(pdfUrl)) as any;
     expect(result.error).toBeUndefined();
-    expect(result.html.length).toBeGreaterThan(100);
-  }, 60_000);
+
+    // Same assertions as the buffer case: fetching the bytes over HTTP must
+    // land in the parser identically to handing them over directly.
+    expect(result.format).toBe("pdf");
+    expect(result.html).toContain("Test Document");
+    expect(result.html).toContain("sample paragraph");
+  }, TIMEOUT);
 });


### PR DESCRIPTION
## The failure

`extract-pdf` has been red on **every branch**, at 224 pass / 1 fail:

```
1 tests failed:
(fail) convertPDFToHTML > accepts a PDF by URL
```

The test fetches a file that belongs to someone else:

```ts
const url = "https://www.africau.edu/images/default/sample.pdf";
```

That host now answers **403**, which throws inside `grab()`:

```
error: HTTP 403
    at grab (src/utils/grab.ts:20:17)
    at async convertPDFToHTML (src/pdf-to-html.ts:154:15)
    at async test/pdf-to-html.test.ts:47:27
```

Nothing in the repo caused it and nothing in the repo can stop it recurring — the suite's colour depends on a third party's uptime and access policy.

## Not a one-off

- #401 (a CSS-only diff, since merged to `master`) failed the **same single test** with the **same counts**: 224 pass / 1 fail.
- #403 reproduced it identically.
- It reproduces locally on a clean checkout.

## The change

Serve the fixture the package already has — `minimalPDFBuffer()` from `test/helpers/minimal-pdf.ts`, used by the five sibling tests in this file — from a `Bun.serve` on an OS-assigned port (`port: 0`, so parallel test files can't collide).

Coverage is unchanged. `convertPDFToHTML` still takes a `string` starting with `http`, still routes it through `grab()` as an arraybuffer, and still parses the fetched bytes — the real URL branch runs end to end. Only the dependency on an external host is gone.

The assertions get stronger while I'm here. `html.length > 100` was a proxy for "something came back"; the URL case now checks the same `format` and extracted text the buffer case does, which is what *"the fetched bytes reached the parser intact"* actually means.

## How to test

```
cd packages/extract-pdf && bun run test:coverage
```

Before: `224 pass, 1 fail` — exit 1
After:  `225 pass, 0 fail` — exit 0

That's the exact command the `extract-pdf` CI job runs. Verified on this branch, including in a sandbox whose proxy also refuses external hosts — the old test fails there for the same reason CI does, the new one passes.

## Not addressed here

`Workers Builds: qwksearch-research-agent` is also red on `master` and is **not** related to this change. Every run shows `started_at == completed_at` (zero duration), so the build never reaches a build step; its log lives behind the Cloudflare dashboard and the GitHub check carries an empty `output.text`. Someone with dashboard access needs to look at it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxPJQApiQvPRqsa8rHkVKv

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxPJQApiQvPRqsa8rHkVKv)_