### PR TITLE
Port AI writing assistant from Tiptap to Plate editor

### DIFF
--- a/packages/reason-editor/src/docs-agent.ts
+++ b/packages/reason-editor/src/docs-agent.ts
@@ -104,6 +104,18 @@ export {
   ReasonPlaygroundEditor,
   type ReasonPlaygroundEditorProps,
 } from './docs-agent/plate/playground-editor';
+export {
+  AiPlugin,
+  DEFAULT_PLATE_AI_OPTIONS,
+  getPlateAiController,
+  type PlateAiController,
+  type PlateAiOptions,
+  type PlateAiPanel,
+  type PlateAiSuggestion,
+} from './docs-agent/plate/ai-controller';
+export { AiKit, createAiKit } from './docs-agent/plate/kits/ai-kit';
+export { AIMenu } from './docs-agent/plate/ui/ai-menu';
+export { AIToolbarButton } from './docs-agent/plate/ui/ai-toolbar-button';
 export { REASON_TOOLBAR_SKIN } from './docs-agent/plate/ui/reason-toolbar-skin';
 export { FixedToolbar } from './docs-agent/plate/ui/fixed-toolbar';
 export { FixedToolbarButtons } from './docs-agent/plate/ui/fixed-toolbar-buttons';

--- a/packages/reason-editor/src/docs-agent/plate/ai-controller.ts
+++ b/packages/reason-editor/src/docs-agent/plate/ai-controller.ts
@@ -1,0 +1,498 @@
+/**
+ * The writing assistant for the Plate editor — the state machine behind the
+ * bubble menu's "Ask AI" button, ported from the Tiptap side's
+ * `src/extensions/Ai/Ai.ts`. Read that extension's doc comment first: the
+ * command set, the prompt construction, the response sanitising and the review
+ * flow are literally the same modules (`src/extensions/Ai/{commands,lib}`), so
+ * a rewrite asks the same route for the same thing on either engine.
+ *
+ * Only the document half is re-implemented here, because Slate has no
+ * ProseMirror plugin state to hang a panel off and no decorations to render a
+ * diff with:
+ *
+ *   - State lives in a per-editor controller (a `WeakMap` + subscribe/notify),
+ *     the same shape `./transcribe-controller.ts` uses, rather than in
+ *     transaction metadata. Components read it with `useSyncExternalStore`.
+ *   - The review surface is the panel's preview, not an inline red/green diff.
+ *     What that preserves is the rule that matters: nothing reaches the
+ *     document until the user accepts, and what is written is the sanitised,
+ *     Markdown-aware content the preview showed.
+ *   - The range a request was launched against is captured when the menu opens
+ *     and is not mapped through later edits — the panel is modal in practice
+ *     (its input holds focus, clicking the document closes it), so there is no
+ *     transaction to map through.
+ *
+ * The plugin is keyed `KEYS.aiChat` and mirrors the panel's open/closed state
+ * into its `open` option because that is the flag `./ui/floating-toolbar.tsx`
+ * already checks (`usePluginOption({ key: KEYS.aiChat }, 'open')`) to get the
+ * selection toolbar out of the way — the same contract Plate's own AI kit has
+ * with that component.
+ */
+
+import { KEYS, NodeApi, PathApi, RangeApi, type Descendant, type TRange } from 'platejs';
+import { createPlatePlugin, type PlateEditor } from 'platejs/react';
+
+import { DEFAULT_AI_COMMANDS } from '@/extensions/Ai/commands';
+import { needsRichInsert } from '@/extensions/Ai/lib/completionToContent';
+import {
+  AI_SYSTEM_PROMPT,
+  buildAiInstruction,
+  clampContext,
+  commandsForSelection,
+} from '@/extensions/Ai/lib/prompt';
+import { createRewriteCompletion, DEFAULT_AI_ENDPOINT } from '@/extensions/Ai/lib/rewriteEndpoint';
+import { sanitizeCompletion } from '@/extensions/Ai/lib/sanitizeCompletion';
+
+import type {
+  AiCommandDefinition,
+  AiCompletionFn,
+  AiSuggestionMode,
+} from '@/extensions/Ai/types';
+
+export type { AiCommandDefinition, AiCompletionFn, AiSuggestionMode };
+
+/** Options the `AiPlugin` carries; the controller reads them on every request. */
+export interface PlateAiOptions {
+  /** Quick commands offered in the panel. Same defaults as the Tiptap extension. */
+  commands: AiCommandDefinition[];
+  /** Runs a completion. Defaults to the shared rewrite endpoint. */
+  getCompletion: AiCompletionFn;
+  /** System message sent with every request. */
+  systemPrompt: string;
+  /** How much surrounding text (characters) is sent as context. `0` sends none. */
+  contextChars: number;
+  /**
+   * Whether the panel is open. Mirrored from the panel state rather than set by
+   * hand — `./ui/floating-toolbar.tsx` reads it to hide the selection toolbar
+   * while the panel is up.
+   */
+  open: boolean;
+}
+
+/** A suggestion being reviewed. Nothing here is in the document yet. */
+export interface PlateAiSuggestion {
+  originalText: string;
+  suggestedText: string;
+  mode: AiSuggestionMode;
+  /** True while text is still streaming in; accept/insert-below stay disabled. */
+  isStreaming: boolean;
+}
+
+export type PlateAiPanel =
+  | { status: 'closed' }
+  | { status: 'menu'; range: TRange }
+  | { status: 'loading'; range: TRange; commandLabel: string }
+  | {
+      status: 'reviewing';
+      range: TRange;
+      suggestion: PlateAiSuggestion;
+      commandLabel: string;
+    }
+  | { status: 'error'; range: TRange; commandLabel: string; message: string };
+
+/** The last request that ran, so "Try again" can re-issue it without retyping. */
+interface PlateAiLastRequest {
+  instruction: string;
+  commandId: string;
+  commandLabel: string;
+  option?: string;
+  range: TRange;
+}
+
+export interface PlateAiController {
+  /** Opens the command menu over the current selection. */
+  open(): void;
+  /** Closes the panel and cancels anything in flight. Writes nothing. */
+  close(): void;
+  /** Runs a quick command by id, with the submenu choice it needs, if any. */
+  runCommand(commandId: string, option?: string): boolean;
+  /** Runs a free-form instruction typed into the panel. */
+  submitPrompt(instruction: string): boolean;
+  /** Re-issues the last request against the same range. */
+  retry(): boolean;
+  /** Stops generating, keeping whatever has already streamed in. */
+  stop(): void;
+  /** Writes the suggestion over the range it was asked about. */
+  accept(): boolean;
+  /** Writes the suggestion into a new block after the range, leaving it intact. */
+  insertBelow(): boolean;
+  /** Same as `close` — named for the button that calls it. */
+  discard(): void;
+  /** Commands available for the panel's current range. */
+  availableCommands(): AiCommandDefinition[];
+  getState(): PlateAiPanel;
+  subscribe(listener: () => void): () => void;
+}
+
+export const DEFAULT_PLATE_AI_OPTIONS: PlateAiOptions = {
+  commands: DEFAULT_AI_COMMANDS,
+  getCompletion: createRewriteCompletion(DEFAULT_AI_ENDPOINT),
+  systemPrompt: AI_SYSTEM_PROMPT,
+  contextChars: 4000,
+  open: false,
+};
+
+/**
+ * Registers the assistant. `render.afterEditable` (the panel) is attached in
+ * `./kits/ai-kit.tsx`, which is what a host should spread into its plugin list;
+ * this is the plugin the options and the `mod+j` shortcut live on.
+ */
+export const AiPlugin = createPlatePlugin({
+  key: KEYS.aiChat,
+  options: DEFAULT_PLATE_AI_OPTIONS,
+  shortcuts: {
+    openAiMenu: {
+      keys: 'mod+j',
+      handler: ({ editor }) => {
+        getPlateAiController(editor).open();
+        return true;
+      },
+    },
+  },
+});
+
+const controllers = new WeakMap<PlateEditor, PlateAiController>();
+
+/** The range a panel state was launched against, if it has one. */
+function panelRange(panel: PlateAiPanel): TRange | null {
+  return panel.status === 'closed' ? null : panel.range;
+}
+
+/** Text of a range, one line per block — `editor.api.string` runs blocks together. */
+function rangeText(editor: PlateEditor, at: TRange): string {
+  try {
+    const fragment = editor.api.fragment(at) ?? [];
+    return fragment.map((node) => NodeApi.string(node as any)).join('\n');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * The document text sent as context: a window centred on the range rather than
+ * the whole document, so cost and latency stay bounded on a long file. Mirrors
+ * `readContextWindow` in `src/extensions/Ai/Ai.ts`.
+ */
+function readContextWindow(editor: PlateEditor, at: TRange, budget: number): string {
+  if (budget <= 0) return '';
+
+  const docStart = editor.api.start([]);
+  const docEnd = editor.api.end([]);
+  if (!docStart || !docEnd) return '';
+
+  const before = rangeText(editor, { anchor: docStart, focus: RangeApi.start(at) });
+  const after = rangeText(editor, { anchor: RangeApi.end(at), focus: docEnd });
+
+  const half = Math.floor(budget / 2);
+  const head = clampContext(before, half);
+  const tail =
+    after.length > budget - head.length ? `${after.slice(0, budget - head.length)}…` : after;
+
+  return `${head}${head && tail ? '\n' : ''}${tail}`.trim();
+}
+
+/**
+ * The content to write for a suggestion: a bare string when the answer is a
+ * single-line rewrite (so the marks already on the range survive), and real
+ * nodes when it carries Markdown structure or spans paragraphs — the same
+ * `needsRichInsert` split the Tiptap side makes before `insertContentAt`.
+ */
+function completionToNodes(editor: PlateEditor, text: string): string | Descendant[] {
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+  if (!needsRichInsert(trimmed)) return trimmed;
+
+  try {
+    const nodes = (editor.api as any).markdown?.deserialize?.(trimmed) as
+      | Descendant[]
+      | undefined;
+    if (nodes?.length) return nodes;
+  } catch {
+    // Markdown plugin missing or the answer would not parse — fall through to
+    // paragraphs, which is still better than writing "- " into the document.
+  }
+
+  return trimmed
+    .split(/\n{2,}/)
+    .map((block) => ({ type: KEYS.p, children: [{ text: block.trim() }] }) as Descendant);
+}
+
+/** Wraps a plain-text result into blocks, for the insert-below path. */
+function asBlocks(content: string | Descendant[]): Descendant[] {
+  if (typeof content !== 'string') return content;
+  return content
+    .split(/\n{2,}/)
+    .map((block) => ({ type: KEYS.p, children: [{ text: block.trim() }] }) as Descendant);
+}
+
+function createController(editor: PlateEditor): PlateAiController {
+  let panel: PlateAiPanel = { status: 'closed' };
+  let lastRequest: PlateAiLastRequest | null = null;
+  let abortController: AbortController | null = null;
+  let requestToken = 0;
+
+  const listeners = new Set<() => void>();
+
+  const readOptions = (): PlateAiOptions => ({
+    ...DEFAULT_PLATE_AI_OPTIONS,
+    ...(editor.getOptions(AiPlugin) as Partial<PlateAiOptions> | undefined),
+  });
+
+  const setPanel = (next: PlateAiPanel) => {
+    panel = next;
+    // Keeps the selection toolbar out of the panel's way; see the module doc.
+    try {
+      editor.setOption(AiPlugin, 'open', next.status !== 'closed');
+    } catch {
+      // The plugin is not registered on this editor — the panel simply has no
+      // toolbar to coordinate with.
+    }
+    listeners.forEach((listener) => listener());
+  };
+
+  /** Cancels any in-flight request so a late chunk cannot revive a closed panel. */
+  const cancelInFlight = () => {
+    abortController?.abort();
+    abortController = null;
+    requestToken += 1;
+  };
+
+  /** Where a request acts: the panel's captured range, else the live selection. */
+  const currentRange = (): TRange | null =>
+    panelRange(panel) ?? editor.selection ?? null;
+
+  async function run(request: {
+    instruction: string;
+    commandId: string;
+    commandLabel: string;
+    option?: string;
+    range: TRange;
+  }) {
+    const options = readOptions();
+    const { range } = request;
+    const selectedText = RangeApi.isCollapsed(range) ? '' : rangeText(editor, range);
+    const documentText = readContextWindow(editor, range, options.contextChars);
+    const mode: AiSuggestionMode = selectedText ? 'replace' : 'insert';
+
+    cancelInFlight();
+    const controller = new AbortController();
+    abortController = controller;
+    const token = requestToken;
+
+    lastRequest = {
+      instruction: request.instruction,
+      commandId: request.commandId,
+      commandLabel: request.commandLabel,
+      option: request.option,
+      range,
+    };
+    setPanel({ status: 'loading', range, commandLabel: request.commandLabel });
+
+    const showSuggestion = (text: string, isStreaming: boolean) => {
+      if (token !== requestToken) return;
+      setPanel({
+        status: 'reviewing',
+        range,
+        commandLabel: request.commandLabel,
+        suggestion: {
+          originalText: selectedText,
+          suggestedText: sanitizeCompletion(text, { streaming: isStreaming }),
+          mode,
+          isStreaming,
+        },
+      });
+    };
+
+    try {
+      const result = await options.getCompletion(
+        {
+          instruction: request.instruction,
+          selectedText,
+          documentText,
+          commandId: request.commandId,
+          commandLabel: request.commandLabel,
+          option: request.option,
+          systemPrompt: options.systemPrompt,
+          mode,
+        },
+        (chunk) => showSuggestion(chunk, true),
+        controller.signal,
+      );
+
+      if (token !== requestToken) return;
+
+      if (!sanitizeCompletion(result)) {
+        setPanel({
+          status: 'error',
+          range,
+          commandLabel: request.commandLabel,
+          message: 'The model returned an empty response.',
+        });
+        return;
+      }
+
+      showSuggestion(result, false);
+    } catch (error) {
+      if (controller.signal.aborted || token !== requestToken) return;
+      setPanel({
+        status: 'error',
+        range,
+        commandLabel: request.commandLabel,
+        message: error instanceof Error ? error.message : 'Something went wrong.',
+      });
+    }
+  }
+
+  /** Writes `content` at `at`, replacing whatever it covers. */
+  const writeAt = (at: TRange, content: string | Descendant[]) => {
+    editor.tf.select(at);
+    if (typeof content === 'string') editor.tf.insertText(content);
+    else editor.tf.insertFragment(content as any);
+    editor.tf.focus();
+  };
+
+  return {
+    open() {
+      cancelInFlight();
+      const range = editor.selection;
+      if (!range) {
+        const end = editor.api.end([]);
+        if (!end) return;
+        setPanel({ status: 'menu', range: { anchor: end, focus: end } });
+        return;
+      }
+      setPanel({ status: 'menu', range });
+    },
+
+    close() {
+      cancelInFlight();
+      setPanel({ status: 'closed' });
+    },
+
+    runCommand(commandId, option) {
+      const options = readOptions();
+      const command = options.commands.find((c) => c.id === commandId);
+      if (!command) return false;
+
+      const range = currentRange();
+      if (!range) return false;
+
+      // A command that rewrites a selection has nothing to act on when the
+      // caret is collapsed; running it anyway produces a confident answer about
+      // nothing, so refuse instead.
+      if (command.requiresSelection !== false && RangeApi.isCollapsed(range)) return false;
+      if (command.options?.length && !option) return false;
+
+      void run({
+        instruction: buildAiInstruction(command, option),
+        commandId: command.id,
+        commandLabel: option ? `${command.label} → ${option}` : command.label,
+        option,
+        range,
+      });
+      return true;
+    },
+
+    submitPrompt(instruction) {
+      const trimmed = instruction.trim();
+      if (!trimmed) return false;
+
+      const range = currentRange();
+      if (!range) return false;
+
+      void run({
+        instruction: trimmed,
+        commandId: 'custom',
+        commandLabel: 'Custom',
+        range,
+      });
+      return true;
+    },
+
+    retry() {
+      if (!lastRequest) return false;
+      void run({ ...lastRequest });
+      return true;
+    },
+
+    stop() {
+      if (panel.status !== 'loading' && panel.status !== 'reviewing') return;
+
+      cancelInFlight();
+
+      // Text already streamed in is worth keeping: settle it so the user can
+      // accept the partial result. With nothing yet to review, fall back to the
+      // command list.
+      if (panel.status === 'reviewing') {
+        setPanel({ ...panel, suggestion: { ...panel.suggestion, isStreaming: false } });
+      } else {
+        setPanel({ status: 'menu', range: panel.range });
+      }
+    },
+
+    accept() {
+      if (panel.status !== 'reviewing' || panel.suggestion.isStreaming) return false;
+
+      const content = completionToNodes(editor, panel.suggestion.suggestedText);
+      if (!content.length) return false;
+
+      const { range } = panel;
+      cancelInFlight();
+      setPanel({ status: 'closed' });
+      writeAt(range, content);
+      return true;
+    },
+
+    insertBelow() {
+      if (panel.status !== 'reviewing' || panel.suggestion.isStreaming) return false;
+
+      const content = completionToNodes(editor, panel.suggestion.suggestedText);
+      if (!content.length) return false;
+
+      const at = RangeApi.end(panel.range);
+      const block = editor.api.block({ at });
+      if (!block) return false;
+
+      cancelInFlight();
+      setPanel({ status: 'closed' });
+      // Insert after the block the suggestion ends in, so the original text is
+      // left exactly as it was rather than being split around the result.
+      editor.tf.insertNodes(asBlocks(content) as any, {
+        at: PathApi.next(block[1]),
+        select: true,
+      });
+      editor.tf.focus();
+      return true;
+    },
+
+    discard() {
+      cancelInFlight();
+      setPanel({ status: 'closed' });
+    },
+
+    availableCommands() {
+      const options = readOptions();
+      const range = currentRange();
+      const hasSelection = !!range && !RangeApi.isCollapsed(range);
+      return commandsForSelection(options.commands, hasSelection);
+    },
+
+    getState: () => panel,
+
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  };
+}
+
+/** One controller per editor instance, created on first use and cached for its lifetime. */
+export function getPlateAiController(editor: PlateEditor): PlateAiController {
+  let controller = controllers.get(editor);
+  if (!controller) {
+    controller = createController(editor);
+    controllers.set(editor, controller);
+  }
+
+  return controller;
+}

--- a/packages/reason-editor/src/docs-agent/plate/kits/ai-kit.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/kits/ai-kit.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { AiPlugin, type PlateAiOptions } from '../ai-controller';
+import { AIMenu } from '../ui/ai-menu';
+
+/**
+ * The writing assistant, in the shape the other kits here have: spread it into
+ * the plugin list and the editor gains the `⌘/Ctrl + J` shortcut, the panel
+ * that `./ui/ai-toolbar-button.tsx` opens from the bubble menu, and the
+ * `KEYS.aiChat` `open` flag the floating toolbar reads to get out of its way.
+ *
+ * Unlike the rest of `./`, this is not a copy of Plate's registry `ai-kit`.
+ * Upstream's is built on `@platejs/ai`'s `AIChatPlugin`, which needs the Vercel
+ * AI SDK (`ai`, `@ai-sdk/react`) in the bundle and a streaming chat route to
+ * talk to — neither of which a published editor library can bring with it. This
+ * package already answers that question once, for Tiptap: a pluggable
+ * `getCompletion` (see `src/extensions/Ai/README.md`) that defaults to the
+ * host's rewrite endpoint. Both engines now share it, so the commands, prompts
+ * and response handling are the same on either side of the port.
+ *
+ * Point it at a different model or command set with `createAiKit`:
+ *
+ * ```ts
+ * createPlateEditor({
+ *   plugins: [
+ *     ...otherPlugins,
+ *     ...createAiKit({
+ *       getCompletion: createStreamingCompletion({ endpoint: '/api/ai' }),
+ *       contextChars: 8000,
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * A host that only needs to swap the model at runtime can leave the kit alone
+ * and call `editor.setOption(AiPlugin, 'getCompletion', fn)`; the controller
+ * reads its options fresh on every request.
+ */
+export const createAiKit = (options?: Partial<PlateAiOptions>) => [
+  AiPlugin.extend({
+    options,
+    render: { afterEditable: AIMenu },
+  }),
+];
+
+/** The assistant with its defaults — what `plate-editor-config` spreads in. */
+export const AiKit = createAiKit();

--- a/packages/reason-editor/src/docs-agent/plate/plate-editor-config.ts
+++ b/packages/reason-editor/src/docs-agent/plate/plate-editor-config.ts
@@ -14,6 +14,7 @@
  *   4. tables
  *   5. images/media
  *   6. slash menu, autoformat, emoji/mentions, floating controls
+ *   7. dictation and the AI writing assistant
  */
 
 import { CaptionPlugin } from '@platejs/caption/react';
@@ -28,6 +29,7 @@ import {
 import { type AnySlatePlugin, KEYS } from 'platejs';
 import type { AnyPlatePlugin } from 'platejs/react';
 
+import { AiKit } from './kits/ai-kit';
 import { AlignKit } from './kits/align-kit';
 import { AutoformatKit } from './kits/autoformat-kit';
 import { BasicNodesKit } from './kits/basic-nodes-kit';
@@ -132,6 +134,9 @@ export const platePlugins: PlatePluginList = [
 
   // 8. Voice commands — the Dictate toggle at the end of the toolbar.
   ...TranscribeKit,
+
+  // 9. The writing assistant behind the bubble menu's "Ask AI" button.
+  ...AiKit,
 ];
 
 /** A single empty paragraph — what a brand-new document starts from. */

--- a/packages/reason-editor/src/docs-agent/plate/ui/ai-menu.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/ai-menu.tsx
@@ -1,0 +1,454 @@
+'use client';
+
+/**
+ * The "Ask AI anything…" panel for the Plate editor — the surface the bubble
+ * menu's `AIToolbarButton` (and `⌘/Ctrl + J`) opens.
+ *
+ * Same panel as the Tiptap side's `src/extensions/Ai/components/AiMenu.tsx`,
+ * button for button: a filterable command palette over a free-form prompt box,
+ * a streaming state with a Stop control, and a review state whose result is
+ * only written to the document when the user picks Replace / Insert below.
+ * Two things differ, both because this one lives with the Plate playground UI
+ * rather than inside the published Tiptap bundle: it reads its state from the
+ * per-editor controller in `../ai-controller.ts` instead of ProseMirror plugin
+ * state, and it is styled with the same Tailwind/shadcn tokens as its
+ * neighbours in `./` instead of the extension's plain `.ai-menu*` CSS.
+ *
+ * It is rendered through a portal and positioned against the captured range's
+ * DOM rect, so it floats above the editor regardless of scroll containers.
+ */
+
+import * as React from 'react';
+
+import { computePosition, flip, offset, shift } from '@floating-ui/dom';
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  CornerDownRight,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+  Square,
+  X,
+} from 'lucide-react';
+import { RangeApi, type TRange } from 'platejs';
+import { useEditorReadOnly, useEditorRef } from 'platejs/react';
+import { createPortal } from 'react-dom';
+
+import { AI_COMMAND_GROUP_LABELS } from '@/extensions/Ai/commands';
+import { groupCommands } from '@/extensions/Ai/lib/prompt';
+import { cn } from '@/lib/utils';
+
+import {
+  getPlateAiController,
+  type PlateAiController,
+  type PlateAiPanel,
+} from '../ai-controller';
+
+import type { AiCommandDefinition } from '@/extensions/Ai/types';
+
+/** Stable snapshot for the server/first render — a fresh object would re-render forever. */
+const CLOSED_PANEL: PlateAiPanel = { status: 'closed' };
+
+function ReviewButton({
+  icon: Icon,
+  label,
+  onClick,
+  title,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  onClick: () => void;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+    >
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      {label}
+    </button>
+  );
+}
+
+/** Keeps the panel anchored to the range the request was launched against. */
+function useAnchoredPosition(
+  editor: ReturnType<typeof useEditorRef>,
+  range: TRange | null,
+  panelRef: React.RefObject<HTMLDivElement | null>,
+) {
+  const [position, setPosition] = React.useState<{ x: number; y: number } | null>(null);
+
+  React.useEffect(() => {
+    if (!range) {
+      setPosition(null);
+      return;
+    }
+
+    const virtualElement = {
+      getBoundingClientRect: () => {
+        try {
+          const domRange = editor.api.toDOMRange(range);
+          if (domRange) return domRange.getBoundingClientRect();
+        } catch {
+          // The range has no DOM to resolve against (the block was replaced, or
+          // the editor is not mounted); fall through to the corner.
+        }
+        return new DOMRect(0, 0, 0, 0);
+      },
+    };
+
+    const update = () => {
+      if (!panelRef.current) return;
+      void computePosition(virtualElement, panelRef.current, {
+        placement: 'bottom-start',
+        strategy: 'fixed',
+        middleware: [offset(8), flip(), shift({ padding: 8 })],
+      }).then(({ x, y }) => setPosition({ x, y }));
+    };
+
+    update();
+    window.addEventListener('resize', update);
+    window.addEventListener('scroll', update, true);
+    return () => {
+      window.removeEventListener('resize', update);
+      window.removeEventListener('scroll', update, true);
+    };
+  }, [editor, range, panelRef]);
+
+  return position;
+}
+
+export function AIMenu() {
+  const editor = useEditorRef();
+  const readOnly = useEditorReadOnly();
+  const controller: PlateAiController = React.useMemo(
+    () => getPlateAiController(editor),
+    [editor],
+  );
+
+  const panel = React.useSyncExternalStore(
+    controller.subscribe,
+    controller.getState,
+    () => CLOSED_PANEL,
+  );
+
+  const panelRef = React.useRef<HTMLDivElement | null>(null);
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const [prompt, setPrompt] = React.useState('');
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+  const [submenu, setSubmenu] = React.useState<AiCommandDefinition | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  const range = panel.status === 'closed' ? null : panel.range;
+  const isOpen = panel.status !== 'closed';
+  const hasSelection = !!range && !RangeApi.isCollapsed(range);
+  const position = useAnchoredPosition(editor, range, panelRef);
+
+  // Typing filters the command list, so the input doubles as a palette rather
+  // than only ever being a free-form prompt box.
+  const query = prompt.trim().toLowerCase();
+  const visibleCommands = React.useMemo(() => {
+    if (!isOpen) return [];
+    const available = controller.availableCommands();
+    if (!query) return available;
+    return available.filter((command) =>
+      `${command.label} ${command.description ?? ''}`.toLowerCase().includes(query),
+    );
+  }, [controller, query, isOpen, hasSelection]);
+
+  const sections = React.useMemo(() => groupCommands(visibleCommands), [visibleCommands]);
+
+  // Reset and focus the input each time the panel opens fresh.
+  React.useEffect(() => {
+    if (panel.status === 'menu') {
+      const raf = requestAnimationFrame(() => inputRef.current?.focus());
+      return () => cancelAnimationFrame(raf);
+    }
+    if (panel.status === 'closed') {
+      setPrompt('');
+      setSubmenu(null);
+      setActiveIndex(-1);
+      setCopied(false);
+    }
+  }, [panel.status]);
+
+  // A filtered-out highlight would run the wrong command on Enter.
+  React.useEffect(() => {
+    setActiveIndex((index) =>
+      index >= visibleCommands.length ? visibleCommands.length - 1 : index,
+    );
+  }, [visibleCommands.length]);
+
+  // Escape / click-outside closes the panel without touching the document.
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(event.target as Node)) {
+        controller.close();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (submenu) {
+          setSubmenu(null);
+          return;
+        }
+        controller.close();
+        return;
+      }
+
+      // Cmd/Ctrl+Enter accepts a settled suggestion from anywhere in the panel.
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+        if (controller.accept()) event.preventDefault();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, controller, submenu]);
+
+  if (readOnly || !isOpen || typeof document === 'undefined') return null;
+
+  const runCommand = (command: AiCommandDefinition) => {
+    if (command.options?.length) {
+      setSubmenu(command);
+      return;
+    }
+    controller.runCommand(command.id);
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        visibleCommands.length ? (index + 1) % visibleCommands.length : -1,
+      );
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index) =>
+        visibleCommands.length
+          ? index <= 0
+            ? visibleCommands.length - 1
+            : index - 1
+          : -1,
+      );
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const highlighted = activeIndex >= 0 ? visibleCommands[activeIndex] : undefined;
+      if (highlighted) {
+        runCommand(highlighted);
+        return;
+      }
+      if (prompt.trim()) controller.submitPrompt(prompt);
+    }
+  };
+
+  const copyResult = async (text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard access can be denied; the result is still visible to select.
+    }
+  };
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label="Ask AI"
+      className="fixed z-[60] w-[22rem] max-w-[90vw] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md"
+      // Rendered before it is placed — `useAnchoredPosition` needs the node in
+      // the DOM to measure against, so it is hidden rather than withheld for
+      // the one frame that takes.
+      style={{
+        left: position?.x ?? 0,
+        top: position?.y ?? 0,
+        visibility: position ? 'visible' : 'hidden',
+      }}
+    >
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <Sparkles className="size-4 shrink-0 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          value={prompt}
+          onChange={(event) => {
+            setPrompt(event.target.value);
+            setActiveIndex(event.target.value.trim() ? 0 : -1);
+          }}
+          onKeyDown={onInputKeyDown}
+          placeholder={hasSelection ? 'Ask AI to change the selection…' : 'Ask AI anything…'}
+          className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          aria-label="Ask AI"
+        />
+      </div>
+
+      {panel.status === 'menu' && submenu && (
+        <div className="max-h-80 overflow-y-auto p-1">
+          <button
+            type="button"
+            onClick={() => setSubmenu(null)}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+          >
+            <ArrowLeft className="size-4 shrink-0 text-muted-foreground" />
+            {submenu.label}
+          </button>
+          {submenu.options?.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => {
+                setSubmenu(null);
+                controller.runCommand(submenu.id, option.label);
+              }}
+              className="flex w-full items-center rounded-sm px-2 py-1.5 pl-8 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {panel.status === 'menu' && !submenu && (
+        <>
+          <div className="px-3 py-1.5 text-muted-foreground text-xs">
+            {hasSelection
+              ? 'Acting on the selection'
+              : 'Nothing selected — select text for rewrite actions'}
+          </div>
+          <div className="max-h-80 overflow-y-auto p-1">
+            {sections.length === 0 && (
+              <div className="px-2 py-3 text-center text-muted-foreground text-sm">
+                No matching actions
+              </div>
+            )}
+            {sections.map((section) => (
+              <div key={section.group}>
+                <div className="px-2 pt-2 pb-1 font-medium text-muted-foreground text-xs">
+                  {AI_COMMAND_GROUP_LABELS[section.group]}
+                </div>
+                {section.commands.map((command) => {
+                  const index = visibleCommands.indexOf(command);
+                  return (
+                    <button
+                      key={command.id}
+                      type="button"
+                      data-active={index === activeIndex ? 'true' : undefined}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onClick={() => runCommand(command)}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm',
+                        'hover:bg-accent hover:text-accent-foreground',
+                        'data-[active=true]:bg-accent data-[active=true]:text-accent-foreground',
+                      )}
+                    >
+                      <command.icon className="size-4 shrink-0 text-muted-foreground" />
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate">{command.label}</span>
+                        {command.description && (
+                          <span className="truncate text-muted-foreground text-xs">
+                            {command.description}
+                          </span>
+                        )}
+                      </span>
+                      {command.options?.length ? (
+                        <span className="ml-auto text-muted-foreground">›</span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {panel.status === 'loading' && (
+        <div className="flex items-center gap-2 px-3 py-2 text-sm">
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          <span className="text-muted-foreground">
+            {panel.commandLabel === 'Custom' ? 'Generating…' : `${panel.commandLabel}…`}
+          </span>
+          <button
+            type="button"
+            onClick={() => controller.stop()}
+            className="ml-auto flex items-center gap-1 rounded-sm px-2 py-1 text-xs hover:bg-accent"
+          >
+            <Square className="size-3" />
+            Stop
+          </button>
+        </div>
+      )}
+
+      {panel.status === 'error' && (
+        <div className="p-1">
+          <p className="px-2 py-1.5 text-destructive text-sm">{panel.message}</p>
+          <ReviewButton icon={RotateCcw} label="Try again" onClick={() => controller.retry()} />
+          <ReviewButton icon={X} label="Dismiss" onClick={() => controller.close()} />
+        </div>
+      )}
+
+      {panel.status === 'reviewing' && (
+        <>
+          <div
+            className="max-h-64 overflow-y-auto whitespace-pre-wrap border-b px-3 py-2 text-sm"
+            aria-live="polite"
+          >
+            {panel.suggestion.suggestedText || '…'}
+          </div>
+          {panel.suggestion.isStreaming ? (
+            <div className="flex items-center gap-2 px-3 py-2 text-sm">
+              <Loader2 className="size-4 animate-spin text-muted-foreground" />
+              <span className="text-muted-foreground">{panel.commandLabel}…</span>
+              <button
+                type="button"
+                onClick={() => controller.stop()}
+                className="ml-auto flex items-center gap-1 rounded-sm px-2 py-1 text-xs hover:bg-accent"
+              >
+                <Square className="size-3" />
+                Stop
+              </button>
+            </div>
+          ) : (
+            <div className="p-1">
+              <ReviewButton
+                icon={Check}
+                label={panel.suggestion.mode === 'replace' ? 'Replace selection' : 'Insert'}
+                title="⌘/Ctrl + Enter"
+                onClick={() => controller.accept()}
+              />
+              <ReviewButton
+                icon={CornerDownRight}
+                label="Insert below"
+                onClick={() => controller.insertBelow()}
+              />
+              <ReviewButton icon={RotateCcw} label="Try again" onClick={() => controller.retry()} />
+              <ReviewButton
+                icon={Copy}
+                label={copied ? 'Copied' : 'Copy'}
+                onClick={() => void copyResult(panel.suggestion.suggestedText)}
+              />
+              <ReviewButton icon={X} label="Discard" onClick={() => controller.discard()} />
+            </div>
+          )}
+        </>
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/reason-editor/src/docs-agent/plate/ui/ai-toolbar-button.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/ai-toolbar-button.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+/**
+ * "Ask AI" — the bubble menu's entry into the writing assistant, and the same
+ * button the fixed toolbar can carry. Opens the panel in `./ai-menu.tsx` over
+ * whatever is selected; `⌘/Ctrl + J` does the same thing from the keyboard.
+ *
+ * `data-plate-focus` follows `./link-toolbar-button.tsx`: the click must not
+ * count as leaving the editor, or the selection the request is about would be
+ * gone by the time the panel opens.
+ */
+
+import * as React from 'react';
+
+import { SparklesIcon } from 'lucide-react';
+import { useEditorRef } from 'platejs/react';
+
+import { getPlateAiController } from '../ai-controller';
+
+import { ToolbarButton } from './toolbar';
+
+export function AIToolbarButton(props: React.ComponentProps<typeof ToolbarButton>) {
+  const editor = useEditorRef();
+
+  return (
+    <ToolbarButton
+      {...props}
+      data-plate-focus
+      onClick={() => getPlateAiController(editor).open()}
+      onMouseDown={(event) => event.preventDefault()}
+      tooltip="Ask AI (⌘J)"
+    >
+      <SparklesIcon />
+      {props.children}
+    </ToolbarButton>
+  );
+}

--- a/packages/reason-editor/src/docs-agent/plate/ui/floating-toolbar-buttons.tsx
+++ b/packages/reason-editor/src/docs-agent/plate/ui/floating-toolbar-buttons.tsx
@@ -12,6 +12,7 @@ import {
 import { KEYS } from 'platejs';
 import { useEditorReadOnly } from 'platejs/react';
 
+import { AIToolbarButton } from './ai-toolbar-button';
 import { InlineEquationToolbarButton } from './equation-toolbar-button';
 import { LinkToolbarButton } from './link-toolbar-button';
 import { MarkToolbarButton } from './mark-toolbar-button';
@@ -27,6 +28,10 @@ export function FloatingToolbarButtons() {
 
   return (
     <>
+      <ToolbarGroup>
+        <AIToolbarButton className="gap-1 text-primary">Ask AI</AIToolbarButton>
+      </ToolbarGroup>
+
       <ToolbarGroup>
         <TurnIntoToolbarButton />
       </ToolbarGroup>

--- a/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
+++ b/packages/reason-editor/src/editor-views/config/pluginRegistry.tsx
@@ -62,12 +62,7 @@ import { Twitter } from 'react-reason-editor/twitter';
 import { Video } from 'react-reason-editor/video';
 import { WordCount } from 'react-reason-editor/wordcount';
 
-import {
-  Ai,
-  buildAiUserPrompt,
-  createStreamingCompletion,
-  mockAiCompletion,
-} from '@/extensions/Ai';
+import { Ai, createRewriteCompletion, DEFAULT_AI_ENDPOINT } from '@/extensions/Ai';
 import { Comment } from '@/extensions/Comment';
 import { Drawio } from '@/extensions/Drawio';
 import { Harper } from '@/extensions/Harper';
@@ -141,37 +136,6 @@ const demoBase64Upload = (file: File) => {
     }, 300);
   });
 };
-
-/**
- * Default endpoint the AI writing assistant posts to. It matches the
- * `{ text, prompt } -> { rewrittenText }` contract the QwkSearch web app
- * serves at `/api/agent/rewrite`, which is where this editor is mounted.
- * Hosts without that route point the setting at their own (or clear it) —
- * an empty value falls back to the offline demo transform rather than
- * failing every action.
- */
-const DEFAULT_AI_ENDPOINT = '/api/agent/rewrite';
-
-/**
- * Builds the extension's `getCompletion`. The request carries the whole
- * instruction — the system rules, the surrounding context window and the text
- * to act on — as one prompt, so a plain rewrite route needs no changes to
- * serve every command in the menu.
- */
-const createAiCompletion = (endpoint: string) =>
-  endpoint
-    ? createStreamingCompletion({
-        endpoint,
-        body: (request) => ({
-          // `prompt` carries the real instruction; `text` is the field such
-          // routes validate as non-empty, so the generate commands (which run
-          // with no selection) fall back to their context and instruction.
-          text: request.selectedText || request.documentText || request.instruction,
-          prompt: `${request.systemPrompt}\n\n${buildAiUserPrompt(request)}`,
-          command: request.commandId,
-        }),
-      })
-    : mockAiCompletion;
 
 // ─── Registry ────────────────────────────────────────────────────────────────
 
@@ -742,7 +706,7 @@ export const PLUGIN_REGISTRY: PluginDefinition[] = [
     ],
     create: (s) =>
       Ai.configure({
-        getCompletion: createAiCompletion(String(s.endpoint ?? '').trim()),
+        getCompletion: createRewriteCompletion(String(s.endpoint ?? '').trim()),
         contextChars: Number.isFinite(Number(s.contextChars)) ? Number(s.contextChars) : 4000,
       }),
   },

--- a/packages/reason-editor/src/extensions/Ai/README.md
+++ b/packages/reason-editor/src/extensions/Ai/README.md
@@ -65,6 +65,39 @@ demo transform) under Settings → Plugins → AI Writing.
 - Commands that rewrite a selection are hidden — and refuse to run — when the
   caret is collapsed, so they never answer confidently about nothing.
 
+## The Plate editor
+
+`src/docs-agent/plate` mounts the same assistant. Its `AiKit`
+(`src/docs-agent/plate/kits/ai-kit.tsx`) registers a Plate plugin keyed
+`KEYS.aiChat` whose panel opens from the bubble menu's ✨ **Ask AI** button or
+`⌘/Ctrl + J`, and it runs the command set, prompts and response sanitising from
+this directory — only the document half is re-implemented for Slate, in
+`src/docs-agent/plate/ai-controller.ts`.
+
+It is deliberately not Plate's own `@platejs/ai` `AIChatPlugin`: that needs the
+Vercel AI SDK in the bundle and a streaming chat route to talk to, neither of
+which a published editor library can bring with it, whereas `getCompletion`
+above is already the answer to that question. Configure it the same way:
+
+```ts
+import { createAiKit } from 'react-reason-editor/docs-agent';
+
+createPlateEditor({
+  plugins: [
+    ...otherPlugins,
+    ...createAiKit({
+      getCompletion: createStreamingCompletion({ endpoint: '/api/ai' }),
+      contextChars: 8000,
+    }),
+  ],
+});
+```
+
+One behavioural difference: on Plate the review surface is the panel's preview
+rather than an inline red/green diff, because Slate has no decoration layer to
+draw one with. What that preserves is the rule that matters — nothing reaches
+the document until the user accepts.
+
 ## Customising the commands
 
 ```ts

--- a/packages/reason-editor/src/extensions/Ai/index.ts
+++ b/packages/reason-editor/src/extensions/Ai/index.ts
@@ -9,6 +9,7 @@ export * from './components/AiMenu';
 export * from './components/RichTextAi';
 export { mockAiCompletion } from './lib/mockCompletion';
 export { createStreamingCompletion } from './lib/createStreamingCompletion';
+export { createRewriteCompletion, DEFAULT_AI_ENDPOINT } from './lib/rewriteEndpoint';
 export type { StreamingCompletionOptions } from './lib/createStreamingCompletion';
 export {
   buildAiInstruction,

--- a/packages/reason-editor/src/extensions/Ai/lib/rewriteEndpoint.ts
+++ b/packages/reason-editor/src/extensions/Ai/lib/rewriteEndpoint.ts
@@ -1,0 +1,51 @@
+/**
+ * The `getCompletion` both editor engines default to: a POST to the host's
+ * rewrite route, with the whole instruction — system rules, context window and
+ * the text to act on — collapsed into one `prompt` string.
+ *
+ * It lives here rather than next to either engine because both need it. The
+ * Tiptap `Ai` extension takes it from the plugin registry
+ * (`src/editor-views/config/pluginRegistry.tsx`, where the endpoint is a user
+ * setting) and the Plate editor takes it from `AiKit`
+ * (`src/docs-agent/plate/kits/ai-kit.tsx`); a single definition keeps the two
+ * asking the same route the same way, so a document rewritten in one engine
+ * reads like a document rewritten in the other.
+ */
+
+import { createStreamingCompletion } from './createStreamingCompletion';
+import { mockAiCompletion } from './mockCompletion';
+import { buildAiUserPrompt } from './prompt';
+
+import type { AiCompletionFn } from '../types';
+
+/**
+ * Default endpoint the AI writing assistant posts to. It matches the
+ * `{ text, prompt } -> { rewrittenText }` contract the QwkSearch web app
+ * serves at `/api/agent/rewrite`, which is where this editor is mounted.
+ * Hosts without that route point it at their own (or clear it) — an empty
+ * value falls back to the offline demo transform rather than failing every
+ * action.
+ */
+export const DEFAULT_AI_ENDPOINT = '/api/agent/rewrite';
+
+/**
+ * Builds a completion function for a rewrite endpoint. The request carries the
+ * whole instruction as one prompt, so a plain rewrite route needs no changes to
+ * serve every command in the menu. An empty `endpoint` returns the offline demo
+ * transform, which is what keeps the menu usable with no backend at all.
+ */
+export function createRewriteCompletion(endpoint: string): AiCompletionFn {
+  if (!endpoint) return mockAiCompletion;
+
+  return createStreamingCompletion({
+    endpoint,
+    body: (request) => ({
+      // `prompt` carries the real instruction; `text` is the field such routes
+      // validate as non-empty, so the generate commands (which run with no
+      // selection) fall back to their context and instruction.
+      text: request.selectedText || request.documentText || request.instruction,
+      prompt: `${request.systemPrompt}\n\n${buildAiUserPrompt(request)}`,
+      command: request.commandId,
+    }),
+  });
+}

--- a/packages/reason-editor/test/docs-agent/plate-ai-controller.test.ts
+++ b/packages/reason-editor/test/docs-agent/plate-ai-controller.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Exercises the Plate writing assistant — the state machine behind the bubble
+ * menu's "Ask AI" button — against a fake completion function, the way
+ * `test/ai-extension.test.ts` exercises the Tiptap `Ai` extension.
+ *
+ * The rule under test throughout: nothing reaches the document until the user
+ * accepts, and what is written is the sanitised result the panel showed.
+ */
+
+import { createPlateEditor } from 'platejs/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AiPlugin, getPlateAiController } from '../../src/docs-agent/plate/ai-controller';
+import { platePlugins } from '../../src/docs-agent/plate/plate-editor-config';
+
+import type { AiCompletionFn } from '../../src/extensions/Ai/types';
+
+const PARAGRAPH = 'The cat sat on the mat.';
+
+function createEditor(getCompletion: AiCompletionFn) {
+  const editor = createPlateEditor({
+    plugins: platePlugins as any,
+    value: [
+      { children: [{ text: PARAGRAPH }], type: 'p' },
+      { children: [{ text: 'A second block.' }], type: 'p' },
+    ],
+  });
+
+  editor.setOption(AiPlugin, 'getCompletion', getCompletion);
+  // The DOM-facing half of `accept()`/`insertBelow()` has no editable to focus
+  // in jsdom; the document writes are what these tests are about.
+  editor.tf.focus = vi.fn() as any;
+
+  return editor;
+}
+
+/** Resolves immediately with `text`, streaming it in `chunks` pieces first. */
+function completionOf(text: string, chunks: string[] = []): AiCompletionFn {
+  return async (_request, onChunk) => {
+    chunks.forEach((chunk) => onChunk(chunk));
+    return text;
+  };
+}
+
+/** Selects the whole first paragraph. */
+function selectFirstParagraph(editor: ReturnType<typeof createEditor>) {
+  editor.tf.select({
+    anchor: { offset: 0, path: [0, 0] },
+    focus: { offset: PARAGRAPH.length, path: [0, 0] },
+  });
+}
+
+const firstBlockText = (editor: ReturnType<typeof createEditor>) =>
+  (editor.children[0] as any).children.map((child: any) => child.text).join('');
+
+describe('plate ai controller', () => {
+  it('is part of the default plugin set, so the bubble button has a panel to open', () => {
+    const editor = createEditor(completionOf('x'));
+
+    // Registered under `KEYS.aiChat`, which is the key
+    // `ui/floating-toolbar.tsx` reads to hide itself while the panel is up.
+    expect(editor.getPlugin(AiPlugin).key).toBe('aiChat');
+    expect(editor.getOption(AiPlugin, 'commands').length).toBeGreaterThan(0);
+  });
+
+  it('opens over the current selection and flags the panel open', () => {
+    const editor = createEditor(completionOf('x'));
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+
+    const panel = ai.getState();
+    expect(panel.status).toBe('menu');
+    // The floating toolbar reads this flag to get out of the panel's way.
+    expect(editor.getOption(AiPlugin, 'open')).toBe(true);
+
+    ai.close();
+    expect(ai.getState().status).toBe('closed');
+    expect(editor.getOption(AiPlugin, 'open')).toBe(false);
+  });
+
+  it('offers only the caret-safe commands with nothing selected', () => {
+    const editor = createEditor(completionOf('x'));
+    editor.tf.select({
+      anchor: { offset: 0, path: [0, 0] },
+      focus: { offset: 0, path: [0, 0] },
+    });
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+
+    const ids = ai.availableCommands().map((command) => command.id);
+    expect(ids).toContain('continue');
+    expect(ids).not.toContain('improve');
+  });
+
+  it('refuses a rewrite command at a collapsed caret', () => {
+    const getCompletion = vi.fn(completionOf('x'));
+    const editor = createEditor(getCompletion);
+    editor.tf.select({
+      anchor: { offset: 0, path: [0, 0] },
+      focus: { offset: 0, path: [0, 0] },
+    });
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+
+    expect(ai.runCommand('improve')).toBe(false);
+    expect(getCompletion).not.toHaveBeenCalled();
+  });
+
+  it('streams a suggestion without touching the document, then replaces on accept', async () => {
+    const editor = createEditor(completionOf('The cat rested.', ['The cat', 'The cat rested.']));
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    expect(ai.runCommand('improve')).toBe(true);
+
+    await vi.waitFor(() => {
+      const panel = ai.getState();
+      expect(panel.status === 'reviewing' && !panel.suggestion.isStreaming).toBe(true);
+    });
+
+    // Still nothing written.
+    expect(firstBlockText(editor)).toBe(PARAGRAPH);
+
+    expect(ai.accept()).toBe(true);
+    expect(firstBlockText(editor)).toBe('The cat rested.');
+    expect(ai.getState().status).toBe('closed');
+  });
+
+  it('sends the selection and a bounded context window to the completion', async () => {
+    const getCompletion = vi.fn(completionOf('ok'));
+    const editor = createEditor(getCompletion);
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('improve');
+
+    await vi.waitFor(() => expect(getCompletion).toHaveBeenCalled());
+
+    const request = getCompletion.mock.calls[0][0];
+    expect(request.selectedText).toBe(PARAGRAPH);
+    expect(request.mode).toBe('replace');
+    expect(request.documentText).toContain('A second block.');
+    expect(request.documentText).not.toContain(PARAGRAPH);
+  });
+
+  it('strips a chat preamble before it is ever shown', async () => {
+    const editor = createEditor(completionOf("Sure! Here's a tighter version:\n\nThe cat sat."));
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('improve');
+
+    await vi.waitFor(() => {
+      const panel = ai.getState();
+      expect(panel.status === 'reviewing' && !panel.suggestion.isStreaming).toBe(true);
+    });
+
+    const panel = ai.getState();
+    expect(panel.status === 'reviewing' && panel.suggestion.suggestedText).toBe('The cat sat.');
+  });
+
+  it('inserts a Markdown answer below as real blocks, leaving the original alone', async () => {
+    const editor = createEditor(completionOf('- first point\n- second point'));
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('key-points');
+
+    await vi.waitFor(() => {
+      const panel = ai.getState();
+      expect(panel.status === 'reviewing' && !panel.suggestion.isStreaming).toBe(true);
+    });
+
+    const blocksBefore = editor.children.length;
+    expect(ai.insertBelow()).toBe(true);
+
+    expect(firstBlockText(editor)).toBe(PARAGRAPH);
+    expect(editor.children.length).toBeGreaterThan(blocksBefore);
+    // The list markers became structure, not literal text.
+    expect(JSON.stringify(editor.children)).not.toContain('- first point');
+    expect(JSON.stringify(editor.children)).toContain('first point');
+  });
+
+  it('discards without writing anything', async () => {
+    const editor = createEditor(completionOf('Something else entirely.'));
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('improve');
+
+    await vi.waitFor(() => expect(ai.getState().status).toBe('reviewing'));
+
+    ai.discard();
+    expect(ai.getState().status).toBe('closed');
+    expect(firstBlockText(editor)).toBe(PARAGRAPH);
+  });
+
+  it('keeps what has streamed in when generation is stopped', async () => {
+    let release: (() => void) | undefined;
+    const getCompletion: AiCompletionFn = async (_request, onChunk) => {
+      onChunk('Half a sen');
+      await new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return 'Half a sentence, finished.';
+    };
+
+    const editor = createEditor(getCompletion);
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('improve');
+
+    await vi.waitFor(() => expect(ai.getState().status).toBe('reviewing'));
+    ai.stop();
+
+    const panel = ai.getState();
+    expect(panel.status === 'reviewing' && panel.suggestion.isStreaming).toBe(false);
+    expect(panel.status === 'reviewing' && panel.suggestion.suggestedText).toBe('Half a sen');
+
+    // A late resolution of the cancelled request must not revive the panel.
+    release?.();
+    await Promise.resolve();
+    expect(
+      ai.getState().status === 'reviewing' &&
+        (ai.getState() as any).suggestion.suggestedText,
+    ).toBe('Half a sen');
+  });
+
+  it('surfaces an empty answer as an error rather than an empty edit', async () => {
+    const editor = createEditor(completionOf('   '));
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('improve');
+
+    await vi.waitFor(() => expect(ai.getState().status).toBe('error'));
+    expect((ai.getState() as any).message).toMatch(/empty response/i);
+    expect(firstBlockText(editor)).toBe(PARAGRAPH);
+  });
+
+  it('surfaces a failed request, and retries the same instruction', async () => {
+    const getCompletion = vi
+      .fn<AiCompletionFn>()
+      .mockRejectedValueOnce(new Error('Model unavailable'))
+      .mockResolvedValueOnce('Second time lucky.');
+
+    const editor = createEditor(getCompletion as unknown as AiCompletionFn);
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    ai.runCommand('improve');
+
+    await vi.waitFor(() => expect(ai.getState().status).toBe('error'));
+    expect((ai.getState() as any).message).toBe('Model unavailable');
+
+    expect(ai.retry()).toBe(true);
+    await vi.waitFor(() => expect(ai.getState().status).toBe('reviewing'));
+    expect(getCompletion.mock.calls[1][0].instruction).toBe(
+      getCompletion.mock.calls[0][0].instruction,
+    );
+  });
+
+  it('runs a free-form prompt as a custom command', async () => {
+    const getCompletion = vi.fn(completionOf('Rewritten.'));
+    const editor = createEditor(getCompletion);
+    selectFirstParagraph(editor);
+
+    const ai = getPlateAiController(editor);
+    ai.open();
+    expect(ai.submitPrompt('  make it rhyme  ')).toBe(true);
+    expect(ai.submitPrompt('   ')).toBe(false);
+
+    await vi.waitFor(() => expect(getCompletion).toHaveBeenCalledTimes(1));
+    expect(getCompletion.mock.calls[0][0].instruction).toBe('make it rhyme');
+    expect(getCompletion.mock.calls[0][0].commandId).toBe('custom');
+  });
+});

--- a/packages/reason-editor/test/docs-agent/plate-ai-menu.test.tsx
+++ b/packages/reason-editor/test/docs-agent/plate-ai-menu.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Mounts the bubble menu's AI entry point over a real Plate editor: the button
+ * `FloatingToolbarButtons` renders, and the panel it opens.
+ *
+ * The value is the wiring rather than any one control — the button, the
+ * per-editor controller and the panel have to agree about the plugin key and
+ * the captured range, and a mismatch there is invisible until someone selects
+ * text in the browser.
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Plate, usePlateEditor } from 'platejs/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AIMenu } from '@/docs-agent/plate/ui/ai-menu';
+import { AIToolbarButton } from '@/docs-agent/plate/ui/ai-toolbar-button';
+import { platePlugins } from '@/docs-agent/plate/plate-editor-config';
+import { Toolbar } from '@/docs-agent/plate/ui/toolbar';
+
+function AiHarness() {
+  const editor = usePlateEditor({
+    plugins: platePlugins,
+    value: [{ children: [{ text: 'The cat sat on the mat.' }], type: 'p' }],
+  });
+
+  return (
+    <Plate editor={editor}>
+      {/* The button is a Radix toolbar item; the bubble menu is its real root. */}
+      <Toolbar>
+        <AIToolbarButton>Ask AI</AIToolbarButton>
+      </Toolbar>
+      <AIMenu />
+    </Plate>
+  );
+}
+
+/** The panel portals to `document.body`, not into the harness container. */
+const panel = () => document.body.querySelector('[role="dialog"][aria-label="Ask AI"]');
+
+describe('plate bubble menu AI', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+
+    act(() => {
+      root.render(<AiHarness />);
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('renders the Ask AI button without a plugin or hook error', () => {
+    const button = container.querySelector('button');
+
+    expect(button).not.toBeNull();
+    expect(button!.textContent).toContain('Ask AI');
+  });
+
+  it('opens the command panel on click, and closes it on Escape', async () => {
+    expect(panel()).toBeNull();
+
+    await act(async () => {
+      container.querySelector('button')!.click();
+    });
+
+    const opened = panel();
+    expect(opened).not.toBeNull();
+    // The caret is collapsed, so only the caret-safe commands are offered.
+    expect(opened!.textContent).toContain('Continue writing');
+    expect(opened!.textContent).not.toContain('Improve writing');
+
+    await act(async () => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(panel()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Ports the AI writing assistant from the Tiptap editor to the Plate editor, enabling the same command palette, streaming suggestions, and review workflow across both editor engines. The implementation reuses the shared command set, prompts, and response sanitization logic while adapting the document manipulation layer for Slate's architecture.

## Key Changes

- **New AI controller for Plate** (`src/docs-agent/plate/ai-controller.ts`): A state machine managing the assistant's lifecycle, replacing ProseMirror plugin state with a per-editor `WeakMap`-based controller that components read via `useSyncExternalStore`. Implements the same command execution, prompt building, and response handling as the Tiptap extension.

- **AI menu panel for Plate** (`src/docs-agent/plate/ui/ai-menu.tsx`): React component rendering the command palette and free-form prompt interface, positioned via floating-ui against the captured range's DOM rect. Mirrors the Tiptap panel's UX with filterable commands, streaming state, and review surface.

- **Toolbar button** (`src/docs-agent/plate/ui/ai-toolbar-button.tsx`): Entry point from the bubble menu that opens the panel, with `⌘/Ctrl + J` keyboard shortcut support.

- **AI Kit for Plate** (`src/docs-agent/plate/kits/ai-kit.tsx`): Plugin registration wrapper following the kit pattern, spreading the `AiPlugin` into the editor's plugin list and rendering the panel.

- **Shared rewrite endpoint** (`src/extensions/Ai/lib/rewriteEndpoint.ts`): Extracted the default completion function so both Tiptap and Plate use the same `/api/agent/rewrite` endpoint with identical request/response handling.

- **Comprehensive test coverage**: Added tests for the controller state machine (`plate-ai-controller.test.ts`) and panel integration (`plate-ai-menu.test.tsx`), verifying the rule that nothing reaches the document until accepted and that streamed content is properly sanitized.

- **Updated exports and config**: Registered `AiPlugin` in the default Plate plugin set, exported controller types from the public API, and updated the Tiptap plugin registry to use the shared rewrite endpoint.

## Implementation Details

- **State management**: Panel state lives in the controller rather than transaction metadata, with listeners notifying React components via `useSyncExternalStore`. The `open` option mirrors to the plugin so the floating toolbar can hide itself.

- **Range capture**: The range a request was launched against is captured when the menu opens and not mapped through later edits, since the panel is modal in practice (input holds focus, clicking the document closes it).

- **Content insertion**: Distinguishes between single-line rewrites (preserving marks) and Markdown-structured answers (parsed into real blocks), with an `insertBelow` path that leaves the original text intact.

- **Shared logic**: Commands, system prompts, context windowing, and response sanitization all reuse the existing Tiptap implementations, ensuring consistent behavior across editors.

https://claude.ai/code/session_01S7f4jt3iNP2btpXE6A2DMU