### PR TITLE
✨ feat(reason-editor): bring the AI writing assistant to the Plate editor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -106,6 +106,79 @@ already reached, and then went past by appending the `(merged)` marker.
 
 ## Completed
 
+## Bring the AI writing assistant to the Plate editor
+
+**Status:** Completed
+**Source:** Direct request — put AI in the Plate bubble menu, and in the other
+places an assistant belongs.
+**Branch:** `claude/youthful-wright-iu0fbh`
+**PR:** Not created yet
+**Started:** 2026-09-10
+**Completed:** 2026-09-10
+
+### Goal
+`ReasonDocs` mounts Plate by default, and Plate had no AI at all: the selection
+toolbar had no "Ask AI", the fixed toolbar's own comment said the AI menu was
+"left out on purpose, because their plugins are not installed", and the slash
+menu's AI item called `AIChatPlugin`, which was never registered — a dead entry.
+The Tiptap engine has had the assistant since `src/extensions/Ai`. Close the gap
+without forking the feature in two.
+
+### What landed
+- `src/extensions/Ai/lib/reasonEndpoint.ts` — the `/api/agent/rewrite` contract
+  and its default endpoint, lifted out of `pluginRegistry.tsx` so both engines
+  build their completion function from one definition.
+- `src/docs-agent/plate/ai-plugin.ts`, `ai-controller.ts`, `ui/ai-menu.tsx`,
+  `ui/ai-toolbar-button.tsx`, `kits/ai-kit.tsx` — the Plate front end, on the
+  shared engine-neutral core (`commands.ts`, `lib/prompt.ts`,
+  `lib/sanitizeCompletion.ts`, `lib/completionToContent.ts`).
+- Entry points: ✨ Ask AI leads the selection (bubble) toolbar and the fixed
+  toolbar, `/ai` in the slash menu now works, and `⌘J` opens the panel. The
+  panel itself is the plugin's `afterEditable`, so `PlateEditorWrapper`,
+  `ReasonPlateEditor` and the playground all get it from `platePlugins` alone.
+- `test/docs-agent/ai-controller.test.ts` — 15 cases mirroring
+  `test/ai-extension.test.ts`, the Tiptap counterpart — plus
+  `test/docs-agent/ai-menu.test.tsx`, which mounts the panel over a real editor.
+
+### The one deliberate difference from Tiptap
+Tiptap reviews a suggestion as an inline red/green diff over the selection.
+Slate decorations can only style text that is already in the document, so
+rendering text that has not been accepted yet would mean writing it first —
+which the feature's first rule forbids. The Plate panel shows the streamed
+result in the panel instead. Everything else is identical: same commands, same
+request, same sanitising, same accept / insert-below / try-again / discard, and
+nothing written until the user accepts.
+
+### Non-goals
+- An AI button in the shared `REASON_TOOLBAR` schema. It is the engine-parity
+  contract, and the Tiptap comparison surface (`ReasonTiptapEditor`, which
+  mounts `NovelEditor` directly) never renders `AiMenu`, so the button would be
+  dead on one of the two engines it declares.
+- Reading the Tiptap plugin registry's saved AI settings (endpoint,
+  `contextChars`) on the Plate side. That config is a Tiptap-extension store;
+  the Plate plugin defaults to the same endpoint, so out-of-the-box behaviour
+  matches, and hosts override it through `ReasonPlateEditor`'s `ai` prop or
+  `editor.setOption(AiPlugin, …)`.
+
+### Verification
+`bunx tsc --noEmit` clean, and `bunx vitest run` in `packages/reason-editor`
+green: 55 files, 607 tests, including the 18 new ones.
+
+Both of those need three builds first, or they fail on module resolution in
+ways that have nothing to do with the change under test — worth knowing before
+concluding a Plate edit broke something:
+- `packages/use-voice-control` and `packages/reason-editor-sidebar`, or
+  `transcribe-controller.test.ts`, `playground-editor.test.tsx` and the
+  `ReasonDocs` tests cannot collect, and `tsc` reports implicit `any`s in the
+  files that import them.
+- `packages/reason-editor` itself (`bun run build:lib`), or the three tests that
+  reach the plugin registry cannot resolve the package's *own* subpath exports
+  (`react-reason-editor/blockquote`, …), which point into `dist/`.
+
+The repo-wide `bun install` outage recorded below is still there; the two
+specifiers were downgraded locally to get a `node_modules` to test against and
+reverted before committing, exactly as that entry warns against shipping.
+
 ## Diagnose the repo-wide CI outage and record it for the next run
 
 **Status:** Completed

--- a/packages/reason-editor/src/docs-agent.ts
+++ b/packages/reason-editor/src/docs-agent.ts
@@ -29,6 +29,13 @@
  * because a ProseMirror document and a Slate document are not interchangeable;
  * they stay separate until there is an explicit conversion/export pipeline.
  *
+ * The AI writing assistant is shared the same way: the commands, prompts,
+ * response sanitising and endpoint contract in `src/extensions/Ai/lib/*` drive
+ * both engines, with the Tiptap extension and the Plate plugin
+ * (`./docs-agent/plate/ai-plugin.ts` and its controller) as the two front ends.
+ * On Plate it is reachable from the selection toolbar, the fixed toolbar, the
+ * slash menu and ⌘J.
+ *
  * `ReasonSidebar` (from `./docs-agent/shared`) is the third shared plugin: the
  * document navigation list both routes mount around their editor, backed by
  * the same document store the production file-tree uses.
@@ -104,6 +111,25 @@ export {
   ReasonPlaygroundEditor,
   type ReasonPlaygroundEditorProps,
 } from './docs-agent/plate/playground-editor';
+/**
+ * The AI writing assistant. `AiKit` is already in `platePlugins`, so every
+ * surface above has it; these exports are for hosts that need to *configure*
+ * it — most often `getCompletion`, either through `ReasonPlateEditor`'s `ai`
+ * prop or `editor.setOption(AiPlugin, 'getCompletion', …)` — or that drive the
+ * panel from chrome of their own through `getAiController`.
+ */
+export { AiPlugin, AI_PLUGIN_KEY, type AiPluginOptions } from './docs-agent/plate/ai-plugin';
+export { AiKit } from './docs-agent/plate/kits/ai-kit';
+export {
+  getAiController,
+  type AiController,
+  type AiControllerState,
+  type AiPanelState,
+  type AiPlateSuggestion,
+} from './docs-agent/plate/ai-controller';
+export { AiMenu } from './docs-agent/plate/ui/ai-menu';
+export { AIToolbarButton } from './docs-agent/plate/ui/ai-toolbar-button';
+
 export { REASON_TOOLBAR_SKIN } from './docs-agent/plate/ui/reason-toolbar-skin';
 export { FixedToolbar } from './docs-agent/plate/ui/fixed-toolbar';
 export { FixedToolbarButtons } from './docs-agent/plate/ui/fixed-toolbar-buttons';

