### PR TITLE
✨ feat(settings): edit the follow-up and query-expansion prompts

### DIFF
--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -424,12 +424,12 @@ function Comparison() {
           <div className="qs-border-beam relative isolate overflow-hidden rounded-3xl p-px">
             <div className="bg-card/80 relative z-10 overflow-hidden rounded-[calc(1.5rem-1px)] border backdrop-blur-sm">
               <div className="overflow-x-auto">
-                <table className="w-full min-w-[1140px] border-collapse text-sm">
+                <table className="w-full min-w-[1080px] border-collapse text-sm">
                   <thead>
                     <tr className="border-b">
                       <th
                         scope="col"
-                        className="bg-card sticky left-0 z-10 w-56 border-r px-5 py-4 text-left align-bottom"
+                        className="bg-card sticky left-0 z-10 w-40 border-r px-4 py-4 text-left align-bottom"
                       >
                         <span className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
                           Feature
@@ -487,7 +487,7 @@ function Comparison() {
                       >
                         <th
                           scope="row"
-                          className="bg-card sticky left-0 z-10 border-r px-5 py-4 text-left text-sm font-medium"
+                          className="bg-card sticky left-0 z-10 w-40 border-r px-4 py-4 text-left text-sm font-medium"
                         >
                           {row.feature}
                         </th>

--- a/apps/qwksearch-web/components/features/data.tsx
+++ b/apps/qwksearch-web/components/features/data.tsx
@@ -462,9 +462,9 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "Self-hostable (Cloudflare Workers, Docker)",
+    feature: "Self-hostable",
     cells: [
-      { status: "yes", note: "Yes" },
+      { status: "yes", note: "Cloudflare Workers or Docker" },
       { status: "no" },
       { status: "no" },
       { status: "no" },
@@ -474,7 +474,7 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "Choice of LLM provider",
+    feature: "Choose any LLM",
     cells: [
       { status: "yes", note: "Claude, GPT, Gemini, Grok, Llama & more" },
       { status: "no", note: "Perplexity-controlled model selection" },
@@ -483,6 +483,18 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
       { status: "no", note: "Gemini only" },
       { status: "no", note: "Grok only" },
       { status: "yes", note: "Multiple open models (Llama, Qwen, DeepSeek…)" },
+    ],
+  },
+  {
+    feature: "Bring your own API keys",
+    cells: [
+      { status: "yes", note: "Your keys, your billing, no markup" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+      { status: "partial", note: "Separate paid API, not in the chat app" },
     ],
   },
   {
@@ -501,7 +513,19 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "Cited answers with APA formatting",
+    feature: "Pick your search sources",
+    cells: [
+      { status: "yes", note: "Enable or disable engines per category" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+      { status: "no" },
+    ],
+  },
+  {
+    feature: "Cited answers (APA)",
     cells: [
       { status: "yes", note: "Built-in citation extraction & formatting" },
       { status: "yes", note: "Yes" },
@@ -513,7 +537,7 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "PDF / YouTube / DOCX ingestion",
+    feature: "PDF / YouTube / DOCX",
     cells: [
       { status: "yes", note: "With transcript & structure extraction" },
       { status: "partial", note: "PDF only" },
@@ -525,7 +549,7 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "Research writing / notes editor",
+    feature: "Writing & notes editor",
     cells: [
       { status: "yes", note: "Full Lexical-based editor with outline notation (REASON)" },
       { status: "no" },
@@ -533,6 +557,69 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
       { status: "no" },
       { status: "no" },
       { status: "no" },
+      { status: "no" },
+    ],
+  },
+  {
+    feature: "Editable AI prompts",
+    cells: [
+      {
+        status: "yes",
+        note: "Edit the answer, follow-up & query-expansion prompts",
+      },
+      { status: "no" },
+      { status: "partial", note: "Custom instructions only" },
+      { status: "partial", note: "Styles & project instructions" },
+      { status: "partial", note: "Gems only" },
+      { status: "partial", note: "Custom instructions only" },
+      { status: "partial", note: "System prompt only" },
+    ],
+  },
+  {
+    feature: "MCP connectors",
+    cells: [
+      { status: "yes", note: "Add any MCP server in settings" },
+      { status: "no" },
+      { status: "yes", note: "Connectors (paid tiers)" },
+      { status: "yes", note: "Yes" },
+      { status: "partial", note: "Extensions, not open MCP" },
+      { status: "no" },
+      { status: "no" },
+    ],
+  },
+  {
+    feature: "Skills & memory",
+    cells: [
+      { status: "yes", note: "Editable agent skills and stored memories" },
+      { status: "partial", note: "Memory only" },
+      { status: "yes", note: "Memory + custom GPTs" },
+      { status: "yes", note: "Skills + memory" },
+      { status: "partial", note: "Memory only" },
+      { status: "partial", note: "Memory only" },
+      { status: "no" },
+    ],
+  },
+  {
+    feature: "Cloud storage sync",
+    cells: [
+      { status: "yes", note: "S3, R2, B2, SSH, Google Docs, Turso" },
+      { status: "no" },
+      { status: "partial", note: "Drive & SharePoint connectors" },
+      { status: "partial", note: "Drive connector" },
+      { status: "yes", note: "Google Drive" },
+      { status: "no" },
+      { status: "no" },
+    ],
+  },
+  {
+    feature: "Read aloud (TTS)",
+    cells: [
+      { status: "yes", note: "On-device Kokoro.js or Cloudflare voices" },
+      { status: "yes", note: "Yes" },
+      { status: "yes", note: "Yes" },
+      { status: "no" },
+      { status: "yes", note: "Yes" },
+      { status: "yes", note: "Yes" },
       { status: "no" },
     ],
   },
@@ -561,7 +648,7 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "Editor / IDE integration",
+    feature: "IDE integration",
     cells: [
       { status: "yes", note: "VS Code extension" },
       { status: "no" },
@@ -573,9 +660,9 @@ export const COMPARISON_ROWS: ComparisonRow[] = [
     ],
   },
   {
-    feature: "Privacy mode (no saved history)",
+    feature: "Private mode",
     cells: [
-      { status: "yes", note: "Yes" },
+      { status: "yes", note: "Nothing saved to history" },
       { status: "partial", note: "Limited" },
       { status: "partial", note: "Limited" },
       { status: "partial", note: "Limited" },

--- a/apps/qwksearch-web/lib/chat/handler.ts
+++ b/apps/qwksearch-web/lib/chat/handler.ts
@@ -277,6 +277,7 @@ export const handleChatRequest = async (req: Request): Promise<Response> => {
       body.category,
       body.sourceExtractionEnabled,
       body.thinkingTimeLimit,
+      body.queryExpansionPrompt ?? undefined,
     );
 
     // --- Set up the SSE response stream ---

--- a/apps/qwksearch-web/lib/chat/schemas.ts
+++ b/apps/qwksearch-web/lib/chat/schemas.ts
@@ -78,6 +78,7 @@ export const chatModelSchema: z.ZodType<ModelWithProvider> = z.object({
  * @property {ModelWithProvider} chatModel         - Selected AI model and provider.
  * @property {boolean}   [sourceExtractionEnabled=false] - Whether to extract and return source content.
  * @property {string|null} [systemInstructions=""]  - Custom system instructions to prepend to the prompt.
+ * @property {string|null} [queryExpansionPrompt=""] - Custom prompt used to rephrase the query for search.
  */
 export const bodySchema = z.object({
   /** The user's chat message. */
@@ -110,6 +111,11 @@ export const bodySchema = z.object({
   sourceExtractionEnabled: z.boolean().optional().default(false),
   /** Custom system instructions to prepend to the prompt. */
   systemInstructions: z.string().nullable().optional().default(""),
+  /**
+   * User-authored replacement for the focus mode's query-expansion prompt
+   * (edited in Settings → Search Settings). Blank means "use the built-in one".
+   */
+  queryExpansionPrompt: z.string().nullable().optional().default(""),
   /**
    * Max seconds to spend extracting source content.
    * 0 = unlimited (uses server default); >0 = budget spread across top 3 sources.

--- a/packages/chat-agent-toolkit/src/prompts/search-prompts.ts
+++ b/packages/chat-agent-toolkit/src/prompts/search-prompts.ts
@@ -92,6 +92,30 @@ https://example.com
   ],
 ];
 
+/**
+ * Default template for generating follow-up question suggestions after an
+ * answer. Interpolated with `{maxQuestions}` and `{chat_history}`.
+ *
+ * Exported (rather than inlined in the suggestion agent) so the settings UI can
+ * show the live default in an editable textarea and users can override it.
+ */
+export const followUpSuggestionsPrompt = `
+You are an AI suggestion generator for an AI powered search engine. You will be given a conversation below. You need to generate {maxQuestions} suggestions based on the conversation. The suggestion should be relevant to the conversation that can be used by the user to ask the chat model for more information.
+You need to make sure the suggestions are relevant to the conversation and are helpful to the user. Keep a note that the user might use these suggestions to ask a chat model for more information.
+Make sure the suggestions are medium in length and are informative and relevant to the conversation.
+
+Provide these suggestions separated by newlines between the XML tags <suggestions> and </suggestions>. For example:
+
+<suggestions>
+Tell me more about SpaceX and their recent projects
+What is the latest news on SpaceX?
+Who is the CEO of SpaceX?
+</suggestions>
+
+Conversation:
+{chat_history}
+`;
+
 export const webSearchResponsePrompt = `
     You are QwkSearch, an AI model skilled in web search and crafting detailed, engaging, and well-structured answers. You excel at summarizing web pages and extracting relevant information to create professional, blog-style responses.
 
@@ -163,4 +187,5 @@ export default {
   webSearchRetrieverPrompt,
   webSearchRetrieverFewShots,
   writingAssistantPrompt,
+  followUpSuggestionsPrompt,
 };

--- a/packages/chat-agent-toolkit/src/tools/search/meta-search-types.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/meta-search-types.ts
@@ -25,6 +25,8 @@ export interface MetaSearchAgentType {
     category?: string,
     sourceExtractionEnabled?: boolean,
     thinkingTimeLimit?: number,
+    /** User-authored replacement for the focus mode's query-expansion prompt. */
+    queryExpansionPrompt?: string,
   ) => Promise<EventEmitter>;
 }
 

--- a/packages/chat-agent-toolkit/src/tools/search/metaSearchAgent.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/metaSearchAgent.ts
@@ -88,11 +88,19 @@ class MetaSearchAgent implements MetaSearchAgentType {
     sourceExtractionEnabled = false,
     thinkingTimeLimit = 0,
     emitter?: EventEmitter,
+    queryGeneratorPromptOverride?: string,
   ): Promise<{ query: string; docs: Document[] }> {
+    // A user-authored query-expansion prompt (Settings → Search Settings)
+    // replaces the focus mode's built-in one. Blank or whitespace-only text
+    // means "use the built-in prompt".
+    const queryGeneratorPrompt = queryGeneratorPromptOverride?.trim()
+      ? queryGeneratorPromptOverride
+      : this.config.queryGeneratorPrompt;
+
     const { text: retrieverOutput } = await generateText({
       model: llm,
       temperature: 0,
-      system: this.config.queryGeneratorPrompt,
+      system: queryGeneratorPrompt,
       messages: [
         ...this.config.queryGeneratorFewShots.map(([role, content]) => ({
           role,
@@ -333,6 +341,7 @@ class MetaSearchAgent implements MetaSearchAgentType {
     category: string,
     sourceExtractionEnabled: boolean,
     thinkingTimeLimit: number,
+    queryExpansionPrompt?: string,
   ): Promise<void> {
     try {
       let docs: Document[] | null = null;
@@ -347,6 +356,7 @@ class MetaSearchAgent implements MetaSearchAgentType {
           sourceExtractionEnabled,
           thinkingTimeLimit,
           emitter,
+          queryExpansionPrompt,
         );
         query = result.query;
         docs = result.docs;
@@ -454,6 +464,7 @@ class MetaSearchAgent implements MetaSearchAgentType {
     category: string = "general",
     sourceExtractionEnabled = false,
     thinkingTimeLimit = 0,
+    queryExpansionPrompt?: string,
   ) {
     const emitter = new EventEmitter();
 
@@ -471,6 +482,7 @@ class MetaSearchAgent implements MetaSearchAgentType {
         category,
         sourceExtractionEnabled,
         thinkingTimeLimit,
+        queryExpansionPrompt,
       );
     }, 0);
 

--- a/packages/chat-agent-toolkit/src/tools/search/suggestionGeneratorAgent.ts
+++ b/packages/chat-agent-toolkit/src/tools/search/suggestionGeneratorAgent.ts
@@ -6,28 +6,18 @@
 import { generateText, type LanguageModel } from "ai";
 import { LineListOutputParser } from "../../utils/outputParser";
 import { formatChatHistoryAsString } from "../../utils";
+import { followUpSuggestionsPrompt } from "../../prompts/search-prompts";
 import type { ChatTurnMessage } from "./meta-search-types";
-
-const createSuggestionGeneratorPrompt = (maxQuestions: number = 4) => `
-You are an AI suggestion generator for an AI powered search engine. You will be given a conversation below. You need to generate ${maxQuestions} suggestions based on the conversation. The suggestion should be relevant to the conversation that can be used by the user to ask the chat model for more information.
-You need to make sure the suggestions are relevant to the conversation and are helpful to the user. Keep a note that the user might use these suggestions to ask a chat model for more information.
-Make sure the suggestions are medium in length and are informative and relevant to the conversation.
-
-Provide these suggestions separated by newlines between the XML tags <suggestions> and </suggestions>. For example:
-
-<suggestions>
-Tell me more about SpaceX and their recent projects
-What is the latest news on SpaceX?
-Who is the CEO of SpaceX?
-</suggestions>
-
-Conversation:
-{chat_history}
-`;
 
 type SuggestionGeneratorInput = {
   chat_history: ChatTurnMessage[];
   maxQuestions?: number;
+  /**
+   * Optional user-authored replacement for {@link followUpSuggestionsPrompt}
+   * (edited in Settings → Search Settings). Blank or whitespace-only values
+   * fall back to the built-in template.
+   */
+  promptTemplate?: string;
 };
 
 const outputParser = new LineListOutputParser({
@@ -39,10 +29,15 @@ const generateSuggestions = async (
   llm: LanguageModel,
 ): Promise<string[]> => {
   const maxQuestions = input.maxQuestions ?? 4;
-  const prompt = createSuggestionGeneratorPrompt(maxQuestions).replace(
-    "{chat_history}",
-    formatChatHistoryAsString(input.chat_history),
-  );
+  const template = input.promptTemplate?.trim()
+    ? input.promptTemplate
+    : followUpSuggestionsPrompt;
+
+  const prompt = template
+    .split("{maxQuestions}")
+    .join(String(maxQuestions))
+    .split("{chat_history}")
+    .join(formatChatHistoryAsString(input.chat_history));
 
   const { text } = await generateText({
     model: llm,

--- a/packages/chat-agent-toolkit/test/metaSearchAgentQueryExpansion.test.ts
+++ b/packages/chat-agent-toolkit/test/metaSearchAgentQueryExpansion.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Tests for the user-editable query-expansion prompt override.
+ *
+ * The prompt that rephrases a chat message into a standalone search query is
+ * configured per focus mode, but Settings → Search Settings lets a user replace
+ * it. These tests pin the precedence: a non-blank override wins, anything blank
+ * falls back to the focus mode's built-in prompt.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const generateTextMock = vi.fn();
+
+vi.mock('ai', () => ({
+  generateText: (args: unknown) => generateTextMock(args),
+  streamText: () => ({ textStream: (async function* () {})() }),
+}));
+
+import MetaSearchAgent from '../src/tools/search/metaSearchAgent';
+
+const BUILT_IN = 'BUILT-IN rephraser prompt';
+
+const fakeLlm = { id: 'fake-model' } as any;
+
+/**
+ * Runs the pipeline far enough to capture the retriever's `generateText` call,
+ * then waits for the emitter to settle. The retriever answers `not_needed` so
+ * no search or answer streaming is attempted.
+ */
+const runWithOverride = async (queryExpansionPrompt?: string) => {
+  const agent = new MetaSearchAgent({
+    activeEngines: [],
+    queryGeneratorPrompt: BUILT_IN,
+    queryGeneratorFewShots: [],
+    responsePrompt: 'answer prompt',
+    rerank: false,
+    rerankThreshold: 0,
+    searchWeb: true,
+  } as any);
+
+  const emitter = await agent.searchAndAnswer(
+    'what is spacex',
+    [],
+    fakeLlm,
+    'speed',
+    [],
+    '',
+    'general',
+    false,
+    0,
+    queryExpansionPrompt,
+  );
+
+  await new Promise<void>((resolve) => {
+    emitter.on('end', () => resolve());
+    emitter.on('error', () => resolve());
+  });
+
+  return generateTextMock.mock.calls[0]?.[0] as Record<string, unknown>;
+};
+
+beforeEach(() => {
+  generateTextMock.mockReset();
+  generateTextMock.mockResolvedValue({
+    text: '<question>\nnot_needed\n</question>',
+  });
+});
+
+describe('MetaSearchAgent query-expansion prompt', () => {
+  it('uses the focus mode prompt when no override is supplied', async () => {
+    const arg = await runWithOverride(undefined);
+    expect(arg.system).toBe(BUILT_IN);
+  });
+
+  it('uses the user-supplied override when it has content', async () => {
+    const arg = await runWithOverride('MY custom rephraser');
+    expect(arg.system).toBe('MY custom rephraser');
+  });
+
+  it('falls back to the focus mode prompt for a blank override', async () => {
+    const arg = await runWithOverride('   \n  ');
+    expect(arg.system).toBe(BUILT_IN);
+  });
+});

--- a/packages/chat-agent-toolkit/test/suggestionGeneratorAgent.test.ts
+++ b/packages/chat-agent-toolkit/test/suggestionGeneratorAgent.test.ts
@@ -80,4 +80,39 @@ describe('generateSuggestions', () => {
     const arg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
     expect(arg.prompt).toContain('generate 2 suggestions');
   });
+
+  it('uses a caller-supplied promptTemplate and interpolates both placeholders', async () => {
+    generateTextMock.mockResolvedValue({ text: '<suggestions>\nfoo\n</suggestions>' });
+
+    await generateSuggestions(
+      {
+        chat_history: [{ role: 'user', content: 'What is SpaceX?' }],
+        maxQuestions: 3,
+        promptTemplate:
+          'Write exactly {maxQuestions} spicy follow-ups.\n{chat_history}',
+      },
+      fakeLlm,
+    );
+
+    const arg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.prompt).toBe(
+      'Write exactly 3 spicy follow-ups.\nUser: What is SpaceX?',
+    );
+    expect(arg.prompt).not.toContain('AI suggestion generator');
+  });
+
+  it('falls back to the built-in template when promptTemplate is blank', async () => {
+    generateTextMock.mockResolvedValue({ text: '<suggestions>\nfoo\n</suggestions>' });
+
+    await generateSuggestions(
+      { chat_history: [{ role: 'user', content: 'hi' }], promptTemplate: '   \n  ' },
+      fakeLlm,
+    );
+
+    const arg = generateTextMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.prompt).toContain('AI suggestion generator');
+    expect(arg.prompt).toContain('generate 4 suggestions');
+    expect(arg.prompt).not.toContain('{maxQuestions}');
+    expect(arg.prompt).not.toContain('{chat_history}');
+  });
 });

--- a/packages/qwksearch-api-client/qwksearch-openapi.json
+++ b/packages/qwksearch-api-client/qwksearch-openapi.json
@@ -198,7 +198,8 @@
                   "chatModel": { "$ref": "#/components/schemas/ModelWithProvider" },
                   "sourceExtractionEnabled": { "type": "boolean" },
                   "thinkingTimeLimit": { "type": "integer", "minimum": 0 },
-                  "systemInstructions": { "type": "string" }
+                  "systemInstructions": { "type": "string" },
+                  "queryExpansionPrompt": { "type": "string" }
                 }
               }
             }
@@ -531,7 +532,8 @@
                 "properties": {
                   "chatHistory": { "type": "array", "items": { "type": "object" } },
                   "chatModel": { "$ref": "#/components/schemas/ModelWithProvider" },
-                  "maxQuestions": { "type": "integer", "default": 3 }
+                  "maxQuestions": { "type": "integer", "default": 3 },
+                  "promptTemplate": { "type": "string" }
                 }
               }
             }

--- a/packages/qwksearch-api-client/src/types.gen.ts
+++ b/packages/qwksearch-api-client/src/types.gen.ts
@@ -294,6 +294,7 @@ export type AgentChatData = {
         sourceExtractionEnabled?: boolean;
         thinkingTimeLimit?: number;
         systemInstructions?: string;
+        queryExpansionPrompt?: string;
     };
     path?: never;
     query?: never;
@@ -643,6 +644,7 @@ export type GenerateSuggestionsData = {
         }>;
         chatModel: ModelWithProvider;
         maxQuestions?: number;
+        promptTemplate?: string;
     };
     path?: never;
     query?: never;

--- a/packages/research-agent-ui/src/api/handlers/suggestions.ts
+++ b/packages/research-agent-ui/src/api/handlers/suggestions.ts
@@ -14,6 +14,11 @@ interface SuggestionsGenerationBody {
   chatHistory: any[];
   chatModel: ModelWithProvider;
   maxQuestions?: number;
+  /**
+   * Optional user-authored follow-up prompt from Settings → Search Settings.
+   * Blank or absent falls back to the toolkit's built-in template.
+   */
+  promptTemplate?: string;
 }
 
 export function createSuggestionsHandler() {
@@ -36,7 +41,11 @@ export function createSuggestionsHandler() {
     );
 
     const rawSuggestions = await generateSuggestions(
-      { chat_history: chatHistory, maxQuestions: body.maxQuestions },
+      {
+        chat_history: chatHistory,
+        maxQuestions: body.maxQuestions,
+        promptTemplate: body.promptTemplate,
+      },
       llm,
     );
 

--- a/packages/research-agent-ui/src/app/CategoryDock.tsx
+++ b/packages/research-agent-ui/src/app/CategoryDock.tsx
@@ -20,6 +20,11 @@ import { useChat } from "../hooks/useChat"
 import { researchAgentUIConfig } from "../config"
 import { siteLinksForPath } from "../lib/site-links"
 import { useMainView } from "./MainViewProvider"
+// Both dock marks are SVGs, and next/image refuses to run SVG through the
+// optimizer unless `dangerouslyAllowSVG` is on — the request 400s and the dock
+// renders two broken-image glyphs. They are already tiny inline-able assets, so
+// every <Image> below opts out of optimization (same as `renderImage` does for
+// the app icon) and serves the file as-is.
 import iconRead from "../icons/icon-read.svg"
 import iconConfigure from "../icons/icon-configure.svg"
 
@@ -39,7 +44,16 @@ export function CategoryDock() {
           {
             href: "/workspace",
             label: "Docs",
-            icon: <Image src={iconRead} alt="Docs" width={24} height={24} className="w-full h-full" />,
+            icon: (
+              <Image
+                src={iconRead}
+                alt="Docs"
+                width={24}
+                height={24}
+                unoptimized
+                className="w-full h-full"
+              />
+            ),
           },
         ]
       : []),
@@ -89,7 +103,16 @@ export function CategoryDock() {
     {
       key: "settings",
       label: "Settings",
-      icon: <Image src={iconConfigure} alt="Settings" width={24} height={24} className="w-full h-full" />,
+      icon: (
+        <Image
+          src={iconConfigure}
+          alt="Settings"
+          width={24}
+          height={24}
+          unoptimized
+          className="w-full h-full"
+        />
+      ),
       menu: {
         renderContent: () => (
           <>

--- a/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
+++ b/packages/research-agent-ui/src/hooks/useChat/sendMessage.ts
@@ -475,6 +475,10 @@ export async function sendMessage(
         sourceExtractionEnabled,
         thinkingTimeLimit,
         systemInstructions: localStorage.getItem("systemInstructions") ?? undefined,
+        // User-editable replacement for the built-in query-expansion prompt
+        // (Settings → Search Settings). Blank means "use the built-in one".
+        queryExpansionPrompt:
+          localStorage.getItem("queryExpansionPrompt") ?? undefined,
       },
       // A chat POST is not idempotent — retrying re-sends the message and
       // hammers the backend while the user sees nothing. Fail fast instead.

--- a/packages/research-agent-ui/src/lib/suggestions.ts
+++ b/packages/research-agent-ui/src/lib/suggestions.ts
@@ -8,6 +8,10 @@ export const getSuggestions = async (chatHistory: Message[]) => {
   const chatModel = localStorage.getItem("chatModelKey");
   const chatModelProvider = localStorage.getItem("chatModelProviderId");
   const maxQuestions = parseInt(localStorage.getItem("maxFollowupQuestions") || "4");
+  // User-editable replacement for the built-in follow-up prompt
+  // (Settings → Search Settings). Blank means "use the built-in one".
+  const promptTemplate =
+    localStorage.getItem("followUpQuestionsPrompt")?.trim() || undefined;
 
   // Only send user/assistant messages — source messages contain large Document
   // objects that bloat the payload and are not needed for suggestion generation.
@@ -27,6 +31,7 @@ export const getSuggestions = async (chatHistory: Message[]) => {
             key: chatModel,
           },
           maxQuestions,
+          promptTemplate,
         }),
       },
     );

--- a/packages/research-agent-ui/src/settings/index.ts
+++ b/packages/research-agent-ui/src/settings/index.ts
@@ -10,6 +10,10 @@
  * reads/writes the values and the components that render them — means the list
  * of settings can change without touching rendering or persistence code.
  */
+import {
+  followUpSuggestionsPrompt,
+  webSearchRetrieverPrompt,
+} from "chat-agent-toolkit/prompts/search-prompts";
 import sectionsJson from "./sections.json";
 import searchJson from "./search.json";
 
@@ -52,6 +56,8 @@ export interface SettingsFieldSchema {
   env?: string;
   options?: SettingsFieldOption[];
   links?: SettingsFieldLink[];
+  /** Visible row count for `textarea` fields. Defaults to 4. */
+  rows?: number;
 }
 
 /** Metadata describing one entry in the settings sidebar/menu. */
@@ -72,9 +78,27 @@ export interface SettingsSectionSchema {
 export const settingsSections: SettingsSectionSchema[] =
   sectionsJson as unknown as SettingsSectionSchema[];
 
+/**
+ * Prompt-editing fields ship with an empty `default` in `search.json` so the
+ * prompt text itself has exactly one home: the toolkit's prompt module. The
+ * live template is spliced in here, which means the settings textarea shows
+ * the real prompt the agent runs, pre-filled and ready to edit. Clearing the
+ * box stores an empty string, and every consumer treats blank as "use the
+ * built-in template" — so the prompts stay in sync as the toolkit evolves.
+ */
+const PROMPT_FIELD_DEFAULTS: Record<string, string> = {
+  followUpQuestionsPrompt: followUpSuggestionsPrompt,
+  queryExpansionPrompt: webSearchRetrieverPrompt,
+};
+
 /** Field declarations for the "Search Settings" section. */
-export const searchSettingsFields: SettingsFieldSchema[] =
-  searchJson as unknown as SettingsFieldSchema[];
+export const searchSettingsFields: SettingsFieldSchema[] = (
+  searchJson as unknown as SettingsFieldSchema[]
+).map((field) =>
+  field.key in PROMPT_FIELD_DEFAULTS
+    ? { ...field, default: PROMPT_FIELD_DEFAULTS[field.key] }
+    : field,
+);
 
 /** Every field group keyed by the section `dataAdd` it belongs to. */
 export const settingsFieldsBySection: Record<string, SettingsFieldSchema[]> = {

--- a/packages/research-agent-ui/src/settings/search.json
+++ b/packages/research-agent-ui/src/settings/search.json
@@ -84,6 +84,28 @@
     "scope": "client"
   },
   {
+    "name": "Follow-up Questions Prompt",
+    "key": "followUpQuestionsPrompt",
+    "type": "textarea",
+    "required": false,
+    "description": "Prompt used to generate the follow-up question suggestions shown after each answer. Use {maxQuestions} for the count set above and {chat_history} for the conversation. Clear the box to restore the built-in prompt.",
+    "placeholder": "Leave blank to use the built-in follow-up prompt.",
+    "default": "",
+    "rows": 14,
+    "scope": "client"
+  },
+  {
+    "name": "Query Expansion Prompt",
+    "key": "queryExpansionPrompt",
+    "type": "textarea",
+    "required": false,
+    "description": "Prompt that rewrites your message into a standalone web-search query before sources are fetched. Keep returning the query inside a <question> block, and any URLs inside a <links> block. Clear the box to restore the built-in prompt.",
+    "placeholder": "Leave blank to use the built-in query expansion prompt.",
+    "default": "",
+    "rows": 14,
+    "scope": "client"
+  },
+  {
     "name": "SearXNG URL",
     "key": "searxngURL",
     "type": "string",

--- a/packages/research-agent-ui/test/settingsPromptFields.test.ts
+++ b/packages/research-agent-ui/test/settingsPromptFields.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Tests for the editable prompt fields in the search settings schema.
+ *
+ * The prompt text itself lives in `chat-agent-toolkit`, and `search.json` ships
+ * these fields with an empty default. `settings/index.ts` splices the live
+ * template in so the settings textarea shows the prompt the agent actually
+ * runs. These tests pin that wiring — a renamed export or a stale copy of the
+ * prompt in JSON would otherwise silently leave the editor blank.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  followUpSuggestionsPrompt,
+  webSearchRetrieverPrompt,
+} from 'chat-agent-toolkit/prompts/search-prompts';
+import { searchSettingsFields } from '../src/settings';
+
+const fieldFor = (key: string) =>
+  searchSettingsFields.find((field) => field.key === key);
+
+describe('search settings prompt fields', () => {
+  it('exposes the follow-up prompt as an editable textarea seeded with the live template', () => {
+    const field = fieldFor('followUpQuestionsPrompt');
+
+    expect(field).toBeDefined();
+    expect(field!.type).toBe('textarea');
+    expect(field!.scope).toBe('client');
+    expect(field!.default).toBe(followUpSuggestionsPrompt);
+  });
+
+  it('exposes the query-expansion prompt seeded with the live retriever prompt', () => {
+    const field = fieldFor('queryExpansionPrompt');
+
+    expect(field).toBeDefined();
+    expect(field!.type).toBe('textarea');
+    expect(field!.scope).toBe('client');
+    expect(field!.default).toBe(webSearchRetrieverPrompt);
+  });
+
+  it('keeps the follow-up template interpolatable from the settings copy', () => {
+    // The description tells users about these two placeholders, so the shipped
+    // default has to actually contain them.
+    const template = String(fieldFor('followUpQuestionsPrompt')!.default);
+    expect(template).toContain('{maxQuestions}');
+    expect(template).toContain('{chat_history}');
+  });
+
+  it('leaves non-prompt fields untouched', () => {
+    expect(fieldFor('maxFollowupQuestions')!.default).toBe('4');
+  });
+});

--- a/packages/shadcn-settings/src/components/fields/text-field.tsx
+++ b/packages/shadcn-settings/src/components/fields/text-field.tsx
@@ -56,7 +56,7 @@ function TextControl({
           onChange={(e) => handleChange(e.target.value)}
           onBlur={(e) => handleBlur(e.target.value)}
           placeholder={field.placeholder}
-          rows={4}
+          rows={typeof field.rows === "number" ? field.rows : 4}
           disabled={isDisabled}
           className={inputClass}
         />

--- a/packages/shadcn-settings/src/types.ts
+++ b/packages/shadcn-settings/src/types.ts
@@ -44,6 +44,8 @@ export interface SettingsFieldSchema {
   default?: string | boolean;
   /** Options for `select` fields. */
   options?: SettingsFieldOption[];
+  /** Visible row count for `textarea` fields. Defaults to 4. */
+  rows?: number;
   /** Reference links rendered under the description. */
   links?: SettingsFieldLink[];
   /** Whether the field must be filled (advisory; not enforced here). */


### PR DESCRIPTION
Both prompts that shape a search — the one that rephrases your message into a standalone web-search query, and the one that generates the follow-up suggestions after an answer — were hard-coded in the toolkit. Settings → Search Settings now exposes each as a textarea, pre-filled with the prompt the agent actually runs so it can be edited in place; clearing the box restores the built-in template.

The prompt text keeps a single home in `chat-agent-toolkit/prompts`. The follow-up template moves out of the suggestion agent into that module, and `settings/index.ts` splices the live templates into the two fields' `default`, so the editor can never drift from what runs. Overrides travel as `queryExpansionPrompt` on the chat body and `promptTemplate` on the suggestions body; every consumer treats blank as "use the built-in one".

Also:

- Comparison table: narrow the Feature column (w-56 → w-40), shorten the row labels that were driving that width, and add seven rows for capabilities the table did not cover — BYO API keys, source selection, editable prompts, MCP connectors, skills & memory, cloud storage sync and read-aloud.
- Dock icons: the Docs and Settings marks rendered as broken images. Both are SVGs, and next/image 400s on SVG unless `dangerouslyAllowSVG` is set, so they now opt out of optimization like the app icon already does.
- `shadcn-settings` textareas honour an optional `rows`, so a long prompt gets a box worth editing in rather than four lines.


Claude-Session: https://claude.ai/code/session_01K9Ypuv1QVujwUenTUdggm3