### PR TITLE
🐛 fix(comfyui): restore the Buffer.from that keeps the resize assignable

### DIFF
--- a/packages-lobe/apps/server/src/services/comfyui/core/imageService.ts
+++ b/packages-lobe/apps/server/src/services/comfyui/core/imageService.ts
@@ -179,12 +179,18 @@ export class ImageService {
             target: { height: resizeResult.height, width: resizeResult.width },
           });
 
-          buffer = await sharp(buffer)
-            .resize(resizeResult.width, resizeResult.height, {
-              fit: 'inside', // Maintain aspect ratio, fit within bounds
-              withoutEnlargement: false, // Allow enlargement if needed
-            })
-            .toBuffer();
+          // `Buffer.from` is load-bearing, not decoration: `buffer` is a
+          // `Buffer<ArrayBuffer>` from the fetch above, while `toBuffer()`
+          // returns the wider `Buffer<ArrayBufferLike>`, which will not assign
+          // back into it.
+          buffer = Buffer.from(
+            await sharp(buffer)
+              .resize(resizeResult.width, resizeResult.height, {
+                fit: 'inside', // Maintain aspect ratio, fit within bounds
+                withoutEnlargement: false, // Allow enlargement if needed
+              })
+              .toBuffer(),
+          );
           log('Image resized successfully, new size:', buffer.length);
         } else {
           log('Image dimensions are within model limits, no resize needed');


### PR DESCRIPTION
Follow-up to #421. That change dropped a `Buffer.from(...)` around the resize result as redundant. It is not: `buffer` is a `Buffer<ArrayBuffer>` produced by `Buffer.from(arrayBuffer)` off the fetch, while `toBuffer()` returns the wider `Buffer<ArrayBufferLike>`, which will not assign back into it.

  imageService.ts(182,11): error TS2322: Type 'Buffer<ArrayBufferLike>'
  is not assignable to type 'Buffer<ArrayBuffer>'.

Restored, with a comment saying what the wrapper is for so it does not get tidied away again. Nothing outside the codec swap needed touching there.

Caught by a tsc run scoped to apps/server; the repo-wide type-check could not be used to find it, as tsgo is OOM-killed at ~14GB on this tree.


Claude-Session: https://claude.ai/code/session_01QxrZ7aqa6az1wT5b2ZjYzL