--- a/packages/reason-editor/src/docs-agent/plate/ai-controller.ts
+++ b/packages/reason-editor/src/docs-agent/plate/ai-controller.ts
@@ -1,0 +1,387 @@
+/**
+ * The Plate writing assistant — the "Ask AI anything…" flow, ported from the
+ * Tiptap side's `src/extensions/Ai/Ai.ts`. Read that file's doc comment first:
+ * the three rules it is built on hold here unchanged.
+ *
+ *   1. Nothing is written to the document until the user accepts.
+ *   2. What is written is the sanitised, Markdown-aware content the review
+ *      panel showed, not the raw model response.
+ *   3. A request only ever carries a bounded window of the document.
+ *
+ * Only the document API differs. ProseMirror's decoration plugin and position
+ * mapping have no Slate equivalent, so the state machine lives in this
+ * per-editor controller — the same shape as `./transcribe-controller.ts` — and
+ * the target range is held in a `rangeRef`, Slate's own way of keeping a range
+ * valid while the document changes under it (the equivalent of mapping
+ * positions through a ProseMirror transaction). The streamed result is
+ * reviewed in the floating panel rather than as an inline red/green diff:
+ * Slate decorations can only style existing text, so there is no way to render
+ * text that is not in the document yet without writing it first, which rule 1
+ * forbids.
+ *
+ * Commands, prompts, response sanitising and the endpoint contract come from
+ * `@/extensions/Ai/lib/*`, which is engine-neutral and shared with Tiptap.
+ */
+
+import { PathApi, RangeApi, type Descendant, type TRange } from 'platejs';
+import { MarkdownPlugin } from '@platejs/markdown';
+
+import { needsRichInsert } from '@/extensions/Ai/lib/completionToContent';
+import { buildAiInstruction, clampContext } from '@/extensions/Ai/lib/prompt';
+import { sanitizeCompletion } from '@/extensions/Ai/lib/sanitizeCompletion';
+
+import { AiPlugin, type AiPluginOptions } from './ai-plugin';
+
+import type { PlateEditor } from 'platejs/react';
+import type { AiCommandDefinition, AiSuggestionMode } from '@/extensions/Ai/types';
+
+/** A suggestion being reviewed. The range it applies to is the controller's, not a copy. */
+export interface AiPlateSuggestion {
+  originalText: string;
+  suggestedText: string;
+  mode: AiSuggestionMode;
+  /** True while text is still streaming in; accept/insert-below are disabled until it settles. */
+  isStreaming: boolean;
+}
+
+export type AiPanelState =
+  | { status: 'closed' }
+  | { status: 'menu' }
+  | { status: 'loading'; commandLabel: string }
+  | { status: 'reviewing'; commandLabel: string; suggestion: AiPlateSuggestion }
+  | { status: 'error'; commandLabel: string; message: string };
+
+/** The last request that ran, kept so "Try again" can be re-issued without retyping. */
+interface AiLastRequest {
+  instruction: string;
+  commandId: string;
+  commandLabel: string;
+  option?: string;
+}
+
+export interface AiControllerState {
+  panel: AiPanelState;
+}
+
+export interface AiController {
+  getState(): AiControllerState;
+  subscribe(listener: () => void): () => void;
+  /**
+   * The range the panel is acting on, read live so it follows edits made while
+   * a completion streams. `null` once the panel is closed.
+   */
+  getRange(): TRange | null;
+  /** Open the command / free-form prompt menu over the current selection. */
+  open(): void;
+  /** Close the panel and drop any pending suggestion without touching the document. */
+  close(): void;
+  /** Run one of the configured commands, optionally with a submenu choice. */
+  runCommand(commandId: string, option?: string): boolean;
+  /** Run a free-form instruction typed into the menu's input. */
+  submitPrompt(instruction: string): boolean;
+  /** Abort an in-flight completion, keeping whatever already streamed in. */
+  stop(): void;
+  /** Re-run the last instruction against its original range. */
+  retry(): boolean;
+  /** Replace the range with the suggestion (or insert it, when nothing was selected). */
+  accept(): boolean;
+  /** Keep the original text and insert the suggestion as a new block below it. */
+  insertBelow(): boolean;
+}
+
+const controllers = new WeakMap<PlateEditor, AiController>();
+
+/** Where the panel opens when the editor has no selection: a caret at the end of the document. */
+function collapsedAtEnd(editor: PlateEditor): TRange | null {
+  const end = editor.api.end([]);
+  return end ? { anchor: end, focus: end } : null;
+}
+
+/**
+ * The document text sent as context: a window centred on the range rather than
+ * the whole document, so cost and latency stay bounded on a long file.
+ */
+function readContextWindow(editor: PlateEditor, range: TRange, budget: number): string {
+  if (budget <= 0) return '';
+
+  const docStart = editor.api.start([]);
+  const docEnd = editor.api.end([]);
+  if (!docStart || !docEnd) return '';
+
+  const [start, end] = RangeApi.edges(range);
+  const before = editor.api.string({ anchor: docStart, focus: start });
+  const after = editor.api.string({ anchor: end, focus: docEnd });
+
+  const half = Math.floor(budget / 2);
+  const head = clampContext(before, half);
+  const tail =
+    after.length > budget - head.length ? `${after.slice(0, budget - head.length)}…` : after;
+
+  return `${head}${head && tail ? '\n' : ''}${tail}`.trim();
+}
+
+/** Renders a completion as Plate nodes, so Markdown the model emitted becomes real blocks. */
+function completionToNodes(editor: PlateEditor, text: string): Descendant[] {
+  return editor.getApi(MarkdownPlugin).markdown.deserialize(text) as Descendant[];
+}
+
+function createController(editor: PlateEditor): AiController {
+  const state: AiControllerState = { panel: { status: 'closed' } };
+
+  const listeners = new Set<() => void>();
+  const notify = () => listeners.forEach((listener) => listener());
+
+  /** Live target range. Slate keeps it valid as the document changes; unref'd on close. */
+  let rangeRef: ReturnType<PlateEditor['api']['rangeRef']> | null = null;
+  let lastRequest: AiLastRequest | null = null;
+  let abortController: AbortController | null = null;
+  let requestToken = 0;
+
+  const options = (): AiPluginOptions => editor.getOptions(AiPlugin);
+
+  const getRange = (): TRange | null => rangeRef?.current ?? null;
+
+  function setRange(range: TRange | null): void {
+    rangeRef?.unref();
+    rangeRef = range ? editor.api.rangeRef(range) : null;
+  }
+
+  /**
+   * The range to act on: the one the panel was opened over, or — for a command
+   * run without opening the panel first, as the toolbars and slash menu can —
+   * the live selection, adopted as the panel's range.
+   */
+  function ensureRange(): TRange | null {
+    if (!getRange()) setRange(editor.selection ?? null);
+    return getRange();
+  }
+
+  /** Cancels any in-flight request so a late chunk cannot revive a settled panel. */
+  function cancelInFlight(): void {
+    abortController?.abort();
+    abortController = null;
+    requestToken += 1;
+  }
+
+  function setPanel(panel: AiPanelState): void {
+    state.panel = panel;
+    notify();
+  }
+
+  function close(): void {
+    cancelInFlight();
+    setRange(null);
+    lastRequest = null;
+    setPanel({ status: 'closed' });
+  }
+
+  function open(): void {
+    cancelInFlight();
+    setRange(editor.selection ?? collapsedAtEnd(editor));
+    setPanel({ status: 'menu' });
+  }
+
+  async function run(request: AiLastRequest): Promise<void> {
+    const range = getRange();
+    if (!range) return;
+
+    const selectedText = editor.api.string(range);
+    const documentText = readContextWindow(editor, range, options().contextChars);
+    const mode: AiSuggestionMode = selectedText ? 'replace' : 'insert';
+
+    cancelInFlight();
+    const controller = new AbortController();
+    abortController = controller;
+    const token = (requestToken += 1);
+
+    lastRequest = request;
+    setPanel({ status: 'loading', commandLabel: request.commandLabel });
+
+    /** True once this request has been superseded, aborted, or the editor is gone. */
+    const stale = () => token !== requestToken || controller.signal.aborted;
+
+    const showSuggestion = (text: string, isStreaming: boolean) => {
+      if (stale()) return;
+      setPanel({
+        status: 'reviewing',
+        commandLabel: request.commandLabel,
+        suggestion: {
+          originalText: selectedText,
+          suggestedText: sanitizeCompletion(text, { streaming: isStreaming }),
+          mode,
+          isStreaming,
+        },
+      });
+    };
+
+    try {
+      const result = await options().getCompletion(
+        {
+          instruction: request.instruction,
+          selectedText,
+          documentText,
+          commandId: request.commandId,
+          commandLabel: request.commandLabel,
+          option: request.option,
+          systemPrompt: options().systemPrompt,
+          mode,
+        },
+        (chunk) => showSuggestion(chunk, true),
+        controller.signal,
+      );
+
+      if (stale()) return;
+
+      if (!sanitizeCompletion(result)) {
+        setPanel({
+          status: 'error',
+          commandLabel: request.commandLabel,
+          message: 'The model returned an empty response.',
+        });
+        return;
+      }
+
+      showSuggestion(result, false);
+    } catch (error) {
+      if (stale()) return;
+      setPanel({
+        status: 'error',
+        commandLabel: request.commandLabel,
+        message: error instanceof Error ? error.message : 'Something went wrong.',
+      });
+    }
+  }
+
+  function findCommand(commandId: string): AiCommandDefinition | undefined {
+    return options().commands.find((command) => command.id === commandId);
+  }
+
+  /** The content to write, and how: plain text keeps the marks already on the range. */
+  function writeSuggestion(text: string, at: TRange): boolean {
+    const trimmed = text.trim();
+    if (!trimmed) return false;
+
+    editor.tf.focus();
+    editor.tf.select(at);
+
+    if (needsRichInsert(trimmed)) {
+      editor.tf.insertFragment(completionToNodes(editor, trimmed));
+    } else {
+      editor.tf.insertText(trimmed);
+    }
+
+    return true;
+  }
+
+  return {
+    getState: () => state,
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getRange,
+    open,
+    close,
+
+    runCommand(commandId: string, option?: string) {
+      const command = findCommand(commandId);
+      if (!command) return false;
+
+      const range = ensureRange();
+      if (!range) return false;
+
+      // A command that rewrites a selection has nothing to act on when the
+      // caret is collapsed; running it anyway produces a confident answer
+      // about nothing, so refuse instead.
+      if (command.requiresSelection !== false && RangeApi.isCollapsed(range)) return false;
+      if (command.options?.length && !option) return false;
+
+      void run({
+        instruction: buildAiInstruction(command, option),
+        commandId: command.id,
+        commandLabel: option ? `${command.label} → ${option}` : command.label,
+        option,
+      });
+      return true;
+    },
+
+    submitPrompt(instruction: string) {
+      const trimmed = instruction.trim();
+      if (!trimmed) return false;
+
+      if (!ensureRange()) return false;
+
+      void run({ instruction: trimmed, commandId: 'custom', commandLabel: 'Custom' });
+      return true;
+    },
+
+    stop() {
+      const { panel } = state;
+      if (panel.status !== 'loading' && panel.status !== 'reviewing') return;
+
+      cancelInFlight();
+
+      // Text already streamed in is worth keeping: settle it so the user can
+      // accept the partial result. With nothing yet to review, fall back to
+      // the command list.
+      if (panel.status === 'reviewing') {
+        setPanel({ ...panel, suggestion: { ...panel.suggestion, isStreaming: false } });
+      } else {
+        setPanel({ status: 'menu' });
+      }
+    },
+
+    retry() {
+      if (!lastRequest) return false;
+      void run(lastRequest);
+      return true;
+    },
+
+    accept() {
+      const { panel } = state;
+      if (panel.status !== 'reviewing' || panel.suggestion.isStreaming) return false;
+
+      const range = getRange();
+      if (!range) return false;
+
+      const written = writeSuggestion(panel.suggestion.suggestedText, range);
+      if (written) close();
+      return written;
+    },
+
+    insertBelow() {
+      const { panel } = state;
+      if (panel.status !== 'reviewing' || panel.suggestion.isStreaming) return false;
+
+      const range = getRange();
+      if (!range) return false;
+
+      const text = panel.suggestion.suggestedText.trim();
+      if (!text) return false;
+
+      // Insert after the block the range ends in, so the original text is left
+      // exactly as it was rather than being split around the result.
+      const block = editor.api.block({ at: RangeApi.end(range) });
+      if (!block) return false;
+
+      editor.tf.focus();
+      editor.tf.insertNodes(completionToNodes(editor, text), {
+        at: PathApi.next(block[1]),
+        select: true,
+      });
+      close();
+      return true;
+    },
+  };
+}
+
+/** One controller per editor instance, created on first use and cached for its lifetime. */
+export function getAiController(editor: PlateEditor): AiController {
+  let controller = controllers.get(editor);
+  if (!controller) {
+    controller = createController(editor);
+    controllers.set(editor, controller);
+  }
+
+  return controller;
+}

