### PR TITLE
✨ feat(search): give the QwkSearch fan-out a layered settings resolver

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,115 @@
 ## In Progress
 
+## Give the search fan-out a settings layer inside the LobeHub engine
+
+**Status:** Completed
+**Source:** Scheduled task — "merge lobehub and qwksearch.com so that lobehub is
+the core engine but the elements of qwksearch are then added". Picked up the
+LobeHub Migration To-Do's own #1 suggested next: a `searchSettings.ts` mirroring
+`extractSettings.ts`, the first of the three steps the Search & Sources pane
+needs.
+**Branch:** `claude/magical-bohr-4t8p0t`
+**PR:** #413
+**Started:** 2026-09-10
+**Completed:** 2026-09-10
+
+### Goal
+`QwkSearchImpl` read `process.env` inside a getter and hard-coded the rest: a
+`general` fallback category, three categories per query, and four query
+parameters the fan-out endpoint accepts that it never sent. Extraction stopped
+doing that in 1.5; search had not. Give it the same resolved-value layer, so
+2.2's Search & Sources pane has somewhere to write to.
+
+### Scope
+One new module and its test beside the impl, the impl rewired onto it, and
+documentation. No new route, no storage, no UI — those are the next two steps.
+
+- `apps/server/src/services/search/impls/qwksearch/searchSettings.ts` (new).
+- `.../searchSettings.test.ts` (new, 44 cases).
+- `.../index.ts` — the category/alias tables move out, the class takes the
+  resolved value; `normalizeCategories` is re-exported so its callers and the
+  manifest drift guard are untouched.
+- `.../index.test.ts` — 11 cases added, the 27 existing ones unchanged.
+- Docs: §F5a in the integrations reference, §1.8 in the migration to-do, the
+  env table and upstream-diff note in `packages-lobe/README.md`, and the
+  file pointer in `searchCategories.ts`.
+
+### Non-goals
+- **Storage and a route.** That is 1.6's equivalent and the recorded next item.
+  It has a genuinely new problem to solve first — see "Remaining work".
+- **The pane.** 1.7's equivalent, blocked on the above.
+- **Editing the endpoint or the API key.** They stay Worker secrets; the client
+  summary reduces them to presence flags and never a value.
+
+### What changed
+Four decisions carry the design:
+
+- **It lives beside its consumer, not under `worker/`.**
+  `extractSettings.ts` sits in `worker/qwksearch/` because the extraction chain
+  does. The search impl is `@/server/*` code, and the dependency runs
+  worker → `@/server/*` and never back — so a future
+  `/api/doc/search-settings` route can import this, while the mirror-image
+  placement would not have worked.
+- **The request layer is narrower than the user layer.** The tool call's
+  arguments are written by the model, so they may narrow only `categories` and
+  `timeRange`. `maxCategories` is withheld from it because it bounds how many
+  upstream requests one query costs.
+- **The category cap is applied once, at the end.** The list can arrive from the
+  request layer while the bound comes from the user layer, so the normalizers
+  return the full validated list and `resolveSearchSettings` truncates last.
+- **Empty is not a value.** A normalizer that finds nothing valid returns
+  `undefined`, so a typo in `QWKSEARCH_SEARCH_CATEGORIES` falls through to the
+  layer above instead of searching nothing.
+
+Three query parameters the endpoint always accepted are now actually sent:
+`lang`, `safesearch` and `publicInstances` were in
+`research-agent-ui/src/api/handlers/search.ts` the whole time. Only `lang`
+changes the default request, and it sends the value the endpoint already
+assumed (`en-US`).
+
+One latent bug surfaced while moving the alias table: `files` had no self-entry
+in it and survived only through an identity fallback in the old lookup. The new
+lookup restores that fallback explicitly, with a comment saying why.
+
+### Verification
+- [x] `bun run check` over all four changed source files — lint clean, 82 tests
+      pass (44 new in `searchSettings.test.ts`, 38 in `index.test.ts`).
+- [x] `npx vitest run apps/server/src/services/search` — 185 passed, 7 skipped,
+      11 files. The whole search service, not just this provider.
+- [x] The 27 pre-existing `index.test.ts` cases pass unmodified, which is the
+      real regression signal: the impl's observable behavior is unchanged
+      wherever no new var is set.
+- [x] Type check: **scoped**, not repo-wide, per the to-do's OOM warning. A
+      `tsconfig` extending the real one and narrowed to the impl directory
+      reports **zero** errors in any changed file. The errors it does report are
+      all pre-existing `apps/desktop`, `packages/builtin-skills` and
+      `worker/cf/env.ts` (missing Cloudflare globals in the scoped `types`).
+
+### Notes for the next run
+- **`pnpm install --ignore-scripts` in `packages-lobe` took 65 seconds here**,
+  not the "few minutes" the to-do records. Anything under `apps/server/` needs
+  it — the `worker/`-only scratch-vitest recipe does not cover that tree.
+- **`bun run check <dir>` silently checks one file.** Pass explicit file paths;
+  a directory argument reported "1 files · lint clean" while three others went
+  unlinted.
+- CI still cannot see `packages-lobe`, and PRs here still auto-merge. Both
+  remain written up in the to-do.
+
+### Remaining work
+- **The user layer has no storage**, so today every deployment resolves
+  defaults-under-env exactly as before. `QwkSearchImpl`'s constructor takes
+  `UserSearchOverrides` and the factory passes none.
+- **How the user id reaches the impl is unsolved.** Extraction never had to
+  answer this: its chain runs inside a Worker route that already has the
+  session. `impls/index.ts` builds the search impl with no request in scope.
+  Two candidates — resolve the overrides in the tool's execution runtime and
+  pass them to the constructor, or give `SearchService` a per-request factory.
+  Decide that before writing the D1 table.
+- **`searchSettingsForClient` has no client**, the same gap 1.6 left before 1.7.
+- **Not seen against the live endpoint.** No Cloudflare credentials here, so the
+  new `lang`/`safesearch`/`publicInstances` parameters are verified by asserting
+  the built URL and never by a real response.
+
 ## Build the Extraction settings pane inside the LobeHub engine
 
 **Status:** Completed

