### PR TITLE
Replace sharp with Photon WASM codec for Workers compatibility

### DIFF
--- a/packages-lobe/apps/server/src/services/aiAgent/ingestAttachment.ts
+++ b/packages-lobe/apps/server/src/services/aiAgent/ingestAttachment.ts
@@ -1,6 +1,6 @@
+import sharp from '@lobechat/image-photon';
 import debug from 'debug';
 import mime from 'mime';
-import sharp from 'sharp';
 
 import type { FileService } from '@/server/services/file';
 

--- a/packages-lobe/apps/server/src/services/bot/platforms/attachmentBudget.test.ts
+++ b/packages-lobe/apps/server/src/services/bot/platforms/attachmentBudget.test.ts
@@ -17,19 +17,19 @@ vi.mock('./publicUrlFetch', async () => ({
   }),
 }));
 
-const sharpMocks = vi.hoisted(() => ({
+const codecMocks = vi.hoisted(() => ({
   metadata: vi.fn(),
   toBuffer: vi.fn(),
 }));
 
-vi.mock('sharp', () => {
+vi.mock('@lobechat/image-photon', () => {
   const chain = {
     flatten: vi.fn(() => chain),
     jpeg: vi.fn(() => chain),
-    metadata: sharpMocks.metadata,
+    metadata: codecMocks.metadata,
     resize: vi.fn(() => chain),
     rotate: vi.fn(() => chain),
-    toBuffer: sharpMocks.toBuffer,
+    toBuffer: codecMocks.toBuffer,
   };
   return { default: vi.fn(() => chain) };
 });
@@ -47,22 +47,22 @@ const MB = 1024 * 1024;
 describe('compressImageToBudget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    sharpMocks.metadata.mockResolvedValue({ pages: 1 });
+    codecMocks.metadata.mockResolvedValue({ pages: 1 });
   });
 
   it('returns the first ladder rung that fits the budget', async () => {
-    sharpMocks.toBuffer
+    codecMocks.toBuffer
       .mockResolvedValueOnce(Buffer.alloc(3 * MB))
       .mockResolvedValueOnce(Buffer.alloc(1 * MB));
 
     const result = await compressImageToBudget(Buffer.alloc(5 * MB), 2 * MB);
 
     expect(result?.length).toBe(1 * MB);
-    expect(sharpMocks.toBuffer).toHaveBeenCalledTimes(2);
+    expect(codecMocks.toBuffer).toHaveBeenCalledTimes(2);
   });
 
   it('returns undefined when no rung fits', async () => {
-    sharpMocks.toBuffer.mockResolvedValue(Buffer.alloc(3 * MB));
+    codecMocks.toBuffer.mockResolvedValue(Buffer.alloc(3 * MB));
 
     const result = await compressImageToBudget(Buffer.alloc(5 * MB), 2 * MB);
 
@@ -70,14 +70,14 @@ describe('compressImageToBudget', () => {
   });
 
   it('refuses an animated image instead of flattening it to one frame', async () => {
-    sharpMocks.metadata.mockResolvedValue({ pages: 24 });
+    codecMocks.metadata.mockResolvedValue({ pages: 24 });
 
     expect(await compressImageToBudget(Buffer.alloc(64), 1024)).toBeUndefined();
-    expect(sharpMocks.toBuffer).not.toHaveBeenCalled();
+    expect(codecMocks.toBuffer).not.toHaveBeenCalled();
   });
 
-  it('returns undefined when sharp cannot decode the source', async () => {
-    sharpMocks.toBuffer.mockRejectedValue(new Error('unsupported image format'));
+  it('returns undefined when the codec cannot decode the source', async () => {
+    codecMocks.toBuffer.mockRejectedValue(new Error('unsupported image format'));
 
     const result = await compressImageToBudget(Buffer.from('not an image'), 2 * MB);
 
@@ -91,7 +91,7 @@ describe('prepareAttachmentsForBudget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.unstubAllGlobals();
-    sharpMocks.metadata.mockResolvedValue({ pages: 1 });
+    codecMocks.metadata.mockResolvedValue({ pages: 1 });
   });
 
   it('passes attachments within budget through untouched', async () => {
@@ -212,7 +212,7 @@ describe('prepareAttachmentsForBudget', () => {
   it('recompresses an over-budget image into inline data', async () => {
     const source = Buffer.alloc(3 * MB, 1);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(source, { status: 200 })));
-    sharpMocks.toBuffer.mockResolvedValueOnce(Buffer.alloc(1 * MB, 2));
+    codecMocks.toBuffer.mockResolvedValueOnce(Buffer.alloc(1 * MB, 2));
 
     const result = await prepareAttachmentsForBudget(
       [
@@ -245,7 +245,7 @@ describe('prepareAttachmentsForBudget', () => {
       'fetch',
       vi.fn().mockResolvedValue(new Response(Buffer.alloc(3 * MB), { status: 200 })),
     );
-    sharpMocks.toBuffer.mockResolvedValue(Buffer.alloc(3 * MB));
+    codecMocks.toBuffer.mockResolvedValue(Buffer.alloc(3 * MB));
 
     const result = await prepareAttachmentsForBudget(
       [
@@ -286,7 +286,7 @@ describe('prepareAttachmentsForBudget', () => {
     );
 
     expect(fetchMock).not.toHaveBeenCalled();
-    expect(sharpMocks.toBuffer).not.toHaveBeenCalled();
+    expect(codecMocks.toBuffer).not.toHaveBeenCalled();
     expect(result.attachments).toEqual([]);
     expect(result.fallbackLines[0]).toContain('big.png');
     expect(result.fallbackLines[0]).toContain('https://example.com/f/big.png');
@@ -298,7 +298,7 @@ describe('prepareAttachmentsForBudget', () => {
       'fetch',
       vi.fn().mockResolvedValue(new Response(Buffer.alloc(3 * MB, 1), { status: 200 })),
     );
-    sharpMocks.toBuffer.mockResolvedValueOnce(Buffer.alloc(1 * MB, 2));
+    codecMocks.toBuffer.mockResolvedValueOnce(Buffer.alloc(1 * MB, 2));
 
     const result = await prepareAttachmentsForBudget(
       [

--- a/packages-lobe/apps/server/src/services/bot/platforms/attachmentBudget.ts
+++ b/packages-lobe/apps/server/src/services/bot/platforms/attachmentBudget.ts
@@ -133,11 +133,12 @@ const COMPRESSION_LADDER: Array<[number, number]> = [
 
 /**
  * Re-encode an image to fit `maxBytes`, or return undefined when it cannot
- * (not an image sharp can decode, or still over budget at the smallest rung).
+ * (not an image the codec can decode, or still over budget at the smallest
+ * rung).
  *
- * sharp is imported lazily: this module is reachable from the outbound push
- * path, which deliberately keeps heavy native dependencies out of its module
- * graph (see services/messenger/outbound.ts) — the import cost is only paid
+ * The codec is imported lazily: this module is reachable from the outbound
+ * push path, which deliberately keeps heavy dependencies out of its module
+ * graph (see services/messenger/outbound.ts) — the WASM binary is only loaded
  * when an over-budget image actually needs recompression.
  */
 export const compressImageToBudget = async (
@@ -145,7 +146,7 @@ export const compressImageToBudget = async (
   maxBytes: number,
 ): Promise<Buffer | undefined> => {
   try {
-    const { default: sharp } = await import('sharp');
+    const { default: sharp } = await import('@lobechat/image-photon');
 
     // An animated GIF or WebP re-encodes to a single static frame, silently
     // turning the user's animation into a still. There is no JPEG that can
@@ -178,7 +179,7 @@ export const compressImageToBudget = async (
     return undefined;
   } catch (error) {
     // Routine input, not a system fault: plenty of things a user attaches are
-    // not images sharp can decode. The caller records `compression-failed`
+    // not images the codec can decode. The caller records `compression-failed`
     // against the attachment, which is where the reason belongs.
     log('compressImageToBudget failed: %O', error);
     return undefined;
@@ -255,8 +256,8 @@ const resolveSize = async (attachment: BotMessageAttachment): Promise<number | u
  * sender can only report the symptom, and "the compression failed" stays a
  * guess. But a per-attachment print is the wrong carrier: it is unattributable
  * prose, it scales with attachment count, and it would put routine input (an
- * image sharp cannot decode) into the error stream. The reason travels with the
- * result instead, and the delivery boundary decides what to record.
+ * image the codec cannot decode) into the error stream. The reason travels
+ * with the result instead, and the delivery boundary decides what to record.
  */
 export type DegradationReason =
   /** Bytes downloaded, but no rung of the ladder produced a small enough JPEG. */

--- a/packages-lobe/apps/server/src/services/comfyui/__tests__/core/imageService.test.ts
+++ b/packages-lobe/apps/server/src/services/comfyui/__tests__/core/imageService.test.ts
@@ -16,8 +16,8 @@ vi.mock('@/server/services/comfyui/core/workflowBuilderService');
 vi.mock('@/server/services/comfyui/core/errorHandlerService');
 vi.mock('@/server/services/comfyui/utils/workflowDetector');
 
-// Mock sharp module for image processing
-vi.mock('sharp', () => ({
+// Mock the image codec used for metadata and resizing
+vi.mock('@lobechat/image-photon', () => ({
   default: vi.fn((buffer) => ({
     metadata: vi.fn().mockResolvedValue({ height: 1024, width: 1024 }),
     resize: vi.fn().mockReturnThis(),

--- a/packages-lobe/apps/server/src/services/comfyui/core/imageService.ts
+++ b/packages-lobe/apps/server/src/services/comfyui/core/imageService.ts
@@ -138,26 +138,11 @@ export class ImageService {
         });
       }
 
-      // Get image metadata using sharp (only on server-side)
-      let originalWidth: number | undefined;
-      let originalHeight: number | undefined;
-
-      // Only use sharp on server-side (Node.js environment)
-      if (typeof window === 'undefined') {
-        const sharpModule = await import('sharp');
-        const sharp = sharpModule.default;
-        const sharpInstance = sharp(buffer);
-        const metadata = await sharpInstance.metadata();
-        originalWidth = metadata.width;
-        originalHeight = metadata.height;
-      } else {
-        // Sharp was incorrectly bundled to client-side - this is a build configuration error
-        throw new Error(
-          'FATAL: Sharp module was bundled to browser environment. This is a build configuration error. ' +
-            'Sharp is a native Node.js module and cannot run in the browser. ' +
-            'Please check your Next.js or webpack configuration.',
-        );
-      }
+      // Read the source dimensions. The codec is WASM, so unlike the native
+      // module it replaced there is no environment that cannot load it — the
+      // server-side guard this used to need is gone.
+      const { default: sharp } = await import('@lobechat/image-photon');
+      const { height: originalHeight, width: originalWidth } = await sharp(buffer).metadata();
 
       if (!originalWidth || !originalHeight) {
         throw new ServicesError(
@@ -194,22 +179,13 @@ export class ImageService {
             target: { height: resizeResult.height, width: resizeResult.width },
           });
 
-          // Resize image using sharp (only on server-side)
-          if (typeof window === 'undefined') {
-            const sharpModule = await import('sharp');
-            const sharp = sharpModule.default;
-            buffer = Buffer.from(
-              await sharp(buffer)
-                .resize(resizeResult.width, resizeResult.height, {
-                  fit: 'inside', // Maintain aspect ratio, fit within bounds
-                  withoutEnlargement: false, // Allow enlargement if needed
-                })
-                .toBuffer(),
-            );
-            log('Image resized successfully, new size:', buffer.length);
-          } else {
-            log('Warning: Cannot resize image in browser environment');
-          }
+          buffer = await sharp(buffer)
+            .resize(resizeResult.width, resizeResult.height, {
+              fit: 'inside', // Maintain aspect ratio, fit within bounds
+              withoutEnlargement: false, // Allow enlargement if needed
+            })
+            .toBuffer();
+          log('Image resized successfully, new size:', buffer.length);
         } else {
           log('Image dimensions are within model limits, no resize needed');
         }

--- a/packages-lobe/apps/server/src/services/generation/index.test.ts
+++ b/packages-lobe/apps/server/src/services/generation/index.test.ts
@@ -1,7 +1,7 @@
+import sharp from '@lobechat/image-photon';
 import { sha256 } from 'js-sha256';
 import mime from 'mime';
 import { nanoid } from 'nanoid';
-import sharp from 'sharp';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FileService } from '@/server/services/file';
@@ -28,7 +28,7 @@ vi.mock('debug', () => ({
 vi.mock('js-sha256');
 vi.mock('mime');
 vi.mock('nanoid');
-vi.mock('sharp');
+vi.mock('@lobechat/image-photon');
 vi.mock('@/server/services/file');
 vi.mock('@/utils/number');
 vi.mock('@/utils/time');

--- a/packages-lobe/apps/server/src/services/generation/index.ts
+++ b/packages-lobe/apps/server/src/services/generation/index.ts
@@ -1,4 +1,5 @@
 import { type LobeChatDatabase } from '@lobechat/database';
+import sharp from '@lobechat/image-photon';
 import { parseDataUri } from '@lobechat/model-runtime';
 import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
 import debug from 'debug';
@@ -6,7 +7,6 @@ import { sha256 } from 'js-sha256';
 import mime from 'mime';
 import { IMAGE_GENERATION_CONFIG } from 'model-bank';
 import { nanoid } from 'nanoid';
-import sharp from 'sharp';
 
 import { FileService } from '@/server/services/file';
 import { calculateThumbnailDimensions } from '@/utils/number';

--- a/packages-lobe/apps/server/src/services/generation/video.ts
+++ b/packages-lobe/apps/server/src/services/generation/video.ts
@@ -8,9 +8,9 @@ import { pipeline } from 'node:stream/promises';
 import { promisify } from 'node:util';
 
 import { type LobeChatDatabase } from '@lobechat/database';
+import sharp from '@lobechat/image-photon';
 import debug from 'debug';
 import { nanoid } from 'nanoid';
-import sharp from 'sharp';
 
 import { FileService } from '@/server/services/file';
 import { calculateThumbnailDimensions } from '@/utils/number';

--- a/packages-lobe/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/packages-lobe/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -16,7 +16,7 @@ const mockChat = vi.hoisted(() => vi.fn());
 const mockInitModelRuntimeFromDB = vi.hoisted(() => vi.fn());
 const mockConsumeStreamUntilDone = vi.hoisted(() => vi.fn());
 const mockImageUrlToBase64 = vi.hoisted(() => vi.fn());
-const mockSharpOptions = vi.hoisted(() => vi.fn());
+const mockCodecOptions = vi.hoisted(() => vi.fn());
 const mockBuiltinModels = vi.hoisted(() => [
   {
     abilities: { audio: true, video: true, vision: true },
@@ -38,6 +38,24 @@ const mockBuiltinModels = vi.hoisted(() => [
 const VALID_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 const VALID_PNG_DATA_URL = `data:image/png;base64,${VALID_PNG_BASE64}`;
+
+/** A 1x1 red GIF: a real image the model formats do not include, so it must be transcoded. */
+const RED_GIF = Buffer.from([
+  0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 1, 0, 1, 0, 0x80, 0, 0, 255, 0, 0, 0, 0, 255, 0x2c, 0, 0, 0,
+  0, 1, 0, 1, 0, 0, 0x02, 0x02, 0x44, 0x01, 0x00, 0x3b,
+]);
+
+/**
+ * An AVIF `ftyp` header. Only the brand matters: the codec rejects AVIF on the
+ * container it identifies, before any decoder runs, so a full file would take
+ * exactly this path.
+ */
+const MINIMAL_AVIF = Buffer.concat([
+  Buffer.from([0, 0, 0, 0x20]),
+  Buffer.from('ftypavif'),
+  Buffer.from([0, 0, 0, 0]),
+  Buffer.from('avifmif1miaf'),
+]);
 
 const createCorruptedPngDataUrl = () => {
   const bytes = Buffer.from(VALID_PNG_BASE64, 'base64');
@@ -85,13 +103,13 @@ vi.mock('model-bank', () => ({
   LOBE_DEFAULT_MODEL_LIST: mockBuiltinModels,
 }));
 
-vi.mock('sharp', async (importOriginal) => {
+vi.mock('@lobechat/image-photon', async (importOriginal) => {
   const actual = (await importOriginal()) as { default: (...args: any[]) => any };
 
   return {
     ...actual,
     default: (input: Buffer, options?: Record<string, unknown>) => {
-      mockSharpOptions(options);
+      mockCodecOptions(options);
       return actual.default(input, options);
     },
   };
@@ -143,23 +161,13 @@ describe('lobeAgentRuntime', () => {
   });
 
   it('should transcode unsupported images before calling the multimodal model', async () => {
-    const { default: sharp } = await import('sharp');
-    const avifBuffer = await sharp({
-      create: {
-        background: { alpha: 1, b: 0, g: 0, r: 255 },
-        channels: 4,
-        height: 1,
-        width: 1,
-      },
-    })
-      .avif()
-      .toBuffer();
+    const { default: codec } = await import('@lobechat/image-photon');
     mockImageUrlToBase64.mockResolvedValueOnce({
-      base64: avifBuffer.toString('base64'),
-      mimeType: 'image/avif',
+      base64: RED_GIF.toString('base64'),
+      mimeType: 'image/gif',
     });
     const runtime = lobeAgentRuntime.factory(baseContext);
-    const imageUrl = 'https://example.com/image.avif?signature=example';
+    const imageUrl = 'https://example.com/image.gif?signature=example';
 
     const result = await runtime.analyzeMedia({
       question: 'what is this?',
@@ -175,21 +183,37 @@ describe('lobeAgentRuntime', () => {
     expect(imagePart.image_url.url).toMatch(/^data:image\/png;base64,/);
 
     const convertedBuffer = Buffer.from(imagePart.image_url.url.split(',')[1], 'base64');
-    await expect(sharp(convertedBuffer).metadata()).resolves.toMatchObject({ format: 'png' });
+    await expect(codec(convertedBuffer).metadata()).resolves.toMatchObject({ format: 'png' });
+  });
+
+  // Photon has no AVIF or HEIF decoder — the libvips-backed sharp it replaced
+  // did. An image in one of those formats can no longer be transcoded for a
+  // model that will not take it, and fails preparation instead.
+  it('should fail preparation for formats the codec cannot decode', async () => {
+    mockImageUrlToBase64.mockResolvedValueOnce({
+      base64: MINIMAL_AVIF.toString('base64'),
+      mimeType: 'image/avif',
+    });
+    const runtime = lobeAgentRuntime.factory(baseContext);
+
+    const result = await runtime.analyzeMedia({
+      question: 'what is this?',
+      urls: ['https://example.com/image.avif'],
+    });
+
+    expect(result).toMatchObject({
+      error: { code: 'MULTIMODAL_IMAGE_PREPARATION_FAILED' },
+      success: false,
+    });
+    expect(mockChat).not.toHaveBeenCalled();
   });
 
   it('should flatten transparent images onto white when transcoding to JPEG', async () => {
-    const { default: sharp } = await import('sharp');
-    const transparentWebp = await sharp({
-      create: {
-        background: { alpha: 0, b: 0, g: 0, r: 0 },
-        channels: 4,
-        height: 1,
-        width: 1,
-      },
-    })
-      .webp({ lossless: true })
-      .toBuffer();
+    // The codec's own encoder, so the fixture needs no image library of its own.
+    const { PhotonImage } = await import('@cf-wasm/photon');
+    const source = new PhotonImage(new Uint8Array(8 * 8 * 4), 8, 8); // fully transparent
+    const transparentWebp = Buffer.from(source.get_bytes_webp());
+    source.free();
     mockToolsEnv.MULTIMODAL_UNDERSTANDING_IMAGE_FORMATS = ['image/jpeg', 'image/png'];
     mockImageUrlToBase64.mockResolvedValueOnce({
       base64: transparentWebp.toString('base64'),
@@ -210,8 +234,10 @@ describe('lobeAgentRuntime', () => {
     expect(imagePart.image_url.url).toMatch(/^data:image\/jpeg;base64,/);
 
     const convertedBuffer = Buffer.from(imagePart.image_url.url.split(',')[1], 'base64');
-    const pixel = await sharp(convertedBuffer).raw().toBuffer();
-    expect([...pixel.subarray(0, 3)]).toEqual([255, 255, 255]);
+    const decoded = PhotonImage.new_from_byteslice(convertedBuffer);
+    const pixels = decoded.get_raw_pixels();
+    decoded.free();
+    expect([...pixels.subarray(0, 3)]).toEqual([255, 255, 255]);
   });
 
   it('should detect suffixless images after downloading without transcoding supported formats', async () => {
@@ -224,7 +250,7 @@ describe('lobeAgentRuntime', () => {
 
     expect(result.success).toBe(true);
     expect(mockImageUrlToBase64).toHaveBeenCalledWith('https://example.com/image');
-    expect(mockSharpOptions).not.toHaveBeenCalled();
+    expect(mockCodecOptions).not.toHaveBeenCalled();
     const [payload] = mockChat.mock.calls[0];
     const imagePart = payload.messages[0].content.find(
       (part: { type: string }) => part.type === 'image_url',

--- a/packages-lobe/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/packages-lobe/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -71,9 +71,9 @@ const findInvalidInlineImageIndexes = async (urls: string[]) => {
   const hasInlineImages = urls.some((url) => /^data:image\//i.test(url));
   if (!hasInlineImages) return invalidIndexes;
 
-  // Keep the native image dependency out of server bundles that never validate
-  // inline images; the server runtime registry imports this module eagerly.
-  const { default: sharp } = await import('sharp');
+  // Keep the image codec out of server bundles that never validate inline
+  // images; the server runtime registry imports this module eagerly.
+  const { default: sharp } = await import('@lobechat/image-photon');
 
   for (const [index, url] of urls.entries()) {
     if (!/^data:image\//i.test(url)) continue;

--- a/packages-lobe/apps/server/src/services/toolExecution/serverRuntimes/lobeAgentImage.ts
+++ b/packages-lobe/apps/server/src/services/toolExecution/serverRuntimes/lobeAgentImage.ts
@@ -3,13 +3,13 @@ import { imageUrlToBase64 } from '@lobechat/utils';
 import { parseDataUri } from '@lobechat/utils/uriParser';
 import mime from 'mime';
 
-const SHARP_FORMAT_BY_MIME_TYPE = {
+const OUTPUT_FORMAT_BY_MIME_TYPE = {
   'image/jpeg': 'jpeg',
   'image/png': 'png',
   'image/webp': 'webp',
 } as const;
 
-type MultimodalImageMimeType = keyof typeof SHARP_FORMAT_BY_MIME_TYPE;
+type MultimodalImageMimeType = keyof typeof OUTPUT_FORMAT_BY_MIME_TYPE;
 
 const normalizeMimeType = (mimeType?: string | null) => {
   const normalized = mimeType?.toLowerCase();
@@ -42,12 +42,12 @@ const readImage = async (uri: string) => {
 
 /** Transcode images, using white for alpha pixels because JPEG cannot preserve transparency. */
 const transcodeImage = async (buffer: Buffer, targetMimeType: MultimodalImageMimeType) => {
-  const { default: sharp } = await import('sharp');
+  const { default: sharp } = await import('@lobechat/image-photon');
   const image = sharp(buffer).rotate();
 
   if (targetMimeType === 'image/jpeg') image.flatten({ background: '#fff' });
 
-  return image.toFormat(SHARP_FORMAT_BY_MIME_TYPE[targetMimeType]).toBuffer();
+  return image.toFormat(OUTPUT_FORMAT_BY_MIME_TYPE[targetMimeType]).toBuffer();
 };
 
 /** Convert only image formats that the configured visual fallback does not accept. */

--- a/packages-lobe/package.json
+++ b/packages-lobe/package.json
@@ -300,6 +300,7 @@
     "@lobechat/fetch-sse": "workspace:*",
     "@lobechat/file-loaders": "workspace:*",
     "@lobechat/heterogeneous-agents": "workspace:*",
+    "@lobechat/image-photon": "workspace:*",
     "@lobechat/llm-generation-tracing": "workspace:*",
     "@lobechat/local-file-shell": "workspace:*",
     "@lobechat/markdown-patch": "workspace:*",
@@ -464,7 +465,6 @@
     "resolve-accept-language": "^3.2.2",
     "rtl-detect": "^1.1.2",
     "semver": "^7.8.5",
-    "sharp": "^0.34.5",
     "shiki": "^4.4.3",
     "stripe": "^17.7.0",
     "superjson": "^2.2.6",
@@ -490,6 +490,7 @@
     "zustand-utils": "^2.1.1"
   },
   "devDependencies": {
+    "@cf-wasm/photon": "^0.4.0",
     "@cloudflare/workers-types": "^4.20260702.1",
     "@commitlint/cli": "^19.8.1",
     "@edge-runtime/vm": "^5.0.0",
@@ -580,6 +581,7 @@
     "require-in-the-middle": "^8.0.1",
     "s3rver": "3.7.1",
     "semantic-release": "^21.1.2",
+    "sharp": "^0.34.5",
     "stylelint": "^16.26.1",
     "tsx": "^4.23.12",
     "type-fest": "^5.8.0",

--- a/packages-lobe/packages/image-photon/README.md
+++ b/packages-lobe/packages/image-photon/README.md
@@ -1,0 +1,95 @@
+# `@lobechat/image-photon`
+
+A `sharp`-shaped image pipeline backed by [Photon](https://github.com/silvia-odwyer/photon)
+(Rust compiled to WebAssembly), packaged for the edge by
+[`@cf-wasm/photon`](https://github.com/fineshopdesign/cf-wasm/tree/main/packages/photon).
+
+## Why
+
+`sharp` is a native Node addon wrapping libvips. workerd cannot load native
+addons, so every server path that touched `sharp` — thumbnail generation,
+attachment compression, multimodal image transcoding — kept the app off
+Cloudflare Workers. Photon is plain WebAssembly and runs unchanged on Workers,
+Node and the edge runtime.
+
+The call sites keep the fluent API they already had; only the import changes:
+
+```diff
+-import sharp from 'sharp';
++import sharp from '@lobechat/image-photon';
+
+ const thumbnail = await sharp(buffer)
+   .resize(320, 320, { fit: 'inside', withoutEnlargement: true })
+   .webp()
+   .toBuffer();
+```
+
+The WASM binary is loaded on first use, not at import time, so modules that
+merely reach this one without processing an image pay nothing.
+
+## Supported surface
+
+| Method                                           | Notes                                                                                                                                       |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sharp(input, options)`                          | `Buffer`, `Uint8Array` or `ArrayBuffer`. Honours `limitInputPixels`.                                                                        |
+| `.metadata()`                                    | `format`, `width`, `height`, `pages`, `orientation`, `hasAlpha`, `size`. Answered from the file header alone where the container allows it. |
+| `.stats()`                                       | Per-channel `min`/`max`/`sum`/`mean`/`stdev`, plus `isOpaque`.                                                                              |
+| `.resize(w, h, opts)` / `.resize(opts)`          | `fit` of `cover` (default), `contain`, `fill`, `inside`, `outside`; `withoutEnlargement`, `withoutReduction`, `background`.                 |
+| `.rotate(angle?)`                                | No argument bakes in the EXIF orientation. Quarter turns are lossless.                                                                      |
+| `.flatten({ background })`                       | Composites onto an opaque colour; accepts `#rgb`/`#rrggbb`/`#rrggbbaa`, an object, or `white`/`black`/`transparent`.                        |
+| `.jpeg()` / `.png()` / `.webp()` / `.toFormat()` | With no explicit format, the input's format is kept.                                                                                        |
+| `.toBuffer()`                                    | Returns a `Buffer`.                                                                                                                         |
+
+Format sniffing recognises PNG (including APNG), JPEG, GIF, WebP, BMP, TIFF,
+ICO, AVIF/HEIF and SVG.
+
+## Differences from `sharp`
+
+These are real behavioural differences, not omissions to be fixed later:
+
+- **WebP quality is fixed.** Photon's WebP encoder takes no quality parameter,
+  so `.webp({ quality })` accepts the option and ignores it. JPEG quality works.
+- **Single frame only.** An animation decodes to its first frame. `metadata()`
+  still reports the true frame count in `pages` — check it before re-encoding
+  if flattening an animation to a still would be wrong. (`attachmentBudget`
+  does exactly this.)
+- **PNG output always carries an alpha channel.** Photon writes RGBA PNGs, so
+  `metadata().hasAlpha` reads `true` on a PNG even after `.flatten()`. The
+  pixels really are opaque — `stats().isOpaque` reports that correctly.
+- **No AVIF or HEIF input, and no SVG.** Photon decodes PNG, JPEG, WebP, GIF
+  and BMP — the libvips-backed `sharp` this replaced also read AVIF and HEIF.
+  `metadata()` still identifies those containers from their header and returns
+  `format`, `pages` and `size` with no dimensions, so a caller sees an image it
+  cannot work with rather than an exception mid-pipeline; anything that needs
+  pixels throws. The visible consequence: an AVIF or HEIC attachment can no
+  longer be transcoded for a model that does not accept it
+  (`normalizeMultimodalImageItems`), and reaches the model in its original
+  format or not at all.
+- **No `.toFile()`.** There is no filesystem on Workers.
+- **`failOn` / `animated` / `density` are accepted and ignored**, so existing
+  call sites type-check unchanged.
+
+## Bundling for Workers
+
+`@cf-wasm/photon` ships one entry per runtime, and only one of them runs on
+workerd. The `node` entry inlines the binary and calls
+`new WebAssembly.Module(bytes)`, which workerd refuses outright — _"Wasm code
+generation disallowed by embedder"_. The `workerd` entry imports the binary as
+a module instead, which is the shape workerd accepts.
+
+Wrangler picks the right entry on its own. A bundler in front of it needs two
+things (see `vite.worker.config.ts` in the QwkSearch worker for a worked
+example):
+
+1. **Pin the `workerd` export.** Listing `workerd` first in `resolve.conditions`
+   is not always enough — an `ssr.target` of `node` can still win.
+2. **Keep the `.wasm` import external** and copy the binary next to the output.
+   Bundlers otherwise rewrite it to an asset URL string, which is not a
+   `WebAssembly.Module`. Wrangler's default `CompiledWasm` rule compiles the
+   file at deploy time; do not add an explicit rule for it, which would shadow
+   that default.
+
+`sharp` itself is still a devDependency of the monorepo, used only by Node-only
+build scripts that need what Photon cannot do: SVG rasterisation for the macOS
+tray icon, and animated GIF → animated WebP in the CDN and docs workflows.
+Nothing at runtime depends on it.

--- a/packages-lobe/packages/image-photon/package.json
+++ b/packages-lobe/packages/image-photon/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@lobechat/image-photon",
+  "version": "1.0.0",
+  "private": true,
+  "description": "sharp-compatible image pipeline backed by the Photon WASM codec, so image processing runs on Cloudflare Workers",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "main": "src/index.ts",
+  "dependencies": {
+    "@cf-wasm/photon": "^0.4.0"
+  }
+}

--- a/packages-lobe/packages/image-photon/src/geometry.ts
+++ b/packages-lobe/packages/image-photon/src/geometry.ts
@@ -1,0 +1,163 @@
+/**
+ * Resize geometry, split out from the pipeline so the arithmetic can be read
+ * against sharp's documented `fit` semantics without the WASM plumbing.
+ */
+
+export type Fit = 'contain' | 'cover' | 'fill' | 'inside' | 'outside';
+
+export interface ResizeOptions {
+  background?: Background;
+  fit?: Fit;
+  height?: number | null;
+  width?: number | null;
+  withoutEnlargement?: boolean;
+  withoutReduction?: boolean;
+}
+
+export interface Background {
+  alpha?: number;
+  b: number;
+  g: number;
+  r: number;
+}
+
+export interface ResizePlan {
+  /** Centre crop applied after scaling, for `fit: 'cover'`. */
+  crop?: { height: number; left: number; top: number; width: number };
+  /** Canvas the scaled image is centred on, for `fit: 'contain'`. */
+  pad?: { height: number; width: number };
+  /** Dimensions to hand to the resampler. */
+  scaledHeight: number;
+  scaledWidth: number;
+}
+
+const DEFAULT_BACKGROUND: Background = { alpha: 1, b: 0, g: 0, r: 0 };
+
+const clamp = (value: number) => Math.max(1, Math.round(value));
+
+/**
+ * Parse the colour spellings sharp accepts on `background`: an object, a
+ * `#rgb`/`#rgba`/`#rrggbb`/`#rrggbbaa` string, or one of a few common names.
+ */
+export const parseBackground = (background?: Background | string): Background => {
+  if (!background) return DEFAULT_BACKGROUND;
+  if (typeof background !== 'string') return { alpha: 1, ...background };
+
+  const named: Record<string, Background> = {
+    black: { alpha: 1, b: 0, g: 0, r: 0 },
+    transparent: { alpha: 0, b: 0, g: 0, r: 0 },
+    white: { alpha: 1, b: 255, g: 255, r: 255 },
+  };
+  const lowered = background.trim().toLowerCase();
+  if (named[lowered]) return named[lowered];
+
+  const hex = lowered.replace('#', '');
+  const expand = (value: string) => Number.parseInt(value.repeat(2 / value.length), 16);
+
+  if (hex.length === 3 || hex.length === 4) {
+    return {
+      alpha: hex.length === 4 ? expand(hex[3]) / 255 : 1,
+      b: expand(hex[2]),
+      g: expand(hex[1]),
+      r: expand(hex[0]),
+    };
+  }
+  if (hex.length === 6 || hex.length === 8) {
+    const byte = (at: number) => Number.parseInt(hex.slice(at, at + 2), 16);
+    return {
+      alpha: hex.length === 8 ? byte(6) / 255 : 1,
+      b: byte(4),
+      g: byte(2),
+      r: byte(0),
+    };
+  }
+
+  return DEFAULT_BACKGROUND;
+};
+
+/**
+ * Work out how to get from `sourceWidth`x`sourceHeight` to what the caller
+ * asked for. Mirrors sharp: one dimension alone preserves the aspect ratio and
+ * ignores `fit`; both dimensions select behaviour by `fit`, defaulting to
+ * `cover`.
+ */
+export const planResize = (
+  sourceWidth: number,
+  sourceHeight: number,
+  options: ResizeOptions,
+): ResizePlan => {
+  const targetWidth = options.width ?? undefined;
+  const targetHeight = options.height ?? undefined;
+
+  if (!targetWidth && !targetHeight) {
+    return { scaledHeight: sourceHeight, scaledWidth: sourceWidth };
+  }
+
+  const limitScale = (scale: number) => {
+    if (options.withoutEnlargement && scale > 1) return 1;
+    if (options.withoutReduction && scale < 1) return 1;
+    return scale;
+  };
+
+  // A single dimension: scale to it and let the other follow.
+  if (!targetWidth || !targetHeight) {
+    const scale = limitScale(
+      targetWidth ? targetWidth / sourceWidth : (targetHeight as number) / sourceHeight,
+    );
+    return {
+      scaledHeight: clamp(sourceHeight * scale),
+      scaledWidth: clamp(sourceWidth * scale),
+    };
+  }
+
+  const widthScale = targetWidth / sourceWidth;
+  const heightScale = targetHeight / sourceHeight;
+  const fit = options.fit ?? 'cover';
+
+  if (fit === 'fill') {
+    // `fill` distorts on purpose, so the two axes are limited independently.
+    return {
+      scaledHeight: clamp(sourceHeight * limitScale(heightScale)),
+      scaledWidth: clamp(sourceWidth * limitScale(widthScale)),
+    };
+  }
+
+  const contains = fit === 'inside' || fit === 'contain';
+  const scale = limitScale(
+    contains ? Math.min(widthScale, heightScale) : Math.max(widthScale, heightScale),
+  );
+
+  const scaledWidth = clamp(sourceWidth * scale);
+  const scaledHeight = clamp(sourceHeight * scale);
+
+  if (fit === 'cover') {
+    // The scaled image covers the box on both axes; trim the overflow. When
+    // enlargement was refused it may be smaller than the box, in which case
+    // there is nothing to crop.
+    const cropWidth = Math.min(scaledWidth, targetWidth);
+    const cropHeight = Math.min(scaledHeight, targetHeight);
+    if (cropWidth === scaledWidth && cropHeight === scaledHeight) {
+      return { scaledHeight, scaledWidth };
+    }
+    return {
+      crop: {
+        height: cropHeight,
+        left: Math.floor((scaledWidth - cropWidth) / 2),
+        top: Math.floor((scaledHeight - cropHeight) / 2),
+        width: cropWidth,
+      },
+      scaledHeight,
+      scaledWidth,
+    };
+  }
+
+  if (fit === 'contain' && (scaledWidth !== targetWidth || scaledHeight !== targetHeight)) {
+    return {
+      pad: { height: targetHeight, width: targetWidth },
+      scaledHeight,
+      scaledWidth,
+    };
+  }
+
+  return { scaledHeight, scaledWidth };
+};

--- a/packages-lobe/packages/image-photon/src/index.ts
+++ b/packages-lobe/packages/image-photon/src/index.ts
@@ -1,0 +1,431 @@
+/**
+ * A `sharp`-shaped image pipeline backed by Photon (Rust → WASM).
+ *
+ * `sharp` is a native Node addon: it cannot be loaded by workerd, so every
+ * server path that touched it kept the whole app off Cloudflare Workers.
+ * Photon is plain WebAssembly and runs unchanged on Workers, Node and the edge
+ * runtime, so the call sites keep the fluent API they already use and only the
+ * import specifier changes.
+ *
+ * The surface here is deliberately the subset the app actually calls, not all
+ * of sharp. Differences worth knowing:
+ *
+ * - **WebP quality is fixed.** Photon's WebP encoder takes no quality
+ *   parameter, so `.webp({ quality })` accepts the option and ignores it.
+ * - **Single frame only.** Animations decode to their first frame. Read
+ *   `metadata().pages` before re-encoding if that would destroy the animation.
+ * - **No AVIF, HEIF or SVG input.** Photon decodes PNG, JPEG, WebP, GIF and
+ *   BMP. `metadata()` still identifies the other containers from their header,
+ *   so callers can take their "cannot handle this" path instead of failing
+ *   mid-pipeline, but any operation that needs pixels throws.
+ * - **`.toFile()` is absent** — there is no filesystem on Workers.
+ */
+// Type-only, so it is erased at compile time and the WASM stays out of the
+// module graph until `loadPhoton()` actually pulls it in.
+import type * as Photon from '@cf-wasm/photon';
+
+import type { Background, Fit, ResizeOptions } from './geometry';
+import { parseBackground, planResize } from './geometry';
+import type { ChannelStats, RawImage } from './pixels';
+import {
+  applyExifOrientation,
+  channelStats,
+  flattenOnto,
+  padToCanvas,
+  rotateQuarterTurns,
+} from './pixels';
+import type { ImageFormat } from './sniff';
+import { sniffImage } from './sniff';
+
+export type { Background, ChannelStats, Fit, ImageFormat, ResizeOptions };
+
+type PhotonModule = typeof Photon;
+type PhotonImage = InstanceType<PhotonModule['PhotonImage']>;
+
+/** Formats Photon can encode. Anything else falls back to PNG on output. */
+export type OutputFormat = 'jpeg' | 'png' | 'webp';
+
+export interface PhotonSharpOptions {
+  /**
+   * Accepted for sharp compatibility and ignored: Photon decodes a single
+   * frame regardless. `metadata().pages` still reports the real frame count.
+   */
+  animated?: boolean;
+  /** Accepted for sharp compatibility and ignored: SVG input is unsupported. */
+  density?: number;
+  /** Accepted for sharp compatibility; Photon fails on any undecodable input. */
+  failOn?: 'error' | 'none' | 'truncated' | 'warning';
+  /** Reject images above this pixel count. `false` disables the check. */
+  limitInputPixels?: boolean | number;
+}
+
+export interface Metadata {
+  channels?: number;
+  format?: ImageFormat;
+  hasAlpha?: boolean;
+  height?: number;
+  orientation?: number;
+  /** Frame count: 1 for a still image, >1 for an animation. */
+  pages: number;
+  size: number;
+  space?: string;
+  width?: number;
+}
+
+export interface Stats {
+  channels: ChannelStats[];
+  isOpaque: boolean;
+}
+
+export interface OutputOptions {
+  quality?: number;
+}
+
+/**
+ * What Photon's decoder actually accepts. Notably absent, and supported by the
+ * libvips-backed `sharp` this replaced: AVIF and HEIF. An image in one of those
+ * reaches `metadata()` intact — format, frame count, EXIF all come off the
+ * header — but cannot be resized, re-encoded or inspected pixel-wise.
+ */
+const DECODABLE_FORMATS = new Set<ImageFormat>(['bmp', 'gif', 'jpeg', 'png', 'webp']);
+
+/** sharp's own default ceiling: 0x3FFF × 0x3FFF pixels. */
+const DEFAULT_PIXEL_LIMIT = 0x3f_ff * 0x3f_ff;
+const DEFAULT_JPEG_QUALITY = 80;
+
+type Operation =
+  | { background: Background; type: 'flatten' }
+  | { angle?: number; type: 'rotate' }
+  | { options: ResizeOptions; type: 'resize' };
+
+let photonModule: Promise<PhotonModule> | undefined;
+
+/**
+ * Loaded on first use rather than at import time. The WASM binary is around a
+ * megabyte, and several call sites reach this module without ever touching an
+ * image.
+ */
+const loadPhoton = () => (photonModule ??= import('@cf-wasm/photon'));
+
+const toBytes = (input: ArrayBuffer | ArrayBufferView | Uint8Array): Uint8Array => {
+  if (input instanceof Uint8Array) return input;
+  if (ArrayBuffer.isView(input)) {
+    return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  }
+  return new Uint8Array(input);
+};
+
+const toRaw = (image: PhotonImage): RawImage => ({
+  height: image.get_height(),
+  pixels: image.get_raw_pixels(),
+  width: image.get_width(),
+});
+
+export class PhotonSharp {
+  private readonly bytes: Uint8Array;
+  private readonly options: PhotonSharpOptions;
+  private readonly operations: Operation[] = [];
+  private outputFormat?: OutputFormat;
+  private outputOptions: OutputOptions = {};
+
+  constructor(input: ArrayBuffer | ArrayBufferView | Uint8Array, options: PhotonSharpOptions = {}) {
+    this.bytes = toBytes(input);
+    this.options = options;
+  }
+
+  // ------------------------------------------------------------ operations
+
+  resize(options: ResizeOptions): this;
+  resize(width?: number | null, height?: number | null, options?: ResizeOptions): this;
+  resize(
+    widthOrOptions?: ResizeOptions | number | null,
+    height?: number | null,
+    options: ResizeOptions = {},
+  ): this {
+    const resolved: ResizeOptions =
+      typeof widthOrOptions === 'object' && widthOrOptions !== null
+        ? widthOrOptions
+        : { ...options, height, width: widthOrOptions };
+
+    this.operations.push({ options: resolved, type: 'resize' });
+    return this;
+  }
+
+  /** No angle auto-orients from EXIF, matching sharp. */
+  rotate(angle?: number): this {
+    this.operations.push({ angle, type: 'rotate' });
+    return this;
+  }
+
+  flatten(options: { background?: Background | string } = {}): this {
+    this.operations.push({ background: parseBackground(options.background), type: 'flatten' });
+    return this;
+  }
+
+  // --------------------------------------------------------------- outputs
+
+  jpeg(options: OutputOptions = {}): this {
+    return this.toFormat('jpeg', options);
+  }
+
+  png(options: OutputOptions = {}): this {
+    return this.toFormat('png', options);
+  }
+
+  /** `quality` is accepted for compatibility; Photon's WebP encoder ignores it. */
+  webp(options: OutputOptions = {}): this {
+    return this.toFormat('webp', options);
+  }
+
+  toFormat(format: OutputFormat, options: OutputOptions = {}): this {
+    this.outputFormat = format;
+    this.outputOptions = options;
+    return this;
+  }
+
+  // ------------------------------------------------------------- terminals
+
+  /**
+   * Header-only where the container allows it: the compression paths call this
+   * first and often return the original bytes without ever decoding.
+   */
+  async metadata(): Promise<Metadata> {
+    const sniffed = sniffImage(this.bytes);
+
+    if (sniffed.width !== undefined && sniffed.height !== undefined) {
+      this.assertWithinPixelLimit(sniffed.width, sniffed.height);
+      return {
+        channels: sniffed.hasAlpha ? 4 : 3,
+        format: sniffed.format,
+        hasAlpha: sniffed.hasAlpha,
+        height: sniffed.height,
+        orientation: sniffed.orientation,
+        pages: sniffed.pages,
+        size: this.bytes.byteLength,
+        space: 'srgb',
+        width: sniffed.width,
+      };
+    }
+
+    // Nothing to gain from a decode that is going to fail: report what the
+    // header gave us and let the caller decide. Undefined dimensions are how
+    // sharp's own callers already detect an image they cannot work with.
+    if (sniffed.format && !DECODABLE_FORMATS.has(sniffed.format)) {
+      return {
+        format: sniffed.format,
+        hasAlpha: sniffed.hasAlpha,
+        orientation: sniffed.orientation,
+        pages: sniffed.pages,
+        size: this.bytes.byteLength,
+      };
+    }
+
+    const image = await this.decode();
+    try {
+      return {
+        channels: 4,
+        format: sniffed.format,
+        hasAlpha: sniffed.hasAlpha,
+        height: image.get_height(),
+        orientation: sniffed.orientation,
+        pages: sniffed.pages,
+        size: this.bytes.byteLength,
+        space: 'srgb',
+        width: image.get_width(),
+      };
+    } finally {
+      image.free();
+    }
+  }
+
+  /**
+   * Only the decode is load-bearing at the call sites — this is how inline
+   * images get validated — but the numbers are real.
+   */
+  async stats(): Promise<Stats> {
+    const image = await this.decode();
+    try {
+      return channelStats(toRaw(image));
+    } finally {
+      image.free();
+    }
+  }
+
+  async toBuffer(): Promise<Buffer> {
+    const photon = await loadPhoton();
+    let image = await this.decode();
+
+    try {
+      for (const operation of this.operations) {
+        image = this.apply(photon, image, operation);
+      }
+      return Buffer.from(this.encode(image));
+    } finally {
+      image.free();
+    }
+  }
+
+  // ------------------------------------------------------------- internals
+
+  private assertWithinPixelLimit(width: number, height: number) {
+    const { limitInputPixels } = this.options;
+    if (limitInputPixels === false) return;
+
+    const limit = typeof limitInputPixels === 'number' ? limitInputPixels : DEFAULT_PIXEL_LIMIT;
+    if (width * height > limit) {
+      throw new Error(
+        `Input image exceeds pixel limit: ${width}x${height} is over ${limit} pixels`,
+      );
+    }
+  }
+
+  private async decode(): Promise<PhotonImage> {
+    const { format } = sniffImage(this.bytes);
+    if (format && !DECODABLE_FORMATS.has(format)) {
+      throw new Error(
+        `Photon cannot decode ${format} images (it handles ${[...DECODABLE_FORMATS].join(', ')})`,
+      );
+    }
+
+    const photon = await loadPhoton();
+
+    let image: PhotonImage;
+    try {
+      image = photon.PhotonImage.new_from_byteslice(this.bytes);
+    } catch (error) {
+      throw new Error(`Failed to decode image${format ? ` (${format})` : ''}`, { cause: error });
+    }
+
+    try {
+      this.assertWithinPixelLimit(image.get_width(), image.get_height());
+    } catch (error) {
+      image.free();
+      throw error;
+    }
+
+    return image;
+  }
+
+  private replace(image: PhotonImage, next: PhotonImage): PhotonImage {
+    if (next !== image) image.free();
+    return next;
+  }
+
+  private fromRaw(photon: PhotonModule, raw: RawImage): PhotonImage {
+    return new photon.PhotonImage(raw.pixels, raw.width, raw.height);
+  }
+
+  private apply(photon: PhotonModule, image: PhotonImage, operation: Operation): PhotonImage {
+    switch (operation.type) {
+      case 'flatten': {
+        return this.replace(
+          image,
+          this.fromRaw(photon, flattenOnto(toRaw(image), operation.background)),
+        );
+      }
+
+      case 'rotate': {
+        // sharp's no-argument `rotate()` means "bake in the EXIF orientation".
+        if (operation.angle === undefined) {
+          const { orientation } = sniffImage(this.bytes);
+          if (!orientation || orientation === 1) return image;
+          return this.replace(
+            image,
+            this.fromRaw(photon, applyExifOrientation(toRaw(image), orientation)),
+          );
+        }
+
+        // Quarter turns stay lossless in JS; anything else needs Photon's
+        // interpolating rotation.
+        const angle = ((operation.angle % 360) + 360) % 360;
+        if (angle === 0) return image;
+        if (angle % 90 === 0) {
+          return this.replace(
+            image,
+            this.fromRaw(photon, rotateQuarterTurns(toRaw(image), angle / 90)),
+          );
+        }
+        return this.replace(image, photon.rotate(image, operation.angle));
+      }
+
+      case 'resize': {
+        const plan = planResize(image.get_width(), image.get_height(), operation.options);
+        let next = image;
+
+        if (plan.scaledWidth !== next.get_width() || plan.scaledHeight !== next.get_height()) {
+          next = this.replace(
+            next,
+            photon.resize(
+              next,
+              plan.scaledWidth,
+              plan.scaledHeight,
+              photon.SamplingFilter.Lanczos3,
+            ),
+          );
+        }
+
+        if (plan.crop) {
+          const { height, left, top, width } = plan.crop;
+          next = this.replace(next, photon.crop(next, left, top, left + width, top + height));
+        }
+
+        if (plan.pad) {
+          next = this.replace(
+            next,
+            this.fromRaw(
+              photon,
+              padToCanvas(
+                toRaw(next),
+                plan.pad.width,
+                plan.pad.height,
+                parseBackground(operation.options.background),
+              ),
+            ),
+          );
+        }
+
+        return next;
+      }
+    }
+  }
+
+  private encode(image: PhotonImage): Uint8Array {
+    // With no explicit output format sharp keeps the input's. Photon can only
+    // write PNG, JPEG and WebP, so anything else lands on PNG.
+    const format =
+      this.outputFormat ??
+      ({ jpeg: 'jpeg', png: 'png', webp: 'webp' } as const)[
+        sniffImage(this.bytes).format as OutputFormat
+      ] ??
+      'png';
+
+    switch (format) {
+      case 'jpeg': {
+        return image.get_bytes_jpeg(this.outputOptions.quality ?? DEFAULT_JPEG_QUALITY);
+      }
+      case 'webp': {
+        return image.get_bytes_webp();
+      }
+      default: {
+        return image.get_bytes();
+      }
+    }
+  }
+}
+
+/**
+ * Drop-in replacement for sharp's factory function.
+ *
+ * ```ts
+ * const thumbnail = await sharp(buffer)
+ *   .resize(320, 320, { fit: 'inside', withoutEnlargement: true })
+ *   .webp()
+ *   .toBuffer();
+ * ```
+ */
+export const sharp = (
+  input: ArrayBuffer | ArrayBufferView | Uint8Array,
+  options?: PhotonSharpOptions,
+): PhotonSharp => new PhotonSharp(input, options);
+
+export default sharp;

--- a/packages-lobe/packages/image-photon/src/pixels.ts
+++ b/packages-lobe/packages/image-photon/src/pixels.ts
@@ -1,0 +1,204 @@
+/**
+ * Raw RGBA operations Photon does not expose.
+ *
+ * Photon's own `rotate` interpolates for arbitrary angles, which is the wrong
+ * tool for EXIF auto-orientation: those are exact quarter turns and mirrors,
+ * and doing them here keeps them lossless. Alpha flattening and letterbox
+ * padding have no Photon equivalent at all.
+ */
+import type { Background } from './geometry';
+
+export interface RawImage {
+  height: number;
+  pixels: Uint8Array;
+  width: number;
+}
+
+/** Composite an RGBA buffer onto an opaque background, dropping the alpha. */
+export const flattenOnto = (
+  { height, pixels, width }: RawImage,
+  background: Background,
+): RawImage => {
+  const out = new Uint8Array(pixels.length);
+  const backgroundAlpha = background.alpha ?? 1;
+
+  for (let index = 0; index < pixels.length; index += 4) {
+    const alpha = pixels[index + 3] / 255;
+    const inverse = 1 - alpha;
+    out[index] = Math.round(pixels[index] * alpha + background.r * backgroundAlpha * inverse);
+    out[index + 1] = Math.round(
+      pixels[index + 1] * alpha + background.g * backgroundAlpha * inverse,
+    );
+    out[index + 2] = Math.round(
+      pixels[index + 2] * alpha + background.b * backgroundAlpha * inverse,
+    );
+    out[index + 3] = 255;
+  }
+
+  return { height, pixels: out, width };
+};
+
+/** Rotate by an exact number of quarter turns, clockwise. */
+export const rotateQuarterTurns = (
+  { height, pixels, width }: RawImage,
+  turns: number,
+): RawImage => {
+  const normalized = ((turns % 4) + 4) % 4;
+  if (normalized === 0) return { height, pixels, width };
+
+  const swapped = normalized % 2 === 1;
+  const outWidth = swapped ? height : width;
+  const outHeight = swapped ? width : height;
+  const out = new Uint8Array(pixels.length);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      let outX: number;
+      let outY: number;
+      if (normalized === 1) {
+        outX = height - 1 - y;
+        outY = x;
+      } else if (normalized === 2) {
+        outX = width - 1 - x;
+        outY = height - 1 - y;
+      } else {
+        outX = y;
+        outY = width - 1 - x;
+      }
+
+      const from = (y * width + x) * 4;
+      const to = (outY * outWidth + outX) * 4;
+      out[to] = pixels[from];
+      out[to + 1] = pixels[from + 1];
+      out[to + 2] = pixels[from + 2];
+      out[to + 3] = pixels[from + 3];
+    }
+  }
+
+  return { height: outHeight, pixels: out, width: outWidth };
+};
+
+/** Mirror across the vertical axis (left↔right). */
+export const mirrorHorizontally = ({ height, pixels, width }: RawImage): RawImage => {
+  const out = new Uint8Array(pixels.length);
+
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const from = (y * width + x) * 4;
+      const to = (y * width + (width - 1 - x)) * 4;
+      out[to] = pixels[from];
+      out[to + 1] = pixels[from + 1];
+      out[to + 2] = pixels[from + 2];
+      out[to + 3] = pixels[from + 3];
+    }
+  }
+
+  return { height, pixels: out, width };
+};
+
+/**
+ * EXIF orientation 1-8 expressed as the mirror-then-rotate pair that undoes it.
+ * Values are [horizontal mirror, clockwise quarter turns].
+ */
+const ORIENTATION_STEPS: Record<number, [boolean, number]> = {
+  1: [false, 0],
+  2: [true, 0],
+  3: [false, 2],
+  4: [true, 2],
+  5: [true, 1],
+  6: [false, 1],
+  7: [true, 3],
+  8: [false, 3],
+};
+
+/** Bake an EXIF orientation into the pixels, as sharp's `.rotate()` does. */
+export const applyExifOrientation = (image: RawImage, orientation?: number): RawImage => {
+  const steps = ORIENTATION_STEPS[orientation ?? 1];
+  if (!steps) return image;
+
+  const [mirror, turns] = steps;
+  return rotateQuarterTurns(mirror ? mirrorHorizontally(image) : image, turns);
+};
+
+/** Centre an image on a larger canvas filled with `background`. */
+export const padToCanvas = (
+  { height, pixels, width }: RawImage,
+  canvasWidth: number,
+  canvasHeight: number,
+  background: Background,
+): RawImage => {
+  const out = new Uint8Array(canvasWidth * canvasHeight * 4);
+  const alpha = Math.round((background.alpha ?? 1) * 255);
+
+  for (let index = 0; index < out.length; index += 4) {
+    out[index] = background.r;
+    out[index + 1] = background.g;
+    out[index + 2] = background.b;
+    out[index + 3] = alpha;
+  }
+
+  const left = Math.floor((canvasWidth - width) / 2);
+  const top = Math.floor((canvasHeight - height) / 2);
+
+  for (let y = 0; y < height; y += 1) {
+    const targetY = top + y;
+    if (targetY < 0 || targetY >= canvasHeight) continue;
+    for (let x = 0; x < width; x += 1) {
+      const targetX = left + x;
+      if (targetX < 0 || targetX >= canvasWidth) continue;
+      const from = (y * width + x) * 4;
+      const to = (targetY * canvasWidth + targetX) * 4;
+      out[to] = pixels[from];
+      out[to + 1] = pixels[from + 1];
+      out[to + 2] = pixels[from + 2];
+      out[to + 3] = pixels[from + 3];
+    }
+  }
+
+  return { height: canvasHeight, pixels: out, width: canvasWidth };
+};
+
+export interface ChannelStats {
+  max: number;
+  mean: number;
+  min: number;
+  squaresSum: number;
+  stdev: number;
+  sum: number;
+}
+
+/** Per-channel statistics, shaped like the subset of `sharp.stats()` we use. */
+export const channelStats = ({ height, pixels, width }: RawImage) => {
+  const count = width * height;
+  const channels: ChannelStats[] = [];
+  let isOpaque = true;
+
+  for (let channel = 0; channel < 4; channel += 1) {
+    let min = 255;
+    let max = 0;
+    let sum = 0;
+    let squaresSum = 0;
+
+    for (let index = channel; index < pixels.length; index += 4) {
+      const value = pixels[index];
+      if (value < min) min = value;
+      if (value > max) max = value;
+      sum += value;
+      squaresSum += value * value;
+    }
+
+    if (channel === 3 && min < 255) isOpaque = false;
+
+    const mean = count === 0 ? 0 : sum / count;
+    channels.push({
+      max,
+      mean,
+      min,
+      squaresSum,
+      stdev: count === 0 ? 0 : Math.sqrt(Math.max(0, squaresSum / count - mean * mean)),
+      sum,
+    });
+  }
+
+  return { channels, isOpaque };
+};

--- a/packages-lobe/packages/image-photon/src/sniff.ts
+++ b/packages-lobe/packages/image-photon/src/sniff.ts
@@ -1,0 +1,348 @@
+/**
+ * Container sniffing.
+ *
+ * Photon decodes pixels but tells us nothing about the file it came from: no
+ * format name, no frame count, no EXIF. Those are exactly the three things the
+ * callers of `metadata()` branch on, so we read them straight off the bytes.
+ *
+ * Reading the header also lets `metadata()` answer without decoding at all,
+ * which matters: the compression paths call `metadata()` first and return the
+ * original buffer untouched when the image is already small enough.
+ */
+
+export type ImageFormat =
+  'avif' | 'bmp' | 'gif' | 'heif' | 'ico' | 'jpeg' | 'png' | 'svg' | 'tiff' | 'webp';
+
+export interface SniffResult {
+  format?: ImageFormat;
+  hasAlpha?: boolean;
+  height?: number;
+  /** EXIF orientation, 1-8. Undefined when the file carries no EXIF. */
+  orientation?: number;
+  /** Frame count. 1 for a still image, >1 for an animation. */
+  pages: number;
+  width?: number;
+}
+
+const ascii = (bytes: Uint8Array, start: number, length: number) =>
+  String.fromCharCode(...bytes.subarray(start, start + length));
+
+const startsWith = (bytes: Uint8Array, signature: readonly number[], offset = 0) =>
+  bytes.length >= offset + signature.length &&
+  signature.every((byte, index) => bytes[offset + index] === byte);
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+// ---------------------------------------------------------------- EXIF
+
+/**
+ * Read the orientation tag out of a TIFF-structured EXIF payload — the same
+ * layout whether it arrived in a JPEG APP1 segment, a WebP `EXIF` chunk, a PNG
+ * `eXIf` chunk, or a bare TIFF file.
+ */
+const readExifOrientation = (bytes: Uint8Array, start: number, end: number) => {
+  if (end - start < 8) return undefined;
+
+  const order = ascii(bytes, start, 2);
+  if (order !== 'II' && order !== 'MM') return undefined;
+  const littleEndian = order === 'II';
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const u16 = (at: number) => view.getUint16(at, littleEndian);
+  const u32 = (at: number) => view.getUint32(at, littleEndian);
+
+  if (u16(start + 2) !== 42) return undefined;
+
+  const ifdOffset = start + u32(start + 4);
+  if (ifdOffset + 2 > end) return undefined;
+
+  const entryCount = u16(ifdOffset);
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = ifdOffset + 2 + index * 12;
+    if (entry + 12 > end) break;
+    // 0x0112 = Orientation, stored as a SHORT inline in the value field.
+    if (u16(entry) !== 0x01_12) continue;
+    const orientation = u16(entry + 8);
+    return orientation >= 1 && orientation <= 8 ? orientation : undefined;
+  }
+
+  return undefined;
+};
+
+// ---------------------------------------------------------------- PNG
+
+const sniffPng = (bytes: Uint8Array): SniffResult => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const result: SniffResult = { format: 'png', pages: 1 };
+
+  let offset = PNG_SIGNATURE.length;
+  while (offset + 8 <= bytes.length) {
+    const length = view.getUint32(offset);
+    const type = ascii(bytes, offset + 4, 4);
+    const data = offset + 8;
+    if (data + length > bytes.length) break;
+
+    switch (type) {
+      case 'IHDR': {
+        result.width = view.getUint32(data);
+        result.height = view.getUint32(data + 4);
+        const colorType = bytes[data + 9];
+        // 4 = grayscale+alpha, 6 = truecolour+alpha. Palettes (3) can still be
+        // transparent, which the tRNS case below picks up.
+        result.hasAlpha = colorType === 4 || colorType === 6;
+        break;
+      }
+      case 'acTL': {
+        // Animated PNG control chunk: the frame count lives in its first word.
+        result.pages = Math.max(1, view.getUint32(data));
+        break;
+      }
+      case 'tRNS': {
+        result.hasAlpha = true;
+        break;
+      }
+      case 'eXIf': {
+        result.orientation = readExifOrientation(bytes, data, data + length);
+        break;
+      }
+      // Everything interesting precedes the pixel data, so stop there.
+      case 'IDAT':
+      case 'IEND': {
+        return result;
+      }
+    }
+
+    offset = data + length + 4;
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------- JPEG
+
+const SOF_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf,
+]);
+
+const sniffJpeg = (bytes: Uint8Array): SniffResult => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const result: SniffResult = { format: 'jpeg', hasAlpha: false, pages: 1 };
+
+  let offset = 2;
+  while (offset + 4 <= bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+
+    const marker = bytes[offset + 1];
+    // Padding fill bytes, and the standalone markers that carry no segment.
+    if (marker === 0xff) {
+      offset += 1;
+      continue;
+    }
+    if (marker === 0xd8 || (marker >= 0xd0 && marker <= 0xd9)) {
+      offset += 2;
+      continue;
+    }
+    // Start of scan: entropy-coded data follows, nothing more to read.
+    if (marker === 0xda) break;
+
+    const length = view.getUint16(offset + 2);
+    const payload = offset + 4;
+    if (length < 2 || payload + length - 2 > bytes.length) break;
+
+    if (SOF_MARKERS.has(marker)) {
+      result.height = view.getUint16(payload + 1);
+      result.width = view.getUint16(payload + 3);
+      if (result.orientation !== undefined) break;
+    } else if (marker === 0xe1 && ascii(bytes, payload, 6) === 'Exif\0\0') {
+      result.orientation = readExifOrientation(bytes, payload + 6, payload + length - 2);
+      if (result.width !== undefined) break;
+    }
+
+    offset = payload + length - 2;
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------- GIF
+
+const sniffGif = (bytes: Uint8Array): SniffResult => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const result: SniffResult = {
+    format: 'gif',
+    hasAlpha: false,
+    height: view.getUint16(8, true),
+    pages: 0,
+    width: view.getUint16(6, true),
+  };
+
+  const flags = bytes[10];
+  let offset = 13;
+  // Global colour table, when present.
+  if (flags & 0x80) offset += 3 * 2 ** ((flags & 0x07) + 1);
+
+  /** Walk a chain of length-prefixed sub-blocks, ending at the zero-length one. */
+  const skipSubBlocks = (from: number) => {
+    let at = from;
+    while (at < bytes.length) {
+      const size = bytes[at];
+      at += 1 + size;
+      if (size === 0) break;
+    }
+    return at;
+  };
+
+  while (offset < bytes.length) {
+    const block = bytes[offset];
+
+    if (block === 0x2c) {
+      // Image descriptor — one per frame.
+      result.pages += 1;
+      const localFlags = bytes[offset + 9];
+      let at = offset + 10;
+      if (localFlags & 0x80) at += 3 * 2 ** ((localFlags & 0x07) + 1);
+      // LZW minimum code size, then the compressed image sub-blocks.
+      offset = skipSubBlocks(at + 1);
+    } else if (block === 0x21) {
+      const label = bytes[offset + 1];
+      // Graphic control extension: bit 0 of its packed field is the
+      // transparent-colour flag.
+      if (label === 0xf9 && bytes[offset + 3] & 0x01) result.hasAlpha = true;
+      offset = skipSubBlocks(offset + 2);
+    } else {
+      // Trailer (0x3b) or a byte we cannot interpret.
+      break;
+    }
+  }
+
+  result.pages = Math.max(1, result.pages);
+  return result;
+};
+
+// ---------------------------------------------------------------- WebP
+
+const sniffWebp = (bytes: Uint8Array): SniffResult => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const result: SniffResult = { format: 'webp', pages: 0 };
+
+  let offset = 12;
+  while (offset + 8 <= bytes.length) {
+    const fourcc = ascii(bytes, offset, 4);
+    const size = view.getUint32(offset + 4, true);
+    const payload = offset + 8;
+    if (payload + size > bytes.length) break;
+
+    switch (fourcc) {
+      case 'VP8X': {
+        const flags = bytes[payload];
+        result.hasAlpha = (flags & 0x10) !== 0;
+        // Canvas size is stored as two 24-bit little-endian "minus one" values.
+        result.width =
+          (bytes[payload + 4] | (bytes[payload + 5] << 8) | (bytes[payload + 6] << 16)) + 1;
+        result.height =
+          (bytes[payload + 7] | (bytes[payload + 8] << 8) | (bytes[payload + 9] << 16)) + 1;
+        break;
+      }
+      case 'VP8 ': {
+        // Lossy: a 3-byte frame tag, the 3-byte start code, then 14-bit dims.
+        if (result.width === undefined) {
+          result.width = view.getUint16(payload + 6, true) & 0x3f_ff;
+          result.height = view.getUint16(payload + 8, true) & 0x3f_ff;
+        }
+        result.hasAlpha ??= false;
+        break;
+      }
+      case 'VP8L': {
+        // Lossless: after the 0x2f signature, 14 bits width-1, 14 bits
+        // height-1, then the alpha-used flag.
+        if (result.width === undefined) {
+          const bits = view.getUint32(payload + 1, true);
+          result.width = (bits & 0x3f_ff) + 1;
+          result.height = ((bits >> 14) & 0x3f_ff) + 1;
+        }
+        result.hasAlpha ??= ((view.getUint32(payload + 1, true) >> 28) & 1) === 1;
+        break;
+      }
+      case 'ANMF': {
+        result.pages += 1;
+        break;
+      }
+      case 'EXIF': {
+        result.orientation = readExifOrientation(bytes, payload, payload + size);
+        break;
+      }
+    }
+
+    // Chunks are padded to an even length.
+    offset = payload + size + (size % 2);
+  }
+
+  result.pages = Math.max(1, result.pages);
+  return result;
+};
+
+// ---------------------------------------------------------------- others
+
+const sniffBmp = (bytes: Uint8Array): SniffResult => {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return {
+    format: 'bmp',
+    hasAlpha: false,
+    // Height is signed: a negative value means the rows are stored top-down.
+    height: Math.abs(view.getInt32(22, true)),
+    pages: 1,
+    width: Math.abs(view.getInt32(18, true)),
+  };
+};
+
+const sniffTiff = (bytes: Uint8Array): SniffResult => ({
+  format: 'tiff',
+  orientation: readExifOrientation(bytes, 0, bytes.length),
+  pages: 1,
+});
+
+const HEIF_BRANDS: Record<string, ImageFormat> = {
+  avif: 'avif',
+  avis: 'avif',
+  heic: 'heif',
+  heim: 'heif',
+  heis: 'heif',
+  heix: 'heif',
+  hevc: 'heif',
+  mif1: 'heif',
+  msf1: 'heif',
+};
+
+const looksLikeSvg = (bytes: Uint8Array) => {
+  const head = ascii(bytes, 0, Math.min(bytes.length, 1024)).trimStart();
+  return head.startsWith('<svg') || (head.startsWith('<?xml') && head.includes('<svg'));
+};
+
+/**
+ * Identify the container and read whatever the header can tell us cheaply.
+ * Returns `{ pages: 1 }` with no format for bytes we do not recognise — the
+ * caller then falls back to decoding, which is the real arbiter anyway.
+ */
+export const sniffImage = (bytes: Uint8Array): SniffResult => {
+  if (bytes.length < 16) return { pages: 1 };
+
+  if (startsWith(bytes, PNG_SIGNATURE)) return sniffPng(bytes);
+  if (startsWith(bytes, [0xff, 0xd8, 0xff])) return sniffJpeg(bytes);
+  if (ascii(bytes, 0, 6) === 'GIF87a' || ascii(bytes, 0, 6) === 'GIF89a') return sniffGif(bytes);
+  if (ascii(bytes, 0, 4) === 'RIFF' && ascii(bytes, 8, 4) === 'WEBP') return sniffWebp(bytes);
+  if (ascii(bytes, 0, 2) === 'BM') return sniffBmp(bytes);
+  if (ascii(bytes, 0, 4) === 'II*\0' || ascii(bytes, 0, 4) === 'MM\0*') {
+    return sniffTiff(bytes);
+  }
+  if (startsWith(bytes, [0x00, 0x00, 0x01, 0x00])) return { format: 'ico', pages: 1 };
+  if (ascii(bytes, 4, 4) === 'ftyp') {
+    const format = HEIF_BRANDS[ascii(bytes, 8, 4)];
+    if (format) return { format, pages: 1 };
+  }
+  if (looksLikeSvg(bytes)) return { format: 'svg', pages: 1 };
+
+  return { pages: 1 };
+};

--- a/packages-lobe/scripts/cdnWorkflow/optimized.ts
+++ b/packages-lobe/scripts/cdnWorkflow/optimized.ts
@@ -1,3 +1,10 @@
+/**
+ * Still on `sharp`, deliberately: `opimizedGif` re-encodes an animated GIF into
+ * an animated WebP, which the Photon WASM codec that replaced `sharp` at
+ * runtime cannot do (it decodes a single frame). This is a Node-only build
+ * script and never reaches the Workers bundle, so the native dependency is
+ * fine here.
+ */
 import sharp from 'sharp';
 
 const WIDTH = 1600;
@@ -6,10 +13,7 @@ export const opimized = async (
   inputBuffer: ArrayBuffer,
   width: number = WIDTH,
 ): Promise<Buffer> => {
-  return await sharp(inputBuffer)
-    .resize({ width: width, withoutEnlargement: true })
-    .webp()
-    .toBuffer();
+  return await sharp(inputBuffer).resize({ width, withoutEnlargement: true }).webp().toBuffer();
 };
 
 export const opimizedGif = async (inputBuffer: ArrayBuffer): Promise<Buffer> => {

--- a/packages-lobe/scripts/docsWorkflow/optimized.ts
+++ b/packages-lobe/scripts/docsWorkflow/optimized.ts
@@ -1,3 +1,10 @@
+/**
+ * Still on `sharp`, deliberately: `opimizedGif` re-encodes an animated GIF into
+ * an animated WebP, which the Photon WASM codec that replaced `sharp` at
+ * runtime cannot do (it decodes a single frame). This is a Node-only build
+ * script and never reaches the Workers bundle, so the native dependency is
+ * fine here.
+ */
 import sharp from 'sharp';
 
 const WIDTH = 1600;
@@ -6,10 +13,7 @@ export const opimized = async (
   inputBuffer: ArrayBuffer,
   width: number = WIDTH,
 ): Promise<Buffer> => {
-  return await sharp(inputBuffer)
-    .resize({ width: width, withoutEnlargement: true })
-    .webp()
-    .toBuffer();
+  return await sharp(inputBuffer).resize({ width, withoutEnlargement: true }).webp().toBuffer();
 };
 
 export const opimizedGif = async (inputBuffer: ArrayBuffer): Promise<Buffer> => {

--- a/packages-lobe/vite.worker.config.ts
+++ b/packages-lobe/vite.worker.config.ts
@@ -5,7 +5,8 @@
  * Node-only packages that cannot run under workerd are aliased to shims (see
  * `worker/shims`); Cloudflare-native replacements are wired in the Worker.
  */
-import { readFileSync } from 'node:fs';
+import { copyFileSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -23,6 +24,41 @@ const rawMdPlugin: Plugin = {
     return `export default ${JSON.stringify(readFileSync(filepath, 'utf8'))};`;
   },
   name: 'lobe-worker-raw-md',
+};
+
+/**
+ * `@cf-wasm/photon` — the image codec that replaced `sharp` — ships one entry
+ * per runtime. Its `node` entry inlines the binary and calls
+ * `new WebAssembly.Module(bytes)`, which workerd refuses outright ("Wasm code
+ * generation disallowed by embedder"); the `workerd` entry instead imports the
+ * binary as a module, which is the only shape that runs. This plugin pins that
+ * entry, because `ssr.target: 'node'` otherwise wins the condition.
+ *
+ * That leaves the import itself: Vite would turn `import wasm from
+ * './lib/photon_rs_bg.wasm'` into an asset URL string. Keep it external so it
+ * survives bundling and copy the binary next to the output, where wrangler's
+ * default `CompiledWasm` rule picks it up and compiles it at deploy time.
+ */
+const WASM_FILE_NAME = 'photon_rs_bg.wasm';
+
+const wasmModulePlugin: Plugin = {
+  enforce: 'pre',
+  name: 'lobe-worker-wasm-module',
+  async resolveId(source, importer, options) {
+    // Matched by name, so a second WASM dependency cannot silently inherit
+    // Photon's binary.
+    if (source.endsWith(WASM_FILE_NAME)) return { external: true, id: `./${WASM_FILE_NAME}` };
+    // `skipSelf` keeps this from matching its own replacement.
+    if (source === '@cf-wasm/photon') {
+      return this.resolve('@cf-wasm/photon/workerd', importer, { ...options, skipSelf: true });
+    }
+    return null;
+  },
+  writeBundle(options) {
+    const require = createRequire(import.meta.url);
+    const outDir = options.dir ?? path.dirname(options.file as string);
+    copyFileSync(require.resolve('@cf-wasm/photon/photon.wasm'), path.join(outDir, WASM_FILE_NAME));
+  },
 };
 
 /** Packages that must be replaced wholesale inside the Worker bundle. */
@@ -52,6 +88,10 @@ const unsupportedModules: Record<string, string> = {
   // from the dev-server template rewriter.
   'nodemailer': shim('nodemailer'),
   'oidc-provider': shim('oidc-provider'),
+  // `sharp` is aliased but NOT stubbed out: the shim forwards to
+  // `@lobechat/image-photon`, a WASM codec that runs on workerd. The alias is
+  // only here for third-party dependencies that still import `sharp` by name;
+  // the app's own code imports the package directly.
   'sharp': shim('sharp'),
   'undici': shim('undici'),
   'ws': shim('ws'),
@@ -243,6 +283,7 @@ export default defineConfig({
     'process.env.NODE_ENV': JSON.stringify('production'),
   },
   plugins: [
+    wasmModulePlugin,
     unsupportedModulePlugin,
     rawMdPlugin,
     tsconfigPaths({ loose: true, projects: [path.resolve(root, 'tsconfig.json')] }),

--- a/packages-lobe/worker/shims/sharp.ts
+++ b/packages-lobe/worker/shims/sharp.ts
@@ -1,5 +1,16 @@
-/** `sharp` shim: native image processing is unavailable on Workers (use Cloudflare Images instead). */
-const sharp = () => {
-  throw new Error('[lobehub-workers] sharp is not available on Cloudflare Workers');
-};
-export default sharp;
+/**
+ * `sharp` alias for the Worker bundle.
+ *
+ * This used to throw: `sharp` is a native Node addon and workerd cannot load
+ * one, so every image path in the Worker was dead. It now resolves to
+ * `@lobechat/image-photon`, a sharp-shaped pipeline over the Photon WASM codec
+ * that runs on workerd, so those paths work instead of failing.
+ *
+ * The app's own code imports `@lobechat/image-photon` directly. This alias only
+ * catches third-party dependencies that still reach for `sharp`.
+ *
+ * Not everything sharp does survives the swap — no SVG rasterisation, no
+ * animated re-encoding, no `toFile` — see that package's README.
+ */
+export * from '@lobechat/image-photon';
+export { default } from '@lobechat/image-photon';


### PR DESCRIPTION
## Summary

Replace the native `sharp` image processing library with `@lobechat/image-photon`, a sharp-compatible API backed by Photon (Rust compiled to WebAssembly). This enables image processing to run on Cloudflare Workers and other edge runtimes, where native Node addons cannot be loaded.

## Key Changes

- **New package**: Created `@lobechat/image-photon` with a sharp-shaped API wrapping the Photon WASM codec
  - Implements core image operations: `resize()`, `rotate()`, `flatten()`, `metadata()`, `stats()`, `toBuffer()`
  - Supports PNG, JPEG, WebP, GIF, and BMP input; outputs PNG, JPEG, or WebP
  - Lazy-loads the WASM binary on first use to avoid overhead for modules that don't process images
  - Includes header-only metadata extraction for efficient compression path decisions

- **Image processing modules**: Added supporting modules for operations Photon doesn't expose
  - `geometry.ts`: Resize planning with support for `fit` modes (cover, contain, fill, inside, outside)
  - `pixels.ts`: Raw RGBA operations (flatten, rotate quarter-turns, pad, channel statistics)
  - `sniff.ts`: Container format detection and EXIF orientation reading from file headers

- **Import migration**: Updated all call sites to import from `@lobechat/image-photon` instead of `sharp`
  - `apps/server/src/services/bot/platforms/attachmentBudget.ts`
  - `apps/server/src/services/comfyui/core/imageService.ts`
  - `apps/server/src/services/generation/index.ts`
  - `apps/server/src/services/generation/video.ts`
  - `apps/server/src/services/aiAgent/ingestAttachment.ts`
  - `apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts`

- **Worker bundle configuration**: Updated `vite.worker.config.ts` to handle `@cf-wasm/photon` WASM binary
  - Pins the `workerd` entry point (which imports the binary as a module) instead of the `node` entry
  - Copies the WASM binary next to the output for wrangler's `CompiledWasm` rule

- **Worker shim**: Changed `worker/shims/sharp.ts` from throwing an error to aliasing `@lobechat/image-photon`
  - Image processing paths now work on Workers instead of being dead code

- **Test updates**: Updated mocks and test imports to use the new codec
  - `lobeAgent.test.ts`: Updated to test GIF and AVIF transcoding scenarios
  - `attachmentBudget.test.ts`: Updated mock imports
  - `imageService.test.ts`: Updated mock imports

## Notable Implementation Details

- **Lazy WASM loading**: The ~1MB Photon binary is only imported when an image is actually processed, not at module load time
- **Header-only metadata**: Format, dimensions, frame count, and EXIF orientation are read directly from file headers without decoding, enabling efficient compression decisions
- **Lossless quarter-turn rotations**: EXIF auto-orientation and 90° rotations are implemented in JavaScript to avoid interpolation artifacts
- **Format limitations**: Photon cannot decode AVIF or HEIF; these are identified from headers but operations fail if pixels are needed, allowing callers to take fallback paths
- **WebP quality ignored**: Photon's WebP encoder doesn't support quality parameters; the option is accepted for API compatibility but has no effect
- **Single-frame only**: Animations decode to their first frame; callers can check `metadata().pages` to detect and handle multi-frame images

https://claude.ai/code/session_01QxrZ7aqa6az1wT5b2ZjYzL