--- a/packages/reason-editor/src/docs-agent/plate/ai-plugin.ts
+++ b/packages/reason-editor/src/docs-agent/plate/ai-plugin.ts
@@ -1,0 +1,66 @@
+/**
+ * The Plate writing assistant's plugin: its configuration, and the presence
+ * flag the toolbars check before rendering an "Ask AI" control.
+ *
+ * Deliberately UI-free and state-free. The panel's state machine and the
+ * request/abort plumbing live in `./ai-controller.ts`, the menu in
+ * `./ui/ai-menu.tsx`, and `./kits/ai-kit.tsx` is what wires the three
+ * together — so this module can be imported from the controller without a
+ * cycle, exactly as `@platejs/*` plugin modules are.
+ *
+ * The commands, prompts, response sanitising and endpoint contract are the
+ * *same* modules the Tiptap `Ai` extension runs on (`@/extensions/Ai/lib/*`):
+ * everything in there is engine-neutral, and only `extensions/Ai/Ai.ts` is
+ * bound to ProseMirror. Sharing them means the two engines offer the same
+ * commands, send the same request, and clean the response the same way; read
+ * `extensions/Ai/Ai.ts`'s doc comment first — this mirrors its design.
+ */
+
+import type { PluginConfig } from 'platejs';
+import { createTPlatePlugin } from 'platejs/react';
+
+import { DEFAULT_AI_COMMANDS } from '@/extensions/Ai/commands';
+import { AI_SYSTEM_PROMPT } from '@/extensions/Ai/lib/prompt';
+import {
+  createReasonAiCompletion,
+  DEFAULT_AI_ENDPOINT,
+} from '@/extensions/Ai/lib/reasonEndpoint';
+
+import type { AiCommandDefinition, AiCompletionFn } from '@/extensions/Ai/types';
+
+/** Plugin key, also what `hasPlugin(editor, 'ai')` and the Tiptap side answer to. */
+export const AI_PLUGIN_KEY = 'ai';
+
+export interface AiPluginOptions {
+  /** Quick commands offered in the "Ask AI anything…" menu and the toolbar dropdown. */
+  commands: AiCommandDefinition[];
+  /**
+   * Runs a completion for an instruction. Defaults to REASON's own rewrite
+   * endpoint; hosts serving a different route (or none) override it, the same
+   * way the Tiptap side's plugin-registry setting does.
+   */
+  getCompletion: AiCompletionFn;
+  /**
+   * System message sent with every request. Constrains the model to return
+   * only the replacement text — override to add house style or domain rules.
+   */
+  systemPrompt: string;
+  /**
+   * How much surrounding document text (in characters) is sent as context.
+   * The window is taken from around the selection, so the nearest text is
+   * what survives the clamp. Set to `0` to send no context at all.
+   */
+  contextChars: number;
+}
+
+export type AiPluginConfig = PluginConfig<typeof AI_PLUGIN_KEY, AiPluginOptions>;
+
+export const AiPlugin = createTPlatePlugin<AiPluginConfig>({
+  key: AI_PLUGIN_KEY,
+  options: {
+    commands: DEFAULT_AI_COMMANDS,
+    getCompletion: createReasonAiCompletion(DEFAULT_AI_ENDPOINT),
+    systemPrompt: AI_SYSTEM_PROMPT,
+    contextChars: 4000,
+  },
+});

--- a/packages/reason-editor/src/docs-agent/plate/editor.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/editor.tsx
@@ -32,6 +32,7 @@ import {
 } from '../collaboration/hocuspocus-client';
 import { createNullAdapter, type EditorToolbarAdapter } from '../shared/editor-types';
 import { ReasonToolbar } from '../shared/toolbar-renderer';
+import { AiPlugin, type AiPluginOptions } from './ai-plugin';
 import { createPlateAdapter } from './plate-adapter';
 import { EMPTY_PLATE_VALUE, platePlugins } from './plate-editor-config';
 import { RemoteCursorOverlay } from './remote-cursor-overlay';
