### PR TITLE
📝 docs(ci): record the lockfile outage blocking every job, and why the obvious fix fails

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,60 @@ already reached, and then went past by appending the `(merged)` marker.
 
 ## Completed
 
+## Diagnose the repo-wide CI outage and record it for the next run
+
+**Status:** Completed
+**Source:** Followed up on #424's own CI: 25 of its 27 checks failed. Same
+scheduled task; this is the post-merge half of that run.
+**Branch:** `claude/magical-bohr-dwq9sp` (restarted from `master` after #424
+merged)
+**Started:** 2026-09-10
+**Completed:** 2026-09-10
+
+### Goal
+Establish whether #424 broke CI, and leave the answer somewhere the next run
+reads before it re-derives it.
+
+### What it is
+Not #424 — the same workflows are red on its base commit `cc5800f3`, and #424
+touches no `package.json` and no `bun.lock`. `bun install --frozen-lockfile`
+cannot resolve two specifiers #422 (`d81427c7`) introduced in
+`packages/qwksearch-api-client/package.json`: `api2client@^1.0.1` (npm has
+1.0.0) and `grab-url@^1.6.23` (npm has 1.6.22). The install dies before
+compiling anything, so all 24 Coverage jobs, Test Reports, Publish to npm,
+Lockfile and the Cloudflare Workers build die with it, repo-wide.
+
+### The finding worth keeping
+**Downgrading the two specifiers does not work, and it was tried rather than
+assumed.** With `^1.0.0`/`^1.6.22` the root install succeeds in ~20s, and
+`qwksearch-api-client`'s own suite then fails to collect 3 of its 4 files:
+`api2client@1.0.0` is *published broken* — its tarball contains only
+`README.md`, `package.json` and `src/`, while `main`, `module`, `types`,
+`exports` and `bin` all point into a `dist/` that is not in the package. So
+`^1.0.1` is waiting on a fixed publish, not being over-careful. `^1.6.23` is
+equally real: it is the first `grab-url` with `onRawResponse`, which is what
+puts the HTTP status on a failed result, and `error-result-shape.test.ts`
+exists to protect that.
+
+Both packages live outside this repo, so there is nothing here to publish and
+no fix to port. The experimental edit was reverted; this change is docs only.
+
+### Scope
+- The CI-health section of the migration to-do, rewritten from two items to
+  three, leading with the outage and with "do not try the downgrade" and why.
+- One comment on #424 recording the diagnosis.
+
+### Notes for the next run
+- **Expect red CI until `api2client@1.0.1` and `grab-url@1.6.23` are on npm.**
+  Read your base commit before believing a failure is yours; right now it is
+  red there too, so local test runs are the only signal.
+- **The local `bun` is 1.3.11 while CI pins 1.4.0** (`bun-version-file:
+  package.json`). Anything that rewrites `bun.lock` locally risks a lockfile
+  CI then calls stale — a reason to leave the lockfile alone unless the change
+  is actually about dependencies.
+- PRs here still auto-merge, and #424 was merged before its checks finished —
+  so this entry's own branch was restarted from the new `master`.
+
 ## Build the Search & Sources settings pane inside the LobeHub engine
 
 **Status:** Completed

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -669,18 +669,49 @@ Then, for whichever you pick:
 
 ## What CI will and will not tell you
 
-Two things about this repo's CI are worth knowing before you read a red check
-on a `packages-lobe` change, both observed on #393:
+Three things about this repo's CI are worth knowing before you read a red check
+on a `packages-lobe` change:
 
+- **🔴 Every CI job in the repo is currently red, for one reason that is nobody's
+  diff.** `bun install --frozen-lockfile` cannot resolve two specifiers that
+  #422 (`d81427c7`) introduced in `packages/qwksearch-api-client/package.json`,
+  because neither version was ever published:
+
+  | Specifier | Latest actually on npm |
+  |---|---|
+  | `api2client: ^1.0.1` | 1.0.0 |
+  | `grab-url: ^1.6.23` | 1.6.22 |
+
+  The install step fails before compiling a line, so all 24 Coverage jobs, Test
+  Reports, Publish to npm, Lockfile and the Cloudflare Workers build go down
+  with it, on `master` and on every branch. Observed on #423's base and on #424.
+
+  **Do not "fix" it by downgrading the two specifiers** — that was tried on #424
+  and does not work. `api2client@1.0.0` is published broken: its tarball ships
+  only `README.md`, `package.json` and `src/`, while `main`, `module`, `types`,
+  `exports` and `bin` all point into a `dist/` that is not in the package, so
+  Vite fails with "Failed to resolve entry for package". The root install
+  succeeds with the downgrade and the package's own suite then fails to collect
+  3 of its 4 files. `^1.6.23` is likewise a real requirement, not caution:
+  #422's message records that it is the first `grab-url` carrying
+  `onRawResponse`, which is what puts the HTTP status on a failed result, and
+  `error-result-shape.test.ts` exists to protect exactly that.
+
+  Both packages live outside this repo, so nothing here can publish them and
+  there is no fix to port. Until `api2client@1.0.1` and `grab-url@1.6.23` are
+  published, **read every red check on your base commit first** — right now it
+  will be red there too, and the signal for your own change has to come from
+  running its tests locally.
 - **Nothing in CI builds or tests `packages-lobe`.** The root `workspaces` are
   `packages/*`, `packages/render-url-to-html/*` and `apps/*`; `packages-lobe` is
   a separate pnpm workspace outside that graph, so no job installs it. A green
   run says nothing about a change made there, and a red one is almost certainly
   not yours. Your own `bunx vitest run` under `packages-lobe` is the only
   signal — which is why 5.4's "bundle budget in CI" needs a whole new job.
