### PR TITLE
Fix Prism global reference in edge runtime environments

### DIFF
--- a/packages/extract-webpage/src/html-to-content/html-utils.ts
+++ b/packages/extract-webpage/src/html-to-content/html-utils.ts
@@ -139,7 +139,9 @@ export function convertURLToAbsoluteURL(base, relative) {
 }
 
 import { marked } from "marked";
-import Prism from "prismjs";
+// Must precede every `prismjs/components/*` import: the grammar scripts read
+// `Prism` off the global object, which this module publishes (see its docs).
+import Prism from "./prism-global";
 import "prismjs/components/prism-markup.js";
 import "prismjs/components/prism-css.js";
 import "prismjs/components/prism-javascript.js";

--- a/packages/extract-webpage/src/html-to-content/prism-global.ts
+++ b/packages/extract-webpage/src/html-to-content/prism-global.ts
@@ -1,0 +1,22 @@
+/**
+ * @module html-to-content/prism-global
+ * @description Publishes Prism on `globalThis` so the `prismjs/components/*`
+ * grammar scripts can find it.
+ *
+ * Those grammar files are plain browser scripts, not modules — `prism-markup.js`
+ * literally opens with `Prism.languages.markup = {...}`, resolving `Prism` as a
+ * free variable off the global object. Prism's core only publishes that global
+ * when it can see `window` (browser), a `WorkerGlobalScope` `self`, or Node's
+ * `global`. On Cloudflare Workers / edge runtimes none of the three exist, so
+ * the first grammar file throws `ReferenceError: Prism is not defined` while the
+ * module graph is still evaluating, taking the whole SSR render down with it.
+ *
+ * Import this module *before* any `prismjs/components/*` import. ES modules are
+ * evaluated in import order, so this file's body runs — and the global lands —
+ * before the grammars reference it.
+ */
+import Prism from "prismjs";
+
+(globalThis as typeof globalThis & { Prism?: unknown }).Prism ??= Prism;
+
+export default Prism;

--- a/packages/write-language/src/utils/prism-global.ts
+++ b/packages/write-language/src/utils/prism-global.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Publishes Prism on `globalThis` so the `prismjs/components/*`
+ * grammar scripts can find it.
+ *
+ * Those grammar files are plain browser scripts, not modules — `prism-markup.js`
+ * literally opens with `Prism.languages.markup = {...}`, resolving `Prism` as a
+ * free variable off the global object. Prism's core only publishes that global
+ * when it can see `window` (browser), a `WorkerGlobalScope` `self`, or Node's
+ * `global`. On Cloudflare Workers / edge runtimes none of the three exist, so
+ * the first grammar file throws `ReferenceError: Prism is not defined` while the
+ * module graph is still evaluating, taking the whole SSR render down with it.
+ *
+ * Import this module *before* any `prismjs/components/*` import. ES modules are
+ * evaluated in import order, so this file's body runs — and the global lands —
+ * before the grammars reference it.
+ */
+import Prism from "prismjs";
+
+(globalThis as typeof globalThis & { Prism?: unknown }).Prism ??= Prism;
+
+export default Prism;

--- a/packages/write-language/src/utils/prism.ts
+++ b/packages/write-language/src/utils/prism.ts
@@ -3,7 +3,9 @@
  * a small `highlightCode` helper used by markdown-to-html.ts for code-block syntax
  * highlighting.
  */
-import Prism from "prismjs";
+// Must precede every `prismjs/components/*` import: the grammar scripts read
+// `Prism` off the global object, which this module publishes (see its docs).
+import Prism from "./prism-global";
 import "prismjs/components/prism-markup";
 import "prismjs/components/prism-css";
 import "prismjs/components/prism-javascript";


### PR DESCRIPTION
## Summary
This PR fixes a `ReferenceError: Prism is not defined` that occurs when using PrismJS grammar components in edge runtime environments (like Cloudflare Workers) where the global object is not accessible as `window`, `self`, or `global`.

## Changes
- **Created `prism-global.ts` modules** in two packages (`extract-webpage` and `write-language`) that explicitly publish the Prism instance to `globalThis` before grammar files are imported
- **Updated imports** in `html-utils.ts` and `prism.ts` to import from the new `prism-global` module instead of directly from `prismjs`
- **Added explanatory comments** documenting why the `prism-global` import must precede grammar component imports

## Implementation Details
The issue occurs because PrismJS grammar files (e.g., `prism-markup.js`) are plain browser scripts that reference `Prism` as a free variable. PrismJS core only publishes this global when it detects a browser or Node.js environment. In edge runtimes, none of these detection mechanisms work, causing the grammar files to fail during module evaluation.

The solution leverages ES module evaluation order: by importing `prism-global` before any grammar components, we ensure the global is published before the grammar files attempt to reference it. The module uses a nullish coalescing assignment (`??=`) to avoid overwriting any existing `Prism` global.

https://claude.ai/code/session_017uMXNx2f3M5YTB4wm6z9eJ