@@ -58,6 +59,12 @@ export interface ReasonPlateEditorProps {
    * floating toolbars expect to sit so they can position against it.
    */
   overlays?: React.ReactNode;
+  /**
+   * Overrides for the AI writing assistant — most usefully `getCompletion`,
+   * for a host serving a route other than REASON's own. Omitted, the assistant
+   * posts to the same endpoint the Tiptap editor's plugin registry defaults to.
+   */
+  ai?: Partial<AiPluginOptions>;
 }
 
 export function ReasonPlateEditor({
@@ -68,16 +75,25 @@ export function ReasonPlateEditor({
   className,
   renderToolbar,
   overlays,
+  ai,
 }: ReasonPlateEditorProps) {
   const room = collaborationRoom('plate', documentId);
   const color = user.color ?? cursorColorFor(user.id);
   const collaborative = Boolean(authToken);
+
+  // A second `AiPlugin` entry overrides the one `platePlugins` registers: same
+  // key, later wins, so only the options given here change.
+  const aiOverride = React.useMemo(
+    () => (ai ? [AiPlugin.configure({ options: ai })] : []),
+    [ai],
+  );
 
   const editor = usePlateEditor(
     {
       plugins: collaborative
         ? [
             ...platePlugins,
+            ...aiOverride,
             YjsPlugin.configure({
               options: {
                 cursors: {
@@ -91,7 +107,7 @@ export function ReasonPlateEditor({
               render: { afterEditable: RemoteCursorOverlay },
             }),
           ]
-        : platePlugins,
+        : [...platePlugins, ...aiOverride],
       // Yjs owns the initial document once collaboration is on; seeding the
       // editor locally first would produce a duplicated document on sync.
       skipInitialization: collaborative,
@@ -99,7 +115,7 @@ export function ReasonPlateEditor({
     },
     // Rebuild when the room or the credential changes, so the editor never
     // keeps a provider pointed at a document the user no longer has open.
-    [room, collaborative],
+    [room, collaborative, aiOverride],
   );
 
   React.useEffect(() => {

--- a/packages/reason-editor/src/docs-agent/plate/kits/ai-kit.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/kits/ai-kit.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AiPlugin } from '@/docs-agent/plate/ai-plugin';
+import { getAiController } from '@/docs-agent/plate/ai-controller';
+import { AiMenu } from '@/docs-agent/plate/ui/ai-menu';
+
+/**
+ * The AI writing assistant, assembled: the plugin's configuration
+ * (`../ai-plugin.ts`), the panel it renders after the editable
+ * (`../ui/ai-menu.tsx`), and the ⌘J shortcut that opens it — the same shortcut
+ * the Tiptap `Ai` extension binds.
+ *
+ * Registering the plugin is all a surface has to do: the panel comes with it
+ * through `render.afterEditable`, so `PlateEditorWrapper`, `ReasonPlateEditor`
+ * and the playground all get the assistant from
+ * `../plate-editor-config.ts` alone. The toolbar and slash-menu entry points
+ * (`../ui/ai-toolbar-button.tsx`, `../ui/slash-node.tsx`) only open it.
+ */
+export const AiKit = [
+  AiPlugin.configure({
+    handlers: {
+      onKeyDown: ({ editor, event }) => {
+        if (!(event.metaKey || event.ctrlKey) || event.key.toLowerCase() !== 'j') return;
+
+        event.preventDefault();
+        getAiController(editor).open();
+      },
+    },
+    render: {
+      afterEditable: () => <AiMenu />,
+    },
+  }),
+];

--- a/packages/reason-editor/src/docs-agent/plate/plate-editor-config.ts
+++ b/packages/reason-editor/src/docs-agent/plate/plate-editor-config.ts
@@ -14,6 +14,7 @@
  *   4. tables
  *   5. images/media
  *   6. slash menu, autoformat, emoji/mentions, floating controls
+ *   7. dictation, and the AI writing assistant
  */
 
 import { CaptionPlugin } from '@platejs/caption/react';
@@ -28,6 +29,7 @@ import {
 import { type AnySlatePlugin, KEYS } from 'platejs';
 import type { AnyPlatePlugin } from 'platejs/react';
 
+import { AiKit } from './kits/ai-kit';
 import { AlignKit } from './kits/align-kit';
 import { AutoformatKit } from './kits/autoformat-kit';
 import { BasicNodesKit } from './kits/basic-nodes-kit';
@@ -132,6 +134,10 @@ export const platePlugins: PlatePluginList = [
 
   // 8. Voice commands — the Dictate toggle at the end of the toolbar.
   ...TranscribeKit,
+
+  // 9. The AI writing assistant, reachable from the selection toolbar, the
+  //    fixed toolbar, the slash menu and ⌘J.
+  ...AiKit,
 ];
 
 /** A single empty paragraph — what a brand-new document starts from. */

--- a/packages/reason-editor/src/docs-agent/plate/ui/ai-menu.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/ai-menu.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import * as React from 'react';
+
+import { flip, getRangeBoundingClientRect, offset, shift, useVirtualFloating } from '@platejs/floating';
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  CornerDownRight,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+  Square,
+  X,
+} from 'lucide-react';
+import { RangeApi } from 'platejs';
+import { useEditorReadOnly, useEditorRef, useEditorSelector } from 'platejs/react';
+
+import { AI_COMMAND_GROUP_LABELS } from '@/extensions/Ai/commands';
+import { commandsForSelection, groupCommands } from '@/extensions/Ai/lib/prompt';
+import { cn } from '@/lib/utils';
+
+import { getAiController, type AiPanelState } from '@/docs-agent/plate/ai-controller';
+import { AiPlugin } from '@/docs-agent/plate/ai-plugin';
+
+import type { AiCommandDefinition } from '@/extensions/Ai/types';
+
+const CLOSED_PANEL: AiPanelState = { status: 'closed' };
+
+/** One action in the review/error footer. */
+function MenuRow({
+  icon: Icon,
+  label,
+  onClick,
+  title,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  onClick: () => void;
+  title?: string;
+}) {
+  return (
+    <button
+      className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground"
+      onClick={onClick}
+      title={title}
+      type="button"
+    >
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      {label}
+    </button>
+  );
+}
+
+/**
+ * The floating "Ask AI anything…" panel: the filterable command list, the
+ * streaming indicator with a Stop control, the accept / insert-below / try
+ * again / discard review controls over a preview of the result, and the error
+ * state — the same four states `src/extensions/Ai/components/AiMenu.tsx`
+ * renders on the Tiptap side, driven by `../ai-controller.ts` instead of a
+ * ProseMirror plugin.
+ *
+ * Mounted by `../kits/ai-kit.tsx` as the AI plugin's `afterEditable`, so every
+ * Plate surface that registers the plugin gets it without wiring of its own.
+ */
+export function AiMenu() {
+  const editor = useEditorRef();
+  const readOnly = useEditorReadOnly();
+  const controller = React.useMemo(() => getAiController(editor), [editor]);
+
+  const panel = React.useSyncExternalStore(
+    controller.subscribe,
+    () => controller.getState().panel,
+    () => CLOSED_PANEL,
+  );
+
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [prompt, setPrompt] = React.useState('');
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+  const [submenu, setSubmenu] = React.useState<AiCommandDefinition | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  const isOpen = panel.status !== 'closed';
+  const range = isOpen ? controller.getRange() : null;
+  const hasSelection = RangeApi.isExpanded(range);
+  const selectionLength = range ? editor.api.string(range).length : 0;
+
+  // Anchored to the range the panel is acting on — read live, so the panel
+  // follows the text as the document changes under a streaming completion.
+  const getBoundingClientRect = React.useCallback(
+    () => getRangeBoundingClientRect(editor, controller.getRange()),
+    [controller, editor],
+  );
+
+  const floating = useVirtualFloating({
+    getBoundingClientRect,
+    middleware: [offset(8), flip({ padding: 12 }), shift({ padding: 8 })],
+    open: isOpen,
+    placement: 'bottom-start',
+  });
+
+  const { update } = floating;
+
+  // Reposition as the selection moves and as the streamed result grows.
+  useEditorSelector(() => {
+    update?.();
+  }, [update]);
+
+  React.useEffect(() => {
+    update?.();
+  }, [panel, update]);
+
+  const allCommands = editor.getOptions(AiPlugin).commands;
+
+  // Typing filters the command list, so the input doubles as a palette rather
+  // than only ever being a free-form prompt box.
+  const query = prompt.trim().toLowerCase();
+  const visibleCommands = React.useMemo(() => {
+    const available = commandsForSelection(allCommands, hasSelection);
+    if (!query) return available;
+
+    return available.filter((command) =>
+      `${command.label} ${command.description ?? ''}`.toLowerCase().includes(query),
+    );
+  }, [allCommands, hasSelection, query]);
+
+  const sections = React.useMemo(() => groupCommands(visibleCommands), [visibleCommands]);
+
+  // Reset and focus the input each time the panel opens fresh.
+  React.useEffect(() => {
+    if (panel.status === 'menu') {
+      const raf = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(raf);
+    }
+    if (panel.status === 'closed') {
+      setPrompt('');
+      setSubmenu(null);
+      setActiveIndex(-1);
+      setCopied(false);
+    }
+  }, [panel.status]);
+
+  // A filtered-out highlight would run the wrong command on Enter.
+  React.useEffect(() => {
+    setActiveIndex((index) => (index >= visibleCommands.length ? visibleCommands.length - 1 : index));
+  }, [visibleCommands.length]);
+
+  // Escape / click-outside closes the panel without touching the document.
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const onPointerDown = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        controller.close();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (submenu) {
+          setSubmenu(null);
+          return;
+        }
+        controller.close();
+        return;
+      }
+
+      // Cmd/Ctrl+Enter accepts a settled suggestion from anywhere in the panel.
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        if (controller.accept()) event.preventDefault();
+      }
+    };
+
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [controller, isOpen, submenu]);
+
+  if (readOnly || !isOpen) return null;
+
+  const runCommand = (command: AiCommandDefinition) => {
+    if (command.options?.length) {
+      setSubmenu(command);
+      return;
+    }
+    controller.runCommand(command.id);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index) => (visibleCommands.length ? (index + 1) % visibleCommands.length : -1));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        visibleCommands.length ? (index <= 0 ? visibleCommands.length - 1 : index - 1) : -1,
+      );
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const highlighted = activeIndex >= 0 ? visibleCommands[activeIndex] : undefined;
+      if (highlighted) {
+        runCommand(highlighted);
+        return;
+      }
+      if (prompt.trim()) controller.submitPrompt(prompt);
+    }
+  };
+
+  const copyResult = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can be denied; the result is still visible to select.
+    }
+  };
+
+  return (
+    <div
+      aria-label="Ask AI"
+      className="z-50 w-[min(28rem,90vw)] rounded-md border bg-popover p-1 text-popover-foreground shadow-md print:hidden"
+      ref={(node) => {
+        containerRef.current = node;
+        floating.refs.setFloating(node);
+      }}
+      role="dialog"
+      style={floating.style}
+    >
+      <div className="flex items-center gap-2 px-2 py-1.5">
+        <Sparkles className="size-4 shrink-0 text-violet-600" />
+        <input
+          aria-label="Ask AI"
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          onChange={(event) => {
+            setPrompt(event.target.value);
+            setActiveIndex(event.target.value.trim() ? 0 : -1);
+          }}
+          onKeyDown={onInputKeyDown}
+          placeholder={hasSelection ? 'Ask AI to change the selection…' : 'Ask AI anything…'}
+          ref={inputRef}
+          value={prompt}
+        />
+      </div>
+
+      {panel.status === 'menu' && submenu && (
+        <div className="flex max-h-80 flex-col overflow-y-auto">
+          <button
+            className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
+            onClick={() => setSubmenu(null)}
+            type="button"
+          >
+            <ArrowLeft className="size-4 shrink-0 text-muted-foreground" />
+            {submenu.label}
+          </button>
+
+          {submenu.options?.map((option) => (
+            <button
+              className="flex items-center rounded-sm px-2 py-1.5 pl-8 text-sm hover:bg-accent"
+              key={option.id}
+              onClick={() => {
+                setSubmenu(null);
+                controller.runCommand(submenu.id, option.label);
+              }}
+              type="button"
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {panel.status === 'menu' && !submenu && (
+        <>
+          <div className="px-2 pb-1 text-xs text-muted-foreground">
+            {hasSelection
+              ? `${selectionLength.toLocaleString()} characters selected`
+              : 'Nothing selected — select text for rewrite actions'}
+          </div>
+
+          <div className="flex max-h-80 flex-col overflow-y-auto">
+            {sections.length === 0 && (
+              <div className="px-2 py-1.5 text-sm text-muted-foreground">No matching actions</div>
+            )}
+
+            {sections.map((section) => (
+              <div key={section.group}>
+                <div className="px-2 py-1 text-xs font-medium text-muted-foreground">
+                  {AI_COMMAND_GROUP_LABELS[section.group]}
+                </div>
+
+                {section.commands.map((command) => {
+                  const index = visibleCommands.indexOf(command);
+
+                  return (
+                    <button
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                        index === activeIndex && 'bg-accent text-accent-foreground',
+                      )}
+                      key={command.id}
+                      onClick={() => runCommand(command)}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      type="button"
+                    >
+                      <command.icon className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate">{command.label}</span>
+                        {command.description && (
+                          <span className="truncate text-xs text-muted-foreground">
+                            {command.description}
+                          </span>
+                        )}
+                      </span>
+                      {command.options?.length ? (
+                        <span className="ml-auto text-muted-foreground">›</span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {panel.status === 'loading' && (
+        <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
+          <Loader2 className="size-4 shrink-0 animate-spin" />
+          <span>{panel.commandLabel === 'Custom' ? 'Generating…' : `${panel.commandLabel}…`}</span>
+          <button
+            className="ml-auto flex items-center gap-1 rounded-sm px-2 py-1 hover:bg-accent"
+            onClick={() => controller.stop()}
+            type="button"
+          >
+            <Square className="size-3.5" />
+            Stop
+          </button>
+        </div>
+      )}
+
+      {panel.status === 'error' && (
+        <div className="px-2 py-1.5">
+          <p className="text-sm text-destructive">{panel.message}</p>
+          <div className="mt-1 flex flex-wrap">
+            <MenuRow icon={RotateCcw} label="Try again" onClick={() => controller.retry()} />
+            <MenuRow icon={X} label="Dismiss" onClick={() => controller.close()} />
+          </div>
+        </div>
+      )}
+
+      {panel.status === 'reviewing' && (
+        <>
+          <div
+            aria-live="polite"
+            className="mx-1 max-h-60 overflow-y-auto whitespace-pre-wrap rounded-sm bg-muted/50 px-2 py-1.5 text-sm"
+          >
+            {panel.suggestion.suggestedText || '…'}
+          </div>
+
+          {panel.suggestion.isStreaming ? (
+            <div className="flex items-center gap-2 px-2 py-1.5 text-sm text-muted-foreground">
+              <Loader2 className="size-4 shrink-0 animate-spin" />
+              <span>{panel.commandLabel}…</span>
+              <button
+                className="ml-auto flex items-center gap-1 rounded-sm px-2 py-1 hover:bg-accent"
+                onClick={() => controller.stop()}
+                type="button"
+              >
+                <Square className="size-3.5" />
+                Stop
+              </button>
+            </div>
+          ) : (
+            <div className="mt-1 flex flex-wrap">
+              <MenuRow
+                icon={Check}
+                label={panel.suggestion.mode === 'replace' ? 'Replace selection' : 'Insert'}
+                onClick={() => controller.accept()}
+                title="⌘/Ctrl + Enter"
+              />
+              <MenuRow
+                icon={CornerDownRight}
+                label="Insert below"
+                onClick={() => controller.insertBelow()}
+              />
+              <MenuRow icon={RotateCcw} label="Try again" onClick={() => controller.retry()} />
+              <MenuRow
+                icon={Copy}
+                label={copied ? 'Copied' : 'Copy'}
+                onClick={() => void copyResult(panel.suggestion.suggestedText)}
+              />
+              <MenuRow icon={X} label="Discard" onClick={() => controller.close()} />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/reason-editor/src/docs-agent/plate/ui/ai-toolbar-button.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/ai-toolbar-button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import * as React from 'react';
+
+import { SparklesIcon } from 'lucide-react';
+import { useEditorRef } from 'platejs/react';
+
+import { getAiController } from '@/docs-agent/plate/ai-controller';
+import { AI_PLUGIN_KEY } from '@/docs-agent/plate/ai-plugin';
+
+import { ToolbarButton } from './toolbar';
+
+/**
+ * "Ask AI" — the shortest path from highlighting text to rewriting it, and the
+ * entry point both toolbars share. It only opens the panel that
+ * `./ai-menu.tsx` renders; the commands, streaming and review flow all live
+ * there, so this is one more way in rather than a second implementation.
+ *
+ * Renders nothing when the AI plugin is not registered, so it can be dropped
+ * into a toolbar unconditionally — the same contract as the Tiptap bubble's
+ * `AskAiButton`.
+ */
+export function AIToolbarButton(props: React.ComponentProps<typeof ToolbarButton>) {
+  const editor = useEditorRef();
+
+  if (!editor.plugins?.[AI_PLUGIN_KEY]) return null;
+
+  return (
+    <ToolbarButton
+      {...props}
+      onClick={() => getAiController(editor).open()}
+      tooltip="Ask AI (⌘J)"
+    >
+      <SparklesIcon className="text-violet-600" />
+    </ToolbarButton>
+  );
+}

--- a/packages/reason-editor/src/docs-agent/plate/ui/fixed-toolbar-buttons.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/fixed-toolbar-buttons.tsx
@@ -15,6 +15,7 @@ import {
 import { KEYS } from 'platejs';
 import { useEditorReadOnly } from 'platejs/react';
 
+import { AIToolbarButton } from './ai-toolbar-button';
 import { AlignToolbarButton } from './align-toolbar-button';
 import { EmojiToolbarButton } from './emoji-toolbar-button';
 import { InlineEquationToolbarButton } from './equation-toolbar-button';
@@ -51,9 +52,13 @@ import { TurnIntoToolbarButton } from './turn-into-toolbar-button';
  * document-level actions. `ToolbarGroup` draws the dividers, so grouping here is
  * also the visual grouping.
  *
- * Left out on purpose, because their plugins are not installed: the AI menu and
- * Copilot, comments, suggestions and the review/edit mode switch, Excalidraw and
- * code drawings, dates and footnotes.
+ * "Ask AI" leads the row, ahead of history: it is the one control that acts on
+ * the whole document rather than the current mark, and the playground puts it
+ * in the same place.
+ *
+ * Left out on purpose, because their plugins are not installed: Copilot,
+ * comments, suggestions and the review/edit mode switch, Excalidraw and code
+ * drawings, dates and footnotes.
  */
 export function FixedToolbarButtons() {
   const readOnly = useEditorReadOnly();
@@ -62,6 +67,10 @@ export function FixedToolbarButtons() {
 
   return (
     <>
+      <ToolbarGroup>
+        <AIToolbarButton />
+      </ToolbarGroup>
+
       <ToolbarGroup>
         <UndoToolbarButton />
         <RedoToolbarButton />

--- a/packages/reason-editor/src/docs-agent/plate/ui/floating-toolbar-buttons.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/floating-toolbar-buttons.tsx
@@ -12,6 +12,7 @@ import {
 import { KEYS } from 'platejs';
 import { useEditorReadOnly } from 'platejs/react';
 
+import { AIToolbarButton } from './ai-toolbar-button';
 import { InlineEquationToolbarButton } from './equation-toolbar-button';
 import { LinkToolbarButton } from './link-toolbar-button';
 import { MarkToolbarButton } from './mark-toolbar-button';
@@ -19,7 +20,12 @@ import { MoreToolbarButton } from './more-toolbar-button';
 import { ToolbarGroup } from './toolbar';
 import { TurnIntoToolbarButton } from './turn-into-toolbar-button';
 
-/** The selection toolbar: the subset of `./fixed-toolbar-buttons.tsx` worth having under the caret. */
+/**
+ * The selection toolbar: the subset of `./fixed-toolbar-buttons.tsx` worth
+ * having under the caret, led by "Ask AI" — with text already highlighted,
+ * rewriting it is the action the bubble exists for, so it comes before the
+ * formatting controls (the Tiptap bubble orders it the same way).
+ */
 export function FloatingToolbarButtons() {
   const readOnly = useEditorReadOnly();
 
@@ -27,6 +33,10 @@ export function FloatingToolbarButtons() {
 
   return (
     <>
+      <ToolbarGroup>
+        <AIToolbarButton />
+      </ToolbarGroup>
+
       <ToolbarGroup>
         <TurnIntoToolbarButton />
       </ToolbarGroup>

--- a/packages/reason-editor/src/docs-agent/plate/ui/floating-toolbar.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/floating-toolbar.tsx
@@ -13,10 +13,12 @@ import { useComposedRef } from '@udecode/cn';
 import { KEYS } from 'platejs';
 import {
   useEditorId,
+  useEditorRef,
   useEventEditorValue,
   usePluginOption,
 } from 'platejs/react';
 
+import { getAiController } from '@/docs-agent/plate/ai-controller';
 import { cn } from '@/lib/utils';
 
 import { Toolbar } from './toolbar';
@@ -32,12 +34,21 @@ export function FloatingToolbar({
   const editorId = useEditorId();
   const focusedEditorId = useEventEditorValue('focus');
   const isFloatingLinkOpen = !!usePluginOption({ key: KEYS.link }, 'mode');
-  const isAIChatOpen = usePluginOption({ key: KEYS.aiChat }, 'open');
+
+  // The AI panel anchors to the same selection this toolbar does, so they would
+  // otherwise stack on top of each other.
+  const editor = useEditorRef();
+  const aiController = React.useMemo(() => getAiController(editor), [editor]);
+  const isAiMenuOpen = React.useSyncExternalStore(
+    aiController.subscribe,
+    () => aiController.getState().panel.status !== 'closed',
+    () => false,
+  );
 
   const floatingToolbarState = useFloatingToolbarState({
     editorId,
     focusedEditorId,
-    hideToolbar: isFloatingLinkOpen || isAIChatOpen,
+    hideToolbar: isFloatingLinkOpen || isAiMenuOpen,
     ...state,
     floatingOptions: {
       middleware: [

--- a/packages/reason-editor/src/docs-agent/plate/ui/slash-node.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/slash-node.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 
 import type { PlateEditor, PlateElementProps } from 'platejs/react';
 
-import { AIChatPlugin } from '@platejs/ai/react';
 import {
   CalendarIcon,
   ChevronRightIcon,
@@ -29,6 +28,7 @@ import {
 import { type TComboboxInputElement, KEYS } from 'platejs';
 import { PlateElement } from 'platejs/react';
 
+import { getAiController } from '@/docs-agent/plate/ai-controller';
 import {
   insertBlock,
   insertInlineElement,
@@ -64,10 +64,12 @@ const groups: Group[] = [
       {
         focusEditor: false,
         icon: <SparklesIcon />,
+        keywords: ['ask', 'write', 'rewrite', 'assistant'],
         value: 'AI',
-        onSelect: (editor) => {
-          editor.getApi(AIChatPlugin).aiChat.show();
-        },
+        // `InlineComboboxItem` has already removed the `/` trigger by the time
+        // this runs, so the panel opens on the caret left behind — not on the
+        // slash input. `focusEditor: false` leaves the focus for its prompt box.
+        onSelect: (editor) => getAiController(editor).open(),
       },
     ],
   },

--- a/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
+++ b/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
@@ -62,12 +62,7 @@ import { Twitter } from 'react-reason-editor/twitter';
 import { Video } from 'react-reason-editor/video';
 import { WordCount } from 'react-reason-editor/wordcount';
 
-import {
-  Ai,
-  buildAiUserPrompt,
-  createStreamingCompletion,
-  mockAiCompletion,
-} from '@/extensions/Ai';
+import { Ai, createReasonAiCompletion, DEFAULT_AI_ENDPOINT } from '@/extensions/Ai';
 import { Comment } from '@/extensions/Comment';
 import { Drawio } from '@/extensions/Drawio';
 import { Harper } from '@/extensions/Harper';
@@ -141,37 +136,6 @@ const demoBase64Upload = (file: File) => {
     }, 300);
   });
 };
-
-/**
- * Default endpoint the AI writing assistant posts to. It matches the
- * `{ text, prompt } -> { rewrittenText }` contract the QwkSearch web app
- * serves at `/api/agent/rewrite`, which is where this editor is mounted.
- * Hosts without that route point the setting at their own (or clear it) —
- * an empty value falls back to the offline demo transform rather than
- * failing every action.
- */
-const DEFAULT_AI_ENDPOINT = '/api/agent/rewrite';
-
-/**
- * Builds the extension's `getCompletion`. The request carries the whole
- * instruction — the system rules, the surrounding context window and the text
- * to act on — as one prompt, so a plain rewrite route needs no changes to
- * serve every command in the menu.
- */
-const createAiCompletion = (endpoint: string) =>
-  endpoint
-    ? createStreamingCompletion({
-        endpoint,
-        body: (request) => ({
-          // `prompt` carries the real instruction; `text` is the field such
-          // routes validate as non-empty, so the generate commands (which run
-          // with no selection) fall back to their context and instruction.
-          text: request.selectedText || request.documentText || request.instruction,
-          prompt: `${request.systemPrompt}\n\n${buildAiUserPrompt(request)}`,
-          command: request.commandId,
-        }),
-      })
-    : mockAiCompletion;
 
 // ─── Registry ────────────────────────────────────────────────────────────────
 
@@ -742,7 +706,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
     ],
     create: (s) =>
       Ai.configure({
-        getCompletion: createAiCompletion(String(s.endpoint ?? '').trim()),
+        getCompletion: createReasonAiCompletion(String(s.endpoint ?? '').trim()),
         contextChars: Number.isFinite(Number(s.contextChars)) ? Number(s.contextChars) : 4000,
       }),
   },

--- a/packages/reason-editor/src/extensions/Ai/README.md
+++ b/packages/reason-editor/src/extensions/Ai/README.md
@@ -17,6 +17,32 @@ All four open the same floating panel (`AiMenu`): a filterable command palette
 plus a free-form prompt box. Typing filters the commands; `↑`/`↓` and `Enter`
 run one, `Enter` on an empty highlight submits the typed prompt instead.
 
+## On the Plate editor
+
+The Plate engine — `ReasonDocs`' default — has the same assistant, with the
+same four entry points: ✨ Ask AI leads the selection (bubble) toolbar and the
+fixed toolbar, `/ai` is in the slash menu, and `⌘/Ctrl + J` opens it anywhere.
+
+What it shares with this extension is everything that is not ProseMirror:
+`commands.ts`, `lib/prompt.ts`, `lib/sanitizeCompletion.ts`,
+`lib/completionToContent.ts` and `lib/reasonEndpoint.ts`. So both engines offer
+the same commands, send the same request to the same route, and clean the
+response the same way. What differs is the document API and one piece of the
+UX: Slate decorations can only style text that is already in the document, so
+the Plate panel reviews the streamed result in place of the inline red/green
+diff. Nothing is written until the user accepts, on either engine.
+
+The Plate side lives in `src/docs-agent/plate/`: `ai-plugin.ts` (options),
+`ai-controller.ts` (the state machine), `ui/ai-menu.tsx` (the panel),
+`ui/ai-toolbar-button.tsx` and `kits/ai-kit.tsx` (which registers all of it).
+Configure it through `ReasonPlateEditor`'s `ai` prop, or at runtime:
+
+```ts
+import { AiPlugin } from 'react-reason-editor/docs-agent';
+
+editor.setOption(AiPlugin, 'getCompletion', createStreamingCompletion({ endpoint: '/api/ai' }));
+```
+
 ## Review flow
 
 Nothing is applied automatically. While the answer streams the panel shows it

--- a/packages/reason-editor/src/extensions/Ai/index.ts
+++ b/packages/reason-editor/src/extensions/Ai/index.ts
@@ -10,6 +10,7 @@ export * from './components/RichTextAi';
 export { mockAiCompletion } from './lib/mockCompletion';
 export { createStreamingCompletion } from './lib/createStreamingCompletion';
 export type { StreamingCompletionOptions } from './lib/createStreamingCompletion';
+export { createReasonAiCompletion, DEFAULT_AI_ENDPOINT } from './lib/reasonEndpoint';
 export {
   buildAiInstruction,
   buildAiUserPrompt,

--- a/packages/reason-editor/src/extensions/Ai/lib/reasonEndpoint.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/reasonEndpoint.ts
@@ -1,0 +1,53 @@
+/**
+ * The completion function REASON itself ships with: the wire contract the
+ * QwkSearch web app's rewrite route speaks, wrapped around the generic
+ * `createStreamingCompletion` fetch/stream glue.
+ *
+ * It lives in `lib/` — with the rest of the engine-neutral helpers — rather
+ * than next to the Tiptap extension that first used it, because both engines
+ * need it: `editor-views/config/pluginRegistry.tsx` builds the Tiptap `Ai`
+ * extension from it, and `docs-agent/plate/ai-plugin.ts` builds the Plate
+ * plugin from it. One definition means the two editors post the same body to
+ * the same route, so a change to the contract cannot land on only one of them.
+ */
+
+import type { AiCompletionFn } from '../types';
+
+import { createStreamingCompletion } from './createStreamingCompletion';
+import { mockAiCompletion } from './mockCompletion';
+import { buildAiUserPrompt } from './prompt';
+
+/**
+ * Default endpoint the AI writing assistant posts to. It matches the
+ * `{ text, prompt } -> { rewrittenText }` contract the QwkSearch web app
+ * serves at `/api/agent/rewrite`, which is where this editor is mounted.
+ * Hosts without that route point the setting at their own (or clear it) —
+ * an empty value falls back to the offline demo transform rather than
+ * failing every action.
+ */
+export const DEFAULT_AI_ENDPOINT = '/api/agent/rewrite';
+
+/**
+ * Builds a `getCompletion` for `endpoint`. The request carries the whole
+ * instruction — the system rules, the surrounding context window and the text
+ * to act on — as one prompt, so a plain rewrite route needs no changes to
+ * serve every command in the menu.
+ *
+ * An empty `endpoint` yields the offline demo transform, so an editor mounted
+ * without a backing route still demonstrates the flow instead of erroring on
+ * every action.
+ */
+export const createReasonAiCompletion = (endpoint: string): AiCompletionFn =>
+  endpoint
+    ? createStreamingCompletion({
+        endpoint,
+        body: (request) => ({
+          // `prompt` carries the real instruction; `text` is the field such
+          // routes validate as non-empty, so the generate commands (which run
+          // with no selection) fall back to their context and instruction.
+          text: request.selectedText || request.documentText || request.instruction,
+          prompt: `${request.systemPrompt}\n\n${buildAiUserPrompt(request)}`,
+          command: request.commandId,
+        }),
+      })
+    : mockAiCompletion;

--- a/packages/reason-editor/test/docs-agent/ai-controller.test.ts
+++ b/packages/reason-editor/test/docs-agent/ai-controller.test.ts
@@ -1,0 +1,305 @@
+/**
+ * The Plate writing assistant's document-facing behaviour: what it refuses to
+ * run, what the completion function is handed, and — the part that matters
+ * most — what actually lands in the document when a suggestion is accepted.
+ *
+ * The Tiptap counterpart is `test/ai-extension.test.ts`; the cases here follow
+ * it deliberately, because the two engines are meant to behave identically.
+ */
+
+import { createPlateEditor } from 'platejs/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getAiController } from '../../src/docs-agent/plate/ai-controller';
+import { AiPlugin } from '../../src/docs-agent/plate/ai-plugin';
+import { platePlugins } from '../../src/docs-agent/plate/plate-editor-config';
+
+import type { PlateEditor } from 'platejs/react';
+import type { AiCompletionFn, AiCompletionRequest } from '../../src/extensions/Ai/types';
+
+/** A completion that resolves immediately with `text`, recording what it was asked. */
+function stubCompletion(text: string) {
+  const seen: AiCompletionRequest[] = [];
+  const fn: AiCompletionFn = async (request, onChunk) => {
+    seen.push(request);
+    onChunk(text);
+    return text;
+  };
+
+  return { fn, seen };
+}
+
+function createEditor(paragraphs: string[], getCompletion: AiCompletionFn) {
+  const editor = createPlateEditor({
+    plugins: platePlugins as any,
+    value: paragraphs.map((text) => ({ children: [{ text }], type: 'p' })),
+  });
+
+  editor.setOption(AiPlugin, 'getCompletion', getCompletion);
+
+  return editor;
+}
+
+/** Selects `[start, end)` of the first paragraph and opens the panel over it. */
+function selectAndOpen(editor: PlateEditor, start: number, end: number) {
+  editor.tf.select({
+    anchor: { offset: start, path: [0, 0] },
+    focus: { offset: end, path: [0, 0] },
+  });
+
+  const controller = getAiController(editor);
+  controller.open();
+
+  return controller;
+}
+
+describe('plate ai controller', () => {
+  it('lets a second AiPlugin entry override the registered options', () => {
+    // What `ReasonPlateEditor`'s `ai` prop relies on: Plate merges plugins that
+    // share a key, and the later entry wins.
+    const editor = createPlateEditor({
+      plugins: [...platePlugins, AiPlugin.configure({ options: { contextChars: 7 } })] as any,
+      value: [{ children: [{ text: 'Hello world' }], type: 'p' }],
+    });
+
+    expect(editor.getOptions(AiPlugin).contextChars).toBe(7);
+    // Everything not overridden keeps the registered default.
+    expect(editor.getOptions(AiPlugin).commands.length).toBeGreaterThan(0);
+    expect(typeof editor.getOptions(AiPlugin).getCompletion).toBe('function');
+  });
+
+  it('refuses a rewrite command when nothing is selected', () => {
+    const { fn, seen } = stubCompletion('rewritten');
+    const editor = createEditor(['Hello world'], fn);
+
+    editor.tf.select({ offset: 5, path: [0, 0] });
+    const controller = getAiController(editor);
+    controller.open();
+
+    expect(controller.runCommand('improve')).toBe(false);
+    expect(seen).toHaveLength(0);
+    expect(controller.getState().panel.status).toBe('menu');
+  });
+
+  it('runs a generate command with no selection', async () => {
+    const { fn, seen } = stubCompletion('A continuation.');
+    const editor = createEditor(['Hello world'], fn);
+
+    editor.tf.select({ offset: 11, path: [0, 0] });
+    const controller = getAiController(editor);
+    controller.open();
+
+    expect(controller.runCommand('continue')).toBe(true);
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0].mode).toBe('insert');
+    expect(seen[0].selectedText).toBe('');
+  });
+
+  it('sends the selection, a bounded context window and the system prompt', async () => {
+    const { fn, seen } = stubCompletion('planet');
+    const editor = createEditor(['Hello world', 'A second paragraph.'], fn);
+    editor.setOption(AiPlugin, 'contextChars', 4);
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+
+    const request = seen[0];
+    expect(request.selectedText).toBe('world');
+    expect(request.mode).toBe('replace');
+    expect(request.commandId).toBe('improve');
+    expect(request.systemPrompt).toContain('writing assistant');
+    // Clamped from both sides of the selection, never the whole document.
+    expect(request.documentText.length).toBeLessThanOrEqual(6);
+    expect(request.documentText).not.toContain('second paragraph');
+  });
+
+  it('sends no context at all when the budget is zero', async () => {
+    const { fn, seen } = stubCompletion('planet');
+    const editor = createEditor(['Hello world'], fn);
+    editor.setOption(AiPlugin, 'contextChars', 0);
+
+    selectAndOpen(editor, 6, 11).runCommand('improve');
+
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0].documentText).toBe('');
+  });
+
+  it('appends the submenu choice to the instruction', async () => {
+    const { fn, seen } = stubCompletion('mundo');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 6, 11);
+
+    // Translate needs a target language before it can run.
+    expect(controller.runCommand('translate')).toBe(false);
+    expect(controller.runCommand('translate', 'Spanish')).toBe(true);
+
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    expect(seen[0].instruction).toContain('Spanish');
+    expect(seen[0].option).toBe('Spanish');
+  });
+
+  it('reviews the suggestion without touching the document', async () => {
+    const { fn } = stubCompletion('Sure, here is the rewrite:\nplanet  ');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => {
+      const { panel } = controller.getState();
+      expect(panel.status).toBe('reviewing');
+      if (panel.status !== 'reviewing') return;
+      expect(panel.suggestion.isStreaming).toBe(false);
+      // The preamble the model volunteered is stripped before review, so what
+      // is shown is what accepting writes.
+      expect(panel.suggestion.suggestedText).toBe('planet');
+    });
+
+    expect(editor.api.string([])).toBe('Hello world');
+  });
+
+  it('replaces the selection on accept', async () => {
+    const { fn } = stubCompletion('planet');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+
+    expect(controller.accept()).toBe(true);
+    expect(editor.api.string([])).toBe('Hello planet');
+    expect(controller.getState().panel.status).toBe('closed');
+  });
+
+  it('accepts Markdown as real blocks rather than literal punctuation', async () => {
+    const { fn } = stubCompletion('- first\n- second');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 0, 11);
+    controller.runCommand('key-points');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+    controller.accept();
+
+    const text = editor.api.string([]);
+    expect(text).toContain('first');
+    expect(text).toContain('second');
+    expect(text).not.toContain('- first');
+    expect(text).not.toContain('Hello world');
+  });
+
+  it('leaves the original text alone when inserting below', async () => {
+    const { fn } = stubCompletion('An added paragraph.');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 0, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+
+    expect(controller.insertBelow()).toBe(true);
+    expect(editor.children).toHaveLength(2);
+    expect(editor.api.string([0])).toBe('Hello world');
+    expect(editor.api.string([1])).toBe('An added paragraph.');
+  });
+
+  it('refuses to accept while the response is still streaming', async () => {
+    const editor = createEditor(['Hello world'], async (_request, onChunk) => {
+      onChunk('pla');
+      // Never settles: the request stays in flight for the length of the test.
+      return new Promise<string>(() => {});
+    });
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+
+    expect(controller.accept()).toBe(false);
+    expect(editor.api.string([])).toBe('Hello world');
+
+    // Stopping keeps what already arrived, so a partial result is still usable.
+    controller.stop();
+    const { panel } = controller.getState();
+    expect(panel.status).toBe('reviewing');
+    if (panel.status !== 'reviewing') return;
+    expect(panel.suggestion.isStreaming).toBe(false);
+    expect(controller.accept()).toBe(true);
+    expect(editor.api.string([])).toBe('Hello pla');
+  });
+
+  it('surfaces a failed request as an error the user can retry', async () => {
+    let attempts = 0;
+    const editor = createEditor(['Hello world'], async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('Model unavailable.');
+      return 'planet';
+    });
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => {
+      const { panel } = controller.getState();
+      expect(panel.status).toBe('error');
+      if (panel.status !== 'error') return;
+      expect(panel.message).toBe('Model unavailable.');
+    });
+
+    expect(editor.api.string([])).toBe('Hello world');
+
+    expect(controller.retry()).toBe(true);
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+    controller.accept();
+    expect(editor.api.string([])).toBe('Hello planet');
+  });
+
+  it('reports an empty response instead of writing nothing', async () => {
+    const { fn } = stubCompletion('   ');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('error'));
+    expect(editor.api.string([])).toBe('Hello world');
+  });
+
+  it('follows edits made while the response streams', async () => {
+    const editor = createEditor(['Hello world'], async (_request, onChunk) => {
+      onChunk('planet');
+      return 'planet';
+    });
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+
+    // Text typed before the target range shifts it; the range ref keeps up, so
+    // accepting still replaces "world" rather than whatever now sits at 6..11.
+    editor.tf.insertText('Oh, ', { at: { offset: 0, path: [0, 0] } });
+    controller.accept();
+
+    expect(editor.api.string([])).toBe('Oh, Hello planet');
+  });
+
+  it('closes without writing when the suggestion is discarded', async () => {
+    const { fn } = stubCompletion('planet');
+    const editor = createEditor(['Hello world'], fn);
+
+    const controller = selectAndOpen(editor, 6, 11);
+    controller.runCommand('improve');
+
+    await vi.waitFor(() => expect(controller.getState().panel.status).toBe('reviewing'));
+
+    controller.close();
+    expect(controller.getState().panel.status).toBe('closed');
+    expect(controller.getRange()).toBeNull();
+    expect(editor.api.string([])).toBe('Hello world');
+  });
+});

--- a/packages/reason-editor/test/docs-agent/ai-menu.test.tsx
+++ b/packages/reason-editor/test/docs-agent/ai-menu.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Mounts the AI panel over a real Plate editor.
+ *
+ * The controller's behaviour is covered by `./ai-controller.test.ts`; what is
+ * checked here is the wiring that only exists once React is involved — that the
+ * plugin renders the panel after the editable at all, that the toolbar button
+ * opens it, that the command list reflects the selection, and that Escape
+ * closes it without writing anything.
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Plate, usePlateEditor } from 'platejs/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { getAiController } from '@/docs-agent/plate/ai-controller';
+import { platePlugins } from '@/docs-agent/plate/plate-editor-config';
+import { AIToolbarButton } from '@/docs-agent/plate/ui/ai-toolbar-button';
+import { Editor, EditorContainer } from '@/docs-agent/plate/ui/editor';
+import { FixedToolbar } from '@/docs-agent/plate/ui/fixed-toolbar';
+
+import type { PlateEditor } from 'platejs/react';
+
+// Floating UI's `autoUpdate` observes the anchor; jsdom has no ResizeObserver.
+class NoopResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// The panel anchors to the DOM range behind the Slate selection. jsdom's
+// `Range` implements no layout, so measuring it has to be faked or Floating
+// UI's async positioning rejects — which says nothing about the component.
+const EMPTY_RECT = {
+  bottom: 0,
+  height: 0,
+  left: 0,
+  right: 0,
+  toJSON: () => ({}),
+  top: 0,
+  width: 0,
+  x: 0,
+  y: 0,
+} as DOMRect;
+
+Range.prototype.getBoundingClientRect ??= () => EMPTY_RECT;
+Range.prototype.getClientRects ??= () =>
+  ({ item: () => null, length: 0, [Symbol.iterator]: function* () {} }) as unknown as DOMRectList;
+
+function Harness({ onEditor }: { onEditor: (editor: PlateEditor) => void }) {
+  const editor = usePlateEditor({
+    plugins: platePlugins,
+    value: [{ children: [{ text: 'Hello world' }], type: 'p' }],
+  });
+
+  onEditor(editor);
+
+  return (
+    <Plate editor={editor}>
+      <FixedToolbar>
+        <AIToolbarButton />
+      </FixedToolbar>
+      <EditorContainer>
+        <Editor />
+      </EditorContainer>
+    </Plate>
+  );
+}
+
+describe('plate ai menu', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let editor: PlateEditor;
+
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', NoopResizeObserver);
+
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => {
+      root.render(<Harness onEditor={(next) => (editor = next)} />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  function panel() {
+    return container.querySelector('[role="dialog"][aria-label="Ask AI"]');
+  }
+
+  it('renders nothing until the panel is opened', () => {
+    expect(panel()).toBeNull();
+  });
+
+  it('opens from the toolbar button and closes on Escape', () => {
+    act(() => {
+      editor.tf.select({
+        anchor: { offset: 0, path: [0, 0] },
+        focus: { offset: 11, path: [0, 0] },
+      });
+    });
+
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+
+    act(() => {
+      button!.click();
+    });
+
+    const opened = panel();
+    expect(opened).not.toBeNull();
+    expect(opened!.textContent).toContain('11 characters selected');
+    // The rewrite commands are offered because there is a selection.
+    expect(opened!.textContent).toContain('Improve writing');
+    expect(opened!.textContent).toContain('Translate');
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' }));
+    });
+
+    expect(panel()).toBeNull();
+    expect(getAiController(editor).getState().panel.status).toBe('closed');
+    expect(editor.api.string([])).toBe('Hello world');
+  });
+
+  it('offers only the commands that work at a bare caret', () => {
+    act(() => {
+      editor.tf.select({ offset: 11, path: [0, 0] });
+      getAiController(editor).open();
+    });
+
+    const opened = panel();
+    expect(opened).not.toBeNull();
+    expect(opened!.textContent).toContain('Nothing selected');
+    expect(opened!.textContent).toContain('Continue writing');
+    expect(opened!.textContent).not.toContain('Improve writing');
+  });
+});

--- a/skills/ask-reason-editor/SKILL.md
+++ b/skills/ask-reason-editor/SKILL.md
@@ -82,6 +82,18 @@ remote embed regardless.
 `buildExtensions` already includes it; a host assembling its own array must add it or
 remapped combos stop working.
 
+**The AI writing assistant.** One feature, two front ends. Everything that is not
+engine-specific — the command list, the prompts, the response sanitiser, the
+Markdown-to-nodes conversion and the `/api/agent/rewrite` contract — lives in
+`src/extensions/Ai/lib/*` and `commands.ts` and is shared. Tiptap mounts it as the `Ai`
+extension (`src/extensions/Ai/Ai.ts`, configured through the plugin registry, so its
+endpoint is editable under Settings → Plugins → AI Writing); Plate mounts it as
+`AiKit` (`src/docs-agent/plate/ai-plugin.ts` + `ai-controller.ts` + `ui/ai-menu.tsx`),
+already in `platePlugins`, and configured with `ReasonPlateEditor`'s `ai` prop or
+`editor.setOption(AiPlugin, 'getCompletion', …)`. On both engines it opens from the
+selection bubble, the toolbar, `/ai` and `⌘J`, and writes nothing until the user
+accepts. Adding a command means editing `src/extensions/Ai/commands.ts` once.
+
 **Collaboration.** `@hocuspocus/provider` + the Tiptap collaboration extensions, against
 `apps/collaboration-server`.
 
@@ -101,4 +113,6 @@ remapped combos stop working.
 | Sidebar sections are missing | `onGenerateTips` / `onGenerateTopics` / `onSearchTopic` / `onSignIn` are optional, and omitting one hides its section. |
 | Closing several tabs at once collapses to one | Implement `onExtraTabsClose` — the fallback issues repeated `onExtraTabClose` calls against pre-close state. |
 | KaTeX/Mermaid fail offline | `externalLibsMode: 'cdn'`. Switch to `'bundled'`. |
+| Every AI action errors | The default endpoint is the web app's `/api/agent/rewrite`. Point `getCompletion` at your own route, or clear the endpoint (Tiptap) / pass `createReasonAiCompletion('')` (Plate) to fall back to the offline demo transform. |
+| An AI command is missing from the menu | Commands that rewrite a selection are hidden at a collapsed caret by design. `requiresSelection: false` makes one available anyway. |
 | Consumers get stale types | `bun run build` runs `vite build`; `build:lib` is the library target and `deploy` also builds the demo. |


### PR DESCRIPTION
## What was missing

`ReasonDocs` mounts **Plate** by default, and Plate had no AI at all:

- the selection (bubble) toolbar had no "Ask AI"
- `fixed-toolbar-buttons.tsx` said in its own comment that the AI menu was *"left out on purpose, because their plugins are not installed"*
- the slash menu's ✨ AI item called `editor.getApi(AIChatPlugin).aiChat.show()` — a plugin that was never registered, so a dead entry

Tiptap has had the assistant since `src/extensions/Ai`.

## Approach: share the feature, don't fork it

Everything in `src/extensions/Ai/` that isn't ProseMirror-specific is engine-neutral, so both editors now run on it — the command list, the prompts, the response sanitiser, the Markdown→nodes conversion, and, newly lifted out of `pluginRegistry.tsx` into `extensions/Ai/lib/reasonEndpoint.ts`, the `/api/agent/rewrite` contract and its default endpoint. Both engines therefore offer the same commands, post the same body to the same route, and clean the response the same way. Adding a command still means editing `commands.ts` once.

The Plate front end is a plugin, a per-editor controller and a floating panel:

| File | Role |
| --- | --- |
| `docs-agent/plate/ai-plugin.ts` | options (commands, `getCompletion`, system prompt, context budget) |
| `docs-agent/plate/ai-controller.ts` | the state machine, streaming and abort, and the document writes |
| `docs-agent/plate/ui/ai-menu.tsx` | the floating panel |
| `docs-agent/plate/ui/ai-toolbar-button.tsx` | ✨ Ask AI, shared by both toolbars |
| `docs-agent/plate/kits/ai-kit.tsx` | wires the three together, plus ⌘J |

Registering `AiKit` in `platePlugins` is all a surface needs: the panel comes with it through `render.afterEditable`, so `PlateEditorWrapper`, `ReasonPlateEditor` and the playground all get the assistant with no wiring of their own.

## Entry points

| Trigger | Where |
| --- | --- |
| ✨ Ask AI | head of the selection (bubble) toolbar |
| ✨ Ask AI | head of the fixed toolbar |
| `/ai` | slash menu — the dead item now works |
| `⌘/Ctrl + J` | anywhere in the editor |

All four open the same panel: a filterable command palette plus a free-form prompt box, then Replace selection (`⌘↵`) / Insert below / Try again / Copy / Discard.

## One deliberate difference from Tiptap

Tiptap reviews a suggestion as an inline red/green diff over the selection. Slate decorations can only style text that is **already in the document**, so rendering an unaccepted suggestion inline would mean writing it first — which the feature's first rule forbids. The Plate panel shows the streamed result in the panel instead.

Everything else is identical: same commands, same request, same sanitising, and nothing written until the user accepts. The target range is held in a Slate `rangeRef`, so edits made while the answer streams don't move the replacement.

## Deliberately out of scope

- **No AI button in the shared `REASON_TOOLBAR` schema.** It is the engine-parity contract, and the Tiptap comparison surface (`ReasonTiptapEditor`, which mounts `NovelEditor` directly) never renders `AiMenu` — the button would be dead on one of the two engines it declares.
- **Plate does not read the Tiptap plugin registry's saved AI settings** (endpoint, `contextChars`). That config is a Tiptap-extension store; the Plate plugin defaults to the same endpoint, so out-of-the-box behaviour matches, and hosts override it through `ReasonPlateEditor`'s new `ai` prop or `editor.setOption(AiPlugin, …)`.
- **`@platejs/ai` is now an unused dependency** — the slash menu was its only consumer. Left declared rather than desync `bun.lock` while install is already broken (see below).

## Verification

`bunx tsc --noEmit` clean, and `bunx vitest run` in `packages/reason-editor` green: **55 files, 607 tests**, including 18 new ones — `test/docs-agent/ai-controller.test.ts` (mirroring the Tiptap `test/ai-extension.test.ts`) and `test/docs-agent/ai-menu.test.tsx` (mounts the panel over a real editor).

Both need three builds first, or they fail on module resolution in ways unrelated to the change under test — worth knowing before concluding a Plate edit broke something:

- `packages/use-voice-control` and `packages/reason-editor-sidebar`, or `transcribe-controller.test.ts`, `playground-editor.test.tsx` and the `ReasonDocs` tests cannot collect;
- `packages/reason-editor` itself (`bun run build:lib`), or the three tests reaching the plugin registry cannot resolve the package's own subpath exports (`react-reason-editor/blockquote`, …), which point into `dist/`.

The repo-wide `bun install` outage already recorded in `TODO.md` (`api2client@^1.0.1`, `grab-url@^1.6.23`) is untouched: those two specifiers were downgraded locally to get a `node_modules` to test against, and reverted before committing — exactly as that entry warns against shipping.

## Docs

`TODO.md` entry, a "On the Plate editor" section in `src/extensions/Ai/README.md`, and a recipe plus two troubleshooting rows in `skills/ask-reason-editor/SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUgU7cNHBzjsQv44mkCGdY

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUgU7cNHBzjsQv44mkCGdY)_