-- **The Coverage workflow is already red on `master`.** As of `52eb7cce`
-  (#412, run 34445607248) **four** jobs fail with nothing of this work in them:
-  `chat-agent-toolkit`, `extract-youtube`, `search-web-api` and
+- **The Coverage workflow was already red on `master` before that**, for
+  unrelated reasons that will resurface once the install is fixed. As of
+  `52eb7cce` (#412, run 34445607248) **four** jobs failed with nothing of this
+  work in them: `chat-agent-toolkit`, `extract-youtube`, `search-web-api` and
   `shadcn-settings`. Two more — `extract-pdf` and `qwksearch-web` — were on this
   list and have since been fixed (#409 was the `extract-pdf` one), so **do not
   treat the list as fixed**: read the same job on your own base commit before


### PR DESCRIPTION
Follow-up to #424. Documentation only — no dependency, source or lockfile change.

## What happened

25 of #424's 27 checks failed. None of them for #424's reasons: the same workflows are red on its base commit `cc5800f3`, and that diff touches no `package.json` and no `bun.lock`.

`bun install --frozen-lockfile` cannot resolve two specifiers that #422 (`d81427c7`) introduced in `packages/qwksearch-api-client/package.json`:

| Specifier | Latest actually on npm |
|---|---|
| `api2client: ^1.0.1` | **1.0.0** |
| `grab-url: ^1.6.23` | **1.6.22** |

The install dies before compiling a line, so all 24 Coverage jobs, Test Reports, Publish to npm, Lockfile and the Cloudflare Workers build die with it — on `master` and on every branch. `qwksearch-api-client` is the only package asking for either; every other consumer pins `grab-url: ^1.6.22`, which resolves fine.

## The finding worth writing down

**The obvious fix — downgrade the two specifiers — does not work, and I tried it rather than assuming.**

With `^1.0.0`/`^1.6.22` the root install succeeds in about 20 seconds. `qwksearch-api-client`'s own suite then fails to collect 3 of its 4 test files:

```
Error: Failed to resolve entry for package "api2client".
 ❯ src/client/client.gen.ts:4:1
   import { createClient as createGrabClient } from "api2client";
```

`api2client@1.0.0` is **published broken**. Its tarball contains only `README.md`, `package.json` and `src/`, while `main`, `module`, `types`, `exports` and `bin` all point into a `dist/` that is not in the package:

```
$ ls node_modules/api2client/
README.md  package.json  src

main    = "./dist/index.cjs.js"
module  = "./dist/index.es.js"
types   = "./dist/index.d.ts"
exports = {".": {"import": "./dist/index.es.js", …}}
files   = ["dist", "src"]     ← dist was never in the tarball
```

So `^1.0.1` is waiting on a fixed publish, not being over-careful. And `^1.6.23` is equally real rather than a stray bump: #422's own message records it as the first `grab-url` carrying `onRawResponse`, which is what puts the HTTP status onto a failed result — the exact behavior `error-result-shape.test.ts` exists to protect.

Both packages live outside this repository, so nothing in its release workflow can produce them and **there is no fix to port**. I reverted the experimental edit; this PR carries no dependency change.

## What this PR changes

- **The migration to-do's "What CI will and will not tell you" section** goes from two items to three, leading with the outage: the table above, an explicit "do not try the downgrade" with the evidence, and the instruction to read every red check on your own base commit first.
- **The four pre-existing red Coverage jobs** (`chat-agent-toolkit`, `extract-youtube`, `search-web-api`, `shadcn-settings`) are re-framed as what will resurface once the install is fixed, rather than as today's failure — they are a different bug and shouldn't be conflated with this one.
- **`TODO.md`** records the diagnosis and two notes for the next run, including that the local `bun` is 1.3.11 while CI pins 1.4.0 via `bun-version-file`, so rewriting `bun.lock` locally risks producing a lockfile CI then calls stale.

## What unblocks the repo

Publishing `api2client@1.0.1` with a real `dist/`, and `grab-url@1.6.23`. Until then CI cannot tell anyone anything, and local test runs are the only signal — which is doubly true for `packages-lobe`, which no CI job installs at all.

Expect this PR's own checks to be red for the reason it documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4M1Nyf58LP1tknzhmmB3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y4M1Nyf58LP1tknzhmmB3Q)_