### PR TITLE
Regroup captions into sentences and improve transcript UX

### DIFF
--- a/packages/extract-youtube/README.md
+++ b/packages/extract-youtube/README.md
@@ -181,6 +181,11 @@ const api = new YouTubeTranscriptApi({
 });
 ```
 
+See [docs/proxy.md](./docs/proxy.md) for the full guide: generic vs. Webshare
+proxies, the CLI flags, why `proxyConfig` does nothing on Cloudflare
+Workers/edge (and what to use there instead), and caching in front of the
+fetcher so a proxy request is only spent on a video you don't already have.
+
 ## Error Handling
 
 ```typescript
@@ -323,7 +328,7 @@ What you get, without wiring any of it up yourself:
 | **Minimize** | Collapses to the title bar. The iframe is hidden with CSS, never unmounted, so playback isn't interrupted. |
 | **Picture-in-picture** | Pops the video into an always-on-top OS window via the Document Picture-in-Picture API, where the browser supports it. The node is *moved*, not cloned, so playback continues. |
 | **Queue** | `addToQueue` / `setQueue` / `playNext`, with an "Up next" strip under the video. |
-| **Synced captions** | Optional subtitles panel above the video — the spoken line highlights and auto-scrolls, and clicking a line seeks. Needs `transcriptUrl` or `fetchTranscript` (see below). |
+| **Synced captions** | Optional subtitles panel above the video — caption cues are regrouped into whole sentences (no timestamps), the spoken one highlights and auto-scrolls, and clicking a sentence seeks. Needs `transcriptUrl` or `fetchTranscript` (see below). |
 | **Resume** | Remembers what was playing, and how far into it, across a reload — plus a per-video position for the last 50 videos, for 24 hours. `storageKey={null}` turns it off. |
 | **Error recovery** | Reads the IFrame API's error codes, explains them ("this video is private", "the owner doesn't allow embedding"), and offers Retry or Watch on YouTube from the same spot. |
 | **Theming** | Colours are CSS custom properties on `.eytp-root` and follow `prefers-color-scheme` by default. Override them to match your app. |
@@ -392,7 +397,7 @@ getPlayerState();   // the same, outside React
 | `fetchTranscript` | `(videoId: string) => Promise<{ snippets, error? }>` | Custom caption loader, instead of `transcriptUrl`. |
 | `extraControls` | `ReactNode \| (ctx: PlayerControlContext) => ReactNode` | Your own buttons, rendered in the control strip. |
 | `renderTitle` | `(ctx: PlayerControlContext) => ReactNode` | Custom title-bar content. Defaults to the video title. |
-| `showSubtitles` | `boolean` | Force the captions button on or off. Defaults to on when a transcript source is given. |
+| `showSubtitles` | `boolean` | Force the captions button on or off. By default it appears only for videos that turned out to have a transcript — every video played is checked, and one without captions gets no button and no error. |
 | `showPictureInPicture` | `boolean` | Show the PiP button where supported. Default `true`. |
 | `storageKey` | `string \| null` | localStorage key for resume-after-reload. `null` disables persistence entirely. |
 | `className` | `string` | Extra class on the player root, for host-side positioning or theming. |