--- a/packages-lobe/README.md
+++ b/packages-lobe/README.md
@@ -66,7 +66,9 @@ data is reused as-is.
   (`QWKSEARCH_SEARCH_URL`, default `https://qwksearch.com/api/agent/search`, optional
   `QWKSEARCH_API_KEY`). Requested categories are normalized across three vocabularies
   (LobeHub's manifest, QwkSearch's 13-category registry, SearXNG's), fanned out one request per
-  category (max 3) and merged by URL — highest score wins, engine lists union.
+  category (3 by default) and merged by URL — highest score wins, engine lists union. Everything
+  the request carries is resolved by `searchSettings.ts`, layering shipped defaults under Worker
+  env under the user's preferences under the tool call's own arguments; the vars are below.
 - **Extraction chain** (`worker/qwksearch/extract.ts`): QwkSearch's own `extract-webpage`
   → Cloudflare Puppeteer scraper (`SCRAPER_URL`, 8s deadline) → Tavily (`TAVILY_API_KEY`) →
   LobeHub's own `@lobechat/web-crawler` (fetch + readability). The chain is routed per URL kind
@@ -182,6 +184,19 @@ Extraction is tuned by an optional group of vars, all defaulted (`worker/qwksear
 | `QWKSEARCH_EXTRACT_PROXY` | — | outbound proxy for the extractor's own fetches |
 | `QWKSEARCH_EXTRACT_THIRD_PARTY_BACKUP` | `false` | let the extractor fall back to a third-party reader |
 
+Search is tuned by the same kind of group, also all defaulted
+(`apps/server/src/services/search/impls/qwksearch/searchSettings.ts`):
+
+| Var | Default | Meaning |
+| --- | --- | --- |
+| `QWKSEARCH_SEARCH_CATEGORIES` | `general` | categories searched when the tool call names none |
+| `QWKSEARCH_SEARCH_MAX_CATEGORIES` | `3` | most categories fanned out per query (1–10) |
+| `QWKSEARCH_SEARCH_LANGUAGE` | `en-US` | BCP-47 tag sent as `lang` |
+| `QWKSEARCH_SEARCH_TIME_RANGE` | — | default recency when the call names none: `day`, `week`, `month`, `year` |
+| `QWKSEARCH_SEARCH_SAFE` | `false` | ask the engines to filter adult content |
+| `QWKSEARCH_SEARCH_PUBLIC_INSTANCES` | `false` | let the fan-out fall back to public SearXNG instances |
+| `QWKSEARCH_SEARCH_RESULT_LIMIT` | — | keep at most this many merged results (1–200) |
+
 Run
 LobeHub's Postgres migrations once against the database: `bun run db:migrate` with `DATABASE_URL` set.
 
@@ -212,7 +227,8 @@ Hyperdrive bridge, and rendered-component tests for the article panel and the do
   the factory switch and enum are the only edits to upstream files there.
 - `packages/builtin-tool-web-browsing/`: new `src/searchCategories.ts`; `manifest.ts` swaps the
   hard-coded `searchCategories` enum for `resolveSearchCategories()` (import + expression) and
-  `src/index.ts` gains one export line.
+  `src/index.ts` gains one export line. No upstream file there changed for the search settings
+  layer — only a doc comment in `searchCategories.ts`, which is a QwkSearch-added file.
 - `packages/env/src/email.ts`: accepts `EMAIL_SERVICE_PROVIDER=cloudflare`.
 - `packages/business/const/src/branding.ts`, `packages/const/src/url.ts`: QwkSearch branding.
 - `packages/locales/src/default/{electron,qwksearch}.ts` + `locales/{en-US,zh-CN}`: new keys.

--- a/packages-lobe/apps/server/src/services/search/impls/qwksearch/index.test.ts
+++ b/packages-lobe/apps/server/src/services/search/impls/qwksearch/index.test.ts
@@ -323,3 +323,155 @@ describe('QwkSearchImpl', () => {
     });
   });
 });
+
+describe('QwkSearchImpl settings', () => {
+  const SEARCH_ENV = [
+    'QWKSEARCH_API_KEY',
+    'QWKSEARCH_SEARCH_CATEGORIES',
+    'QWKSEARCH_SEARCH_LANGUAGE',
+    'QWKSEARCH_SEARCH_MAX_CATEGORIES',
+    'QWKSEARCH_SEARCH_PUBLIC_INSTANCES',
+    'QWKSEARCH_SEARCH_RESULT_LIMIT',
+    'QWKSEARCH_SEARCH_SAFE',
+    'QWKSEARCH_SEARCH_TIME_RANGE',
+    'QWKSEARCH_SEARCH_URL',
+  ];
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.mocked(fetch).mockResolvedValue(createMockResponse({ results: [] }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    for (const key of SEARCH_ENV) delete process.env[key];
+  });
+
+  it('sends the resolved language on every request', async () => {
+    await new QwkSearchImpl().query('q');
+    expect(requestedUrls()[0].searchParams.get('lang')).toBe('en-US');
+
+    vi.mocked(fetch).mockClear();
+    process.env.QWKSEARCH_SEARCH_LANGUAGE = 'ja-jp';
+    await new QwkSearchImpl().query('q');
+    expect(requestedUrls()[0].searchParams.get('lang')).toBe('ja-JP');
+  });
+
+  it('omits safesearch and publicInstances unless they are on', async () => {
+    await new QwkSearchImpl().query('q');
+
+    const url = requestedUrls()[0];
+    expect(url.searchParams.has('safesearch')).toBe(false);
+    expect(url.searchParams.has('publicInstances')).toBe(false);
+  });
+
+  it('sends safesearch and publicInstances when the operator turns them on', async () => {
+    process.env.QWKSEARCH_SEARCH_PUBLIC_INSTANCES = 'true';
+    process.env.QWKSEARCH_SEARCH_SAFE = 'true';
+
+    await new QwkSearchImpl().query('q');
+
+    const url = requestedUrls()[0];
+    expect(url.searchParams.get('safesearch')).toBe('true');
+    expect(url.searchParams.get('publicInstances')).toBe('true');
+  });
+
+  it('applies a configured default recency when the call asks for none', async () => {
+    process.env.QWKSEARCH_SEARCH_TIME_RANGE = 'month';
+
+    await new QwkSearchImpl().query('q');
+    expect(requestedUrls()[0].searchParams.get('recency')).toBe('month');
+
+    // …and the call still wins where it names a range the endpoint knows.
+    vi.mocked(fetch).mockClear();
+    await new QwkSearchImpl().query('q', { searchTimeRange: 'day' });
+    expect(requestedUrls()[0].searchParams.get('recency')).toBe('day');
+  });
+
+  it('searches the operator default categories when the call names none', async () => {
+    process.env.QWKSEARCH_SEARCH_CATEGORIES = 'news,science';
+
+    await new QwkSearchImpl().query('q');
+
+    expect(requestedUrls().map((u) => u.searchParams.get('cat'))).toEqual(['news', 'science']);
+  });
+
+  it('lets the operator widen the fan-out past three categories', async () => {
+    process.env.QWKSEARCH_SEARCH_MAX_CATEGORIES = '4';
+
+    await new QwkSearchImpl().query('q', {
+      searchCategories: ['general', 'news', 'images', 'videos', 'science'],
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('caps the merged results when a limit is configured', async () => {
+    process.env.QWKSEARCH_SEARCH_RESULT_LIMIT = '2';
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse({
+        results: [
+          { score: 0.1, title: 'C', url: 'https://c.com' },
+          { score: 0.9, title: 'A', url: 'https://a.com' },
+          { score: 0.5, title: 'B', url: 'https://b.com' },
+        ],
+      }),
+    );
+
+    const { resultNumbers, results } = await new QwkSearchImpl().query('q');
+
+    // Capped after the merge, so it keeps the highest-scoring URLs.
+    expect(results.map((r) => r.url)).toEqual(['https://a.com', 'https://b.com']);
+    expect(resultNumbers).toBe(2);
+  });
+
+  it('returns every result when no limit is configured', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      createMockResponse({
+        results: [
+          { title: 'A', url: 'https://a.com' },
+          { title: 'B', url: 'https://b.com' },
+          { title: 'C', url: 'https://c.com' },
+        ],
+      }),
+    );
+
+    expect((await new QwkSearchImpl().query('q')).results).toHaveLength(3);
+  });
+
+  it('takes user preferences over the environment, and the call over both', async () => {
+    process.env.QWKSEARCH_SEARCH_CATEGORIES = 'news';
+    process.env.QWKSEARCH_SEARCH_LANGUAGE = 'de-DE';
+
+    const impl = new QwkSearchImpl({ categories: ['music'], language: 'fr-FR' });
+
+    await impl.query('q');
+    expect(requestedUrls()[0].searchParams.get('cat')).toBe('music');
+    expect(requestedUrls()[0].searchParams.get('lang')).toBe('fr-FR');
+
+    vi.mocked(fetch).mockClear();
+    await impl.query('q', { searchCategories: ['videos'] });
+    expect(requestedUrls()[0].searchParams.get('cat')).toBe('videos');
+    // The call may narrow the categories; it has no say over the language.
+    expect(requestedUrls()[0].searchParams.get('lang')).toBe('fr-FR');
+  });
+
+  it('reads the environment per query, not once at construction', async () => {
+    const impl = new QwkSearchImpl();
+    await impl.query('q');
+    expect(requestedUrls()[0].origin).toBe('https://qwksearch.com');
+
+    vi.mocked(fetch).mockClear();
+    process.env.QWKSEARCH_SEARCH_URL = 'https://staging.example/api/agent/search';
+    await impl.query('q');
+    expect(requestedUrls()[0].origin).toBe('https://staging.example');
+  });
+
+  it('ignores an endpoint that is not an http(s) URL', async () => {
+    process.env.QWKSEARCH_SEARCH_URL = 'file:///etc/passwd';
+
+    await new QwkSearchImpl().query('q');
+
+    expect(requestedUrls()[0].origin).toBe('https://qwksearch.com');
+  });
+});

--- a/packages-lobe/apps/server/src/services/search/impls/qwksearch/index.ts
+++ b/packages-lobe/apps/server/src/services/search/impls/qwksearch/index.ts
@@ -14,6 +14,12 @@
  *
  * The endpoint takes one category per request, so multiple `searchCategories`
  * fan out in parallel and merge here, deduplicated by URL.
+ *
+ * Every knob the requests carry — the endpoint, the categories, the language,
+ * safe search, the recency filter and the result cap — is resolved by
+ * `./searchSettings`, which layers defaults under the environment under the
+ * user's preferences under this call's own arguments. This file only turns the
+ * resolved value into HTTP.
  */
 import {
   type SearchParams,
@@ -24,76 +30,17 @@ import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 
 import { type SearchServiceImpl } from '../type';
+import {
+  resolveSearchSettings,
+  searchOverridesFromParams,
+  type SearchSettings,
+  type UserSearchOverrides,
+} from './searchSettings';
 import { type QwkSearchResponse, type QwkSearchResult } from './type';
 
 const log = debug('lobe-search:QwkSearch');
 
-const DEFAULT_ENDPOINT = 'https://qwksearch.com/api/agent/search';
-
-/** SearXNG category names the fan-out endpoint understands. */
-const SUPPORTED_CATEGORIES = new Set([
-  'files',
-  'general',
-  'images',
-  'it',
-  'map',
-  'music',
-  'news',
-  'science',
-  'social+media',
-  'videos',
-]);
-
-/**
- * QwkSearch's category registry (`search-web-api/registry`) names a few
- * categories differently from SearXNG, and LobeHub's tool manifest offers a
- * fifth set again. Normalize every spelling we might receive onto what the
- * endpoint accepts; anything unknown falls back to `general` rather than
- * returning an empty page.
- */
-const CATEGORY_ALIASES: Record<string, string> = {
-  'academic': 'science',
-  'apps': 'files',
-  'code': 'it',
-  'file': 'files',
-  'general': 'general',
-  'image': 'images',
-  'images': 'images',
-  'it': 'it',
-  'map': 'map',
-  'maps': 'map',
-  'music': 'music',
-  'news': 'news',
-  'science': 'science',
-  'shopping': 'general',
-  'social': 'social+media',
-  'social media': 'social+media',
-  'social+media': 'social+media',
-  'specialized': 'general',
-  'tech': 'it',
-  'torrents': 'files',
-  'video': 'videos',
-  'videos': 'videos',
-};
-
-const TIME_RANGES = new Set(['day', 'week', 'month', 'year']);
-
-/** Max categories fanned out per query, to bound the request budget. */
-const MAX_CATEGORIES = 3;
-
-export const normalizeCategories = (categories?: string[]): string[] => {
-  if (!categories?.length) return ['general'];
-
-  const normalized = categories
-    .map((category) => category?.trim().toLowerCase())
-    .filter(Boolean)
-    .map((category) => CATEGORY_ALIASES[category] ?? category)
-    .filter((category) => SUPPORTED_CATEGORIES.has(category));
-
-  const unique = [...new Set(normalized)];
-
-  return unique.length > 0 ? unique.slice(0, MAX_CATEGORIES) : ['general'];
-};
+export { normalizeCategories } from './searchSettings';
 
 const hostnameOf = (url: string): string => {
   try {
@@ -155,23 +102,40 @@ export class QwkSearchImpl implements SearchServiceImpl {
    */
   readonly useAutoSearchEngineSelection = true;
 
-  private get endpoint(): string {
-    return process.env.QWKSEARCH_SEARCH_URL || DEFAULT_ENDPOINT;
+  /**
+   * The signed-in user's preferences, if the caller has them.
+   *
+   * Nothing constructs the impl with them yet — that is the storage step of
+   * migration to-do § 2.2, the search-side mirror of extraction's 1.6. Until
+   * then every deployment resolves to defaults under the environment, exactly
+   * as before, and the seam is here for that step to fill.
+   */
+  constructor(private readonly overrides: UserSearchOverrides = {}) {}
+
+  /**
+   * Resolved per query, not per instance: `SearchService` holds one impl for
+   * the lifetime of the process, and reading the environment lazily is what
+   * lets a test set `QWKSEARCH_SEARCH_URL` after construction.
+   */
+  private settingsFor(params: SearchParams): SearchSettings {
+    return resolveSearchSettings(
+      process.env as Record<string, string | undefined>,
+      this.overrides,
+      searchOverridesFromParams(params),
+    );
   }
 
-  private get apiKey(): string | undefined {
-    return process.env.QWKSEARCH_API_KEY;
-  }
-
-  private buildUrl(query: string, category: string, params: SearchParams): URL {
-    const url = new URL(this.endpoint);
+  private buildUrl(query: string, category: string, settings: SearchSettings): URL {
+    const url = new URL(settings.endpoint);
     url.searchParams.set('q', query);
     url.searchParams.set('cat', category);
+    url.searchParams.set('lang', settings.language);
 
-    const timeRange = params.searchTimeRange;
-    if (timeRange && TIME_RANGES.has(timeRange)) {
-      url.searchParams.set('recency', timeRange);
-    }
+    if (settings.timeRange) url.searchParams.set('recency', settings.timeRange);
+    // Both are read by the endpoint as `=== 'true'`, so send them only when on
+    // rather than spelling out the default in every request.
+    if (settings.safeSearch) url.searchParams.set('safesearch', 'true');
+    if (settings.publicInstances) url.searchParams.set('publicInstances', 'true');
 
     return url;
   }
@@ -179,11 +143,11 @@ export class QwkSearchImpl implements SearchServiceImpl {
   private async queryCategory(
     query: string,
     category: string,
-    params: SearchParams,
+    settings: SearchSettings,
   ): Promise<UniformSearchResult[]> {
-    const url = this.buildUrl(query, category, params);
+    const url = this.buildUrl(query, category, settings);
     const headers: Record<string, string> = { Accept: 'application/json' };
-    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+    if (settings.apiKey) headers['Authorization'] = `Bearer ${settings.apiKey}`;
 
     const response = await fetch(url, { headers });
 
@@ -206,7 +170,8 @@ export class QwkSearchImpl implements SearchServiceImpl {
   }
 
   async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
-    const categories = normalizeCategories(params.searchCategories);
+    const settings = this.settingsFor(params);
+    const categories = settings.categories;
     log('querying %o across categories %o', query, categories);
 
     const startAt = Date.now();
@@ -214,7 +179,7 @@ export class QwkSearchImpl implements SearchServiceImpl {
     let lists: UniformSearchResult[][];
     try {
       lists = await Promise.all(
-        categories.map((category) => this.queryCategory(query, category, params)),
+        categories.map((category) => this.queryCategory(query, category, settings)),
       );
     } catch (error) {
       console.error('[QwkSearchImpl] query failed', error);
@@ -225,7 +190,10 @@ export class QwkSearchImpl implements SearchServiceImpl {
       });
     }
 
-    const results = mergeResults(lists);
+    const merged = mergeResults(lists);
+    // Capped after the merge, so the cap counts distinct URLs rather than
+    // per-category rows, and always keeps the highest-scoring ones.
+    const results = settings.resultLimit ? merged.slice(0, settings.resultLimit) : merged;
     log('got %d results in %dms', results.length, Date.now() - startAt);
 
     return {

--- a/packages-lobe/apps/server/src/services/search/impls/qwksearch/searchSettings.test.ts
+++ b/packages-lobe/apps/server/src/services/search/impls/qwksearch/searchSettings.test.ts
@@ -1,0 +1,407 @@
+// @vitest-environment node
+import { QWKSEARCH_SEARCH_CATEGORIES } from '@lobechat/builtin-tool-web-browsing';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_MAX_CATEGORIES,
+  DEFAULT_SEARCH_ENDPOINT,
+  DEFAULT_SEARCH_LANGUAGE,
+  DEFAULT_SEARCH_SETTINGS,
+  MAX_MAX_CATEGORIES,
+  MAX_RESULT_LIMIT,
+  normalizeHttpUrl,
+  normalizeSearchCategories,
+  normalizeSearchLanguage,
+  normalizeSearchOverrides,
+  normalizeTimeRange,
+  redactSearchSettings,
+  resolveSearchSettings,
+  SEARCH_CATEGORIES,
+  searchOverridesFromParams,
+  type SearchSettings,
+  searchSettingsForClient,
+  searchSettingsFromEnv,
+  type UserSearchOverrides,
+} from './searchSettings';
+
+/** Resolve against an explicit env so the ambient process is never consulted. */
+const resolve = (
+  env: Record<string, string | undefined> = {},
+  ...overrides: Array<undefined | UserSearchOverrides>
+) => resolveSearchSettings(env, ...overrides);
+
+describe('the category vocabulary', () => {
+  it('accepts every category the tool manifest advertises', () => {
+    // The guard against drift between the two halves of the seam: a category
+    // the manifest offers the model but this module drops gets silently
+    // replaced by `general`, which is the empty-page failure the enum exists
+    // to prevent.
+    for (const category of QWKSEARCH_SEARCH_CATEGORIES) {
+      expect(SEARCH_CATEGORIES as readonly string[], category).toContain(category);
+    }
+  });
+
+  it('advertises nothing the endpoint cannot serve', () => {
+    expect([...SEARCH_CATEGORIES].sort()).toEqual([...QWKSEARCH_SEARCH_CATEGORIES].sort());
+  });
+});
+
+describe('normalizeSearchCategories', () => {
+  it('maps the registry names onto the endpoint vocabulary', () => {
+    expect(normalizeSearchCategories(['academic', 'social', 'tech'])).toEqual([
+      'science',
+      'social+media',
+      'it',
+    ]);
+  });
+
+  it('preserves the order asked for', () => {
+    expect(normalizeSearchCategories(['videos', 'news', 'general'])).toEqual([
+      'videos',
+      'news',
+      'general',
+    ]);
+  });
+
+  it('deduplicates aliases that collapse onto the same category', () => {
+    expect(normalizeSearchCategories(['videos', 'video', 'Videos'])).toEqual(['videos']);
+  });
+
+  it('drops unknown categories but keeps the recognized ones', () => {
+    expect(normalizeSearchCategories(['nonsense', 'news'])).toEqual(['news']);
+  });
+
+  it('returns undefined rather than an empty list, so the layer above stands', () => {
+    expect(normalizeSearchCategories(['nonsense'])).toBeUndefined();
+    expect(normalizeSearchCategories([])).toBeUndefined();
+    expect(normalizeSearchCategories(undefined)).toBeUndefined();
+    expect(normalizeSearchCategories('   ')).toBeUndefined();
+  });
+
+  it('reads a comma-separated string, which is how the environment carries it', () => {
+    expect(normalizeSearchCategories('news, science ,videos')).toEqual([
+      'news',
+      'science',
+      'videos',
+    ]);
+  });
+
+  it('does not cap — the cap belongs to resolveSearchSettings', () => {
+    expect(normalizeSearchCategories([...SEARCH_CATEGORIES])).toHaveLength(
+      SEARCH_CATEGORIES.length,
+    );
+  });
+});
+
+describe('normalizeTimeRange', () => {
+  it('accepts the four the endpoint forwards', () => {
+    for (const range of ['day', 'week', 'month', 'year']) {
+      expect(normalizeTimeRange(range)).toBe(range);
+    }
+    expect(normalizeTimeRange('WEEK')).toBe('week');
+  });
+
+  it('drops anything else, including the manifest\'s "no filter" value', () => {
+    expect(normalizeTimeRange('anytime')).toBeUndefined();
+    expect(normalizeTimeRange('')).toBeUndefined();
+    expect(normalizeTimeRange(7)).toBeUndefined();
+  });
+});
+
+describe('normalizeSearchLanguage', () => {
+  it('canonicalizes case so two spellings are not two settings', () => {
+    expect(normalizeSearchLanguage('EN-us')).toBe('en-US');
+    expect(normalizeSearchLanguage('zh-hans-cn')).toBe('zh-Hans-CN');
+    expect(normalizeSearchLanguage(' fr ')).toBe('fr');
+  });
+
+  it('rejects anything that is not a language tag', () => {
+    expect(normalizeSearchLanguage('en_US')).toBeUndefined();
+    expect(normalizeSearchLanguage('english (american)')).toBeUndefined();
+    expect(normalizeSearchLanguage('')).toBeUndefined();
+    expect(normalizeSearchLanguage(42)).toBeUndefined();
+  });
+});
+
+describe('normalizeHttpUrl', () => {
+  it('keeps http(s) URLs and trims the trailing slash', () => {
+    expect(normalizeHttpUrl('https://a.example/search/')).toBe('https://a.example/search');
+  });
+
+  it('drops every other scheme and anything unparseable', () => {
+    expect(normalizeHttpUrl('file:///etc/passwd')).toBeUndefined();
+    expect(normalizeHttpUrl('javascript:alert(1)')).toBeUndefined();
+    expect(normalizeHttpUrl('not a url')).toBeUndefined();
+    expect(normalizeHttpUrl(undefined)).toBeUndefined();
+  });
+});
+
+describe('searchSettingsFromEnv', () => {
+  it('reads every knob', () => {
+    expect(
+      searchSettingsFromEnv({
+        QWKSEARCH_API_KEY: 'secret',
+        QWKSEARCH_SEARCH_CATEGORIES: 'news,science',
+        QWKSEARCH_SEARCH_LANGUAGE: 'fr-fr',
+        QWKSEARCH_SEARCH_MAX_CATEGORIES: '2',
+        QWKSEARCH_SEARCH_PUBLIC_INSTANCES: 'yes',
+        QWKSEARCH_SEARCH_RESULT_LIMIT: '25',
+        QWKSEARCH_SEARCH_SAFE: 'true',
+        QWKSEARCH_SEARCH_TIME_RANGE: 'month',
+        QWKSEARCH_SEARCH_URL: 'https://staging.example/api/agent/search',
+      }),
+    ).toEqual({
+      apiKey: 'secret',
+      categories: ['news', 'science'],
+      endpoint: 'https://staging.example/api/agent/search',
+      language: 'fr-FR',
+      maxCategories: 2,
+      publicInstances: true,
+      resultLimit: 25,
+      safeSearch: true,
+      timeRange: 'month',
+    });
+  });
+
+  it('leaves every field undefined when nothing is set', () => {
+    expect(Object.values(searchSettingsFromEnv({})).every((v) => v === undefined)).toBe(true);
+  });
+
+  it('clamps the numeric knobs instead of rejecting them', () => {
+    const tooBig = searchSettingsFromEnv({
+      QWKSEARCH_SEARCH_MAX_CATEGORIES: '99',
+      QWKSEARCH_SEARCH_RESULT_LIMIT: '10000',
+    });
+    expect(tooBig.maxCategories).toBe(MAX_MAX_CATEGORIES);
+    expect(tooBig.resultLimit).toBe(MAX_RESULT_LIMIT);
+
+    const tooSmall = searchSettingsFromEnv({
+      QWKSEARCH_SEARCH_MAX_CATEGORIES: '0',
+      QWKSEARCH_SEARCH_RESULT_LIMIT: '-5',
+    });
+    expect(tooSmall.maxCategories).toBe(1);
+    expect(tooSmall.resultLimit).toBe(1);
+  });
+
+  it('ignores a malformed value rather than failing the search', () => {
+    const env = searchSettingsFromEnv({
+      QWKSEARCH_SEARCH_CATEGORIES: 'nonsense',
+      QWKSEARCH_SEARCH_LANGUAGE: 'not a tag',
+      QWKSEARCH_SEARCH_MAX_CATEGORIES: 'three',
+      QWKSEARCH_SEARCH_TIME_RANGE: 'fortnight',
+      QWKSEARCH_SEARCH_URL: 'ftp://example.com',
+    });
+
+    expect(env.categories).toBeUndefined();
+    expect(env.language).toBeUndefined();
+    expect(env.maxCategories).toBeUndefined();
+    expect(env.timeRange).toBeUndefined();
+    expect(env.endpoint).toBeUndefined();
+  });
+});
+
+describe('searchOverridesFromParams', () => {
+  it('takes only the two fields the manifest offers the model', () => {
+    expect(
+      searchOverridesFromParams({
+        searchCategories: ['tech'],
+        searchEngines: ['google'],
+        searchTimeRange: 'week',
+      }),
+    ).toEqual({ categories: ['it'], timeRange: 'week' });
+  });
+
+  it('never carries an engine restriction', () => {
+    const overrides = searchOverridesFromParams({ searchEngines: ['google', 'bing'] });
+    expect(overrides).toEqual({});
+    expect(JSON.stringify(overrides)).not.toContain('google');
+  });
+
+  it('omits a time range the endpoint does not understand', () => {
+    expect(searchOverridesFromParams({ searchTimeRange: 'anytime' })).toEqual({});
+  });
+
+  it('omits an unknown category rather than searching general instead', () => {
+    // The whole list survives or the layer above decides; a call for `music`
+    // must not quietly become a call for `general`.
+    expect(searchOverridesFromParams({ searchCategories: ['nonsense'] })).toEqual({});
+  });
+
+  it('handles being called with nothing', () => {
+    expect(searchOverridesFromParams()).toEqual({});
+    expect(searchOverridesFromParams({})).toEqual({});
+  });
+});
+
+describe('normalizeSearchOverrides', () => {
+  it('drops the keys it could not validate, so they inherit', () => {
+    expect(
+      normalizeSearchOverrides({
+        categories: ['nonsense'] as never,
+        language: 'not a tag',
+        maxCategories: Number.NaN,
+        timeRange: 'fortnight' as never,
+      }),
+    ).toEqual({});
+  });
+
+  it('keeps false as a value, distinct from unset', () => {
+    expect(normalizeSearchOverrides({ safeSearch: false })).toEqual({ safeSearch: false });
+    expect(normalizeSearchOverrides({})).toEqual({});
+  });
+
+  it('rounds and clamps a numeric preference', () => {
+    expect(normalizeSearchOverrides({ maxCategories: 2.4 })).toEqual({ maxCategories: 2 });
+    expect(normalizeSearchOverrides({ resultLimit: 1e6 })).toEqual({
+      resultLimit: MAX_RESULT_LIMIT,
+    });
+  });
+
+  it('cannot reach the endpoint or the api key', () => {
+    const smuggled = { apiKey: 'stolen', endpoint: 'https://evil.example' };
+    expect(normalizeSearchOverrides(smuggled as UserSearchOverrides)).toEqual({});
+  });
+});
+
+describe('resolveSearchSettings', () => {
+  it('is the shipped defaults with no env and no overrides', () => {
+    expect(resolve()).toEqual(DEFAULT_SEARCH_SETTINGS);
+    expect(resolve().endpoint).toBe(DEFAULT_SEARCH_ENDPOINT);
+    expect(resolve().language).toBe(DEFAULT_SEARCH_LANGUAGE);
+    expect(resolve().maxCategories).toBe(DEFAULT_MAX_CATEGORIES);
+    expect(resolve().resultLimit).toBeUndefined();
+    expect(resolve().timeRange).toBeUndefined();
+  });
+
+  it('layers env over defaults and overrides over env', () => {
+    const settings = resolve(
+      { QWKSEARCH_SEARCH_LANGUAGE: 'de-DE', QWKSEARCH_SEARCH_SAFE: 'true' },
+      { language: 'ja-JP' },
+    );
+
+    expect(settings.language).toBe('ja-JP');
+    expect(settings.safeSearch).toBe(true);
+  });
+
+  it('lets a later layer win only where it carries a valid value', () => {
+    const settings = resolve({ QWKSEARCH_SEARCH_LANGUAGE: 'de-DE' }, { language: '' });
+    expect(settings.language).toBe('de-DE');
+  });
+
+  it('never lets an override blank out the operator endpoint or key', () => {
+    const env = { QWKSEARCH_API_KEY: 'secret', QWKSEARCH_SEARCH_URL: 'https://staging.example/s' };
+    const settings = resolve(env, { apiKey: '', endpoint: '' } as UserSearchOverrides);
+
+    expect(settings.endpoint).toBe('https://staging.example/s');
+    expect(settings.apiKey).toBe('secret');
+  });
+
+  it('applies the category cap after every layer, not inside one', () => {
+    // The list comes from the request layer and the bound from the user layer;
+    // capping inside a layer would use the wrong bound.
+    const settings = resolve(
+      {},
+      { maxCategories: 2 },
+      { categories: ['news', 'science', 'videos', 'music'] },
+    );
+
+    expect(settings.categories).toEqual(['news', 'science']);
+  });
+
+  it('caps at three by default', () => {
+    expect(
+      resolve({}, { categories: ['general', 'news', 'images', 'videos', 'science'] }).categories,
+    ).toHaveLength(DEFAULT_MAX_CATEGORIES);
+  });
+
+  it('lets the operator widen the fan-out past the default', () => {
+    const settings = resolve(
+      { QWKSEARCH_SEARCH_MAX_CATEGORIES: '5' },
+      { categories: ['general', 'news', 'images', 'videos', 'science'] },
+    );
+
+    expect(settings.categories).toHaveLength(5);
+  });
+
+  it('falls back to the layer above when a request names nothing valid', () => {
+    const settings = resolve(
+      { QWKSEARCH_SEARCH_CATEGORIES: 'news' },
+      searchOverridesFromParams({ searchCategories: ['nonsense'] }),
+    );
+
+    expect(settings.categories).toEqual(['news']);
+  });
+
+  it('ignores an undefined layer', () => {
+    expect(resolve({}, undefined, { safeSearch: true }).safeSearch).toBe(true);
+  });
+
+  it('does not mutate the defaults', () => {
+    resolve({}, { categories: ['news'] });
+    expect(DEFAULT_SEARCH_SETTINGS.categories).toEqual(['general']);
+  });
+});
+
+describe('redactSearchSettings', () => {
+  it('reduces the key to a presence flag and keeps everything else', () => {
+    const settings: SearchSettings = { ...DEFAULT_SEARCH_SETTINGS, apiKey: 'secret' };
+    const redacted = redactSearchSettings(settings);
+
+    expect(redacted.apiKey).toBe(true);
+    expect(JSON.stringify(redacted)).not.toContain('secret');
+    expect(redacted.endpoint).toBe(DEFAULT_SEARCH_ENDPOINT);
+  });
+
+  it('reports an unset key as false', () => {
+    expect(redactSearchSettings(DEFAULT_SEARCH_SETTINGS).apiKey).toBe(false);
+  });
+});
+
+describe('searchSettingsForClient', () => {
+  const summary = searchSettingsForClient(
+    resolve({
+      QWKSEARCH_API_KEY: 'secret',
+      QWKSEARCH_SEARCH_URL: 'https://user:pass@staging.example/s',
+    }),
+  );
+
+  it('leaks neither the endpoint nor the key, only whether they are set', () => {
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain('secret');
+    expect(serialized).not.toContain('staging.example');
+    expect(serialized).not.toContain('pass');
+    expect(summary.configured).toEqual({ apiKey: true, endpoint: true });
+  });
+
+  it('carries exactly the fields a user may change', () => {
+    expect(Object.keys(summary).toSorted()).toEqual([
+      'categories',
+      'configured',
+      'language',
+      'maxCategories',
+      'publicInstances',
+      'resultLimit',
+      'safeSearch',
+      'timeRange',
+    ]);
+  });
+
+  it('serializes the two optional fields as null, not as absent', () => {
+    // Absent means "inherit" everywhere else in this seam; "no recency filter"
+    // is a value in force.
+    expect(summary.resultLimit).toBeNull();
+    expect(summary.timeRange).toBeNull();
+    // `undefined` would have been dropped by the route's own JSON encoding.
+    expect(JSON.stringify(summary)).toContain('"timeRange":null');
+  });
+
+  it('reports what is actually in force when it is set', () => {
+    const set = searchSettingsForClient(
+      resolve({ QWKSEARCH_SEARCH_RESULT_LIMIT: '10', QWKSEARCH_SEARCH_TIME_RANGE: 'day' }),
+    );
+
+    expect(set.resultLimit).toBe(10);
+    expect(set.timeRange).toBe('day');
+    expect(set.configured.apiKey).toBe(false);
+  });
+});

--- a/packages-lobe/apps/server/src/services/search/impls/qwksearch/searchSettings.ts
+++ b/packages-lobe/apps/server/src/services/search/impls/qwksearch/searchSettings.ts
@@ -1,0 +1,423 @@
+/**
+ * Resolved configuration for the QwkSearch search fan-out.
+ *
+ * Before this module every knob in `QwkSearchImpl` was a literal or a direct
+ * `process.env` read: `general` as the fallback category, three categories per
+ * query, `QWKSEARCH_SEARCH_URL` read inside a getter, and four query parameters
+ * the fan-out endpoint accepts (`lang`, `safesearch`, `publicInstances`, and a
+ * default `recency`) that the impl never sent at all. That is fine while the
+ * tool call is the only caller, and wrong the moment the Search & Sources pane
+ * (migration to-do § 2.2) needs somewhere to write to.
+ *
+ * So the impl now takes a {@link SearchSettings} value, and this module is the
+ * only place that decides what one contains:
+ *
+ * ```
+ * DEFAULT_SEARCH_SETTINGS       the shipped behaviour
+ *   ← environment (Worker vars + secrets)      server operator
+ *   ← UserSearchOverrides                      the signed-in user's settings
+ *   ← RequestSearchOverrides                   this tool call's own arguments
+ * ```
+ *
+ * Each layer only *narrows* the one above it, and every value is validated on
+ * the way in — an unparseable setting falls back rather than throwing, because
+ * a bad preference should not turn a search into a 500.
+ *
+ * This is the search-side mirror of `worker/qwksearch/extractSettings.ts`, and
+ * deliberately the same shape: the two panes in § 2.2 then read the same way.
+ * It lives beside its consumer rather than under `worker/` because the
+ * dependency runs worker → `@/server/*` and never back.
+ *
+ * ## Why the layers are not symmetric
+ *
+ * `endpoint` and `apiKey` are resolvable **from the environment only**. They
+ * name a host the Worker will send requests — and a bearer token — to, so
+ * accepting them from a user preference would leak the configured key to
+ * whatever host that user chose. {@link UserSearchOverrides} is typed to
+ * exclude them.
+ *
+ * {@link RequestSearchOverrides} is narrower again. The tool call is written by
+ * the model, not by a person, so it may only narrow the two fields the
+ * web-browsing manifest actually offers it: which categories to search and how
+ * recent the results should be. `maxCategories` in particular is withheld —
+ * it bounds how many upstream requests one query costs, which is a budget the
+ * operator sets and not something a generated argument should raise.
+ */
+import { type SearchParams } from '@lobechat/types';
+
+/**
+ * SearXNG category names the fan-out endpoint understands.
+ *
+ * Kept in step with `QWKSEARCH_SEARCH_CATEGORIES` in
+ * `packages/builtin-tool-web-browsing/src/searchCategories.ts`, which is the
+ * enum the model is offered; `searchSettings.test.ts` guards the two against
+ * drift. Advertising a category this list does not accept would send the model
+ * an empty page.
+ */
+export const SEARCH_CATEGORIES = [
+  'files',
+  'general',
+  'images',
+  'it',
+  'map',
+  'music',
+  'news',
+  'science',
+  'social+media',
+  'videos',
+] as const;
+
+export type SearchCategory = (typeof SEARCH_CATEGORIES)[number];
+
+/** Recency filters the fan-out endpoint forwards to the engines. */
+export const SEARCH_TIME_RANGES = ['day', 'month', 'week', 'year'] as const;
+
+export type SearchTimeRange = (typeof SEARCH_TIME_RANGES)[number];
+
+export interface SearchSettings {
+  /** Bearer token for the fan-out endpoint. Environment-only. */
+  apiKey?: string;
+  /** Categories to search when the caller names none, in fan-out order. */
+  categories: SearchCategory[];
+  /** Base URL of the fan-out endpoint. Environment-only. */
+  endpoint: string;
+  /** UI language / region tag handed to the engines as `lang`. */
+  language: string;
+  /** Most categories fanned out per query — the request budget for one search. */
+  maxCategories: number;
+  /** Let the fan-out fall back to public SearXNG instances. */
+  publicInstances: boolean;
+  /** Keep at most this many merged results. Unset means every result. */
+  resultLimit?: number;
+  /** Ask the engines to filter adult content. */
+  safeSearch: boolean;
+  /** Default recency filter. Unset means no filter. */
+  timeRange?: SearchTimeRange;
+}
+
+/** Settings a signed-in user may choose. Excludes the host and the credential. */
+export type UserSearchOverrides = Partial<
+  Pick<
+    SearchSettings,
+    | 'categories'
+    | 'language'
+    | 'maxCategories'
+    | 'publicInstances'
+    | 'resultLimit'
+    | 'safeSearch'
+    | 'timeRange'
+  >
+>;
+
+/**
+ * What one tool call may narrow. Exactly the two fields the web-browsing
+ * manifest offers the model — see the module comment.
+ */
+export type RequestSearchOverrides = Partial<Pick<SearchSettings, 'categories' | 'timeRange'>>;
+
+export const DEFAULT_SEARCH_ENDPOINT = 'https://qwksearch.com/api/agent/search';
+export const DEFAULT_SEARCH_LANGUAGE = 'en-US';
+export const DEFAULT_MAX_CATEGORIES = 3;
+
+/** The one category every engine serves, and the fallback when nothing else survives. */
+export const DEFAULT_SEARCH_CATEGORY: SearchCategory = 'general';
+
+export const MAX_MAX_CATEGORIES = SEARCH_CATEGORIES.length;
+export const MAX_RESULT_LIMIT = 200;
+
+export const DEFAULT_SEARCH_SETTINGS: SearchSettings = {
+  categories: [DEFAULT_SEARCH_CATEGORY],
+  endpoint: DEFAULT_SEARCH_ENDPOINT,
+  language: DEFAULT_SEARCH_LANGUAGE,
+  maxCategories: DEFAULT_MAX_CATEGORIES,
+  publicInstances: false,
+  safeSearch: false,
+};
+
+/**
+ * QwkSearch's category registry (`search-web-api/registry`) names a few
+ * categories differently from SearXNG, and LobeHub's tool manifest offers a
+ * fifth set again. Normalize every spelling we might receive onto what the
+ * endpoint accepts; anything unknown is dropped rather than guessed at.
+ */
+const CATEGORY_ALIASES: Record<string, SearchCategory> = {
+  'academic': 'science',
+  'apps': 'files',
+  'code': 'it',
+  'file': 'files',
+  'general': 'general',
+  'image': 'images',
+  'images': 'images',
+  'it': 'it',
+  'map': 'map',
+  'maps': 'map',
+  'music': 'music',
+  'news': 'news',
+  'science': 'science',
+  'shopping': 'general',
+  'social': 'social+media',
+  'social media': 'social+media',
+  'social+media': 'social+media',
+  'specialized': 'general',
+  'tech': 'it',
+  'torrents': 'files',
+  'video': 'videos',
+  'videos': 'videos',
+};
+
+/** A BCP-47-shaped tag: `en`, `en-US`, `zh-Hans-CN`. */
+const LANGUAGE_TAG = /^[a-z]{2,3}(?:-[a-z\d]{2,8})*$/i;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+/** A trimmed non-empty string, or `undefined`. Never `''`. */
+const text = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const list = (value: unknown): string[] | undefined => {
+  if (Array.isArray(value)) return value.map((v) => text(v)).filter((v): v is string => !!v);
+  const raw = text(value);
+  return raw
+    ? raw
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean)
+    : undefined;
+};
+
+const boolish = (value: unknown): boolean | undefined => {
+  if (typeof value === 'boolean') return value;
+  const raw = text(value)?.toLowerCase();
+  if (raw === undefined) return undefined;
+  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on') return true;
+  if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'off') return false;
+  return undefined;
+};
+
+const integer = (value: unknown, min: number, max: number): number | undefined => {
+  const raw = typeof value === 'number' ? value : Number(text(value));
+  if (!Number.isFinite(raw)) return undefined;
+  return clamp(Math.round(raw), min, max);
+};
+
+/**
+ * Keep the categories the endpoint accepts, aliased and deduplicated, in the
+ * order given.
+ *
+ * Unknown entries are dropped rather than mapped to `general`: a list of
+ * `['news', 'nonsense']` should still search news, and a list with nothing
+ * valid left returns `undefined` so the caller falls back to the layer above
+ * instead of searching nothing. This is *not* the cap — that is applied once,
+ * at the end of {@link resolveSearchSettings}, because `maxCategories` may
+ * arrive from a different layer than the categories it bounds.
+ */
+export const normalizeSearchCategories = (value: unknown): SearchCategory[] | undefined => {
+  const entries = list(value);
+  if (!entries) return undefined;
+
+  const seen = new Set<SearchCategory>();
+  for (const entry of entries) {
+    const raw = entry.toLowerCase();
+    // The alias map does not repeat every endpoint category as its own key
+    // (`files` has three aliases but no self-entry), so an exact name that is
+    // not an alias is still valid.
+    const category =
+      CATEGORY_ALIASES[raw] ??
+      (SEARCH_CATEGORIES.includes(raw as SearchCategory) ? (raw as SearchCategory) : undefined);
+    if (category) seen.add(category);
+  }
+
+  return seen.size > 0 ? [...seen] : undefined;
+};
+
+export const normalizeTimeRange = (value: unknown): SearchTimeRange | undefined => {
+  const raw = text(value)?.toLowerCase();
+  return SEARCH_TIME_RANGES.includes(raw as SearchTimeRange) ? (raw as SearchTimeRange) : undefined;
+};
+
+/**
+ * Validate a language tag's shape and canonicalize its case (`EN-us` → `en-US`)
+ * so two spellings of one language do not read as two settings. Region
+ * subtags are uppercased and script subtags title-cased, per BCP-47.
+ */
+export const normalizeSearchLanguage = (value: unknown): string | undefined => {
+  const raw = text(value);
+  if (!raw || !LANGUAGE_TAG.test(raw)) return undefined;
+
+  const [primary, ...subtags] = raw.split('-');
+  const canonical = subtags.map((subtag) =>
+    subtag.length === 2
+      ? subtag.toUpperCase()
+      : subtag.length === 4
+        ? subtag[0].toUpperCase() + subtag.slice(1).toLowerCase()
+        : subtag.toLowerCase(),
+  );
+
+  return [primary.toLowerCase(), ...canonical].join('-');
+};
+
+/** A `URL`-parseable http(s) endpoint. Anything else is dropped. */
+export const normalizeHttpUrl = (value: unknown): string | undefined => {
+  const raw = text(value);
+  if (!raw) return undefined;
+  try {
+    const parsed = new URL(raw);
+    return /^https?:$/.test(parsed.protocol) ? parsed.toString().replace(/\/$/, '') : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+export type SearchEnv = Record<string, string | undefined>;
+
+/**
+ * The environment layer: Worker vars and secrets.
+ *
+ * `QWKSEARCH_SEARCH_URL` and `QWKSEARCH_API_KEY` keep the names the impl
+ * already read, so existing deployments need no change. The rest are new and
+ * all optional.
+ */
+export const searchSettingsFromEnv = (
+  env: SearchEnv = process.env as SearchEnv,
+): Partial<SearchSettings> => ({
+  apiKey: text(env.QWKSEARCH_API_KEY),
+  categories: normalizeSearchCategories(env.QWKSEARCH_SEARCH_CATEGORIES),
+  endpoint: normalizeHttpUrl(env.QWKSEARCH_SEARCH_URL),
+  language: normalizeSearchLanguage(env.QWKSEARCH_SEARCH_LANGUAGE),
+  maxCategories: integer(env.QWKSEARCH_SEARCH_MAX_CATEGORIES, 1, MAX_MAX_CATEGORIES),
+  publicInstances: boolish(env.QWKSEARCH_SEARCH_PUBLIC_INSTANCES),
+  resultLimit: integer(env.QWKSEARCH_SEARCH_RESULT_LIMIT, 1, MAX_RESULT_LIMIT),
+  safeSearch: boolish(env.QWKSEARCH_SEARCH_SAFE),
+  timeRange: normalizeTimeRange(env.QWKSEARCH_SEARCH_TIME_RANGE),
+});
+
+/** Drop `undefined` values so a partial layer cannot erase the layer below it. */
+const defined = <T extends object>(value: T): Partial<T> =>
+  Object.fromEntries(Object.entries(value).filter(([, v]) => v !== undefined)) as Partial<T>;
+
+/**
+ * Validate and clamp an override layer. Applied to the user and request layers
+ * alike, so a value that reaches {@link resolveSearchSettings} through either
+ * path gets the same treatment.
+ */
+export const normalizeSearchOverrides = (
+  overrides: UserSearchOverrides = {},
+): UserSearchOverrides =>
+  defined({
+    categories: normalizeSearchCategories(overrides.categories),
+    language: normalizeSearchLanguage(overrides.language),
+    maxCategories: integer(overrides.maxCategories, 1, MAX_MAX_CATEGORIES),
+    publicInstances: boolish(overrides.publicInstances),
+    resultLimit: integer(overrides.resultLimit, 1, MAX_RESULT_LIMIT),
+    safeSearch: boolish(overrides.safeSearch),
+    timeRange: normalizeTimeRange(overrides.timeRange),
+  });
+
+/**
+ * The tool call's own arguments, as an override layer.
+ *
+ * `searchEngines` is deliberately not read: QwkSearch picks engines per
+ * category from its own registry, which is what `useAutoSearchEngineSelection`
+ * tells the caller. A `searchTimeRange` the endpoint does not understand
+ * (`anytime`, the manifest's "no filter" value) drops out here, leaving
+ * whatever the operator configured — which is `undefined`, no filter, unless
+ * they set one.
+ */
+export const searchOverridesFromParams = (params: SearchParams = {}): RequestSearchOverrides =>
+  defined({
+    categories: normalizeSearchCategories(params.searchCategories),
+    timeRange: normalizeTimeRange(params.searchTimeRange),
+  });
+
+/**
+ * Fold the layers into the settings one query runs with.
+ *
+ * Later arguments win, but only where they carry a value that survived
+ * validation — so a user preference cannot blank out the operator's endpoint by
+ * sending an empty string. The category cap is applied last, after every layer
+ * has had its say, because the list and the bound on it can come from
+ * different layers.
+ */
+export const resolveSearchSettings = (
+  env: SearchEnv = process.env as SearchEnv,
+  ...overrides: Array<RequestSearchOverrides | undefined | UserSearchOverrides>
+): SearchSettings => {
+  let settings: SearchSettings = {
+    ...DEFAULT_SEARCH_SETTINGS,
+    ...defined(searchSettingsFromEnv(env)),
+  };
+
+  for (const layer of overrides) {
+    if (layer) settings = { ...settings, ...normalizeSearchOverrides(layer) };
+  }
+
+  return { ...settings, categories: settings.categories.slice(0, settings.maxCategories) };
+};
+
+/**
+ * The categories one query actually fans out to.
+ *
+ * Preserved as a named export because the tool-manifest drift guard in
+ * `index.test.ts` is written against it: anything the manifest offers the model
+ * but this drops silently becomes `general`, which is the empty-page failure
+ * the enum exists to prevent.
+ */
+export const normalizeCategories = (categories?: string[]): string[] =>
+  resolveSearchSettings({}, { categories: normalizeSearchCategories(categories) }).categories;
+
+/** Settings minus the credential, for logging and diagnostics. */
+export const redactSearchSettings = (
+  settings: SearchSettings,
+): Omit<SearchSettings, 'apiKey'> & { apiKey: boolean } => {
+  const { apiKey, ...rest } = settings;
+  return { ...rest, apiKey: !!apiKey };
+};
+
+/**
+ * What the Search & Sources pane is told is currently in force.
+ *
+ * The value fields are exactly {@link UserSearchOverrides}' keys, so "what
+ * applies" and "what you may change" have the same shape. Everything the user
+ * cannot set is reduced to a presence flag under `configured`: those fields name
+ * a host and a credential, and an endpoint URL may itself carry basic-auth
+ * credentials in its userinfo, so the pane learns *whether* the operator
+ * configured one and never what it is.
+ *
+ * The two optional fields are serialized as `null` rather than omitted: absent
+ * means "inherit" everywhere else in this seam, and "no recency filter" is a
+ * value in force, not an unset one.
+ */
+export interface SearchSettingsSummary extends Omit<
+  Required<UserSearchOverrides>,
+  'resultLimit' | 'timeRange'
+> {
+  configured: {
+    apiKey: boolean;
+    endpoint: boolean;
+  };
+  resultLimit: null | number;
+  timeRange: null | SearchTimeRange;
+}
+
+export const searchSettingsForClient = (settings: SearchSettings): SearchSettingsSummary => {
+  const redacted = redactSearchSettings(settings);
+
+  return {
+    categories: redacted.categories,
+    configured: {
+      apiKey: redacted.apiKey,
+      // Configured by default — the shipped fan-out — but the flag stays honest
+      // if an operator blanks it.
+      endpoint: !!redacted.endpoint,
+    },
+    language: redacted.language,
+    maxCategories: redacted.maxCategories,
+    publicInstances: redacted.publicInstances,
+    resultLimit: redacted.resultLimit ?? null,
+    safeSearch: redacted.safeSearch,
+    timeRange: redacted.timeRange ?? null,
+  };
+};

--- a/packages-lobe/packages/builtin-tool-web-browsing/src/searchCategories.ts
+++ b/packages-lobe/packages/builtin-tool-web-browsing/src/searchCategories.ts
@@ -9,9 +9,11 @@
  * QwkSearch's fan-out endpoint accepts five categories LobeHub's manifest does
  * not offer (`files`, `it`, `map`, `music`, `social+media`); its 13-name
  * registry aliases onto those in
- * `apps/server/src/services/search/impls/qwksearch/index.ts`, which is the file
- * to keep this list in step with. They are only safe to advertise when
- * QwkSearch is the *sole* configured provider, so that is the condition here.
+ * `apps/server/src/services/search/impls/qwksearch/searchSettings.ts`, whose
+ * `SEARCH_CATEGORIES` is the list to keep this one in step with —
+ * `searchSettings.test.ts` asserts the two are equal. They are only safe to
+ * advertise when QwkSearch is the *sole* configured provider, so that is the
+ * condition here.
  *
  * This file is new rather than inlined into `manifest.ts` on purpose: everything
  * under `packages/` is upstream LobeHub, and the edit there stays two lines.

--- a/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
@@ -246,10 +246,11 @@ LobeHub web-browsing tool
 |---|---|
 | Enable | `SEARCH_PROVIDERS=qwksearch` (set in `wrangler.jsonc` vars) |
 | Endpoint | `QWKSEARCH_SEARCH_URL`, default `https://qwksearch.com/api/agent/search`; optional `QWKSEARCH_API_KEY` sent as a bearer token |
-| Categories | Three vocabularies are normalized onto the endpoint's ten SearXNG names: LobeHub's manifest, QwkSearch's 13-category registry (`academic`, `social`, `tech`, `torrents`, …) and SearXNG's. Unknown names fall back to `general` rather than returning an empty page |
+| Configuration | Every knob the request carries is resolved by `searchSettings.ts` — see F5a. `index.ts` only turns the resolved value into HTTP |
+| Categories | Three vocabularies are normalized onto the endpoint's ten SearXNG names: LobeHub's manifest, QwkSearch's 13-category registry (`academic`, `social`, `tech`, `torrents`, …) and SearXNG's. A name none of them knows is dropped; a call left with nothing valid falls through to the configured default (`general` unless an operator set otherwise) rather than returning an empty page |
 | Advertised categories | The manifest enum is resolved at module evaluation by `packages/builtin-tool-web-browsing/src/searchCategories.ts`. With `SEARCH_PROVIDERS=qwksearch` and nothing else, the model is offered all ten (`files`, `it`, `map`, `music`, `social+media` on top of LobeHub's five); any other configuration keeps LobeHub's five, so no backend is asked for a category it cannot serve |
-| Fan-out | One request per category, capped at 3, issued in parallel |
-| Merge | Deduplicated by URL — highest score wins, engine lists union, a missing snippet is backfilled from the duplicate |
+| Fan-out | One request per category, issued in parallel, capped at `maxCategories` (3 by default, operator-raisable to 10) |
+| Merge | Deduplicated by URL — highest score wins, engine lists union, a missing snippet is backfilled from the duplicate. Capped after the merge when `resultLimit` is set, so the cap counts distinct URLs and keeps the highest-scoring ones |
 | Engines | Never forwarded. `useAutoSearchEngineSelection = true` tells `SearchService` not to retry by stripping engine restrictions, because QwkSearch already picks engines per category |
 | Failure | Any category request failing raises `TRPCError SERVICE_UNAVAILABLE`, so `SearchService` can fail over to the next configured provider |
 
@@ -264,6 +265,50 @@ Note that `packages/**` is excluded from the root Vitest config and the
 web-browsing tool package has no config of its own, so a test placed beside
 `searchCategories.ts` would never run. Its coverage lives in
 `impls/qwksearch/index.test.ts` instead, which imports the package by name.
+
+### F5a — Search settings contract
+
+The search-side mirror of F2a, and the first of the three steps the Search &
+Sources pane needs. `QwkSearchImpl` used to read `process.env` inside a getter
+and hard-code the rest: `general` as the fallback category, three categories per
+query, and four query parameters the fan-out endpoint accepts that it never
+sent. `searchSettings.ts` replaces all of it with one resolved `SearchSettings`,
+folded out of three layers.
+
+```
+DEFAULT_SEARCH_SETTINGS              shipped behaviour
+  ← searchSettingsFromEnv(env)       Worker vars + secrets   (operator)
+  ← UserSearchOverrides              persisted preferences   (signed-in user)
+  ← searchOverridesFromParams(p)     this tool call's args   (the model)
+      ↓
+  one GET per resolved category, carrying lang / recency / safesearch /
+  publicInstances, merged and then capped at `resultLimit`
+```
+
+| Concern | Behavior |
+|---|---|
+| Validation | Every value is normalized on the way in — categories aliased onto the endpoint's ten names, language tags matched against a BCP-47 shape and case-canonicalized (`EN-us` → `en-US`), numbers rounded and clamped, enums matched case-insensitively. A value that fails falls back to the layer below; nothing throws, because a bad preference must not turn a search into a 500 |
+| Layer asymmetry | `endpoint` and `apiKey` resolve **from the environment only** — a user-supplied backend URL would leak the configured bearer token to whatever host they chose. `RequestSearchOverrides` is narrower again: the tool call is written by the model, so it may narrow only `categories` and `timeRange`, the two fields the manifest offers it. `maxCategories` is withheld from it because it bounds how many upstream requests one query costs |
+| Where the cap is applied | `maxCategories` truncates the category list once, after every layer has resolved — the list can arrive from the request layer while the bound comes from the user layer, so capping inside a layer would use the wrong bound |
+| Empty is not a value | A normalizer that finds nothing valid returns `undefined`, not `[]`, so a typo in `QWKSEARCH_SEARCH_CATEGORIES` falls through to the layer above instead of searching nothing |
+| `searchTimeRange: 'anytime'` | The manifest's "no filter" value is not one the endpoint understands, so it drops out of the request layer and whatever the operator configured stands — `undefined`, no filter, unless they set one |
+| Diagnostics | `redactSearchSettings` replaces the credential with a boolean. `searchSettingsForClient` goes further for the future pane: it returns exactly the fields a user may change, reduces the endpoint and the key to presence flags under `configured` (an endpoint URL can carry basic-auth credentials in its userinfo), and serializes the two optional fields as `null` rather than omitting them, because absent means "inherit" everywhere else in this seam |
+| Where the user layer lives | Nowhere yet. `QwkSearchImpl`'s constructor takes `UserSearchOverrides` and nothing passes them — that is the storage step, the search-side mirror of F2b |
+
+Env vars, all optional and all defaulted: `QWKSEARCH_SEARCH_CATEGORIES`,
+`QWKSEARCH_SEARCH_MAX_CATEGORIES`, `QWKSEARCH_SEARCH_LANGUAGE`,
+`QWKSEARCH_SEARCH_TIME_RANGE`, `QWKSEARCH_SEARCH_SAFE`,
+`QWKSEARCH_SEARCH_PUBLIC_INSTANCES`, `QWKSEARCH_SEARCH_RESULT_LIMIT`. The
+existing `QWKSEARCH_SEARCH_URL` and `QWKSEARCH_API_KEY` keep their names, so no
+deployment needs to change; setting none of the new ones reproduces the
+behavior the impl had before the settings layer existed, with one deliberate
+addition — `lang=en-US` is now sent explicitly, which is the value the endpoint
+already defaulted to.
+
+The module lives beside its consumer in `impls/qwksearch/` rather than under
+`worker/` (where `extractSettings.ts` sits) because the dependency runs
+worker → `@/server/*` and never back: a future `/api/doc/search-settings` route
+in the Worker can import this, but this could not import from `worker/`.
 
 ## 3. Shared infrastructure
 
@@ -300,6 +345,12 @@ Optional extraction vars, all defaulted, are listed under §F2a and in
 OCR processor for scanned PDFs) and its companion `PDF_PROCESSOR`. Setting none
 of them reproduces the behavior the chain had before the settings layer existed.
 
+Optional search vars, likewise all defaulted, are listed under §F5a:
+`QWKSEARCH_SEARCH_CATEGORIES`, `QWKSEARCH_SEARCH_MAX_CATEGORIES`,
+`QWKSEARCH_SEARCH_LANGUAGE`, `QWKSEARCH_SEARCH_TIME_RANGE`,
+`QWKSEARCH_SEARCH_SAFE`, `QWKSEARCH_SEARCH_PUBLIC_INSTANCES`,
+`QWKSEARCH_SEARCH_RESULT_LIMIT`.
+
 Secrets (`wrangler secret put`): `KEY_VAULTS_SECRET`, `AUTH_SECRET`,
 `DATABASE_URL` (when not using Hyperdrive), `S3_*`, `TAVILY_API_KEY`,
 `SCRAPER_API_KEY`, `QWKSEARCH_API_KEY`, per-provider model keys, `QSTASH_*`.
@@ -326,7 +377,8 @@ bunx vitest run worker/qwksearch
 bunx vitest run worker/routes/qwksearch/extractionSettings.test.ts \
   worker/routes/qwksearch/article.test.ts
 
-# Worker, Cloudflare adapters, QwkSearch features, the search provider
+# Worker, Cloudflare adapters, QwkSearch features, the search provider and its
+# settings layer (82 cases across index.test.ts and searchSettings.test.ts)
 bunx vitest run worker src/features/QwkSearch \
   src/libs/better-auth/utils/kvSecondaryStorage.test.ts \
   apps/server/src/services/email/impls/cloudflare \

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -16,15 +16,15 @@ The map of what already connects is
 
 **Legend** — ✅ done · 🚧 in progress · ⬜ not started · 🔒 blocked
 
-Last updated: 2026-09-09.
+Last updated: 2026-09-10.
 
 ## Snapshot
 
 | Phase | State |
 |---|---|
 | 0. Baseline — LobeHub builds and deploys on Workers | ✅ |
-| 1. Chat mode on the engine (staging) | 🚧 search and extraction wired; parity open |
-| 2. Settings as the single system of record | 🚧 Extraction pane shipped end to end; Search & Sources pane open |
+| 1. Chat mode on the engine (staging) | 🚧 search and extraction wired, both with a settings layer; parity open |
+| 2. Settings as the single system of record | 🚧 Extraction shipped end to end; Search & Sources has its resolution layer, needs storage + pane |
 | 3. REASON docs inside the engine | ⬜ |
 | 4. Public cutover | 🔒 needs the license answer |
 | 5. Decommission + satellites + ops gaps | ⬜ |
@@ -302,6 +302,64 @@ Follow-ups:
   `ExtractionSettingsApiError` already carries and prompt to sign in, the way
   `article.error.loginRequired` does.
 
+### 1.8 Search settings resolution ✅
+
+The search-side mirror of 1.5, and the first of the three steps the Search &
+Sources pane needs. `QwkSearchImpl` no longer reads `process.env` itself or
+hard-codes its knobs:
+`apps/server/src/services/search/impls/qwksearch/searchSettings.ts` owns one
+`SearchSettings` value and folds it out of three layers — shipped defaults, then
+Worker env, then the signed-in user's preferences, then this tool call's own
+arguments — validating every value on the way in. `index.ts` is left turning the
+resolved value into HTTP.
+
+| Setting | Env var | Reaches |
+|---|---|---|
+| Endpoint + bearer token | `QWKSEARCH_SEARCH_URL`, `QWKSEARCH_API_KEY` | the request URL and its `Authorization` header |
+| Default categories | `QWKSEARCH_SEARCH_CATEGORIES` | `cat`, one request per category |
+| Fan-out bound | `QWKSEARCH_SEARCH_MAX_CATEGORIES` | how many of them run (3 by default, up to 10) |
+| Result language | `QWKSEARCH_SEARCH_LANGUAGE` | `lang` — **newly sent**; the endpoint already defaulted to `en-US` |
+| Default recency | `QWKSEARCH_SEARCH_TIME_RANGE` | `recency`, when the call names none |
+| Safe search | `QWKSEARCH_SEARCH_SAFE` | `safesearch` — newly sent |
+| Public SearXNG fallback | `QWKSEARCH_SEARCH_PUBLIC_INSTANCES` | `publicInstances` — newly sent |
+| Result cap | `QWKSEARCH_SEARCH_RESULT_LIMIT` | applied after the URL merge |
+
+Four things worth knowing before building the pane on top of it:
+
+- **It lives beside its consumer, not under `worker/`.** `extractSettings.ts`
+  sits in `worker/qwksearch/` because the extraction chain does. The search impl
+  does not: it is `@/server/*` code. The dependency runs worker → `@/server/*`
+  and never back, so a future `/api/doc/search-settings` route can import this,
+  while the reverse placement would not have worked.
+- **The request layer is narrower than the user layer.** The tool call's
+  arguments are written by the model, so they may narrow only `categories` and
+  `timeRange` — the two fields the manifest offers it. `maxCategories` is
+  withheld from it deliberately: it bounds how many upstream requests one query
+  costs, which is the operator's budget and not a generated argument's to raise.
+  `searchEngines` is still never read at all.
+- **The cap is applied once, at the end.** The category list can arrive from the
+  request layer while `maxCategories` comes from the user layer, so each
+  normalizer returns the full validated list and `resolveSearchSettings`
+  truncates after every layer has resolved.
+- **Three query parameters the endpoint always accepted are now actually sent.**
+  `lang`, `safesearch` and `publicInstances` were in
+  `research-agent-ui/src/api/handlers/search.ts` the whole time and the impl
+  never used them. Only `lang` changes the default request, and it sends the
+  value the endpoint already assumed.
+
+Follow-ups:
+
+- ⬜ **The user layer has no storage.** `QwkSearchImpl`'s constructor takes
+  `UserSearchOverrides` and the factory in
+  `apps/server/src/services/search/impls/index.ts` passes none, so today every
+  deployment resolves defaults-under-env exactly as before. This is 1.6's
+  equivalent and the next step: a `search_settings` D1 table and a
+  `/api/doc/search-settings` route, then the factory needs the request's user id
+  to reach the impl — which extraction did not have to solve, because its chain
+  runs inside a Worker route that already has the session.
+- ⬜ **`searchSettingsForClient` has no client**, the same gap 1.6 left before
+  1.7 closed it.
+
 ### 1.4 Agent parity checklist ⬜
 
 Reproduce today's chat-mode behavior on the engine and record each gap:
@@ -331,12 +389,13 @@ Reproduce today's chat-mode behavior on the engine and record each gap:
   ✅ **Extraction is done** — 1.5 (resolution), 1.6 (storage + API) and 1.7 (the
   pane). It is a client of `GET`/`PUT`/`DELETE /api/doc/extraction-settings` and
   has no slice in `src/store/user/slices/settings/`; 1.6 records why.
-  ⬜ **Search & Sources** is what remains, and it is not symmetrical with
-  Extraction: it still has no resolution layer. `QwkSearchImpl` reads
-  `QWKSEARCH_SEARCH_URL` and its category normalizer straight from env, the way
-  the extraction tiers used to, so the same three steps apply in the same order
-  — a `searchSettings.ts`, then storage and a route, then the pane. Take 1.5–1.7
-  as the template; each is written up above.
+  🚧 **Search & Sources** is one of the same three steps in: the resolution
+  layer landed as 1.8 above, mirroring 1.5. What remains is storage plus a
+  route (1.6's equivalent) and then the pane (1.7's). One asymmetry to plan
+  for: extraction's chain runs inside a Worker route that already has the
+  session, while the search impl is constructed by a factory with no request in
+  scope, so the storage step has to get the user id to `QwkSearchImpl` before
+  the pane can do anything.
 - ⬜ **2.3 Key migration.** Server env keys stay Worker secrets. Per-user keys
   live in `localStorage` today and have no server copy — announce a one-time
   re-entry into the engine's key vault; do not build a migrator.
@@ -418,13 +477,17 @@ Blocked on the LobeHub Community License answer, recorded in
 **Suggested next, in order** — all code-only, all testable without Cloudflare
 credentials:
 
-1. **A `searchSettings.ts` for the Search & Sources pane**, mirroring
-   `extractSettings.ts`: one resolved value, layered defaults → env → user, with
-   the same rule that hosts and keys are environment-only. `QwkSearchImpl` reads
-   `QWKSEARCH_SEARCH_URL` and its category normalizer straight from env today,
-   the way the extraction tiers used to. Extraction took three passes to get
-   here (1.5 → 1.6 → 1.7) and this is the first of the three; doing them in that
-   order is what made each one testable on its own.
+1. **Search preferences: the user layer** — 1.6's equivalent, now that 1.8 has
+   landed the resolution layer. A `search_settings` D1 table and a
+   `GET`/`PUT`/`DELETE /api/doc/search-settings` route, both close copies of
+   `extractionPreferences.ts` and `routes/qwksearch/extractionSettings.ts`.
+   The one thing that is genuinely new: the extraction chain runs inside a
+   Worker route that already has the session, but `QwkSearchImpl` is built by
+   `impls/index.ts` with no request in scope, so this step also has to decide
+   how the user id reaches the impl — resolve the overrides in the tool's
+   execution runtime and pass them to the constructor (the seam is already
+   there), or give `SearchService` a per-request factory. Pick that before
+   writing the table.
 2. **1.3's open question — two chains in `extract.ts`.** `defaultTiersFor`,
    `extractViaYouTube`, `extractViaPdf`, `loadCiteExtractor` and
    `articleViaCiteExtractor` have never been on a request path, and lint reports


### PR DESCRIPTION
Continues the LobeHub ⇄ QwkSearch merge by picking up the [migration to-do](https://github.com/OpenSourceAGI/qwksearch-research-agent/blob/master/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx)'s own #1 suggested next item: a `searchSettings.ts` mirroring `extractSettings.ts`. It is the first of the three steps § 2.2's **Search & Sources** pane needs, the same 1.5 → 1.6 → 1.7 sequence extraction went through.

## The problem

`QwkSearchImpl` read `process.env` inside a getter and hard-coded the rest: `general` as the fallback category, three categories per query, and four query parameters the fan-out endpoint accepts that it never sent. The extraction chain stopped doing that in phase 1.5; search had not, so the pane had nowhere to write to.

## What this adds

`apps/server/src/services/search/impls/qwksearch/searchSettings.ts` owns one resolved `SearchSettings`, folded out of four layers with every value validated on the way in. `index.ts` is left turning the resolved value into HTTP.

```
DEFAULT_SEARCH_SETTINGS              shipped behaviour
  ← searchSettingsFromEnv(env)       Worker vars + secrets   (operator)
  ← UserSearchOverrides              persisted preferences   (signed-in user)
  ← searchOverridesFromParams(p)     this tool call's args   (the model)
```

Four decisions carry the design:

- **It lives beside its consumer, not under `worker/`.** `extractSettings.ts` sits in `worker/qwksearch/` because the extraction chain does. The search impl is `@/server/*` code, and the dependency runs worker → `@/server/*` and never back — so a future `/api/doc/search-settings` route can import this, while the mirror-image placement would not have worked.
- **The request layer is narrower than the user layer.** Tool arguments are written by the model, so they may narrow only `categories` and `timeRange` — the two fields the manifest offers it. `maxCategories` is withheld because it bounds how many upstream requests one query costs. `endpoint` and `apiKey` stay environment-only, so a preference can never redirect the bearer token to a host the user picked.
- **The category cap is applied once, at the end.** The list can arrive from the request layer while `maxCategories` comes from the user layer, so each normalizer returns the full validated list and `resolveSearchSettings` truncates last.
- **Empty is not a value.** A normalizer that finds nothing valid returns `undefined`, not `[]`, so a typo in `QWKSEARCH_SEARCH_CATEGORIES` falls through to the layer above instead of searching nothing.

Three query parameters the endpoint always accepted are now actually sent — `lang`, `safesearch` and `publicInstances` were in `research-agent-ui/src/api/handlers/search.ts` the whole time. Only `lang` changes the default request, and it sends the `en-US` the endpoint already assumed.

One latent gap surfaced while moving the alias table: `files` had no self-entry in it and survived only through an identity fallback in the old lookup. The new lookup restores that fallback explicitly, with a comment saying why.

### New environment variables

All optional, all defaulted; setting none reproduces today's behavior.

| Var | Default | Meaning |
| --- | --- | --- |
| `QWKSEARCH_SEARCH_CATEGORIES` | `general` | categories searched when the tool call names none |
| `QWKSEARCH_SEARCH_MAX_CATEGORIES` | `3` | most categories fanned out per query (1–10) |
| `QWKSEARCH_SEARCH_LANGUAGE` | `en-US` | BCP-47 tag sent as `lang` |
| `QWKSEARCH_SEARCH_TIME_RANGE` | — | default recency when the call names none |
| `QWKSEARCH_SEARCH_SAFE` | `false` | ask the engines to filter adult content |
| `QWKSEARCH_SEARCH_PUBLIC_INSTANCES` | `false` | allow public SearXNG fallback |
| `QWKSEARCH_SEARCH_RESULT_LIMIT` | — | keep at most this many merged results (1–200) |

`QWKSEARCH_SEARCH_URL` and `QWKSEARCH_API_KEY` keep their names.

## Not in this change

Storage and a route (1.6's equivalent) and the pane (1.7's). `QwkSearchImpl`'s constructor takes `UserSearchOverrides` and the factory passes none, so every deployment resolves defaults-under-env exactly as before. The next step also has a genuinely new problem to solve: extraction's chain runs inside a Worker route that already has the session, while the search impl is built by `impls/index.ts` with no request in scope. Both are written up in the to-do.

## Documentation

- §F5a **Search settings contract** in the integrations reference, plus the F5 table rows and the config surface it changes.
- §1.8 in the migration to-do, with the snapshot, § 2.2 and the "suggested next" list re-pointed at the storage step.
- The env table and upstream-diff note in `packages-lobe/README.md`, and the file pointer in `searchCategories.ts`.
- A tracker entry in `TODO.md`.

## Verification

- `bun run check` over all five changed source files — **lint clean, 82 tests pass** (44 new in `searchSettings.test.ts`, 38 in `index.test.ts`).
- `vitest run apps/server/src/services/search` — **185 passed, 7 skipped**, 11 files: the whole search service, not just this provider.
- The **27 pre-existing `index.test.ts` cases pass unmodified**, which is the real regression signal — observable behavior is unchanged wherever no new var is set.
- `vitest run` in `packages/user-help-docs` — 37 passed, covering every page under `content/docs`.
- Type check: **scoped**, not repo-wide, per the to-do's recorded OOM. A `tsconfig` extending the real one and narrowed to the impl directory reports **zero errors in any changed file**; everything it does report is pre-existing `apps/desktop`, `packages/builtin-skills` and `worker/cf/env.ts`.

Not seen against the live endpoint — no Cloudflare credentials in this environment, so the three newly-sent parameters are verified by asserting the built URL rather than by a real response.

Note that nothing in CI builds or tests `packages-lobe`; it is a separate pnpm workspace outside the root turbo graph. The local runs above are the only signal for that half of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TTFiocVXbTRdF9U3xJCcn

---
_Generated by [Claude Code](https://claude.ai/code/session_019TTFiocVXbTRdF9U3xJCcn)_