### PR TITLE
📝 docs(migration): correct the stale list of already-red coverage jobs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -92,8 +92,17 @@ lookup restores that fallback explicitly, with a comment saying why.
 - **`bun run check <dir>` silently checks one file.** Pass explicit file paths;
   a directory argument reported "1 files · lint clean" while three others went
   unlinted.
-- CI still cannot see `packages-lobe`, and PRs here still auto-merge. Both
-  remain written up in the to-do.
+- CI still cannot see `packages-lobe`, and PRs here still auto-merge — #413
+  merged ten seconds after opening, before a single coverage job finished.
+- **The recorded list of already-red packages was stale**, and that is the
+  dangerous kind of stale: it named six, two of which (`extract-pdf`,
+  `qwksearch-web`) have since been fixed, so the next run would have waved
+  through a real failure in them. Verified against the base run for #412
+  (`52eb7cce`, run 34445607248): four fail there — `chat-agent-toolkit`,
+  `extract-youtube`, `search-web-api`, `shadcn-settings` — and #413's own run
+  failed a strict subset of exactly those. `user-help-docs`, the one root
+  package this change touched, passed on both. The to-do now says to read the
+  base run rather than trust the list.
 
 ### Remaining work
 - **The user layer has no storage**, so today every deployment resolves

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -554,11 +554,14 @@ on a `packages-lobe` change, both observed on #393:
   run says nothing about a change made there, and a red one is almost certainly
   not yours. Your own `bunx vitest run` under `packages-lobe` is the only
   signal — which is why 5.4's "bundle budget in CI" needs a whole new job.
-- **The Coverage workflow is already red on `master`.** On `f10e1091` six jobs
-  failed before any of this work existed: `extract-youtube`, `extract-pdf`,
-  `qwksearch-web`, `shadcn-settings`, `search-web-api` and
-  `chat-agent-toolkit`. Check the same job on the base commit before treating a
-  failure as yours.
+- **The Coverage workflow is already red on `master`.** As of `52eb7cce`
+  (#412, run 34445607248) **four** jobs fail with nothing of this work in them:
+  `chat-agent-toolkit`, `extract-youtube`, `search-web-api` and
+  `shadcn-settings`. Two more — `extract-pdf` and `qwksearch-web` — were on this
+  list and have since been fixed (#409 was the `extract-pdf` one), so **do not
+  treat the list as fixed**: read the same job on your own base commit before
+  treating a failure as yours, or you will wave through a real one. The list
+  shrinks as packages get fixed, and every entry on it is someone's open bug.
 
 Also: **PRs here auto-merge.** `.github/workflows/auto-merge-claude.yml` merged
 #393 about ten seconds after it was opened, before its own checks finished. So


### PR DESCRIPTION
Follow-up to #413, which auto-merged before its own checks finished. Reading those checks afterwards turned up a documentation bug worth fixing on its own.

## The problem

The migration to-do's **"What CI will and will not tell you"** section named six packages as already failing on `master`, off a run from `f10e1091`:

> `extract-youtube`, `extract-pdf`, `qwksearch-web`, `shadcn-settings`, `search-web-api` and `chat-agent-toolkit`

Two of those — `extract-pdf` and `qwksearch-web` — have since been fixed; #409 was the `extract-pdf` one. That makes the list the dangerous kind of stale. Its whole purpose is to let a run dismiss a red check as pre-existing, so an over-long list means the next run waves through a real failure in a package that someone already repaired.

## The correction

Verified against the base run for #412 (`52eb7cce`, [run 34445607248](https://github.com/OpenSourceAGI/qwksearch-research-agent/actions/runs/34445607248)) — **four** jobs fail there:

| Job | On `52eb7cce` | On #413's run |
|---|---|---|
| `chat-agent-toolkit` | failure | failure |
| `extract-youtube` | failure | failure |
| `shadcn-settings` | failure | failure |
| `search-web-api` | failure | still running when read |
| `extract-pdf` | **success** | success |
| `qwksearch-web` | **success** | success |
| `user-help-docs` | success | success |

#413's run failed a strict subset of exactly the base's failures, and `user-help-docs` — the one root-workspace package it changed — passed on both, so nothing in #413 broke CI.

The entry now gives the current four with the run they came from, and says to read the same job on your own base commit rather than trust the list, because the list shrinks as packages get fixed and every entry on it is someone's open bug.

## Verification

`vitest run` in `packages/user-help-docs` — 37 passed, covering every page under `content/docs`, so the edited MDX still compiles in the bundler (the pipeline #412 introduced).

Docs and a tracker note only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019TTFiocVXbTRdF9U3xJCcn

---
_Generated by [Claude Code](https://claude.ai/code/session_019TTFiocVXbTRdF9U3xJCcn)_