--- a/packages/extract-youtube/docs/proxy.md
+++ b/packages/extract-youtube/docs/proxy.md
@@ -1,0 +1,159 @@
+# Adding a proxy to the transcript fetcher
+
+YouTube rate-limits and bot-checks server IPs. A datacenter IP that has been
+fetching transcripts for a while starts getting `LOGIN_REQUIRED` /
+"Sign in to confirm you're not a bot" instead of caption tracks — which
+surfaces from this package as `IpBlocked` / `RequestBlocked`. Routing the
+fetcher through a proxy (ideally a rotating residential one) is the fix.
+
+There are three ways in, depending on where the fetcher runs.
+
+## 1. Node / Bun / Lambda: `proxyConfig`
+
+`YouTubeTranscriptApi` takes a `proxyConfig`. Everything it fetches — the
+InnerTube/watch requests *and* the caption track downloads — then goes through
+the proxy.
+
+### Any HTTP/HTTPS/SOCKS proxy
+
+```typescript
+import { YouTubeTranscriptApi, GenericProxyConfig } from 'extract-youtube';
+
+const api = new YouTubeTranscriptApi({
+  proxyConfig: new GenericProxyConfig({
+    httpUrl: 'http://user:pass@proxy.example.com:8080',
+    httpsUrl: 'http://user:pass@proxy.example.com:8080',
+  }),
+});
+
+const transcript = await api.fetchTranscript('jNQXAC9IVRw');
+```
+
+Only one of the two URLs is required — whichever you give is used for both
+schemes. Credentials go in the URL's userinfo, so URL-encode a password
+containing `@` or `:`.
+
+### Webshare rotating residential proxies
+
+The most reliable option, and the one the config class is tuned for: buy a
+**Residential** package (not "Proxy Server", not "Static Residential"), then
+pass the *proxy* username and password from
+[the Webshare proxy settings](https://dashboard.webshare.io/proxy/settings):
+
+```typescript
+import { YouTubeTranscriptApi, WebshareProxyConfig } from 'extract-youtube';
+
+const api = new YouTubeTranscriptApi({
+  proxyConfig: new WebshareProxyConfig({
+    proxyUsername: process.env.WEBSHARE_PROXY_USERNAME!,
+    proxyPassword: process.env.WEBSHARE_PROXY_PASSWORD!,
+    // Optional: restrict the IP pool to given countries — lower latency, and
+    // it works around location-based restrictions.
+    filterIpLocations: ['us', 'de'],
+    // Optional: a blocked IP is retried this many times, and each retry
+    // rotates to a different IP. Defaults to 10.
+    retriesWhenBlocked: 10,
+  }),
+});
+```
+
+`WebshareProxyConfig` appends `-rotate` to the username itself, so pass the
+plain username — with or without the suffix, both work.
+
+### From the CLI
+
+```bash
+# Generic proxy
+extract-youtube jNQXAC9IVRw --proxy http://user:pass@proxy.example.com:8080
+
+# Webshare residential
+extract-youtube jNQXAC9IVRw \
+  --webshare-user "$WEBSHARE_PROXY_USERNAME" \
+  --webshare-pass "$WEBSHARE_PROXY_PASSWORD"
+```
+
+Nothing reads proxy settings from the environment on its own. To drive the
+library from env vars, build the config yourself:
+
+```typescript
+const proxyUrl = process.env.YOUTUBE_PROXY_URL;
+const api = new YouTubeTranscriptApi({
+  proxyConfig: proxyUrl ? new GenericProxyConfig({ httpUrl: proxyUrl }) : undefined,
+});
+```
+
+## 2. Cloudflare Workers / Vercel Edge: a custom `httpClient`
+
+`proxyConfig` works by attaching an [`https-proxy-agent`][hpa] to each request
+(see `src/http/fetch-http-client.ts`). Agents are a Node socket-level feature —
+edge runtimes have no `net`/`tls` and ignore the `agent` option entirely, so on
+Workers a `proxyConfig` silently fetches direct.
+
+[hpa]: https://www.npmjs.com/package/https-proxy-agent
+
+What works there is a *fetch-through* proxy: an HTTP endpoint that takes the
+target URL and fetches it for you (Bright Data / ScrapingBee / ScraperAPI all
+offer this shape, and it is ~15 lines to run your own on another Worker or a
+small VPS). Inject it as the API's `httpClient` — that interface is the seam
+the package fetches through:
+
+```typescript
+import { YouTubeTranscriptApi, type HttpClient } from 'extract-youtube';
+
+/** Sends every request through a fetch-through proxy endpoint. */
+class ProxiedHttpClient implements HttpClient {
+  constructor(
+    private endpoint: string,
+    private apiKey: string,
+  ) {}
+
+  private proxied(url: string): string {
+    return `${this.endpoint}?api_key=${this.apiKey}&url=${encodeURIComponent(url)}`;
+  }
+
+  get(url: string, options?: RequestInit) {
+    return fetch(this.proxied(url), { ...options, method: 'GET' });
+  }
+
+  post(url: string, options?: RequestInit) {
+    return fetch(this.proxied(url), { ...options, method: 'POST' });
+  }
+}
+
+const api = new YouTubeTranscriptApi({
+  httpClient: new ProxiedHttpClient(env.PROXY_ENDPOINT, env.PROXY_API_KEY),
+});
+```
+
+Two things a proxy endpoint has to preserve for this to work: the request
+method and body (the InnerTube calls are POSTs with a JSON body), and the
+response body verbatim (caption payloads are JSON or XML, not HTML — a proxy
+that "renders" pages will hand back the wrong thing).
+
+## 3. Fronting it with your own cache
+
+A proxy costs money per request, so don't spend one on a video you already
+have. Cache transcripts keyed by `videoId` (plus language, if you fetch more
+than one) in whatever store the app already has — a database table, KV, R2 —
+and only fall through to the fetcher on a miss. Two consequences worth
+planning for:
+
+- **Cache the negative case too, briefly.** A video genuinely without captions
+  will never grow them on a retry, but a bot-check failure is transient. Store
+  "no captions" for hours and a rate-limit failure for minutes at most, so a
+  bad afternoon doesn't get baked in.
+- **Retry blocked requests, not missing ones.** `retriesWhenBlocked` on the
+  proxy config only rotates IPs for requests that were *blocked*; a video with
+  no caption tracks fails immediately and no proxy will change that.
+
+## When it still fails
+
+`IpBlocked` / `RequestBlocked` with a proxy configured means one of two
+things:
+
+- **The proxy's IP is blocked too.** Datacenter proxies get burned quickly;
+  rotating residential IPs are what actually hold up.
+- **The proxy was never used.** On an edge runtime `proxyConfig` is ignored
+  outright (§2). Elsewhere, the fastest check is from the other side — point
+  the same proxy URL at an IP-echo service with plain `curl -x` and confirm it
+  answers with the proxy's IP, not the machine's.

--- a/packages/extract-youtube/src/react/YouTubeTranscriptModal.tsx
+++ b/packages/extract-youtube/src/react/YouTubeTranscriptModal.tsx
@@ -1,8 +1,9 @@
 /**
  * @fileoverview Popout modal: a YouTube player alongside its transcript, with
- * the transcript synced to playback — the currently spoken line is
- * highlighted and auto-scrolled, an approximate per-word sweep highlights
- * across the active line, and clicking any line seeks the player there.
+ * the transcript synced to playback — caption cues are regrouped into whole
+ * sentences and read as prose (no timestamps), the currently spoken sentence
+ * is highlighted and auto-scrolled, an approximate per-word sweep highlights
+ * across it, and clicking a sentence seeks the player to where it starts.
  *
  * Ported from debate-ai.com's `TranscriptModal` component. This version has
  * no dependency on any particular design system — it ships its own minimal,
@@ -27,12 +28,13 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { Captions, Loader2, AlertCircle, X } from 'lucide-react';
+import { Captions, Loader2, X } from 'lucide-react';
 
-import { formatTime, loadTranscript, type TranscriptSnippet } from './transcript';
+import { loadTranscript, type TranscriptSnippet } from './transcript';
+import { groupIntoSentences } from './sentences';
 
 // Re-exported so existing deep imports of this module keep working; the type
-// itself now lives in `./transcript`, shared with the floating player.
+// itself now lives in `./sentences`, shared with the floating player.
 export type { TranscriptSnippet };
 
 export interface YouTubeTranscriptModalProps {
@@ -88,14 +90,11 @@ const TranscriptLine = forwardRef<
       }}
       className={`eyt-line${isActive ? ' eyt-line-active' : ''}`}
     >
-      <span className="eyt-line-time">{formatTime(snippet.start)}</span>
-      <span className="eyt-line-text">
-        {words.map((word, i) => (
-          <span key={i} className={i === activeWordIndex ? 'eyt-word-active' : undefined}>
-            {word}{' '}
-          </span>
-        ))}
-      </span>
+      {words.map((word, i) => (
+        <span key={i} className={i === activeWordIndex ? 'eyt-word-active' : undefined}>
+          {word}{' '}
+        </span>
+      ))}
     </button>
   );
 });
@@ -110,9 +109,8 @@ export function YouTubeTranscriptModal({
   onOpenChange,
 }: YouTubeTranscriptModalProps) {
   const [open, setOpen] = useState(false);
-  const [snippets, setSnippets] = useState<TranscriptSnippet[] | null>(providedSnippets ?? null);
+  const [cues, setCues] = useState<TranscriptSnippet[] | null>(providedSnippets ?? null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [currentTime, setCurrentTime] = useState(0);
 
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -132,17 +130,16 @@ export function YouTubeTranscriptModal({
     if (!open || providedSnippets) return;
     let cancelled = false;
     setLoading(true);
-    setError(null);
-    setSnippets(null);
+    setCues(null);
     setCurrentTime(0);
 
     loadTranscript(videoId, { transcriptUrl, fetchTranscript })
       .then((result) => {
-        if (!cancelled) setSnippets(result);
+        if (!cancelled) setCues(result);
       })
-      .catch((err: unknown) => {
-        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load transcript');
-      })
+      // A transcript that can't be loaded is simply not shown — see
+      // `hasTranscript` below.
+      .catch(() => undefined)
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
@@ -201,6 +198,14 @@ export function YouTubeTranscriptModal({
     );
   }, []);
 
+  // Cues are cut for on-screen display and break mid-clause; read as prose
+  // instead by regrouping them into sentences.
+  const snippets = useMemo(() => (cues ? groupIntoSentences(cues) : null), [cues]);
+
+  // A video whose captions are missing or unreadable shows no transcript at
+  // all rather than an error: the modal is then just the player.
+  const hasTranscript = loading || (snippets?.length ?? 0) > 0;
+
   const activeIndex = useMemo(() => {
     if (!snippets || snippets.length === 0) return -1;
     let idx = -1;
@@ -248,7 +253,7 @@ export function YouTubeTranscriptModal({
               </button>
             </div>
 
-            <div className="eyt-body">
+            <div className={`eyt-body${hasTranscript ? ' eyt-body-split' : ''}`}>
               <div className="eyt-player">
                 <iframe
                   ref={iframeRef}
@@ -261,35 +266,31 @@ export function YouTubeTranscriptModal({
                 />
               </div>
 
-              <div className="eyt-sidebar">
-                <div className="eyt-sidebar-heading">Transcript</div>
-                <div className="eyt-sidebar-scroll">
-                  {loading && (
-                    <div className="eyt-status">
-                      <Loader2 size={16} className="eyt-spin" />
-                      Loading transcript...
-                    </div>
-                  )}
-                  {error && !loading && (
-                    <div className="eyt-status eyt-error">
-                      <AlertCircle size={16} />
-                      <span>{error}</span>
-                    </div>
-                  )}
-                  {snippets?.map((snippet, index) => (
-                    <TranscriptLine
-                      key={index}
-                      ref={(el) => {
-                        lineRefs.current[index] = el;
-                      }}
-                      snippet={snippet}
-                      isActive={index === activeIndex}
-                      currentTime={currentTime}
-                      onSeek={() => seekTo(snippet.start)}
-                    />
-                  ))}
+              {hasTranscript && (
+                <div className="eyt-sidebar">
+                  <div className="eyt-sidebar-heading">Transcript</div>
+                  <div className="eyt-sidebar-scroll">
+                    {loading && (
+                      <div className="eyt-status">
+                        <Loader2 size={16} className="eyt-spin" />
+                        Loading transcript...
+                      </div>
+                    )}
+                    {snippets?.map((snippet, index) => (
+                      <TranscriptLine
+                        key={index}
+                        ref={(el) => {
+                          lineRefs.current[index] = el;
+                        }}
+                        snippet={snippet}
+                        isActive={index === activeIndex}
+                        currentTime={currentTime}
+                        onSeek={() => seekTo(snippet.start)}
+                      />
+                    ))}
+                  </div>
                 </div>
-              </div>
+              )}
             </div>
           </div>
         </div>
@@ -312,7 +313,7 @@ const EYT_STYLES = `
 .eyt-close { border: none; background: transparent; color: #6b7280; cursor: pointer; padding: 4px; border-radius: 6px; display: flex; }
 .eyt-close:hover { background: rgba(0,0,0,0.05); color: #111827; }
 .eyt-body { display: grid; grid-template-columns: 1fr; flex: 1; min-height: 0; }
-@media (min-width: 1024px) { .eyt-body { grid-template-columns: 1fr 360px; } }
+@media (min-width: 1024px) { .eyt-body-split { grid-template-columns: 1fr 360px; } }
 .eyt-player { position: relative; width: 100%; background: #000; padding-top: 56.25%; }
 .eyt-iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
 .eyt-sidebar { display: flex; flex-direction: column; min-height: 0; border-top: 1px solid #e5e7eb; }
@@ -321,12 +322,10 @@ const EYT_STYLES = `
 .eyt-sidebar-scroll { flex: 1; min-height: 280px; max-height: 280px; overflow-y: auto; padding: 8px; }
 @media (min-width: 1024px) { .eyt-sidebar-scroll { max-height: none; } }
 .eyt-status { display: flex; align-items: center; gap: 8px; font-size: 14px; color: #6b7280; padding: 12px; }
-.eyt-error { color: #dc2626; align-items: flex-start; }
 .eyt-spin { animation: eyt-spin 1s linear infinite; }
 @keyframes eyt-spin { to { transform: rotate(360deg); } }
-.eyt-line { display: flex; gap: 8px; width: 100%; text-align: left; border: none; background: transparent; border-radius: 6px; padding: 6px 8px; font-size: 13px; cursor: pointer; color: inherit; }
+.eyt-line { display: block; width: 100%; text-align: left; border: none; background: transparent; border-radius: 6px; padding: 6px 8px; font-size: 13px; line-height: 1.5; cursor: pointer; color: inherit; }
 .eyt-line:hover { background: rgba(0,0,0,0.05); }
 .eyt-line-active { background: rgba(59,130,246,0.12); }
-.eyt-line-time { flex-shrink: 0; font-variant-numeric: tabular-nums; font-size: 11px; color: #9ca3af; padding-top: 2px; }
 .eyt-word-active { background: rgba(59,130,246,0.3); border-radius: 3px; padding: 0 2px; font-weight: 500; color: #1d4ed8; }
 `;

--- a/packages/extract-youtube/src/react/index.ts
+++ b/packages/extract-youtube/src/react/index.ts
@@ -31,3 +31,5 @@ export {
 
 export { loadTranscript, useTranscript, formatTime } from './transcript';
 export type { TranscriptSnippet, TranscriptSource, TranscriptResponse } from './transcript';
+
+export { groupIntoSentences } from './sentences';

--- a/packages/extract-youtube/src/react/player/FloatingYouTubePlayer.tsx
+++ b/packages/extract-youtube/src/react/player/FloatingYouTubePlayer.tsx
@@ -16,7 +16,7 @@
 
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 import { AlertCircle } from 'lucide-react';
 
@@ -47,7 +47,8 @@ import {
   youtubePlayer,
   type PlayerVideo,
 } from './playerStore';
-import type { TranscriptSource } from '../transcript';
+import { useTranscript, type TranscriptSource } from '../transcript';
+import { groupIntoSentences } from '../sentences';
 
 /** What a host app's custom controls are handed when they render. */
 export interface PlayerControlContext {
@@ -72,7 +73,11 @@ export interface FloatingYouTubePlayerProps extends TranscriptSource {
   extraControls?: ReactNode | ((context: PlayerControlContext) => ReactNode);
   /** Custom title-bar content (badges, links, metadata). Defaults to the video title. */
   renderTitle?: (context: PlayerControlContext) => ReactNode;
-  /** Show the captions button. Needs `transcriptUrl` or `fetchTranscript`; off without one. */
+  /**
+   * Force the captions button on or off. By default it shows only for videos
+   * that turned out to have a transcript — needs `transcriptUrl` or
+   * `fetchTranscript` to check for one at all.
+   */
   showSubtitles?: boolean;
   /** Show the picture-in-picture button where the browser supports it. Default true. */
   showPictureInPicture?: boolean;
@@ -140,7 +145,20 @@ function FloatingPlayerWidget({
   });
 
   const hasTranscriptSource = Boolean(transcriptUrl || fetchTranscript);
-  const showSubtitles = showSubtitlesProp ?? hasTranscriptSource;
+
+  // Every video that plays gets checked for a transcript, whether or not the
+  // subtitles panel is open: that check is what decides whether the subtitles
+  // control is offered at all. A video without usable captions simply doesn't
+  // get the control — no error is surfaced for it.
+  const { snippets: cues } = useTranscript(activeVideo?.videoId ?? null, hasTranscriptSource, {
+    transcriptUrl,
+    fetchTranscript,
+  });
+
+  // Cues are cut for on-screen display and break mid-clause; read as prose
+  // instead by regrouping them into sentences.
+  const sentences = useMemo(() => (cues ? groupIntoSentences(cues) : []), [cues]);
+  const showSubtitles = showSubtitlesProp ?? sentences.length > 0;
 
   const setIframeRef = useCallback((el: HTMLIFrameElement | null) => {
     iframeRef.current = el;
@@ -423,13 +441,7 @@ function FloatingPlayerWidget({
       </div>
 
       {subtitlesOpen && !isMinimized && (
-        <PlayerSubtitles
-          videoId={activeVideo.videoId}
-          currentTime={subtitleTime}
-          onSeek={youtubePlayer.seekTo}
-          transcriptUrl={transcriptUrl}
-          fetchTranscript={fetchTranscript}
-        />
+        <PlayerSubtitles sentences={sentences} currentTime={subtitleTime} onSeek={youtubePlayer.seekTo} />
       )}
 
       {/* Hidden via CSS when minimized so playback is never interrupted. While

--- a/packages/extract-youtube/src/react/player/PlayerSubtitles.tsx
+++ b/packages/extract-youtube/src/react/player/PlayerSubtitles.tsx
@@ -1,18 +1,24 @@
 /**
  * @fileoverview Scrollable, playback-synced captions panel shown above the
- * video when subtitles are toggled on. Clicking any line seeks the player
- * there; the active line auto-scrolls and gets an approximate karaoke-style
- * per-word sweep.
+ * video when subtitles are toggled on. Sentences are shown as prose (no
+ * timestamps) — clicking one seeks the player to where it starts, and the
+ * active one auto-scrolls and gets an approximate karaoke-style per-word
+ * sweep.
+ *
+ * The transcript itself is loaded by the player, which only offers the
+ * subtitles control for videos that turned out to have one — so this panel
+ * has no loading or error state of its own: given nothing to show, it
+ * renders nothing.
  */
 
 'use client';
 
 import { forwardRef, useEffect, useMemo, useRef } from 'react';
-import { AlertCircle, Loader2 } from 'lucide-react';
-import { formatTime, useTranscript, type TranscriptSnippet, type TranscriptSource } from '../transcript';
+import type { TranscriptSnippet } from '../transcript';
 
-interface PlayerSubtitlesProps extends TranscriptSource {
-  videoId: string;
+interface PlayerSubtitlesProps {
+  /** The video's transcript, already regrouped into sentences. */
+  sentences: TranscriptSnippet[];
   currentTime: number;
   onSeek: (seconds: number) => void;
 }
@@ -43,37 +49,26 @@ const SubtitleLine = forwardRef<
       }}
       className={`eytp-line${isActive ? ' eytp-line-active' : ''}`}
     >
-      <span className="eytp-line-time">{formatTime(snippet.start)}</span>
-      <span>
-        {words.map((word, i) => (
-          <span key={i} className={i === activeWordIndex ? 'eytp-word-active' : undefined}>
-            {word}{' '}
-          </span>
-        ))}
-      </span>
+      {words.map((word, i) => (
+        <span key={i} className={i === activeWordIndex ? 'eytp-word-active' : undefined}>
+          {word}{' '}
+        </span>
+      ))}
     </button>
   );
 });
 
-export function PlayerSubtitles({
-  videoId,
-  currentTime,
-  onSeek,
-  transcriptUrl,
-  fetchTranscript,
-}: PlayerSubtitlesProps) {
-  const { snippets, loading, error } = useTranscript(videoId, true, { transcriptUrl, fetchTranscript });
+export function PlayerSubtitles({ sentences, currentTime, onSeek }: PlayerSubtitlesProps) {
   const lineRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
   const activeIndex = useMemo(() => {
-    if (!snippets || snippets.length === 0) return -1;
     let idx = -1;
-    for (let i = 0; i < snippets.length; i++) {
-      if (snippets[i].start <= currentTime) idx = i;
+    for (let i = 0; i < sentences.length; i++) {
+      if (sentences[i].start <= currentTime) idx = i;
       else break;
     }
     return idx;
-  }, [snippets, currentTime]);
+  }, [sentences, currentTime]);
 
   // Keep the active line in view as playback advances.
   useEffect(() => {
@@ -81,21 +76,11 @@ export function PlayerSubtitles({
     lineRefs.current[activeIndex]?.scrollIntoView({ block: 'center', behavior: 'smooth' });
   }, [activeIndex]);
 
+  if (sentences.length === 0) return null;
+
   return (
     <div className="eytp-subtitles">
-      {loading && (
-        <div className="eytp-status">
-          <Loader2 size={14} className="eytp-spin" />
-          Loading captions...
-        </div>
-      )}
-      {error && !loading && (
-        <div className="eytp-status eytp-status-error">
-          <AlertCircle size={14} />
-          <span>{error}</span>
-        </div>
-      )}
-      {snippets?.map((snippet, index) => (
+      {sentences.map((snippet, index) => (
         <SubtitleLine
           key={index}
           ref={(el) => {

--- a/packages/extract-youtube/src/react/player/styles.ts
+++ b/packages/extract-youtube/src/react/player/styles.ts
@@ -128,15 +128,11 @@ export const PLAYER_STYLES = `
 .eytp-queue-rest { font-size: 10px; color: var(--eytp-muted); margin: 2px 0 0; }
 
 .eytp-subtitles { max-height: 190px; overflow-y: auto; border-bottom: 1px solid var(--eytp-border); padding: 6px; }
-.eytp-status { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--eytp-muted); padding: 8px; }
-.eytp-status-error { color: var(--eytp-danger); align-items: flex-start; }
-.eytp-spin { animation: eytp-spin 1s linear infinite; }
-@keyframes eytp-spin { to { transform: rotate(360deg); } }
 
 .eytp-line {
-  display: flex;
-  gap: 8px;
+  display: block;
   width: 100%;
+  line-height: 1.5;
   text-align: left;
   border: none;
   background: transparent;
@@ -148,7 +144,6 @@ export const PLAYER_STYLES = `
 }
 .eytp-line:hover { background: rgba(127, 127, 127, 0.14); }
 .eytp-line-active { background: rgba(59, 130, 246, 0.14); }
-.eytp-line-time { flex-shrink: 0; font-variant-numeric: tabular-nums; font-size: 10px; color: var(--eytp-muted); padding-top: 2px; }
 .eytp-word-active { background: rgba(59, 130, 246, 0.3); border-radius: 3px; padding: 0 2px; font-weight: 500; }
 
 .eytp-handle { position: absolute; }

--- a/packages/extract-youtube/src/react/sentences.ts
+++ b/packages/extract-youtube/src/react/sentences.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Turns raw caption cues into readable sentences.
+ *
+ * YouTube's caption tracks are cut for on-screen display, not for reading: a
+ * cue is a couple of seconds long and breaks mid-clause ("powers aligning
+ * with each other to" / "balance between United States and China."). Rendered
+ * one cue per row, next to a timestamp, the transcript reads as a column of
+ * fragments. Regrouping the cues into sentences gives back the prose while
+ * keeping every sentence seekable, since each one still carries the start
+ * time of the cue its first word came from.
+ *
+ * Framework-free on purpose — no React import — so it can be unit tested and
+ * reused by non-UI callers.
+ */
+
+/** One timed caption cue (or, after grouping, one timed sentence). */
+export interface TranscriptSnippet {
+  text: string;
+  start: number;
+  duration: number;
+}
+
+/** A word ending a sentence, allowing a trailing quote or bracket. */
+const SENTENCE_END = /[.!?…]["')\]]*$/;
+
+/**
+ * Words that end in a period without ending a sentence: single-letter
+ * initials, dotted initialisms ("U.S."), and the common title/abbreviation
+ * set. Without this, "the U.S. and China" becomes two "sentences".
+ */
+const ABBREVIATION = /^(?:[A-Za-z]\.)+$|^(?:mr|mrs|ms|dr|prof|sr|jr|st|vs|etc|no|fig|approx|e\.g|i\.e)\.$/i;
+
+/**
+ * Auto-generated captions frequently carry no punctuation at all, which would
+ * make the whole video one unreadable sentence. A run that never terminates
+ * is broken at a word boundary once it reaches this many characters.
+ */
+const MAX_SENTENCE_CHARS = 220;
+
+/**
+ * Regroups caption cues into sentences.
+ *
+ * Each returned entry has the same `{ text, start, duration }` shape as the
+ * cues going in, so callers can keep treating the list as snippets: `start`
+ * is when the sentence's first word is spoken and `duration` runs to the end
+ * of its last word, which keeps click-to-seek and the active-line highlight
+ * working unchanged.
+ *
+ * @param snippets - Caption cues in playback order.
+ * @returns One entry per sentence, in playback order.
+ */
+export function groupIntoSentences(snippets: TranscriptSnippet[]): TranscriptSnippet[] {
+  const sentences: TranscriptSnippet[] = [];
+
+  let words: string[] = [];
+  let chars = 0;
+  let start = 0;
+  let end = 0;
+
+  const flush = () => {
+    if (words.length === 0) return;
+    sentences.push({ text: words.join(' '), start, duration: Math.max(0, end - start) });
+    words = [];
+    chars = 0;
+  };
+
+  for (const snippet of snippets) {
+    const cueWords = snippet.text.split(/\s+/).filter(Boolean);
+    if (cueWords.length === 0) continue;
+
+    // Words don't carry their own timestamps, so spread the cue's duration
+    // evenly across them — that way a sentence boundary falling mid-cue still
+    // gets a start time close to when it is actually spoken.
+    const perWord = snippet.duration > 0 ? snippet.duration / cueWords.length : 0;
+
+    cueWords.forEach((word, index) => {
+      if (words.length === 0) start = snippet.start + perWord * index;
+      words.push(word);
+      chars += word.length + 1;
+      end = snippet.start + perWord * (index + 1);
+
+      const endsSentence = SENTENCE_END.test(word) && !ABBREVIATION.test(word);
+      if (endsSentence || chars >= MAX_SENTENCE_CHARS) flush();
+    });
+  }
+
+  flush();
+  return sentences;
+}

--- a/packages/extract-youtube/src/react/transcript.ts
+++ b/packages/extract-youtube/src/react/transcript.ts
@@ -12,11 +12,12 @@
 
 import { useEffect, useState } from 'react';
 
-export interface TranscriptSnippet {
-  text: string;
-  start: number;
-  duration: number;
-}
+import type { TranscriptSnippet } from './sentences';
+
+// Re-exported so `./transcript` stays the one import site for the transcript
+// types, even though the snippet shape itself lives with the sentence
+// grouping that produces it.
+export type { TranscriptSnippet };
 
 export interface TranscriptResponse {
   snippets?: TranscriptSnippet[];

--- a/packages/extract-youtube/test/sentences.test.ts
+++ b/packages/extract-youtube/test/sentences.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @fileoverview Unit tests for regrouping display-cut caption cues into
+ * readable sentences.
+ */
+
+import { groupIntoSentences } from '../src/react/sentences';
+
+function cue(text: string, start: number, duration = 2) {
+  return { text, start, duration };
+}
+
+describe('groupIntoSentences', () => {
+  it('joins cues that break mid-clause into one sentence', () => {
+    const result = groupIntoSentences([
+      cue('powers aligning with each other to', 10),
+      cue('balance between United States and China.', 12),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe(
+      'powers aligning with each other to balance between United States and China.'
+    );
+  });
+
+  it('keeps the start of the sentence and runs the duration to its last word', () => {
+    const [sentence] = groupIntoSentences([cue('one two', 10, 2), cue('three four.', 12, 2)]);
+
+    expect(sentence.start).toBe(10);
+    expect(sentence.duration).toBeCloseTo(4);
+  });
+
+  it('splits a cue that carries the end of one sentence and the start of the next', () => {
+    const result = groupIntoSentences([cue('the first one. And then the', 10, 4), cue('second one.', 14, 2)]);
+
+    expect(result.map((s) => s.text)).toEqual(['the first one.', 'And then the second one.']);
+    // The second sentence starts partway through the first cue, not at 14.
+    expect(result[1].start).toBeCloseTo(12);
+  });
+
+  it('does not treat abbreviations or initials as sentence ends', () => {
+    const result = groupIntoSentences([cue('policy in the U.S. and Dr. Smith agrees.', 0, 4)]);
+
+    expect(result.map((s) => s.text)).toEqual(['policy in the U.S. and Dr. Smith agrees.']);
+  });
+
+  it('breaks unpunctuated auto-captions into readable chunks', () => {
+    const cues = Array.from({ length: 40 }, (_, i) => cue('word '.repeat(5).trim(), i * 2));
+    const result = groupIntoSentences(cues);
+
+    expect(result.length).toBeGreaterThan(1);
+    for (const sentence of result) {
+      expect(sentence.text.length).toBeLessThanOrEqual(240);
+    }
+  });
+
+  it('ignores blank cues and returns nothing for an empty transcript', () => {
+    expect(groupIntoSentences([])).toEqual([]);
+    expect(groupIntoSentences([cue('   ', 0)])).toEqual([]);
+  });
+
+  it('emits a trailing run that never gets punctuation', () => {
+    const result = groupIntoSentences([cue('so anyway that is the plan', 0, 3)]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('so anyway that is the plan');
+  });
+});


### PR DESCRIPTION
## Summary

This PR improves the transcript reading experience by regrouping YouTube's display-cut caption cues into readable sentences, and simplifies the UI by removing error states for missing transcripts.

## Key Changes

- **New sentence grouping logic** (`src/react/sentences.ts`): Implements `groupIntoSentences()` to join caption cues that break mid-clause into complete sentences. Handles abbreviations, unpunctuated auto-captions, and preserves seekability by keeping the start time of each sentence's first word.

- **Simplified transcript display**: Removed timestamps and error messages from transcript lines. Captions now render as prose without per-line timestamps, making them more readable.

- **Graceful handling of missing transcripts**: Videos without captions no longer show an error state. The transcript panel and subtitles control simply don't appear if no transcript is available, keeping the UI clean.

- **Updated both transcript components**:
  - `YouTubeTranscriptModal`: Removed error state management, integrated sentence grouping, and conditionally renders the sidebar only when a transcript exists
  - `PlayerSubtitles`: Simplified to accept pre-grouped sentences instead of managing loading/error states
  - `FloatingYouTubePlayer`: Now checks for transcript availability and only shows the subtitles control for videos that have one

- **CSS refinements**: Updated styles to remove timestamp display, adjust line layout from flex to block, and improve line-height for prose reading.

- **Comprehensive test coverage** (`test/sentences.test.ts`): Added unit tests for sentence grouping covering edge cases like abbreviations, mid-cue sentence boundaries, and unpunctuated captions.

- **Documentation**: Added `docs/proxy.md` with detailed guidance on configuring proxies to handle YouTube rate-limiting, including generic HTTP/HTTPS/SOCKS proxies, Webshare residential proxies, edge runtime alternatives, and caching strategies.

## Implementation Details

- The `TranscriptSnippet` type was moved to `sentences.ts` (where it's produced) and re-exported from `transcript.ts` to maintain the existing import surface.
- Sentence grouping distributes cue duration evenly across words to estimate per-word timing, enabling accurate seek positions even when sentence boundaries fall mid-cue.
- The `MAX_SENTENCE_CHARS` limit (220 chars) prevents unpunctuated auto-captions from creating unreadably long runs.
- Abbreviation detection prevents false sentence breaks on "U.S.", "Dr.", etc.

https://claude.ai/code/session_01BhLgbX4QjN1zN2wCXaD6GP