### PR TITLE
🐛 fix(react-weather-forecast): stop 400s, retry with backoff, fall ba…

### DIFF
--- a/packages/react-weather-forecast/README.md
+++ b/packages/react-weather-forecast/README.md
@@ -2,14 +2,16 @@
 
 [![Coverage](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent/graph/badge.svg?component=package-react-weather-forecast)](https://codecov.io/gh/OpenSourceAGI/qwksearch-research-agent)
 
-React weather forecast component using Open-Meteo for current, hourly, and daily forecasts and Cloudflare/ipapi.co for IP geolocation.
+React weather forecast component using Open-Meteo for current, hourly, and daily forecasts and Cloudflare/ipapi.co for IP geolocation, with a fallback chain behind both.
 
 ## Features
 
 - Current weather.
 - Next hours forecast.
 - Next days forecast.
-- IP geolocation fallback.
+- Four weather upstreams tried in order, four IP geolocation upstreams behind that.
+- Every request validated before it is sent, retried with backoff when it can recover.
+- Stale-cache fallback so a total outage still renders a widget.
 - Latitude/longitude override.
 - Split SVG weather icon components.
 - TypeScript + tsup library scaffold.
@@ -35,6 +37,66 @@ export default function App() {
     />
   );
 }
+```
+
+## Reliability
+
+Nothing here needs configuring -- these are the defaults -- but this is what
+the package does when an upstream misbehaves.
+
+### `Weather request failed: 400 Bad Request`
+
+Open-Meteo answers `400` for a query it cannot parse, and the usual way to
+build one is not a typo in your props: an IP geolocation upstream answers
+`200` with no coordinates in the body, `Number(undefined)` becomes `NaN`,
+`latitude=NaN` goes out on the wire. Everything that goes into a request is
+validated first now:
+
+| Input | What happens to it |
+| --- | --- |
+| `latitude` / `longitude` | Must be finite and on the globe, and are rounded to 4 decimals. A geolocation response without them counts as a failed lookup, so the next provider gets a turn. Unusable props fall back to IP geolocation. |
+| `location.timezone` | Canonicalized (`US/Pacific` becomes `America/Los_Angeles`); a zone the runtime cannot resolve is dropped rather than sent, and Open-Meteo resolves the zone from the coordinates instead. |
+| `forecastDays` / `forecastHours` | Clamped to the 1-16 days and 1-384 hours the API accepts. |
+| Variable list | A `400` from an endpoint that refused one of the optional variables is retried once with the minimal set the widget needs. |
+
+### Retries
+
+Requests go through [`grab-url`](https://www.npmjs.com/package/grab-url) rather
+than `fetch`. Each one is tried up to `retryAttempts` times (3 by default for a
+forecast, 2 per geolocation provider since that chain is longer) with
+exponential backoff from `retryDelay` (400ms, then 800ms, ...). A `429`, a
+`5xx`, a timeout or a dropped connection is repeated; a request the server
+called invalid (`400`, `404`) is not, since replaying it only burns the
+upstream's rate limit.
+
+### Fallback APIs
+
+| Order | Weather | IP geolocation |
+| --- | --- | --- |
+| 1 | `open-meteo` -- `api.open-meteo.com/v1/forecast` | `geoEndpoint` (the bundled worker), when given |
+| 2 | `open-meteo-gfs` -- the GFS model endpoint | `ipapi` -- ipapi.co |
+| 3 | `met-no` -- met.no, a different operator and model | `ipwho` -- ipwho.is |
+| 4 | `wttr` -- wttr.in, no key required | `geojs` -- get.geojs.io |
+| 5 | | `freeipapi` -- freeipapi.com |
+
+The fallbacks normalize their own condition codes, units and timestamps into
+the same shape Open-Meteo returns, so a failover is invisible in the rendered
+widget (wttr.in is 3-hourly rather than hourly). If every provider fails, a
+cached forecast up to a day old is served instead of throwing; only if there is
+no cache either does an error reach the widget, listing what each provider
+said.
+
+```tsx
+<WeatherForecast
+  weatherProviders={['open-meteo', 'met-no']}
+  geoProviders={['ipwho', 'geojs']}
+  retryAttempts={3}
+  retryDelay={400}
+  timeout={15}
+  fallbackLocation={{ city: 'Austin', latitude: 30.27, longitude: -97.74 }}
+  allowStaleCache
+  onProviderError={({ provider, stage, error }) => console.warn(stage, provider, error.message)}
+/>
 ```
 
 ## Direct API usage
@@ -72,10 +134,17 @@ This package no longer uses ipinfo.io. Instead:
   no mixed-content issues, though ipapi.co's free tier is rate-limited (1,000
   requests/day) — deploy the worker and pass `geoEndpoint` for higher-volume or
   production use.
-- A failed lookup is **repeated** before it throws: `getClientLocation` tries three
-  times by default, waiting 500ms, then 1s, so a single rate-limited or cold-start
-  response doesn't take the whole forecast down. Tune it with the third argument:
-  `getClientLocation(geoEndpoint, ip, { attempts: 5, retryDelay: 250 })`.
+- A failed lookup is **repeated** before the chain moves on: `getClientLocation`
+  tries each provider twice by default, waiting 500ms, then walks the rest of the
+  chain (ipapi.co, ipwho.is, get.geojs.io, freeipapi.com) so a single rate-limited
+  or cold-start response doesn't take the whole forecast down. Tune it with the
+  third argument: `getClientLocation(geoEndpoint, ip, { attempts: 5, retryDelay: 250, providers: ['ipwho'] })`.
+- A response **without usable coordinates counts as a failure** rather than being
+  passed on as `NaN`, and `fallbackLocation` covers the case where every provider
+  is down.
+- The bundled worker does the same on its side: it falls back to the IP lookups
+  when Cloudflare's own geolocation carries no coordinates, and answers `502` with
+  a reason instead of a body the caller cannot use.
 
 ### Deploying the geo worker
 
@@ -90,16 +159,20 @@ This deploys `worker/geo-worker.ts` via Wrangler. Use the resulting `*.workers.d
 ## Caching
 
 `getWeatherForecast` caches each response in `localStorage` for 30 minutes, keyed by
-the exact request URL (location + units + forecast range). Repeated calls for the same
+the request itself (location + units + forecast range + timezone), so a fallback
+provider's answer is reused exactly like the primary one's. Repeated calls for the same
 location/options within that window are served from the cache instead of hitting
-Open-Meteo again, which keeps the widget well under Open-Meteo's rate limits. Call
-`clearWeatherForecastCache()` to evict everything (e.g. in tests). The cache is a no-op
-in non-browser environments (SSR) or when `localStorage` is unavailable/full.
+Open-Meteo again, which keeps the widget well under Open-Meteo's rate limits. Past
+the 30 minutes an entry is kept for a day as the last-resort fallback described
+above, and evicted after that. Call `clearWeatherForecastCache()` to evict
+everything (e.g. in tests). The cache is a no-op in non-browser environments (SSR)
+or when `localStorage` is unavailable/full.
 
 ## Notes
 
-- Open-Meteo powers the forecast data.
-- Cloudflare's `request.cf` and ipapi.co power IP geolocation (see above).
+- Open-Meteo powers the forecast data, with met.no and wttr.in behind it.
+- Cloudflare's `request.cf`, ipapi.co, ipwho.is, get.geojs.io and freeipapi.com
+  power IP geolocation (see above).
 - HTTP requests go through [`grab-url`](https://www.npmjs.com/package/grab-url), the
   repo-wide client, rather than raw `fetch`. It is the package's only runtime
   dependency.

--- a/packages/react-weather-forecast/package.json
+++ b/packages/react-weather-forecast/package.json
@@ -1,7 +1,7 @@
 {
   "name": "use-weather-forecast",
-  "version": "0.1.127",
-  "description": "React weather forecast component using Open-Meteo and IP geolocation",
+  "version": "0.2.0",
+  "description": "React weather forecast component using Open-Meteo and IP geolocation, with retries and fallback providers",
   "keywords": ["react", "weather", "forecast", "open-meteo", "cloudflare", "ipapi", "component-library"],
   "repository": {
     "type": "git",

--- a/packages/react-weather-forecast/src/api/forecast.ts
+++ b/packages/react-weather-forecast/src/api/forecast.ts
@@ -1,112 +1,131 @@
 import type { WeatherForecastData, WeatherForecastOptions, WeatherLocation } from '../types';
-import { getWeatherIcon } from '../weatherCodes';
+import { readCachedForecast, readStaleForecast, writeCachedForecast } from '../lib/cache';
+import {
+  clampInteger,
+  MAX_FORECAST_DAYS,
+  MAX_FORECAST_HOURS,
+  normalizeCoordinates,
+  normalizeTimezone,
+} from '../lib/validate';
 import { getClientLocation } from './geolocation';
-import { grabJson } from './http';
-import { readCachedForecast, writeCachedForecast } from '../lib/cache';
+import type { GrabJsonOptions } from './http';
+import { resolveWeatherProviders, type ForecastRequest } from './providers';
 
-function buildUrl(latitude: number, longitude: number, options: WeatherForecastOptions) {
-  const params = new URLSearchParams({
-    latitude: String(latitude),
-    longitude: String(longitude),
-    timezone: options.location?.timezone || 'auto',
-    temperature_unit: options.temperatureUnit || 'fahrenheit',
-    wind_speed_unit: options.windSpeedUnit || 'mph',
-    forecast_days: String(options.forecastDays ?? 5),
-    forecast_hours: String(options.forecastHours ?? 24),
-    current: [
-      'temperature_2m',
-      'weather_code',
-      'is_day',
-      'rain',
-      'showers',
-      'snowfall',
-      'wind_speed_10m',
-    ].join(','),
-    hourly: [
-      'temperature_2m',
-      'weather_code',
-      'precipitation_probability',
-      'rain',
-      'showers',
-      'snowfall',
-    ].join(','),
-    daily: [
-      'temperature_2m_max',
-      'temperature_2m_min',
-      'weather_code',
-      'precipitation_probability_max',
-      'precipitation_sum',
-      'wind_speed_10m_max',
-    ].join(','),
-  });
+/**
+ * Everything that goes on the wire is validated first, then the providers are
+ * tried in order until one answers.
+ *
+ * The `400 Bad Request` this used to render came from an unvalidated request:
+ * a geolocation upstream answering 200 with no coordinates put `latitude=NaN`
+ * in the URL, and an unknown timezone string or an out-of-range `forecastDays`
+ * did the same. Those are caught in {@link buildForecastRequest} now, before a
+ * request is sent, and anything that still fails falls through to the next
+ * provider and finally to a stale cache entry.
+ */
 
-  return `https://api.open-meteo.com/v1/forecast?${params.toString()}`;
+/** Cache key for a request, so a fallback provider's answer is reused like the primary one's. */
+export function forecastCacheKey(request: ForecastRequest): string {
+  const { latitude, longitude } = request.location;
+  return [
+    'v2',
+    `${latitude},${longitude}`,
+    request.temperatureUnit,
+    request.windSpeedUnit,
+    `${request.forecastDays}d`,
+    `${request.forecastHours}h`,
+    request.timezone ?? 'auto',
+  ].join('|');
 }
 
+/** Resolve the location for a request, falling back to IP geolocation. */
+async function resolveLocation(options: WeatherForecastOptions): Promise<WeatherLocation> {
+  const explicit = normalizeCoordinates(options.latitude, options.longitude);
+  if (explicit) {
+    return {
+      ...options.location,
+      ...explicit,
+      timezone: normalizeTimezone(options.location?.timezone),
+    };
+  }
+
+  // Coordinates that were passed but unusable (a NaN from a parent component's
+  // own geolocation, say) are treated as absent rather than sent upstream.
+  return getClientLocation(options.geoEndpoint, options.ip, {
+    attempts: options.retryAttempts,
+    retryDelay: options.retryDelay,
+    providers: options.geoProviders,
+    fallbackLocation: options.fallbackLocation,
+    onProviderError: options.onProviderError
+      ? ({ provider, error }) => options.onProviderError?.({ provider, error, stage: 'geolocation' })
+      : undefined,
+  });
+}
+
+/** Validate and clamp every option into a request that no upstream can reject as malformed. */
+export async function buildForecastRequest(
+  options: WeatherForecastOptions = {}
+): Promise<ForecastRequest> {
+  const location = await resolveLocation(options);
+  const transport: GrabJsonOptions = {
+    attempts: options.retryAttempts,
+    retryDelay: options.retryDelay,
+    timeout: options.timeout,
+  };
+
+  return {
+    location,
+    temperatureUnit: options.temperatureUnit || 'fahrenheit',
+    windSpeedUnit: options.windSpeedUnit || 'mph',
+    forecastDays: clampInteger(options.forecastDays ?? 5, 5, 1, MAX_FORECAST_DAYS),
+    forecastHours: clampInteger(options.forecastHours ?? 24, 24, 1, MAX_FORECAST_HOURS),
+    // `undefined` means "let the provider resolve the zone from the
+    // coordinates" (Open-Meteo's `timezone=auto`); an unrecognised zone string
+    // is dropped here rather than sent, since Open-Meteo answers 400 for one.
+    timezone: normalizeTimezone(options.location?.timezone),
+    transport,
+  };
+}
+
+/**
+ * Current, hourly and daily forecast for a location.
+ *
+ * @param options Location, units, range, provider chain and retry settings.
+ * @returns The first provider's answer, a cached one, or -- if every provider
+ *   failed and `allowStaleCache` is on -- the last good answer for this exact
+ *   request.
+ */
 export async function getWeatherForecast(
   options: WeatherForecastOptions = {}
 ): Promise<WeatherForecastData> {
-  let location: WeatherLocation;
+  const request = await buildForecastRequest(options);
+  const key = forecastCacheKey(request);
 
-  if (typeof options.latitude === 'number' && typeof options.longitude === 'number') {
-    location = {
-      ...options.location,
-      latitude: options.latitude,
-      longitude: options.longitude,
-    };
-  } else {
-    location = await getClientLocation(options.geoEndpoint, options.ip);
-  }
-
-  const url = buildUrl(location.latitude, location.longitude, { ...options, location });
-
-  const cached = readCachedForecast<WeatherForecastData>(url);
+  const cached = readCachedForecast<WeatherForecastData>(key);
   if (cached) return cached;
 
-  const data = await grabJson<any>(url, 'Weather request', {
-    headers: { 'Content-Type': 'application/json' },
-    retryAttempts: 1,
-  });
+  const providers = resolveWeatherProviders(options.weatherProviders);
+  const failures: string[] = [];
 
-  if (!data?.current || !data?.hourly || !data?.daily) {
-    throw new Error('Invalid weather response');
+  for (const provider of providers) {
+    try {
+      const data = await provider.fetchForecast(request);
+      writeCachedForecast(key, data);
+      return data;
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error));
+      options.onProviderError?.({ provider: provider.id, error: failure, stage: 'forecast' });
+      // grab-url already labelled the message `Weather request failed: ...`;
+      // the provider's own name replaces that prefix in the summary below.
+      failures.push(`${provider.label}: ${failure.message.replace(/^Weather request failed:\s*/, '')}`);
+    }
   }
 
-  const result: WeatherForecastData = {
-    location: { ...location, timezone: data.timezone || location.timezone },
-    current: {
-      time: data.current.time,
-      temperature: Math.round(data.current.temperature_2m),
-      weatherCode: data.current.weather_code,
-      icon: getWeatherIcon(data.current.weather_code, data.current.is_day),
-      isDay: data.current.is_day,
-      rain: data.current.rain,
-      showers: data.current.showers,
-      snowfall: data.current.snowfall,
-      windSpeed: data.current.wind_speed_10m,
-    },
-    hourly: data.hourly.time.map((time: string, index: number) => ({
-      time,
-      temperature: Math.round(data.hourly.temperature_2m[index]),
-      weatherCode: data.hourly.weather_code[index],
-      precipitationProbability: data.hourly.precipitation_probability?.[index],
-      rain: data.hourly.rain?.[index],
-      showers: data.hourly.showers?.[index],
-      snowfall: data.hourly.snowfall?.[index],
-      icon: getWeatherIcon(data.hourly.weather_code[index]),
-    })),
-    daily: data.daily.time.map((date: string, index: number) => ({
-      date,
-      min: Math.round(data.daily.temperature_2m_min[index]),
-      max: Math.round(data.daily.temperature_2m_max[index]),
-      weatherCode: data.daily.weather_code[index],
-      precipitationProbabilityMax: data.daily.precipitation_probability_max?.[index],
-      precipitationSum: data.daily.precipitation_sum?.[index],
-      windSpeedMax: data.daily.wind_speed_10m_max?.[index],
-      icon: getWeatherIcon(data.daily.weather_code[index]),
-    })),
-  };
+  // Every upstream is down or rate-limited: a forecast from up to a few hours
+  // ago is still a better widget than an error message.
+  if (options.allowStaleCache !== false) {
+    const stale = readStaleForecast<WeatherForecastData>(key);
+    if (stale) return stale;
+  }
 
-  writeCachedForecast(url, result);
-  return result;
+  throw new Error(`Weather request failed: ${failures.join('; ')}`);
 }

--- a/packages/react-weather-forecast/src/api/geolocation.ts
+++ b/packages/react-weather-forecast/src/api/geolocation.ts
@@ -1,104 +1,229 @@
 import type { WeatherLocation } from '../types';
-import { grabJson } from './http';
-
-const DEFAULT_IP_API_URL = 'https://ipapi.co';
+import { normalizeCoordinates, normalizeTimezone } from '../lib/validate';
+import { grabJson, type GrabJsonOptions } from './http';
 
 /**
- * ipapi.co's free tier rate-limits by IP and answers a 200 carrying
- * `{ error: true, reason: 'RateLimited' }`, and a geo worker can drop a
- * request while it cold-starts. Both clear on their own, so the lookup is
- * repeated before the error reaches the caller.
+ * IP geolocation, over a chain of upstreams.
+ *
+ * Every free IP lookup rate-limits (ipapi.co allows 1,000 requests/day and
+ * answers a 200 carrying `{ error: true, reason: 'RateLimited' }` past that),
+ * and a geo worker can drop a request while it cold-starts. Worse, a lookup
+ * can "succeed" with no coordinates in the body -- which used to become
+ * `latitude=NaN` in the forecast URL and surface as
+ * `Weather request failed: 400 Bad Request`.
+ *
+ * So each provider is retried, a payload without usable coordinates counts as
+ * a failure, and the next provider in the chain gets a turn.
  */
-const DEFAULT_ATTEMPTS = 3;
+
+/** default=2 Tries per provider before moving to the next one. */
+const DEFAULT_ATTEMPTS = 2;
 const DEFAULT_RETRY_DELAY_MS = 500;
+/** Geolocation is on the critical path of the first render, so it waits less than a forecast. */
+const DEFAULT_TIMEOUT_SECONDS = 8;
+
+/** One IP geolocation upstream. */
+export type GeoProvider = {
+  id: string;
+  /** Used in the thrown message, e.g. `ipapi.co lookup`. */
+  label: string;
+  /** Full URL for the lookup; `ip` is the address to look up, if any. */
+  url: (ip?: string) => string;
+  /** Map the body onto a location, or return `null` if it carries none. */
+  parse: (body: Record<string, any>) => Partial<WeatherLocation> | null;
+};
 
 export type GeolocationOptions = {
-  /** default=3 How many times the lookup is tried before the error is thrown. */
+  /** default=2 How many times each provider is tried before the next one is used. */
   attempts?: number;
-  /** default=500 Milliseconds to wait before the second try; each further wait grows by that much. */
+  /** default=500 Milliseconds before a retry; each further wait doubles. */
   retryDelay?: number;
+  /** default=8 Seconds before a single lookup is aborted. */
+  timeout?: number;
+  /** Providers to try, by id or as objects. Omit for {@link DEFAULT_GEO_PROVIDERS}. */
+  providers?: (string | GeoProvider)[];
+  /** Used when every provider failed, instead of throwing. */
+  fallbackLocation?: Partial<WeatherLocation> | null;
+  /** Called for each provider that failed, before the next one is tried. */
+  onProviderError?: (info: { provider: string; error: Error }) => void;
 };
 
-type IpApiResponse = {
-  city?: string;
-  region?: string;
-  country_name?: string;
-  timezone?: string;
-  latitude?: number;
-  longitude?: number;
-  error?: boolean;
-  reason?: string;
-};
-
-type GeoWorkerResponse = {
-  city?: string;
-  region?: string;
-  country?: string;
-  timezone?: string;
-  latitude?: number | string;
-  longitude?: number | string;
-};
-
-const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-async function lookupViaWorker(geoEndpoint: string, ip?: string): Promise<WeatherLocation> {
-  const url = ip ? `${geoEndpoint}?ip=${encodeURIComponent(ip)}` : geoEndpoint;
-  const data = await grabJson<GeoWorkerResponse>(url, 'Geolocation worker lookup');
-
-  return {
-    city: data.city,
-    region: data.region,
-    country: data.country,
-    timezone: data.timezone,
-    latitude: Number(data.latitude),
-    longitude: Number(data.longitude),
-  };
-}
-
-async function lookupViaIpApi(ip?: string): Promise<WeatherLocation> {
-  const url = `${DEFAULT_IP_API_URL}/${ip ? `${encodeURIComponent(ip)}/` : ''}json/`;
-  const data = await grabJson<IpApiResponse>(url, 'ipapi.co lookup');
-
-  return {
+export const ipapiProvider: GeoProvider = {
+  id: 'ipapi',
+  label: 'ipapi.co lookup',
+  url: (ip) => `https://ipapi.co/${ip ? `${encodeURIComponent(ip)}/` : ''}json/`,
+  parse: (data) => ({
     city: data.city,
     region: data.region,
     country: data.country_name,
     timezone: data.timezone,
-    latitude: Number(data.latitude),
-    longitude: Number(data.longitude),
+    latitude: data.latitude,
+    longitude: data.longitude,
+  }),
+};
+
+export const ipwhoProvider: GeoProvider = {
+  id: 'ipwho',
+  label: 'ipwho.is lookup',
+  url: (ip) => `https://ipwho.is/${ip ? encodeURIComponent(ip) : ''}`,
+  parse: (data) => {
+    // ipwho.is reports a failure as a 200 with `success: false`.
+    if (data.success === false) return null;
+    return {
+      city: data.city,
+      region: data.region,
+      country: data.country,
+      timezone: data.timezone?.id ?? data.timezone,
+      latitude: data.latitude,
+      longitude: data.longitude,
+    };
+  },
+};
+
+export const geojsProvider: GeoProvider = {
+  id: 'geojs',
+  label: 'geojs.io lookup',
+  url: (ip) =>
+    ip
+      ? `https://get.geojs.io/v1/ip/geo/${encodeURIComponent(ip)}.json`
+      : 'https://get.geojs.io/v1/ip/geo.json',
+  parse: (data) => {
+    const body = Array.isArray(data) ? data[0] : data;
+    if (!body) return null;
+    return {
+      city: body.city,
+      region: body.region,
+      country: body.country,
+      timezone: body.timezone,
+      latitude: body.latitude,
+      longitude: body.longitude,
+    };
+  },
+};
+
+export const freeipapiProvider: GeoProvider = {
+  id: 'freeipapi',
+  label: 'freeipapi.com lookup',
+  url: (ip) => `https://freeipapi.com/api/json${ip ? `/${encodeURIComponent(ip)}` : ''}`,
+  parse: (data) => ({
+    city: data.cityName,
+    region: data.regionName,
+    country: data.countryName,
+    timezone: data.timeZone,
+    latitude: data.latitude,
+    longitude: data.longitude,
+  }),
+};
+
+/** Tried in order; each is a different operator, so a rate limit on one is not a rate limit on all. */
+export const DEFAULT_GEO_PROVIDERS: GeoProvider[] = [
+  ipapiProvider,
+  ipwhoProvider,
+  geojsProvider,
+  freeipapiProvider,
+];
+
+const BY_ID = new Map(DEFAULT_GEO_PROVIDERS.map((provider) => [provider.id, provider]));
+
+/** The bundled Cloudflare worker, wrapped as a provider so it joins the same chain. */
+export function createWorkerGeoProvider(geoEndpoint: string): GeoProvider {
+  return {
+    id: 'worker',
+    label: 'Geolocation worker lookup',
+    url: (ip) => (ip ? `${geoEndpoint}?ip=${encodeURIComponent(ip)}` : geoEndpoint),
+    parse: (data) => ({
+      city: data.city,
+      region: data.region,
+      country: data.country,
+      timezone: data.timezone,
+      latitude: data.latitude,
+      longitude: data.longitude,
+    }),
+  };
+}
+
+export function resolveGeoProviders(
+  providers?: (string | GeoProvider)[],
+  geoEndpoint?: string
+): GeoProvider[] {
+  const configured = providers
+    ?.map((provider) => (typeof provider === 'string' ? BY_ID.get(provider) : provider))
+    .filter((provider): provider is GeoProvider => Boolean(provider));
+
+  const chain = configured && configured.length > 0 ? configured : DEFAULT_GEO_PROVIDERS;
+
+  // A deployed worker is both faster and not rate-limited, so it goes first.
+  return geoEndpoint ? [createWorkerGeoProvider(geoEndpoint), ...chain] : chain;
+}
+
+/** A provider's body, only if it carries coordinates that can go in a URL. */
+function toLocation(provider: GeoProvider, body: Record<string, any>): WeatherLocation | null {
+  const parsed = provider.parse(body);
+  if (!parsed) return null;
+
+  const coordinates = normalizeCoordinates(parsed.latitude, parsed.longitude);
+  if (!coordinates) return null;
+
+  return {
+    city: parsed.city,
+    region: parsed.region,
+    country: parsed.country,
+    timezone: normalizeTimezone(parsed.timezone),
+    ...coordinates,
   };
 }
 
 /**
- * Resolve the caller's location, either from a deployed geo worker or from
- * ipapi.co directly.
+ * Resolve the caller's location from a deployed geo worker or from one of the
+ * public IP lookups.
  *
- * A failed lookup is repeated with a growing delay and only the last error is
- * thrown, so a single rate-limited or cold-started response no longer takes
- * the whole forecast down with it.
+ * Each provider is retried with a growing delay, then the chain moves on; only
+ * if all of them fail (and no `fallbackLocation` was given) does an error
+ * reach the caller, listing what every provider said.
  *
- * @param geoEndpoint URL of a deployed geo worker; omit to use ipapi.co.
+ * @param geoEndpoint URL of a deployed geo worker; it is tried before the public providers.
  * @param ip Look up this IP instead of the caller's own.
- * @param options How often to repeat the lookup, and how long to wait between tries.
+ * @param options Retry, timeout, provider chain and fallback settings.
  */
 export async function getClientLocation(
   geoEndpoint?: string,
   ip?: string,
   options: GeolocationOptions = {}
 ): Promise<WeatherLocation> {
-  const attempts = Math.max(1, Math.trunc(options.attempts ?? DEFAULT_ATTEMPTS));
-  const retryDelay = Math.max(0, options.retryDelay ?? DEFAULT_RETRY_DELAY_MS);
+  const providers = resolveGeoProviders(options.providers, geoEndpoint);
+  const transport: GrabJsonOptions = {
+    attempts: Math.max(1, Math.trunc(options.attempts ?? DEFAULT_ATTEMPTS)),
+    retryDelay: Math.max(0, options.retryDelay ?? DEFAULT_RETRY_DELAY_MS),
+    timeout: options.timeout ?? DEFAULT_TIMEOUT_SECONDS,
+  };
 
-  let lastError: unknown;
+  const failures: Error[] = [];
 
-  for (let attempt = 1; attempt <= attempts; attempt++) {
+  for (const provider of providers) {
     try {
-      return geoEndpoint ? await lookupViaWorker(geoEndpoint, ip) : await lookupViaIpApi(ip);
+      const body = await grabJson<Record<string, any>>(provider.url(ip), provider.label, transport);
+      const location = toLocation(provider, body);
+      if (location) return location;
+
+      throw new Error(`${provider.label} failed: no coordinates in the response`);
     } catch (error) {
-      lastError = error;
-      if (attempt < attempts && retryDelay > 0) await wait(retryDelay * attempt);
+      const failure = error instanceof Error ? error : new Error(String(error));
+      failures.push(failure);
+      options.onProviderError?.({ provider: provider.id, error: failure });
     }
   }
 
-  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  const fallback = options.fallbackLocation
+    ? normalizeCoordinates(options.fallbackLocation.latitude, options.fallbackLocation.longitude)
+    : null;
+  if (fallback && options.fallbackLocation) {
+    return {
+      ...options.fallbackLocation,
+      timezone: normalizeTimezone(options.fallbackLocation.timezone),
+      ...fallback,
+    };
+  }
+
+  if (failures.length === 1) throw failures[0];
+  throw new Error(`Geolocation lookup failed: ${failures.map((error) => error.message).join('; ')}`);
 }

--- a/packages/react-weather-forecast/src/api/http.ts
+++ b/packages/react-weather-forecast/src/api/http.ts
@@ -1,28 +1,68 @@
 import grab from 'grab-url';
 
 /**
- * Shared JSON transport for the package's upstreams (the geo worker, ipapi.co
- * and Open-Meteo).
+ * Shared JSON transport for every upstream this package talks to (the geo
+ * worker, the IP geolocation providers and the weather providers).
  *
- * `grab-url` is the HTTP client used across this repo: it parses the JSON,
- * applies a timeout and can repeat a failed request itself. Unlike `fetch` it
- * resolves rather than rejects when a request fails, handing back the message
- * on `.error`, so every call site has to inspect the payload -- that check
- * lives here so the callers can just `await` a typed body.
+ * `grab-url` is the HTTP client used across this repo rather than `fetch`: it
+ * parses the JSON, applies a timeout and can repeat a failed request itself.
+ * Unlike `fetch` it resolves rather than rejects when a request fails, handing
+ * back the message on `.error`, so every call site has to inspect the payload
+ * -- that check lives here so the callers can just `await` a typed body.
+ *
+ * On top of that this module adds what the upstreams actually need to stay up:
+ * a classified retry loop (repeat what can recover, give up immediately on a
+ * request the server called invalid) with exponential backoff.
  */
 export type GrabJsonOptions = {
   headers?: Record<string, string>;
-  /** default=0 Times grab-url repeats a request that failed at the transport level. */
-  retryAttempts?: number;
-  /** default=15 Seconds before the request is aborted. */
+  /** default=3 Total tries for this request, including the first one. */
+  attempts?: number;
+  /** default=400 Milliseconds before the second try; each further wait doubles. */
+  retryDelay?: number;
+  /** default=15 Seconds before a single try is aborted. */
   timeout?: number;
+  /**
+   * default=0 Times grab-url itself repeats a try that failed at the transport
+   * level, inside each of our `attempts`. Left at 0 so the backoff and the
+   * status classification below stay in charge of every repeat.
+   */
+  retryAttempts?: number;
+  /**
+   * default=false Repeat even when the server rejected the request as invalid
+   * (a 4xx other than 408/429). Off by default: replaying a request that is
+   * malformed only wastes the upstream's rate limit.
+   */
+  retryClientErrors?: boolean;
 };
 
 /**
- * Both upstreams can answer HTTP 200 with an error flag instead of data:
- * ipapi.co does it for rate limits, Open-Meteo for a malformed query.
+ * Both kinds of upstream can answer HTTP 200 with an error flag instead of
+ * data: ipapi.co does it for rate limits, Open-Meteo for a malformed query.
  */
 type ErrorPayload = { error?: boolean | string; reason?: string };
+
+/** Statuses worth repeating: the upstream is busy, cold or briefly broken. */
+const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504, 520, 521, 522, 523, 524]);
+
+/** A failed upstream call, carrying the HTTP status when the failure had one. */
+export class HttpRequestError extends Error {
+  readonly status?: number;
+  readonly retryable: boolean;
+
+  constructor(message: string, options: { status?: number; retryable?: boolean } = {}) {
+    super(message);
+    this.name = 'HttpRequestError';
+    this.status = options.status;
+    this.retryable = options.retryable ?? isRetryableStatus(options.status);
+  }
+}
+
+/** No status at all means the request never reached the server -- worth a repeat. */
+export function isRetryableStatus(status?: number): boolean {
+  if (status === undefined) return true;
+  return RETRYABLE_STATUS.has(status) || status >= 500;
+}
 
 /**
  * grab-url reports a failed request as `HTTP error: 429 Too Many Requests`.
@@ -33,34 +73,98 @@ function describeFailure(error: string): string {
   return error.replace(/^HTTP error:\s*/i, '').trim() || 'unknown error';
 }
 
+/** Read the HTTP status back out of the message grab-url built for it. */
+function parseStatus(error: string): number | undefined {
+  const match = /^\s*(?:HTTP error:\s*)?([1-5]\d{2})\b/.exec(error.replace(/^HTTP error:\s*/i, 'HTTP error: '));
+  const status = match ? Number(match[1]) : Number.NaN;
+  return Number.isFinite(status) ? status : undefined;
+}
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
- * Request a JSON body, throwing a labelled error for any failure.
+ * grab-url writes a parsed JSON object to the root of its response, but hands
+ * back anything it could not parse as JSON under `.data`. Unwrap that shape so
+ * providers only ever see the body itself.
+ */
+function unwrapBody<T>(payload: Record<string, unknown>): T {
+  const keys = Object.keys(payload).filter((key) => key !== 'isLoading' && key !== 'error');
+  if (keys.length === 1 && keys[0] === 'data') {
+    const body = payload.data;
+    if (body && typeof body === 'object') return body as T;
+  }
+  return payload as T;
+}
+
+/** One try. Throws an {@link HttpRequestError} describing why it failed. */
+async function grabJsonOnce<T>(url: string, label: string, options: GrabJsonOptions): Promise<T> {
+  const { headers, retryAttempts = 0, timeout = 15 } = options;
+
+  const data = (await grab(url, {
+    headers,
+    retryAttempts,
+    timeout,
+    // Several widgets (or several locations in one widget) hit the same path
+    // at once, and grab-url aborts the earlier call of a duplicate path by
+    // default -- which would surface as a spurious failure here.
+    cancelOngoingIfNew: false,
+    // These upstreams answer JSON; skip grab-url's HTML/ZIP post-processing so
+    // an error page is never handed back as a parsed DOM.
+    dom: false,
+    unzip: false,
+  })) as (T & ErrorPayload) | null | undefined;
+
+  if (typeof data?.error === 'string') {
+    const status = parseStatus(data.error);
+    throw new HttpRequestError(`${label} failed: ${describeFailure(data.error)}`, { status });
+  }
+
+  if (data?.error === true) {
+    // A 200 carrying an error flag is the upstream's own complaint (a rate
+    // limit, or a query it could not parse) rather than a transport failure.
+    const reason = data.reason ?? 'unknown error';
+    throw new HttpRequestError(`${label} failed: ${reason}`, {
+      retryable: /rate|limit|busy|timeout|try again/i.test(reason),
+    });
+  }
+
+  if (!data) throw new HttpRequestError(`${label} failed: empty response`);
+
+  return unwrapBody<T>(data as unknown as Record<string, unknown>);
+}
+
+/**
+ * Request a JSON body, repeating what can recover and throwing a labelled
+ * {@link HttpRequestError} once it cannot.
  *
  * @param url Full URL to request.
  * @param label Prefix for the thrown message, e.g. `ipapi.co lookup`.
- * @param options Transport options passed through to grab-url.
+ * @param options Transport and retry options.
  */
 export async function grabJson<T>(
   url: string,
   label: string,
   options: GrabJsonOptions = {}
 ): Promise<T> {
-  const { headers, retryAttempts = 0, timeout = 15 } = options;
+  const attempts = Math.max(1, Math.trunc(options.attempts ?? 3));
+  const retryDelay = Math.max(0, options.retryDelay ?? 400);
 
-  const data = (await grab(url, { headers, retryAttempts, timeout })) as
-    | (T & ErrorPayload)
-    | null
-    | undefined;
+  let lastError: unknown;
 
-  if (typeof data?.error === 'string') {
-    throw new Error(`${label} failed: ${describeFailure(data.error)}`);
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await grabJsonOnce<T>(url, label, options);
+    } catch (error) {
+      lastError = error;
+
+      const retryable =
+        !(error instanceof HttpRequestError) || error.retryable || options.retryClientErrors === true;
+      if (!retryable || attempt === attempts) break;
+
+      // Exponential backoff: 1x, 2x, 4x ... of the configured delay.
+      if (retryDelay > 0) await wait(retryDelay * 2 ** (attempt - 1));
+    }
   }
 
-  if (data?.error === true) {
-    throw new Error(`${label} failed: ${data.reason ?? 'unknown error'}`);
-  }
-
-  if (!data) throw new Error(`${label} failed: empty response`);
-
-  return data as T;
+  throw lastError instanceof Error ? lastError : new HttpRequestError(String(lastError));
 }

--- a/packages/react-weather-forecast/src/api/providers/index.ts
+++ b/packages/react-weather-forecast/src/api/providers/index.ts
@@ -1,0 +1,44 @@
+import { metNoProvider } from './met-no';
+import { openMeteoGfsProvider, openMeteoProvider } from './open-meteo';
+import type { WeatherProvider } from './types';
+import { wttrProvider } from './wttr';
+
+export * from './types';
+export { createOpenMeteoProvider, openMeteoProvider, openMeteoGfsProvider } from './open-meteo';
+export { metNoProvider, symbolToWmoCode } from './met-no';
+export { wttrProvider, wwoToWmoCode } from './wttr';
+
+/**
+ * Tried in order until one answers.
+ *
+ * Open-Meteo stays the primary source; its GFS endpoint covers a query the
+ * default model refused or rate-limited, and met.no and wttr.in are run by
+ * different operators entirely, so they still answer when Open-Meteo itself is
+ * unreachable.
+ */
+export const DEFAULT_WEATHER_PROVIDERS: WeatherProvider[] = [
+  openMeteoProvider,
+  openMeteoGfsProvider,
+  metNoProvider,
+  wttrProvider,
+];
+
+const BY_ID = new Map(DEFAULT_WEATHER_PROVIDERS.map((provider) => [provider.id, provider]));
+
+/**
+ * Turn the `weatherProviders` option into the list to try.
+ *
+ * @param providers Ids (`'open-meteo'`, `'met-no'`, `'wttr'`, `'open-meteo-gfs'`)
+ *   or provider objects of your own. Omit for {@link DEFAULT_WEATHER_PROVIDERS}.
+ */
+export function resolveWeatherProviders(
+  providers?: (string | WeatherProvider)[]
+): WeatherProvider[] {
+  if (!providers || providers.length === 0) return DEFAULT_WEATHER_PROVIDERS;
+
+  const resolved = providers
+    .map((provider) => (typeof provider === 'string' ? BY_ID.get(provider) : provider))
+    .filter((provider): provider is WeatherProvider => Boolean(provider));
+
+  return resolved.length > 0 ? resolved : DEFAULT_WEATHER_PROVIDERS;
+}

--- a/packages/react-weather-forecast/src/api/providers/met-no.ts
+++ b/packages/react-weather-forecast/src/api/providers/met-no.ts
@@ -1,0 +1,184 @@
+import type { DailyWeather, HourlyWeather, WeatherForecastData } from '../../types';
+import { getWeatherIcon } from '../../weatherCodes';
+import { fromCelsius, fromMetresPerSecond, round1 } from '../../lib/units';
+import { toZonedDate, toZonedIsoMinutes } from '../../lib/time';
+import { grabJson } from '../http';
+import type { ForecastRequest, WeatherProvider } from './types';
+
+const ENDPOINT = 'https://api.met.no/weatherapi/locationforecast/2.0/compact';
+
+/**
+ * met.no names conditions (`lightrainshowers_day`) where Open-Meteo uses WMO
+ * codes, so the widget's icon and code mapping keeps working after a failover.
+ */
+const SYMBOL_TO_WMO: Record<string, number> = {
+  clearsky: 0,
+  fair: 1,
+  partlycloudy: 2,
+  cloudy: 3,
+  fog: 45,
+  lightrain: 61,
+  rain: 63,
+  heavyrain: 65,
+  lightrainshowers: 80,
+  rainshowers: 81,
+  heavyrainshowers: 82,
+  lightsleet: 66,
+  sleet: 66,
+  heavysleet: 67,
+  lightsleetshowers: 85,
+  sleetshowers: 85,
+  heavysleetshowers: 86,
+  lightsnow: 71,
+  snow: 73,
+  heavysnow: 75,
+  lightsnowshowers: 85,
+  snowshowers: 85,
+  heavysnowshowers: 86,
+};
+
+export function symbolToWmoCode(symbol: string | undefined): number {
+  if (!symbol) return 3;
+  const base = symbol.replace(/_(day|night|polartwilight)$/, '');
+  if (base.includes('thunder')) return base.startsWith('heavy') ? 96 : 95;
+  return SYMBOL_TO_WMO[base] ?? 3;
+}
+
+type MetNoEntry = {
+  time: string;
+  data?: {
+    instant?: { details?: Record<string, number> };
+    next_1_hours?: { summary?: { symbol_code?: string }; details?: Record<string, number> };
+    next_6_hours?: { summary?: { symbol_code?: string }; details?: Record<string, number> };
+  };
+};
+
+type MetNoResponse = { properties?: { timeseries?: MetNoEntry[] } };
+
+const symbolOf = (entry: MetNoEntry) =>
+  entry.data?.next_1_hours?.summary?.symbol_code ?? entry.data?.next_6_hours?.summary?.symbol_code;
+
+const precipitationOf = (entry: MetNoEntry) =>
+  entry.data?.next_1_hours?.details?.precipitation_amount ??
+  entry.data?.next_6_hours?.details?.precipitation_amount;
+
+/**
+ * met.no is an independent upstream (a different operator, a different model),
+ * so it stays useful exactly when Open-Meteo is the thing that is down.
+ *
+ * It reports instants in UTC with Celsius and m/s; everything is converted to
+ * the request's units and rewritten into the naive local timestamps the widget
+ * renders, so a failover is invisible.
+ */
+export const metNoProvider: WeatherProvider = {
+  id: 'met-no',
+  label: 'met.no',
+
+  async fetchForecast(request: ForecastRequest): Promise<WeatherForecastData> {
+    const { latitude, longitude } = request.location;
+    const url = `${ENDPOINT}?lat=${latitude}&lon=${longitude}`;
+    const zone = request.timezone || request.location.timezone;
+
+    const data = await grabJson<MetNoResponse>(url, 'Weather request', {
+      ...request.transport,
+      headers: {
+        // met.no asks every client to identify itself; browsers refuse to set
+        // this header, in which case the request simply goes out without it.
+        'User-Agent': 'use-weather-forecast (https://npmjs.com/package/use-weather-forecast)',
+        ...request.transport.headers,
+      },
+    });
+
+    const entries = data.properties?.timeseries ?? [];
+    if (entries.length === 0) throw new Error('Invalid weather response');
+
+    const temperature = (entry: MetNoEntry) => entry.data?.instant?.details?.air_temperature;
+    const toDisplayTemp = (celsius: number) => Math.round(fromCelsius(celsius, request.temperatureUnit));
+    const toDisplayWind = (ms: number) => round1(fromMetresPerSecond(ms, request.windSpeedUnit));
+
+    const first = entries[0];
+    const firstTemperature = temperature(first);
+    if (firstTemperature === undefined) throw new Error('Invalid weather response');
+
+    const currentCode = symbolToWmoCode(symbolOf(first));
+    const currentSymbol = symbolOf(first) ?? '';
+    const isDay = currentSymbol.endsWith('_night') ? 0 : 1;
+    const currentWind = first.data?.instant?.details?.wind_speed;
+
+    const hourly: HourlyWeather[] = entries
+      .filter((entry) => entry.data?.next_1_hours || entry.data?.next_6_hours)
+      .slice(0, request.forecastHours)
+      .map((entry) => {
+        const code = symbolToWmoCode(symbolOf(entry));
+        const celsius = temperature(entry);
+        return {
+          time: toZonedIsoMinutes(new Date(entry.time), zone),
+          temperature: celsius === undefined ? Number.NaN : toDisplayTemp(celsius),
+          weatherCode: code,
+          precipitationProbability: entry.data?.next_1_hours?.details?.probability_of_precipitation,
+          rain: precipitationOf(entry),
+          icon: getWeatherIcon(code),
+        };
+      })
+      .filter((hour) => Number.isFinite(hour.temperature));
+
+    // met.no reports instants, not days, so the days are aggregated here: the
+    // extremes of every reading that falls on the same local calendar date,
+    // with the condition taken from the reading closest to local midday.
+    const byDate = new Map<string, MetNoEntry[]>();
+    for (const entry of entries) {
+      const date = toZonedDate(new Date(entry.time), zone);
+      const bucket = byDate.get(date);
+      if (bucket) bucket.push(entry);
+      else byDate.set(date, [entry]);
+    }
+
+    const daily: DailyWeather[] = [...byDate.entries()]
+      .slice(0, request.forecastDays)
+      .map(([date, dayEntries]) => {
+        const temperatures = dayEntries.map(temperature).filter((value): value is number => value !== undefined);
+        const winds = dayEntries
+          .map((entry) => entry.data?.instant?.details?.wind_speed)
+          .filter((value): value is number => value !== undefined);
+        const precipitation = dayEntries
+          .map(precipitationOf)
+          .filter((value): value is number => value !== undefined);
+
+        const middayEntry = dayEntries.reduce((closest, entry) => {
+          const hourOf = (candidate: MetNoEntry) =>
+            Math.abs(Number(toZonedIsoMinutes(new Date(candidate.time), zone).slice(11, 13)) - 12);
+          return hourOf(entry) < hourOf(closest) ? entry : closest;
+        }, dayEntries[0]);
+
+        const code = symbolToWmoCode(symbolOf(middayEntry));
+
+        return {
+          date,
+          min: temperatures.length ? toDisplayTemp(Math.min(...temperatures)) : Number.NaN,
+          max: temperatures.length ? toDisplayTemp(Math.max(...temperatures)) : Number.NaN,
+          weatherCode: code,
+          precipitationSum: precipitation.length ? round1(precipitation.reduce((a, b) => a + b, 0)) : undefined,
+          windSpeedMax: winds.length ? toDisplayWind(Math.max(...winds)) : undefined,
+          icon: getWeatherIcon(code),
+        };
+      })
+      .filter((day) => Number.isFinite(day.min) && Number.isFinite(day.max));
+
+    if (hourly.length === 0 || daily.length === 0) throw new Error('Invalid weather response');
+
+    return {
+      location: { ...request.location, timezone: zone },
+      current: {
+        time: toZonedIsoMinutes(new Date(first.time), zone),
+        temperature: toDisplayTemp(firstTemperature),
+        weatherCode: currentCode,
+        icon: getWeatherIcon(currentCode, isDay),
+        isDay,
+        rain: precipitationOf(first),
+        windSpeed: currentWind === undefined ? undefined : toDisplayWind(currentWind),
+      },
+      hourly,
+      daily,
+    };
+  },
+};

--- a/packages/react-weather-forecast/src/api/providers/open-meteo.ts
+++ b/packages/react-weather-forecast/src/api/providers/open-meteo.ts
@@ -1,0 +1,167 @@
+import type { WeatherForecastData } from '../../types';
+import { getWeatherIcon } from '../../weatherCodes';
+import { grabJson, HttpRequestError } from '../http';
+import type { ForecastRequest, WeatherProvider } from './types';
+
+/** Every variable the widget can render. */
+const FULL_VARIABLES = {
+  current: ['temperature_2m', 'weather_code', 'is_day', 'rain', 'showers', 'snowfall', 'wind_speed_10m'],
+  hourly: ['temperature_2m', 'weather_code', 'precipitation_probability', 'rain', 'showers', 'snowfall'],
+  daily: [
+    'temperature_2m_max',
+    'temperature_2m_min',
+    'weather_code',
+    'precipitation_probability_max',
+    'precipitation_sum',
+    'wind_speed_10m_max',
+  ],
+};
+
+/**
+ * The subset every Open-Meteo model endpoint supports. Some models (and some
+ * of the free API's mirrors) reject one of the optional variables above with a
+ * flat `400 Bad Request`, so a rejected query is repeated once with only what
+ * the widget cannot render without.
+ */
+const MINIMAL_VARIABLES = {
+  current: ['temperature_2m', 'weather_code', 'is_day'],
+  hourly: ['temperature_2m', 'weather_code'],
+  daily: ['temperature_2m_max', 'temperature_2m_min', 'weather_code'],
+};
+
+type Variables = typeof FULL_VARIABLES;
+
+export function buildOpenMeteoUrl(
+  endpoint: string,
+  request: ForecastRequest,
+  variables: Variables = FULL_VARIABLES
+): string {
+  const params = new URLSearchParams({
+    latitude: String(request.location.latitude),
+    longitude: String(request.location.longitude),
+    timezone: request.timezone || 'auto',
+    temperature_unit: request.temperatureUnit,
+    wind_speed_unit: request.windSpeedUnit,
+    forecast_days: String(request.forecastDays),
+    forecast_hours: String(request.forecastHours),
+    current: variables.current.join(','),
+    hourly: variables.hourly.join(','),
+    daily: variables.daily.join(','),
+  });
+
+  return `${endpoint}?${params.toString()}`;
+}
+
+/** Shape the widget needs; anything else in the payload is ignored. */
+type OpenMeteoResponse = {
+  timezone?: string;
+  current?: Record<string, number | string>;
+  hourly?: Record<string, (number | null)[] | string[]>;
+  daily?: Record<string, (number | null)[] | string[]>;
+};
+
+function parse(data: OpenMeteoResponse, request: ForecastRequest): WeatherForecastData {
+  if (!data?.current || !data?.hourly || !data?.daily) {
+    throw new Error('Invalid weather response');
+  }
+
+  const current = data.current as Record<string, number>;
+  const hourly = data.hourly as Record<string, number[]> & { time: string[] };
+  const daily = data.daily as Record<string, number[]> & { time: string[] };
+
+  return {
+    location: {
+      ...request.location,
+      timezone: (data.timezone as string) || request.location.timezone,
+    },
+    current: {
+      time: current.time as unknown as string,
+      temperature: Math.round(current.temperature_2m),
+      weatherCode: current.weather_code,
+      icon: getWeatherIcon(current.weather_code, current.is_day),
+      isDay: current.is_day,
+      rain: current.rain,
+      showers: current.showers,
+      snowfall: current.snowfall,
+      windSpeed: current.wind_speed_10m,
+    },
+    hourly: hourly.time.map((time, index) => ({
+      time,
+      temperature: Math.round(hourly.temperature_2m[index]),
+      weatherCode: hourly.weather_code[index],
+      precipitationProbability: hourly.precipitation_probability?.[index],
+      rain: hourly.rain?.[index],
+      showers: hourly.showers?.[index],
+      snowfall: hourly.snowfall?.[index],
+      icon: getWeatherIcon(hourly.weather_code[index]),
+    })),
+    daily: daily.time.map((date, index) => ({
+      date,
+      min: Math.round(daily.temperature_2m_min[index]),
+      max: Math.round(daily.temperature_2m_max[index]),
+      weatherCode: daily.weather_code[index],
+      precipitationProbabilityMax: daily.precipitation_probability_max?.[index],
+      precipitationSum: daily.precipitation_sum?.[index],
+      windSpeedMax: daily.wind_speed_10m_max?.[index],
+      icon: getWeatherIcon(daily.weather_code[index]),
+    })),
+  };
+}
+
+/**
+ * Open-Meteo, the package's primary source.
+ *
+ * @param id Provider id, e.g. `open-meteo`.
+ * @param label Name used in the aggregated error message.
+ * @param endpoint Full endpoint URL; the model endpoints (`/v1/gfs` and
+ *   friends) take the same query as `/v1/forecast`.
+ */
+export function createOpenMeteoProvider(id: string, label: string, endpoint: string): WeatherProvider {
+  return {
+    id,
+    label,
+    async fetchForecast(request) {
+      try {
+        const data = await grabJson<OpenMeteoResponse>(
+          buildOpenMeteoUrl(endpoint, request),
+          'Weather request',
+          request.transport
+        );
+        return parse(data, request);
+      } catch (error) {
+        // A 400 means this endpoint refused one of the optional variables (or
+        // the whole variable list); ask again for the bare minimum before
+        // handing the request to the next provider. A body we could not parse
+        // is not a query problem, so it is not worth a second request.
+        if (!(error instanceof HttpRequestError)) throw error;
+        const invalidQuery =
+          error.status === 400 || /cannot initialize|invalid|not supported/i.test(error.message);
+        if (!invalidQuery) throw error;
+
+        const data = await grabJson<OpenMeteoResponse>(
+          buildOpenMeteoUrl(endpoint, request, MINIMAL_VARIABLES),
+          'Weather request',
+          request.transport
+        );
+        return parse(data, request);
+      }
+    },
+  };
+}
+
+/** `https://api.open-meteo.com/v1/forecast` -- the default, best-model source. */
+export const openMeteoProvider = createOpenMeteoProvider(
+  'open-meteo',
+  'Open-Meteo',
+  'https://api.open-meteo.com/v1/forecast'
+);
+
+/**
+ * The GFS model endpoint on the same host. It answers when `/v1/forecast` is
+ * rate-limited or refuses the query, and speaks exactly the same dialect.
+ */
+export const openMeteoGfsProvider = createOpenMeteoProvider(
+  'open-meteo-gfs',
+  'Open-Meteo (GFS)',
+  'https://api.open-meteo.com/v1/gfs'
+);

--- a/packages/react-weather-forecast/src/api/providers/types.ts
+++ b/packages/react-weather-forecast/src/api/providers/types.ts
@@ -1,0 +1,32 @@
+import type { GrabJsonOptions } from '../http';
+import type { TemperatureUnit, WeatherForecastData, WeatherLocation, WindSpeedUnit } from '../../types';
+
+/** A forecast request after validation: every field is safe to put in a URL. */
+export type ForecastRequest = {
+  location: WeatherLocation;
+  temperatureUnit: TemperatureUnit;
+  windSpeedUnit: WindSpeedUnit;
+  /** 1-16. */
+  forecastDays: number;
+  /** 1-384. */
+  forecastHours: number;
+  /** A validated IANA zone, or `undefined` to let the provider resolve it. */
+  timezone?: string;
+  /** Transport and retry settings passed through to grab-url. */
+  transport: GrabJsonOptions;
+};
+
+/**
+ * One upstream that can answer a {@link ForecastRequest}.
+ *
+ * Providers are tried in order and the first one to answer wins, so each has
+ * to return the same normalized shape whatever units or codes it speaks
+ * natively.
+ */
+export type WeatherProvider = {
+  /** Stable id, e.g. `open-meteo`. Used in options and in the error message. */
+  id: string;
+  /** Human-readable name for the aggregated error message. */
+  label: string;
+  fetchForecast: (request: ForecastRequest) => Promise<WeatherForecastData>;
+};

--- a/packages/react-weather-forecast/src/api/providers/wttr.ts
+++ b/packages/react-weather-forecast/src/api/providers/wttr.ts
@@ -1,0 +1,184 @@
+import type { DailyWeather, HourlyWeather, WeatherForecastData } from '../../types';
+import { getWeatherIcon } from '../../weatherCodes';
+import { fromKilometresPerHour, round1 } from '../../lib/units';
+import { toZonedIsoMinutes } from '../../lib/time';
+import { grabJson } from '../http';
+import type { ForecastRequest, WeatherProvider } from './types';
+
+/**
+ * wttr.in maps the World Weather Online condition codes it inherited onto the
+ * WMO codes the rest of this package speaks.
+ */
+const WWO_TO_WMO: Record<number, number> = {
+  113: 0,
+  116: 2,
+  119: 3,
+  122: 3,
+  143: 45,
+  176: 80,
+  179: 85,
+  182: 85,
+  185: 56,
+  200: 95,
+  227: 73,
+  230: 75,
+  248: 45,
+  260: 48,
+  263: 51,
+  266: 53,
+  281: 56,
+  284: 57,
+  293: 61,
+  296: 61,
+  299: 63,
+  302: 63,
+  305: 65,
+  308: 65,
+  311: 66,
+  314: 67,
+  317: 66,
+  320: 67,
+  323: 71,
+  326: 71,
+  329: 73,
+  332: 73,
+  335: 75,
+  338: 75,
+  350: 77,
+  353: 80,
+  356: 81,
+  359: 82,
+  362: 85,
+  365: 86,
+  368: 85,
+  371: 86,
+  374: 85,
+  377: 86,
+  386: 95,
+  389: 95,
+  392: 95,
+  395: 96,
+};
+
+export function wwoToWmoCode(code: unknown): number {
+  const parsed = Number(code);
+  return WWO_TO_WMO[parsed] ?? 3;
+}
+
+type WttrHour = Record<string, string>;
+type WttrDay = { date?: string; maxtempC?: string; maxtempF?: string; mintempC?: string; mintempF?: string; hourly?: WttrHour[] };
+type WttrResponse = {
+  current_condition?: Record<string, unknown>[];
+  weather?: WttrDay[];
+  nearest_area?: { areaName?: { value?: string }[]; region?: { value?: string }[]; country?: { value?: string }[] }[];
+};
+
+/** wttr.in reports hours as `0`, `300`, `1200`; turn that into `HH:MM`. */
+function hourLabel(time: string | undefined): string {
+  const minutes = Number(time ?? 0);
+  const hours = Math.floor(minutes / 100);
+  return `${String(hours).padStart(2, '0')}:${String(minutes % 100).padStart(2, '0')}`;
+}
+
+/**
+ * wttr.in, the second independent fallback.
+ *
+ * Its free endpoint needs no key and answers with the location's own local
+ * times, in both Celsius and Fahrenheit, so only the wind speed has to be
+ * converted. It is 3-hourly rather than hourly -- a coarser forecast, but a
+ * rendered widget rather than an error message.
+ */
+export const wttrProvider: WeatherProvider = {
+  id: 'wttr',
+  label: 'wttr.in',
+
+  async fetchForecast(request: ForecastRequest): Promise<WeatherForecastData> {
+    const { latitude, longitude } = request.location;
+    const url = `https://wttr.in/${latitude},${longitude}?format=j1&lang=en`;
+
+    const data = await grabJson<WttrResponse>(url, 'Weather request', request.transport);
+
+    const current = data.current_condition?.[0];
+    const days = (data.weather ?? []).filter((day) => day.date && day.hourly?.length);
+    if (!current || days.length === 0) throw new Error('Invalid weather response');
+
+    const zone = request.timezone || request.location.timezone;
+    const unit = request.temperatureUnit === 'celsius' ? 'C' : 'F';
+    // The hourly rows name the field `tempC`, the current conditions `temp_C`.
+    const temperatureOf = (source: Record<string, unknown>, field: string) => {
+      const value = source[`${field}${unit}`] ?? source[`${field}_${unit}`];
+      return Math.round(Number(value));
+    };
+    const windOf = (source: Record<string, unknown>) =>
+      round1(fromKilometresPerHour(Number(source.windspeedKmph ?? 0), request.windSpeedUnit));
+
+    // Open-Meteo starts the hourly series at the current hour, so wttr.in's
+    // past hours are dropped to keep the widget's first column meaning "now".
+    const nowLocal = toZonedIsoMinutes(new Date(), zone);
+    const hourly: HourlyWeather[] = days
+      .flatMap((day) =>
+        (day.hourly ?? []).map((hour) => {
+          const code = wwoToWmoCode(hour.weatherCode);
+          return {
+            time: `${day.date}T${hourLabel(hour.time)}`,
+            temperature: temperatureOf(hour, 'temp'),
+            weatherCode: code,
+            precipitationProbability: hour.chanceofrain === undefined ? undefined : Number(hour.chanceofrain),
+            rain: hour.precipMM === undefined ? undefined : Number(hour.precipMM),
+            icon: getWeatherIcon(code),
+          };
+        })
+      )
+      .filter((hour) => hour.time >= nowLocal.slice(0, 13))
+      .slice(0, request.forecastHours);
+
+    const daily: DailyWeather[] = days.slice(0, request.forecastDays).map((day) => {
+      const hours = day.hourly ?? [];
+      const midday = hours.find((hour) => hour.time === '1200') ?? hours[Math.floor(hours.length / 2)];
+      const code = wwoToWmoCode(midday?.weatherCode);
+      const precipitation = hours.reduce((total, hour) => total + Number(hour.precipMM ?? 0), 0);
+      const windMax = hours.reduce((peak, hour) => Math.max(peak, windOf(hour)), 0);
+
+      return {
+        date: day.date as string,
+        min: temperatureOf(day as Record<string, unknown>, 'mintemp'),
+        max: temperatureOf(day as Record<string, unknown>, 'maxtemp'),
+        weatherCode: code,
+        precipitationProbabilityMax: hours.reduce(
+          (peak, hour) => Math.max(peak, Number(hour.chanceofrain ?? 0)),
+          0
+        ),
+        precipitationSum: round1(precipitation),
+        windSpeedMax: windMax,
+        icon: getWeatherIcon(code),
+      };
+    });
+
+    if (hourly.length === 0) throw new Error('Invalid weather response');
+
+    const area = data.nearest_area?.[0];
+    const currentCode = wwoToWmoCode(current.weatherCode);
+    const isDay = nowLocal.slice(11, 13) >= '06' && nowLocal.slice(11, 13) < '19' ? 1 : 0;
+
+    return {
+      location: {
+        ...request.location,
+        city: request.location.city ?? area?.areaName?.[0]?.value,
+        region: request.location.region ?? area?.region?.[0]?.value,
+        country: request.location.country ?? area?.country?.[0]?.value,
+        timezone: zone,
+      },
+      current: {
+        time: nowLocal,
+        temperature: temperatureOf(current, 'temp'),
+        weatherCode: currentCode,
+        icon: getWeatherIcon(currentCode, isDay),
+        isDay,
+        rain: current.precipMM === undefined ? undefined : Number(current.precipMM),
+        windSpeed: windOf(current),
+      },
+      hourly,
+      daily,
+    };
+  },
+};

--- a/packages/react-weather-forecast/src/components/WeatherForecast.tsx
+++ b/packages/react-weather-forecast/src/components/WeatherForecast.tsx
@@ -219,7 +219,9 @@ function SingleWeatherForecast(props: Props) {
   // Keep showing the last forecast while a unit switch refetches in the
   // background; only suppress output on the very first load.
   if (loading && !data) return null;
-  if (error) return <div className={props.className} style={props.style}>Error: {error.message}</div>;
+  // A failed refetch (a rate limit, say) leaves the previous forecast on
+  // screen; the error only takes over when there is nothing to show.
+  if (error && !data) return <div className={props.className} style={props.style}>Error: {error.message}</div>;
   if (!data) return <div className={props.className} style={props.style}>No forecast available.</div>;
 
   const timezone = data.location?.timezone;

--- a/packages/react-weather-forecast/src/hooks/useWeatherForecast.ts
+++ b/packages/react-weather-forecast/src/hooks/useWeatherForecast.ts
@@ -2,6 +2,21 @@ import { useEffect, useState } from 'react';
 import type { WeatherForecastData, WeatherForecastOptions } from '../types';
 import { getWeatherForecast } from '../api/forecast';
 
+/** Provider lists are usually inline arrays, so the effect keys off their ids. */
+function providerKey(options: WeatherForecastOptions): string {
+  const ids = (list: WeatherForecastOptions['weatherProviders'] | WeatherForecastOptions['geoProviders']) =>
+    (list ?? []).map((provider) => (typeof provider === 'string' ? provider : provider.id)).join(',');
+
+  return `${ids(options.weatherProviders)}|${ids(options.geoProviders)}`;
+}
+
+/**
+ * Fetch a forecast for `options`, refetching whenever they change.
+ *
+ * The last good forecast is kept while a refetch is in flight *and* if that
+ * refetch fails, so a rate-limited upstream leaves the widget showing the
+ * previous data rather than replacing it with an error.
+ */
 export function useWeatherForecast(options: WeatherForecastOptions = {}) {
   const [data, setData] = useState<WeatherForecastData | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -28,6 +43,13 @@ export function useWeatherForecast(options: WeatherForecastOptions = {}) {
     options.temperatureUnit,
     options.windSpeedUnit,
     options.location?.timezone,
+    options.retryAttempts,
+    options.retryDelay,
+    options.timeout,
+    options.allowStaleCache,
+    options.fallbackLocation?.latitude,
+    options.fallbackLocation?.longitude,
+    providerKey(options),
   ]);
 
   return { data, error, loading };

--- a/packages/react-weather-forecast/src/index.ts
+++ b/packages/react-weather-forecast/src/index.ts
@@ -1,6 +1,14 @@
 export * from './types';
 export * from './weatherCodes';
 export { clearWeatherForecastCache } from './lib/cache';
+export { grabJson, HttpRequestError, isRetryableStatus, type GrabJsonOptions } from './api/http';
+export {
+  normalizeCoordinates,
+  normalizeTimezone,
+  isValidLatitude,
+  isValidLongitude,
+} from './lib/validate';
+export * from './api/providers';
 export * from './api/geolocation';
 export * from './api/forecast';
 export * from './hooks/useWeatherForecast';

--- a/packages/react-weather-forecast/src/lib/cache.ts
+++ b/packages/react-weather-forecast/src/lib/cache.ts
@@ -1,5 +1,7 @@
 const CACHE_PREFIX = 'weather-forecast-cache:';
 const CACHE_TTL_MS = 30 * 60 * 1000;
+/** How long a cached forecast may still be served after every provider failed. */
+const STALE_TTL_MS = 24 * 60 * 60 * 1000;
 
 type CacheEntry<T> = {
   timestamp: number;
@@ -11,25 +13,49 @@ function getStorage(): Storage | null {
   return window.localStorage;
 }
 
-/** Returns the cached value for `key` if it was written within the last 30 minutes. */
-export function readCachedForecast<T>(key: string): T | null {
+/** The stored entry for `key`, however old, or `null` if there is none. */
+function readEntry<T>(key: string): CacheEntry<T> | null {
   const storage = getStorage();
   if (!storage) return null;
 
   try {
     const raw = storage.getItem(CACHE_PREFIX + key);
     if (!raw) return null;
-
-    const entry = JSON.parse(raw) as CacheEntry<T>;
-    if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
-      storage.removeItem(CACHE_PREFIX + key);
-      return null;
-    }
-
-    return entry.data;
+    return JSON.parse(raw) as CacheEntry<T>;
   } catch {
     return null;
   }
+}
+
+/** Returns the cached value for `key` if it was written within the last 30 minutes. */
+export function readCachedForecast<T>(key: string): T | null {
+  const entry = readEntry<T>(key);
+  if (!entry) return null;
+
+  if (Date.now() - entry.timestamp > CACHE_TTL_MS) return null;
+
+  return entry.data;
+}
+
+/**
+ * Returns the cached value for `key` regardless of its age, up to a day old.
+ *
+ * The last resort when every weather provider failed: an hour-old forecast is
+ * a better widget than `Error: Weather request failed`. Kept apart from
+ * {@link readCachedForecast} so a served-stale answer is always a deliberate
+ * choice by the caller.
+ */
+export function readStaleForecast<T>(key: string, maxAgeMs = STALE_TTL_MS): T | null {
+  const entry = readEntry<T>(key);
+  if (!entry) return null;
+
+  if (Date.now() - entry.timestamp > maxAgeMs) {
+    const storage = getStorage();
+    storage?.removeItem(CACHE_PREFIX + key);
+    return null;
+  }
+
+  return entry.data;
 }
 
 export function writeCachedForecast<T>(key: string, data: T): void {

--- a/packages/react-weather-forecast/src/lib/time.ts
+++ b/packages/react-weather-forecast/src/lib/time.ts
@@ -1,0 +1,42 @@
+/**
+ * Open-Meteo (with `timezone=auto`) reports naive local timestamps such as
+ * `2024-01-01T13:00`, and the widget renders them with plain `new Date(...)`.
+ * The fallback providers report instants in UTC instead, so their timestamps
+ * are rewritten into the same naive local shape before they reach the widget
+ * -- otherwise a failover would silently shift every hour label.
+ */
+
+type Parts = Record<string, string>;
+
+function zonedParts(instant: Date, timeZone: string | undefined): Parts | null {
+  try {
+    const format = new Intl.DateTimeFormat('en-US', {
+      timeZone: timeZone || undefined,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+    const parts: Parts = {};
+    for (const part of format.formatToParts(instant)) parts[part.type] = part.value;
+    return parts;
+  } catch {
+    return null;
+  }
+}
+
+/** `2024-01-01T13:00` for the given instant, as read in `timeZone`. */
+export function toZonedIsoMinutes(instant: Date, timeZone?: string): string {
+  const parts = zonedParts(instant, timeZone);
+  if (!parts) return instant.toISOString().slice(0, 16);
+  // Intl renders midnight as hour 24 in some engines; normalize it back to 00.
+  const hour = parts.hour === '24' ? '00' : parts.hour;
+  return `${parts.year}-${parts.month}-${parts.day}T${hour}:${parts.minute}`;
+}
+
+/** `2024-01-01` for the given instant, as read in `timeZone`. */
+export function toZonedDate(instant: Date, timeZone?: string): string {
+  return toZonedIsoMinutes(instant, timeZone).slice(0, 10);
+}

--- a/packages/react-weather-forecast/src/lib/units.ts
+++ b/packages/react-weather-forecast/src/lib/units.ts
@@ -1,0 +1,36 @@
+import type { TemperatureUnit, WindSpeedUnit } from '../types';
+
+/**
+ * Open-Meteo answers in whatever units the query asked for, but the fallback
+ * providers each have their own fixed ones (met.no reports Celsius and m/s,
+ * wttr.in reports both Celsius and Fahrenheit alongside km/h and mph). These
+ * helpers bring every provider onto the units the caller asked for, so a
+ * failover is invisible in the rendered widget.
+ */
+
+/** Celsius -> the requested temperature unit. */
+export function fromCelsius(value: number, unit: TemperatureUnit): number {
+  return unit === 'fahrenheit' ? value * 1.8 + 32 : value;
+}
+
+const FROM_METRES_PER_SECOND: Record<WindSpeedUnit, number> = {
+  kmh: 3.6,
+  mph: 2.236_936,
+  ms: 1,
+  kn: 1.943_844,
+};
+
+/** Metres per second -> the requested wind speed unit. */
+export function fromMetresPerSecond(value: number, unit: WindSpeedUnit): number {
+  return value * FROM_METRES_PER_SECOND[unit];
+}
+
+/** Kilometres per hour -> the requested wind speed unit. */
+export function fromKilometresPerHour(value: number, unit: WindSpeedUnit): number {
+  return fromMetresPerSecond(value / 3.6, unit);
+}
+
+/** Round to one decimal, the precision Open-Meteo itself reports. */
+export function round1(value: number): number {
+  return Math.round(value * 10) / 10;
+}

--- a/packages/react-weather-forecast/src/lib/validate.ts
+++ b/packages/react-weather-forecast/src/lib/validate.ts
@@ -1,0 +1,105 @@
+/**
+ * Guards for everything that goes into a forecast URL.
+ *
+ * Open-Meteo answers `400 Bad Request` for a query it cannot parse, and the
+ * most common way to build one is not a typo in this package but a geolocation
+ * upstream that answered 200 with no coordinates in the body: `Number(undefined)`
+ * becomes `NaN`, `latitude=NaN` goes out on the wire, and the widget renders
+ * `Error: Weather request failed: 400 Bad Request`. Everything below fails
+ * that request *before* it is sent, so the caller can fall back to another
+ * geolocation provider instead.
+ */
+
+/** Open-Meteo rejects more than 4 decimals of precision from some endpoints, and met.no's terms require rounding. */
+const COORDINATE_PRECISION = 4;
+
+/** Open-Meteo accepts 0-16 forecast days. */
+export const MAX_FORECAST_DAYS = 16;
+/** Open-Meteo accepts up to 16 days' worth of hours. */
+export const MAX_FORECAST_HOURS = 384;
+
+export function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function roundCoordinate(value: number): number {
+  const factor = 10 ** COORDINATE_PRECISION;
+  return Math.round(value * factor) / factor;
+}
+
+export function isValidLatitude(value: unknown): value is number {
+  const parsed = toFiniteNumber(value);
+  return parsed !== null && parsed >= -90 && parsed <= 90;
+}
+
+export function isValidLongitude(value: unknown): value is number {
+  const parsed = toFiniteNumber(value);
+  return parsed !== null && parsed >= -180 && parsed <= 180;
+}
+
+/**
+ * Coordinates rounded to the precision every upstream accepts, or `null` when
+ * either of them is missing, unparseable or off the globe.
+ */
+export function normalizeCoordinates(
+  latitude: unknown,
+  longitude: unknown
+): { latitude: number; longitude: number } | null {
+  if (!isValidLatitude(latitude) || !isValidLongitude(longitude)) return null;
+  return {
+    latitude: roundCoordinate(toFiniteNumber(latitude) as number),
+    longitude: roundCoordinate(toFiniteNumber(longitude) as number),
+  };
+}
+
+/**
+ * Anything carrying coordinates: an option object, or a body from one of the
+ * geolocation providers. Kept structural so this module stays free of the
+ * package's React-facing types and can be imported by the Cloudflare worker.
+ */
+export type CoordinateSource = {
+  latitude?: unknown;
+  longitude?: unknown;
+  timezone?: unknown;
+  [key: string]: unknown;
+};
+
+/** The same location with usable coordinates, or `null` if it has none. */
+export function normalizeLocation<T extends CoordinateSource>(
+  location: T | undefined
+): (T & { latitude: number; longitude: number; timezone?: string }) | null {
+  if (!location) return null;
+  const coordinates = normalizeCoordinates(location.latitude, location.longitude);
+  if (!coordinates) return null;
+  return { ...location, ...coordinates, timezone: normalizeTimezone(location.timezone) };
+}
+
+/**
+ * The canonical IANA name of a zone the runtime recognises, or `undefined`.
+ *
+ * IP geolocation providers disagree on this field (`timezone`, `timezone.id`,
+ * `timeZone`, sometimes a legacy alias like `PST` or `US/Pacific`), and
+ * Open-Meteo answers 400 for a zone it does not know. So an alias is
+ * canonicalized to what every upstream accepts (`America/Los_Angeles`) and a
+ * zone the runtime cannot resolve at all is dropped rather than sent.
+ */
+export function normalizeTimezone(timezone: unknown): string | undefined {
+  if (typeof timezone !== 'string') return undefined;
+  const trimmed = timezone.trim();
+  if (!trimmed || trimmed.toLowerCase() === 'auto') return undefined;
+
+  try {
+    return new Intl.DateTimeFormat('en-US', { timeZone: trimmed }).resolvedOptions().timeZone || trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Whole number inside `[min, max]`, falling back to `fallback` for anything else. */
+export function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed = toFiniteNumber(value);
+  if (parsed === null) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(parsed)));
+}

--- a/packages/react-weather-forecast/src/types.ts
+++ b/packages/react-weather-forecast/src/types.ts
@@ -1,4 +1,6 @@
 import type React from 'react';
+import type { GeoProvider } from './api/geolocation';
+import type { WeatherProvider } from './api/providers/types';
 
 export type TemperatureUnit = 'celsius' | 'fahrenheit';
 export type WindSpeedUnit = 'kmh' | 'mph' | 'ms' | 'kn';
@@ -76,6 +78,12 @@ export type WeatherForecastData = {
   daily: DailyWeather[];
 };
 
+/** Ids of the weather upstreams bundled with the package. */
+export type WeatherProviderId = 'open-meteo' | 'open-meteo-gfs' | 'met-no' | 'wttr';
+
+/** Ids of the IP geolocation upstreams bundled with the package. */
+export type GeoProviderId = 'ipapi' | 'ipwho' | 'geojs' | 'freeipapi';
+
 export type WeatherForecastOptions = {
   latitude?: number;
   longitude?: number;
@@ -83,10 +91,41 @@ export type WeatherForecastOptions = {
   locations?: WeatherLocationInput[];
   geoEndpoint?: string;
   ip?: string;
+  /** default=5 Days of daily forecast, 1-16. Anything outside that is clamped. */
   forecastDays?: number;
+  /** default=24 Hours of hourly forecast, 1-384. Anything outside that is clamped. */
   forecastHours?: number;
   temperatureUnit?: TemperatureUnit;
   windSpeedUnit?: WindSpeedUnit;
+  /**
+   * default=['open-meteo', 'open-meteo-gfs', 'met-no', 'wttr'] Weather
+   * upstreams, tried in order until one answers.
+   */
+  weatherProviders?: (WeatherProviderId | WeatherProvider)[];
+  /**
+   * default=['ipapi', 'ipwho', 'geojs', 'freeipapi'] IP geolocation upstreams,
+   * tried in order. `geoEndpoint`, when given, is always tried first.
+   */
+  geoProviders?: (GeoProviderId | GeoProvider)[];
+  /** default=3 Tries per upstream request before it is treated as failed. */
+  retryAttempts?: number;
+  /** default=400 Milliseconds before the first retry; each further wait doubles. */
+  retryDelay?: number;
+  /** default=15 Seconds before a single request is aborted. */
+  timeout?: number;
+  /** Used when every geolocation provider failed, instead of throwing. */
+  fallbackLocation?: Partial<WeatherLocation>;
+  /**
+   * default=true Serve a cached forecast up to a day old when every weather
+   * provider failed, rather than throwing.
+   */
+  allowStaleCache?: boolean;
+  /** Called for each upstream that failed, before the next one is tried. */
+  onProviderError?: (info: {
+    provider: string;
+    error: Error;
+    stage: 'geolocation' | 'forecast';
+  }) => void;
 };
 
 export type IconProps = React.SVGProps<SVGSVGElement> & {

--- a/packages/react-weather-forecast/test/cache.test.ts
+++ b/packages/react-weather-forecast/test/cache.test.ts
@@ -2,11 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   clearWeatherForecastCache,
   readCachedForecast,
+  readStaleForecast,
   writeCachedForecast,
 } from '../src/lib/cache';
 
 const CACHE_PREFIX = 'weather-forecast-cache:';
 const TTL_MS = 30 * 60 * 1000;
+const STALE_TTL_MS = 24 * 60 * 60 * 1000;
 
 describe('forecast cache', () => {
   beforeEach(() => {
@@ -44,15 +46,43 @@ describe('forecast cache', () => {
     expect(readCachedForecast('key-a')).toBe('fresh');
   });
 
-  it('expires and evicts entries older than the TTL', () => {
+  it('stops serving entries older than the TTL', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
     writeCachedForecast('key-a', 'stale');
 
     vi.setSystemTime(Date.now() + TTL_MS + 1);
     expect(readCachedForecast('key-a')).toBeNull();
-    // The expired entry is removed rather than left to accumulate.
+  });
+
+  it('keeps an expired entry so it can still be served as a stale fallback', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    writeCachedForecast('key-a', 'stale');
+
+    vi.setSystemTime(Date.now() + TTL_MS + 1);
+    expect(readCachedForecast('key-a')).toBeNull();
+    expect(readStaleForecast('key-a')).toBe('stale');
+  });
+
+  it('evicts and stops serving an entry once it is a day old', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    writeCachedForecast('key-a', 'ancient');
+
+    vi.setSystemTime(Date.now() + STALE_TTL_MS + 1);
+    expect(readStaleForecast('key-a')).toBeNull();
+    // Past the stale window the entry is removed rather than left to accumulate.
     expect(window.localStorage.getItem(CACHE_PREFIX + 'key-a')).toBeNull();
+  });
+
+  it('honours a custom stale window', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    writeCachedForecast('key-a', 'stale');
+
+    vi.setSystemTime(Date.now() + 2 * TTL_MS);
+    expect(readStaleForecast('key-a', TTL_MS)).toBeNull();
   });
 
   it('returns null instead of throwing on corrupted JSON', () => {

--- a/packages/react-weather-forecast/test/forecast.test.ts
+++ b/packages/react-weather-forecast/test/forecast.test.ts
@@ -50,6 +50,17 @@ function requestedUrl(fetchMock: typeof mockGrab, call = 0): URL {
   return new URL(fetchMock.mock.calls[call][0] as unknown as string);
 }
 
+/**
+ * Failures fan out across the whole provider chain by design, so the tests
+ * that assert on one upstream's error pin the chain to Open-Meteo alone and
+ * drop the backoff.
+ */
+const onlyOpenMeteo = {
+  weatherProviders: ['open-meteo'] as const,
+  retryDelay: 0,
+  allowStaleCache: false,
+};
+
 describe('getWeatherForecast', () => {
   beforeEach(() => {
     clearWeatherForecastCache();
@@ -210,16 +221,16 @@ describe('getWeatherForecast', () => {
   it('throws with status and status text on a failed request', async () => {
     mockFetch({ error: 'HTTP error: 503 Service Unavailable' });
 
-    await expect(getWeatherForecast({ latitude: 1, longitude: 2 })).rejects.toThrow(
-      'Weather request failed: 503 Service Unavailable'
+    await expect(getWeatherForecast({ ...onlyOpenMeteo, latitude: 1, longitude: 2 })).rejects.toThrow(
+      'Weather request failed: Open-Meteo: 503 Service Unavailable'
     );
   });
 
   it('throws with the reason when Open-Meteo answers 200 with an error flag', async () => {
     mockFetch({ error: true, reason: 'Cannot initialize WeatherVariable from invalid String value' });
 
-    await expect(getWeatherForecast({ latitude: 1, longitude: 2 })).rejects.toThrow(
-      'Weather request failed: Cannot initialize WeatherVariable from invalid String value'
+    await expect(getWeatherForecast({ ...onlyOpenMeteo, latitude: 1, longitude: 2 })).rejects.toThrow(
+      'Cannot initialize WeatherVariable from invalid String value'
     );
   });
 
@@ -230,9 +241,163 @@ describe('getWeatherForecast', () => {
       delete payload[missing];
       mockFetch(payload);
 
-      await expect(getWeatherForecast({ latitude: 1, longitude: 2 })).rejects.toThrow(
+      await expect(getWeatherForecast({ ...onlyOpenMeteo, latitude: 1, longitude: 2 })).rejects.toThrow(
         'Invalid weather response'
       );
     }
   );
+});
+
+describe('getWeatherForecast fallbacks', () => {
+  beforeEach(() => {
+    clearWeatherForecastCache();
+    vi.resetAllMocks();
+  });
+
+  /** met.no's compact payload, enough of it for one hour and one day. */
+  function metNoResponse() {
+    return {
+      properties: {
+        timeseries: Array.from({ length: 4 }, (_, index) => ({
+          time: new Date(Date.UTC(2024, 0, 1, index)).toISOString(),
+          data: {
+            instant: { details: { air_temperature: 20, wind_speed: 3 } },
+            next_1_hours: { summary: { symbol_code: 'clearsky_day' }, details: { precipitation_amount: 0 } },
+          },
+        })),
+      },
+    };
+  }
+
+  it('never sends coordinates Open-Meteo would reject as a 400', async () => {
+    // A geolocation upstream answering 200 with no coordinates used to become
+    // `latitude=NaN` in the forecast URL.
+    const fetchMock = mockGrab.mockImplementation(async (input: string) => {
+      if (input.includes('ipapi.co')) return { city: 'Nowhere' };
+      if (input.includes('ipwho.is')) return { latitude: 30.27, longitude: -97.74, city: 'Austin' };
+      return openMeteoResponse();
+    });
+
+    const result = await getWeatherForecast({ retryDelay: 0 });
+
+    const weatherCall = fetchMock.mock.calls.find(([url]) => String(url).includes('open-meteo'));
+    expect(String(weatherCall?.[0])).not.toContain('NaN');
+    expect(result.location.city).toBe('Austin');
+  });
+
+  it('looks the location up by IP when the given coordinates are unusable', async () => {
+    const fetchMock = mockGrab.mockImplementation(async (input: string) => {
+      if (input.includes('ipapi.co')) return { latitude: 30.27, longitude: -97.74, city: 'Austin' };
+      return openMeteoResponse();
+    });
+
+    const result = await getWeatherForecast({ latitude: Number.NaN, longitude: -97.74, retryDelay: 0 });
+
+    expect(String(fetchMock.mock.calls[0][0])).toContain('ipapi.co');
+    expect(result.location.city).toBe('Austin');
+  });
+
+  it('clamps a forecast range no upstream would accept', async () => {
+    const fetchMock = mockFetch(openMeteoResponse());
+
+    await getWeatherForecast({ latitude: 1, longitude: 2, forecastDays: 99, forecastHours: 0 });
+
+    const params = requestedUrl(fetchMock).searchParams;
+    expect(params.get('forecast_days')).toBe('16');
+    expect(params.get('forecast_hours')).toBe('1');
+  });
+
+  it('drops a timezone the runtime does not recognise instead of sending it', async () => {
+    const fetchMock = mockFetch(openMeteoResponse());
+
+    await getWeatherForecast({ latitude: 1, longitude: 2, location: { timezone: 'Mars/Phobos' } });
+
+    expect(requestedUrl(fetchMock).searchParams.get('timezone')).toBe('auto');
+  });
+
+  it('falls back to met.no when both Open-Meteo endpoints fail', async () => {
+    mockGrab.mockImplementation(async (input: string) => {
+      if (input.includes('open-meteo')) return { error: 'HTTP error: 503 Service Unavailable' };
+      if (input.includes('met.no')) return metNoResponse();
+      return { error: 'HTTP error: 500 Internal Server Error' };
+    });
+
+    const result = await getWeatherForecast({ latitude: 30.27, longitude: -97.74, retryDelay: 0 });
+
+    expect(result.current.temperature).toBe(68); // 20C rendered as Fahrenheit
+    expect(result.daily.length).toBeGreaterThan(0);
+  });
+
+  it('reports what every provider said when the whole chain fails', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 503 Service Unavailable' } as never);
+
+    await expect(
+      getWeatherForecast({ latitude: 1, longitude: 2, retryDelay: 0 })
+    ).rejects.toThrow(
+      'Weather request failed: Open-Meteo: 503 Service Unavailable; Open-Meteo (GFS): 503 Service Unavailable; met.no: 503 Service Unavailable; wttr.in: 503 Service Unavailable'
+    );
+  });
+
+  it('notifies onProviderError as the chain moves on', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 503 Service Unavailable' } as never);
+    const onProviderError = vi.fn();
+
+    await expect(
+      getWeatherForecast({ latitude: 1, longitude: 2, retryDelay: 0, onProviderError })
+    ).rejects.toThrow();
+
+    expect(onProviderError.mock.calls.map(([info]) => info.provider)).toEqual([
+      'open-meteo',
+      'open-meteo-gfs',
+      'met-no',
+      'wttr',
+    ]);
+    expect(onProviderError.mock.calls[0][0].stage).toBe('forecast');
+  });
+
+  it('serves an expired cache entry rather than an error when everything is down', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    mockFetch(openMeteoResponse());
+    const fresh = await getWeatherForecast({ latitude: 1, longitude: 2 });
+
+    // Past the 30 minute TTL, with every provider failing.
+    vi.setSystemTime(new Date('2024-01-01T02:00:00Z'));
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 503 Service Unavailable' } as never);
+
+    const stale = await getWeatherForecast({ latitude: 1, longitude: 2, retryDelay: 0 });
+
+    expect(stale).toEqual(fresh);
+    vi.useRealTimers();
+  });
+
+  it('throws instead of serving stale data when that is turned off', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T00:00:00Z'));
+    mockFetch(openMeteoResponse());
+    await getWeatherForecast({ latitude: 1, longitude: 2 });
+
+    vi.setSystemTime(new Date('2024-01-01T02:00:00Z'));
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 503 Service Unavailable' } as never);
+
+    await expect(
+      getWeatherForecast({ latitude: 1, longitude: 2, retryDelay: 0, allowStaleCache: false })
+    ).rejects.toThrow('Weather request failed');
+    vi.useRealTimers();
+  });
+
+  it('caches a fallback provider\'s answer like the primary one\'s', async () => {
+    mockGrab.mockImplementation(async (input: string) => {
+      if (input.includes('open-meteo')) return { error: 'HTTP error: 503 Service Unavailable' };
+      if (input.includes('met.no')) return metNoResponse();
+      return { error: 'HTTP error: 500 Internal Server Error' };
+    });
+
+    const first = await getWeatherForecast({ latitude: 30.27, longitude: -97.74, retryDelay: 0 });
+    const callsAfterFirst = mockGrab.mock.calls.length;
+    const second = await getWeatherForecast({ latitude: 30.27, longitude: -97.74, retryDelay: 0 });
+
+    expect(second).toEqual(first);
+    expect(mockGrab.mock.calls.length).toBe(callsAfterFirst);
+  });
 });

--- a/packages/react-weather-forecast/test/geolocation.test.ts
+++ b/packages/react-weather-forecast/test/geolocation.test.ts
@@ -147,20 +147,20 @@ describe('getClientLocation', () => {
       expect(location.city).toBe('Austin');
     });
 
-    it('repeats the lookup three times by default before giving up', async () => {
+    it('tries each provider twice by default before moving to the next one', async () => {
       mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
 
-      await expect(getClientLocation(undefined, undefined, noDelay)).rejects.toThrow(
-        'ipapi.co lookup failed: RateLimited'
-      );
-      expect(mockGrab).toHaveBeenCalledTimes(3);
+      await expect(
+        getClientLocation(undefined, undefined, { ...noDelay, providers: ['ipapi'] })
+      ).rejects.toThrow('ipapi.co lookup failed: RateLimited');
+      expect(mockGrab).toHaveBeenCalledTimes(2);
     });
 
     it('honours a custom attempt count', async () => {
       mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
 
       await expect(
-        getClientLocation(undefined, undefined, { attempts: 5, retryDelay: 0 })
+        getClientLocation(undefined, undefined, { attempts: 5, retryDelay: 0, providers: ['ipapi'] })
       ).rejects.toThrow('ipapi.co lookup failed: RateLimited');
       expect(mockGrab).toHaveBeenCalledTimes(5);
     });
@@ -172,6 +172,15 @@ describe('getClientLocation', () => {
 
       expect(mockGrab).toHaveBeenCalledTimes(2);
       expect(location.latitude).toBe(1);
+    });
+
+    it('does not repeat a lookup the provider rejected as invalid', async () => {
+      mockGrab.mockResolvedValue({ error: 'HTTP error: 404 Not Found' } as never);
+
+      await expect(
+        getClientLocation(undefined, undefined, { ...noDelay, providers: ['ipapi'] })
+      ).rejects.toThrow('ipapi.co lookup failed: 404 Not Found');
+      expect(mockGrab).toHaveBeenCalledTimes(1);
     });
 
     it('waits between tries when a delay is configured', async () => {
@@ -190,6 +199,135 @@ describe('getClientLocation', () => {
       await getClientLocation(undefined, undefined, noDelay);
 
       expect(mockGrab).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('falling back to the next provider', () => {
+    it('moves on to ipwho.is when ipapi.co stays rate-limited', async () => {
+      grabResolves(
+        { error: true, reason: 'RateLimited' },
+        { error: true, reason: 'RateLimited' },
+        { success: true, city: 'Berlin', timezone: { id: 'Europe/Berlin' }, latitude: 52.52, longitude: 13.4 }
+      );
+
+      const location = await getClientLocation(undefined, undefined, noDelay);
+
+      expect(mockGrab.mock.calls[2][0]).toBe('https://ipwho.is/');
+      expect(location).toEqual({
+        city: 'Berlin',
+        region: undefined,
+        country: undefined,
+        timezone: 'Europe/Berlin',
+        latitude: 52.52,
+        longitude: 13.4,
+      });
+    });
+
+    it('treats a 200 without coordinates as a failure instead of returning NaN', async () => {
+      // This is the response that used to become `latitude=NaN` in the
+      // forecast URL and surface as `Weather request failed: 400 Bad Request`.
+      grabResolves(
+        { city: 'Nowhere' },
+        { city: 'Nowhere' },
+        { success: true, city: 'Austin', latitude: 30.27, longitude: -97.74 }
+      );
+
+      const location = await getClientLocation(undefined, undefined, noDelay);
+
+      expect(location.latitude).toBe(30.27);
+      expect(Number.isFinite(location.latitude)).toBe(true);
+    });
+
+    it('rejects coordinates that are off the globe', async () => {
+      grabResolves({ latitude: 999, longitude: 0 }, { latitude: 999, longitude: 0 });
+
+      await expect(
+        getClientLocation(undefined, undefined, { ...noDelay, providers: ['ipapi'] })
+      ).rejects.toThrow('no coordinates in the response');
+    });
+
+    it('canonicalizes a legacy timezone alias', async () => {
+      grabResolves({ latitude: 1, longitude: 2, timezone: 'US/Pacific' });
+
+      const location = await getClientLocation(undefined, undefined, noDelay);
+
+      expect(location.timezone).toBe('America/Los_Angeles');
+    });
+
+    it('drops a timezone the runtime does not recognise', async () => {
+      grabResolves({ latitude: 1, longitude: 2, timezone: 'Mars/Phobos' });
+
+      const location = await getClientLocation(undefined, undefined, noDelay);
+
+      expect(location.timezone).toBeUndefined();
+    });
+
+    it('rounds coordinates to the precision every upstream accepts', async () => {
+      grabResolves({ latitude: 30.267_153_3, longitude: -97.743_057_9 });
+
+      const location = await getClientLocation(undefined, undefined, noDelay);
+
+      expect(location.latitude).toBe(30.2672);
+      expect(location.longitude).toBe(-97.7431);
+    });
+
+    it('tries the worker first and the public providers after it', async () => {
+      grabResolves(
+        { error: 'HTTP error: 502 Bad Gateway' },
+        { error: 'HTTP error: 502 Bad Gateway' },
+        { city: 'Austin', latitude: 30.27, longitude: -97.74 }
+      );
+
+      const location = await getClientLocation('https://geo.example.workers.dev', undefined, noDelay);
+
+      expect(mockGrab.mock.calls[0][0]).toBe('https://geo.example.workers.dev');
+      expect(mockGrab.mock.calls[2][0]).toBe('https://ipapi.co/json/');
+      expect(location.city).toBe('Austin');
+    });
+
+    it('reports every provider that failed', async () => {
+      mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
+
+      await expect(
+        getClientLocation(undefined, undefined, { ...noDelay, providers: ['ipapi', 'ipwho'] })
+      ).rejects.toThrow(
+        'Geolocation lookup failed: ipapi.co lookup failed: RateLimited; ipwho.is lookup failed: RateLimited'
+      );
+    });
+
+    it('notifies onProviderError for each failed provider', async () => {
+      mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
+      const onProviderError = vi.fn();
+
+      await expect(
+        getClientLocation(undefined, undefined, { ...noDelay, providers: ['ipapi', 'ipwho'], onProviderError })
+      ).rejects.toThrow();
+
+      expect(onProviderError.mock.calls.map(([info]) => info.provider)).toEqual(['ipapi', 'ipwho']);
+    });
+
+    it('falls back to the configured location when every provider fails', async () => {
+      mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
+
+      const location = await getClientLocation(undefined, undefined, {
+        ...noDelay,
+        providers: ['ipapi'],
+        fallbackLocation: { city: 'Austin', latitude: 30.27, longitude: -97.74 },
+      });
+
+      expect(location).toEqual({ city: 'Austin', timezone: undefined, latitude: 30.27, longitude: -97.74 });
+    });
+
+    it('still throws when the fallback location has no usable coordinates', async () => {
+      mockGrab.mockResolvedValue({ error: true, reason: 'RateLimited' } as never);
+
+      await expect(
+        getClientLocation(undefined, undefined, {
+          ...noDelay,
+          providers: ['ipapi'],
+          fallbackLocation: { city: 'Austin' },
+        })
+      ).rejects.toThrow('ipapi.co lookup failed: RateLimited');
     });
   });
 });

--- a/packages/react-weather-forecast/test/http.test.ts
+++ b/packages/react-weather-forecast/test/http.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import grab from 'grab-url';
+import { grabJson, HttpRequestError, isRetryableStatus } from '../src/api/http';
+
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
+
+const noDelay = { retryDelay: 0 };
+
+describe('grabJson', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns the parsed body', async () => {
+    mockGrab.mockResolvedValue({ temperature: 21 } as never);
+
+    await expect(grabJson('https://example.test', 'Weather request')).resolves.toEqual({ temperature: 21 });
+  });
+
+  it('unwraps a body grab-url could not parse as root JSON', async () => {
+    mockGrab.mockResolvedValue({ data: { temperature: 21 } } as never);
+
+    await expect(grabJson('https://example.test', 'Weather request')).resolves.toEqual({ temperature: 21 });
+  });
+
+  it('keeps duplicate requests to one path alive', async () => {
+    mockGrab.mockResolvedValue({ ok: true } as never);
+
+    await grabJson('https://example.test', 'Weather request');
+
+    // Several widgets share one upstream path; grab-url aborts the earlier
+    // call of a duplicate path unless this is off.
+    expect(mockGrab.mock.calls[0][1]).toMatchObject({ cancelOngoingIfNew: false });
+  });
+
+  it('labels a transport failure and carries the status', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 400 Bad Request' } as never);
+
+    const error = await grabJson('https://example.test', 'Weather request', noDelay).catch((e) => e);
+
+    expect(error).toBeInstanceOf(HttpRequestError);
+    expect(error.message).toBe('Weather request failed: 400 Bad Request');
+    expect(error.status).toBe(400);
+  });
+
+  it('labels a 200 that carries an error flag', async () => {
+    mockGrab.mockResolvedValue({ error: true, reason: 'Invalid hourly variable' } as never);
+
+    await expect(grabJson('https://example.test', 'Weather request', noDelay)).rejects.toThrow(
+      'Weather request failed: Invalid hourly variable'
+    );
+  });
+
+  it('labels an empty response', async () => {
+    mockGrab.mockResolvedValue(null as never);
+
+    await expect(grabJson('https://example.test', 'Weather request', noDelay)).rejects.toThrow(
+      'Weather request failed: empty response'
+    );
+  });
+
+  it('repeats a request the upstream was too busy to serve', async () => {
+    mockGrab
+      .mockResolvedValueOnce({ error: 'HTTP error: 429 Too Many Requests' } as never)
+      .mockResolvedValueOnce({ error: 'HTTP error: 503 Service Unavailable' } as never)
+      .mockResolvedValueOnce({ temperature: 21 } as never);
+
+    await expect(grabJson('https://example.test', 'Weather request', noDelay)).resolves.toEqual({
+      temperature: 21,
+    });
+    expect(mockGrab).toHaveBeenCalledTimes(3);
+  });
+
+  it('repeats a request that never reached the server', async () => {
+    mockGrab
+      .mockResolvedValueOnce({ error: 'Request timed out' } as never)
+      .mockResolvedValueOnce({ temperature: 21 } as never);
+
+    await expect(grabJson('https://example.test', 'Weather request', noDelay)).resolves.toEqual({
+      temperature: 21,
+    });
+  });
+
+  it('gives up immediately on a request the server called invalid', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 400 Bad Request' } as never);
+
+    await expect(grabJson('https://example.test', 'Weather request', noDelay)).rejects.toThrow(
+      '400 Bad Request'
+    );
+    // Replaying a malformed request only burns the upstream's rate limit.
+    expect(mockGrab).toHaveBeenCalledTimes(1);
+  });
+
+  it('repeats even a 4xx when asked to', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 400 Bad Request' } as never);
+
+    await expect(
+      grabJson('https://example.test', 'Weather request', { ...noDelay, retryClientErrors: true })
+    ).rejects.toThrow('400 Bad Request');
+    expect(mockGrab).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops after the configured number of attempts', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 503 Service Unavailable' } as never);
+
+    await expect(
+      grabJson('https://example.test', 'Weather request', { ...noDelay, attempts: 2 })
+    ).rejects.toThrow('503 Service Unavailable');
+    expect(mockGrab).toHaveBeenCalledTimes(2);
+  });
+
+  it('backs off exponentially between tries', async () => {
+    mockGrab
+      .mockResolvedValueOnce({ error: 'HTTP error: 503 Service Unavailable' } as never)
+      .mockResolvedValueOnce({ error: 'HTTP error: 503 Service Unavailable' } as never)
+      .mockResolvedValueOnce({ temperature: 21 } as never);
+
+    const start = Date.now();
+    await grabJson('https://example.test', 'Weather request', { retryDelay: 20 });
+
+    // 20ms then 40ms.
+    expect(Date.now() - start).toBeGreaterThanOrEqual(60);
+  });
+
+  it('repeats a rate-limited 200 but not a rejected query', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(undefined)).toBe(true);
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+});

--- a/packages/react-weather-forecast/test/providers.test.ts
+++ b/packages/react-weather-forecast/test/providers.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockedFunction } from 'vitest';
+import grab from 'grab-url';
+import { metNoProvider, openMeteoProvider, resolveWeatherProviders, symbolToWmoCode, wttrProvider, wwoToWmoCode } from '../src/api/providers';
+import type { ForecastRequest } from '../src/api/providers';
+
+vi.mock('grab-url');
+const mockGrab = grab as MockedFunction<typeof grab>;
+
+const request: ForecastRequest = {
+  location: { latitude: 30.27, longitude: -97.74, city: 'Austin', timezone: 'UTC' },
+  temperatureUnit: 'celsius',
+  windSpeedUnit: 'ms',
+  forecastDays: 3,
+  forecastHours: 6,
+  timezone: 'UTC',
+  transport: { retryDelay: 0 },
+};
+
+/** met.no reports instants in UTC, hourly for the first days. */
+function metNoResponse(hours = 30) {
+  const start = Date.UTC(2024, 0, 1, 0, 0, 0);
+  return {
+    properties: {
+      timeseries: Array.from({ length: hours }, (_, index) => ({
+        time: new Date(start + index * 3_600_000).toISOString(),
+        data: {
+          instant: { details: { air_temperature: 10 + (index % 12), wind_speed: 3 + (index % 4) } },
+          next_1_hours: {
+            summary: { symbol_code: index % 2 ? 'lightrain' : 'clearsky_day' },
+            details: { precipitation_amount: index % 2 ? 0.4 : 0, probability_of_precipitation: index % 2 ? 60 : 0 },
+          },
+        },
+      })),
+    },
+  };
+}
+
+/** wttr.in reports the location's own local times, in both C and F. */
+function wttrResponse() {
+  const day = (date: string) => ({
+    date,
+    maxtempC: '24',
+    maxtempF: '75',
+    mintempC: '11',
+    mintempF: '52',
+    hourly: Array.from({ length: 8 }, (_, index) => ({
+      time: String(index * 300),
+      tempC: String(12 + index),
+      tempF: String(54 + index),
+      weatherCode: index % 2 ? '296' : '113',
+      precipMM: index % 2 ? '0.3' : '0.0',
+      chanceofrain: index % 2 ? '70' : '0',
+      windspeedKmph: String(10 + index),
+      windspeedMiles: String(6 + index),
+    })),
+  });
+
+  return {
+    current_condition: [
+      { temp_C: '18', temp_F: '64', weatherCode: '116', windspeedKmph: '18', precipMM: '0.0' },
+    ],
+    nearest_area: [{ areaName: [{ value: 'Austin' }], region: [{ value: 'Texas' }], country: [{ value: 'United States' }] }],
+    weather: [day('2024-01-01'), day('2024-01-02'), day('2024-01-03'), day('2024-01-04')],
+  };
+}
+
+describe('condition code mapping', () => {
+  it('maps met.no symbols onto WMO codes', () => {
+    expect(symbolToWmoCode('clearsky_day')).toBe(0);
+    expect(symbolToWmoCode('partlycloudy_night')).toBe(2);
+    expect(symbolToWmoCode('heavyrainshowers_day')).toBe(82);
+    expect(symbolToWmoCode('rainandthunder')).toBe(95);
+    expect(symbolToWmoCode('heavysnowandthunder')).toBe(96);
+    expect(symbolToWmoCode('somethingnew')).toBe(3);
+    expect(symbolToWmoCode(undefined)).toBe(3);
+  });
+
+  it('maps wttr.in codes onto WMO codes', () => {
+    expect(wwoToWmoCode('113')).toBe(0);
+    expect(wwoToWmoCode('296')).toBe(61);
+    expect(wwoToWmoCode(389)).toBe(95);
+    expect(wwoToWmoCode('nonsense')).toBe(3);
+  });
+});
+
+describe('Open-Meteo provider', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  const payload = {
+    timezone: 'UTC',
+    current: { time: '2024-01-01T12:00', temperature_2m: 21, weather_code: 0, is_day: 1 },
+    hourly: { time: ['2024-01-01T12:00'], temperature_2m: [21], weather_code: [0] },
+    daily: { time: ['2024-01-01'], temperature_2m_min: [11], temperature_2m_max: [24], weather_code: [0] },
+  };
+
+  it('asks for every variable the widget can render', async () => {
+    mockGrab.mockResolvedValue(payload as never);
+
+    await openMeteoProvider.fetchForecast(request);
+
+    const url = new URL(mockGrab.mock.calls[0][0] as unknown as string);
+    expect(url.searchParams.get('hourly')).toContain('precipitation_probability');
+    expect(url.searchParams.get('daily')).toContain('wind_speed_10m_max');
+    expect(url.searchParams.get('timezone')).toBe('UTC');
+    expect(url.searchParams.get('forecast_days')).toBe('3');
+  });
+
+  it('retries a rejected query with only the variables every model supports', async () => {
+    // A 400 here means the endpoint refused one of the optional variables --
+    // exactly the failure that used to reach the widget as
+    // `Error: Weather request failed: 400 Bad Request`.
+    mockGrab
+      .mockResolvedValueOnce({ error: 'HTTP error: 400 Bad Request' } as never)
+      .mockResolvedValueOnce(payload as never);
+
+    const data = await openMeteoProvider.fetchForecast(request);
+
+    const retried = new URL(mockGrab.mock.calls[1][0] as unknown as string);
+    expect(retried.searchParams.get('hourly')).toBe('temperature_2m,weather_code');
+    expect(retried.searchParams.get('daily')).not.toContain('precipitation_probability_max');
+    expect(data.current.temperature).toBe(21);
+  });
+
+  it('gives up when even the minimal query is refused', async () => {
+    mockGrab.mockResolvedValue({ error: 'HTTP error: 400 Bad Request' } as never);
+
+    await expect(openMeteoProvider.fetchForecast(request)).rejects.toThrow('400 Bad Request');
+    expect(mockGrab).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('met.no provider', () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it('requests the compact endpoint with the rounded coordinates', async () => {
+    mockGrab.mockResolvedValue(metNoResponse() as never);
+
+    await metNoProvider.fetchForecast(request);
+
+    expect(mockGrab.mock.calls[0][0]).toBe(
+      'https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=30.27&lon=-97.74'
+    );
+  });
+
+  it('normalizes the payload into the widget shape', async () => {
+    mockGrab.mockResolvedValue(metNoResponse() as never);
+
+    const data = await metNoProvider.fetchForecast(request);
+
+    expect(data.current).toMatchObject({ time: '2024-01-01T00:00', temperature: 10, weatherCode: 0, icon: 'sun' });
+    expect(data.hourly).toHaveLength(6);
+    expect(data.hourly[1]).toMatchObject({ time: '2024-01-01T01:00', weatherCode: 61, precipitationProbability: 60 });
+    expect(data.daily[0]).toMatchObject({ date: '2024-01-01' });
+    expect(data.daily.length).toBeGreaterThan(0);
+  });
+
+  it('converts to the requested units', async () => {
+    mockGrab.mockResolvedValue(metNoResponse() as never);
+
+    const data = await metNoProvider.fetchForecast({
+      ...request,
+      temperatureUnit: 'fahrenheit',
+      windSpeedUnit: 'mph',
+    });
+
+    // 10C is 50F; 3 m/s is 6.7 mph.
+    expect(data.current.temperature).toBe(50);
+    expect(data.current.windSpeed).toBe(6.7);
+  });
+
+  it('rejects a response with no timeseries', async () => {
+    mockGrab.mockResolvedValue({ properties: { timeseries: [] } } as never);
+
+    await expect(metNoProvider.fetchForecast(request)).rejects.toThrow('Invalid weather response');
+  });
+});
+
+describe('wttr.in provider', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-01T12:00:00Z'));
+  });
+
+  afterEach(() => vi.useRealTimers());
+
+  it('requests the JSON format for the coordinates', async () => {
+    mockGrab.mockResolvedValue(wttrResponse() as never);
+
+    await wttrProvider.fetchForecast(request);
+
+    expect(mockGrab.mock.calls[0][0]).toBe('https://wttr.in/30.27,-97.74?format=j1&lang=en');
+  });
+
+  it('starts the hourly series at the current hour, like Open-Meteo does', async () => {
+    mockGrab.mockResolvedValue(wttrResponse() as never);
+
+    const data = await wttrProvider.fetchForecast(request);
+
+    expect(data.hourly[0].time).toBe('2024-01-01T12:00');
+    expect(data.hourly).toHaveLength(6);
+  });
+
+  it('normalizes conditions, units and the location', async () => {
+    mockGrab.mockResolvedValue(wttrResponse() as never);
+
+    const data = await wttrProvider.fetchForecast(request);
+
+    expect(data.current).toMatchObject({ temperature: 18, weatherCode: 2, icon: 'cloud-sun' });
+    // 18 km/h is 5 m/s.
+    expect(data.current.windSpeed).toBe(5);
+    expect(data.location?.region).toBe('Texas');
+    expect(data.daily).toHaveLength(3);
+    expect(data.daily[0]).toMatchObject({ date: '2024-01-01', min: 11, max: 24 });
+  });
+
+  it('reads Fahrenheit straight from the payload when asked for it', async () => {
+    mockGrab.mockResolvedValue(wttrResponse() as never);
+
+    const data = await wttrProvider.fetchForecast({ ...request, temperatureUnit: 'fahrenheit' });
+
+    expect(data.current.temperature).toBe(64);
+    expect(data.daily[0]).toMatchObject({ min: 52, max: 75 });
+  });
+
+  it('rejects a response with no forecast in it', async () => {
+    mockGrab.mockResolvedValue({ current_condition: [{ temp_C: '18' }] } as never);
+
+    await expect(wttrProvider.fetchForecast(request)).rejects.toThrow('Invalid weather response');
+  });
+});
+
+describe('resolveWeatherProviders', () => {
+  it('defaults to the whole chain', () => {
+    expect(resolveWeatherProviders().map((provider) => provider.id)).toEqual([
+      'open-meteo',
+      'open-meteo-gfs',
+      'met-no',
+      'wttr',
+    ]);
+  });
+
+  it('resolves ids in the given order', () => {
+    expect(resolveWeatherProviders(['wttr', 'open-meteo']).map((p) => p.id)).toEqual(['wttr', 'open-meteo']);
+  });
+
+  it('keeps a custom provider object', () => {
+    const custom = { id: 'custom', label: 'Custom', fetchForecast: vi.fn() };
+    expect(resolveWeatherProviders([custom])).toEqual([custom]);
+  });
+
+  it('falls back to the default chain for ids it does not know', () => {
+    expect(resolveWeatherProviders(['nope']).map((p) => p.id)).toEqual([
+      'open-meteo',
+      'open-meteo-gfs',
+      'met-no',
+      'wttr',
+    ]);
+  });
+});

--- a/packages/react-weather-forecast/test/validate.test.ts
+++ b/packages/react-weather-forecast/test/validate.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampInteger,
+  isValidLatitude,
+  isValidLongitude,
+  normalizeCoordinates,
+  normalizeLocation,
+  normalizeTimezone,
+} from '../src/lib/validate';
+
+describe('coordinate validation', () => {
+  it('accepts coordinates on the globe', () => {
+    expect(isValidLatitude(30.27)).toBe(true);
+    expect(isValidLongitude(-97.74)).toBe(true);
+  });
+
+  it.each([Number.NaN, undefined, null, '', 'north', 91, -91])(
+    'rejects %s as a latitude',
+    (value) => {
+      expect(isValidLatitude(value)).toBe(false);
+    }
+  );
+
+  it.each([Number.NaN, undefined, null, '', 181, -181])('rejects %s as a longitude', (value) => {
+    expect(isValidLongitude(value)).toBe(false);
+  });
+
+  it('coerces string coordinates', () => {
+    expect(normalizeCoordinates('30.27', '-97.74')).toEqual({ latitude: 30.27, longitude: -97.74 });
+  });
+
+  it('rounds to the precision every upstream accepts', () => {
+    expect(normalizeCoordinates(30.267_153_3, -97.743_057_9)).toEqual({
+      latitude: 30.2672,
+      longitude: -97.7431,
+    });
+  });
+
+  it('returns null when either coordinate is unusable', () => {
+    // `latitude=NaN` in a forecast URL is what Open-Meteo answers 400 for.
+    expect(normalizeCoordinates(Number.NaN, 12)).toBeNull();
+    expect(normalizeCoordinates(12, undefined)).toBeNull();
+  });
+
+  it('normalizes a whole location, or rejects it', () => {
+    expect(normalizeLocation({ city: 'Austin', latitude: 30.27, longitude: -97.74 })).toEqual({
+      city: 'Austin',
+      latitude: 30.27,
+      longitude: -97.74,
+      timezone: undefined,
+    });
+    expect(normalizeLocation({ city: 'Austin' })).toBeNull();
+    expect(normalizeLocation(undefined)).toBeNull();
+  });
+});
+
+describe('normalizeTimezone', () => {
+  it('keeps an IANA zone', () => {
+    expect(normalizeTimezone('Europe/Berlin')).toBe('Europe/Berlin');
+  });
+
+  it('canonicalizes a legacy alias', () => {
+    expect(normalizeTimezone('US/Pacific')).toBe('America/Los_Angeles');
+  });
+
+  it.each(['', '   ', 'auto', 'Mars/Phobos', undefined, null, 42])('drops %s', (value) => {
+    expect(normalizeTimezone(value)).toBeUndefined();
+  });
+});
+
+describe('clampInteger', () => {
+  it('keeps a value inside the range', () => {
+    expect(clampInteger(7, 5, 1, 16)).toBe(7);
+  });
+
+  it('clamps a value outside the range', () => {
+    expect(clampInteger(0, 5, 1, 16)).toBe(1);
+    expect(clampInteger(99, 5, 1, 16)).toBe(16);
+  });
+
+  it('falls back for a value that is not a number', () => {
+    expect(clampInteger('many', 5, 1, 16)).toBe(5);
+    expect(clampInteger(Number.NaN, 5, 1, 16)).toBe(5);
+  });
+
+  it('truncates a fractional value', () => {
+    expect(clampInteger(7.9, 5, 1, 16)).toBe(7);
+  });
+});

--- a/packages/react-weather-forecast/worker/geo-worker.ts
+++ b/packages/react-weather-forecast/worker/geo-worker.ts
@@ -1,3 +1,6 @@
+import { grabJson } from '../src/api/http';
+import { normalizeCoordinates, normalizeTimezone } from '../src/lib/validate';
+
 export interface Env {}
 
 type CloudflareGeo = {
@@ -10,69 +13,158 @@ type CloudflareGeo = {
   postalCode?: string;
 };
 
-type IpApiResponse = {
-  ip?: string;
-  country_name?: string;
-  country_code?: string;
+type GeoResult = {
+  source: string;
+  ip?: string | null;
+  country?: string;
+  countryCode?: string;
   region?: string;
   city?: string;
-  latitude?: number;
-  longitude?: number;
+  latitude: number;
+  longitude: number;
   timezone?: string;
-  org?: string;
-  asn?: string;
-  error?: boolean;
-  reason?: string;
+  postalCode?: string;
 };
 
-async function lookupIpApi(ip: string): Promise<IpApiResponse> {
-  const res = await fetch(`https://ipapi.co/${encodeURIComponent(ip)}/json/`);
-  if (!res.ok) throw new Error(`ipapi.co HTTP ${res.status}`);
-  return res.json() as Promise<IpApiResponse>;
+/**
+ * Upstreams for an explicit `?ip=`, and for the rare request whose Cloudflare
+ * geolocation carries no coordinates. They are run by different operators, so
+ * one of them being rate-limited is not all of them being rate-limited.
+ *
+ * Requests go through `grab-url` rather than `fetch` so a cold or throttled
+ * upstream is retried (with backoff) before the next one is tried.
+ */
+const IP_LOOKUPS: { source: string; url: (ip: string) => string; parse: (body: any) => Partial<GeoResult> }[] = [
+  {
+    source: 'ipapi.co',
+    url: (ip) => `https://ipapi.co/${encodeURIComponent(ip)}/json/`,
+    parse: (data) => ({
+      ip: data.ip,
+      country: data.country_name,
+      countryCode: data.country_code,
+      region: data.region,
+      city: data.city,
+      latitude: data.latitude,
+      longitude: data.longitude,
+      timezone: data.timezone,
+      postalCode: data.postal,
+    }),
+  },
+  {
+    source: 'ipwho.is',
+    url: (ip) => `https://ipwho.is/${encodeURIComponent(ip)}`,
+    parse: (data) =>
+      data?.success === false
+        ? {}
+        : {
+            ip: data.ip,
+            country: data.country,
+            countryCode: data.country_code,
+            region: data.region,
+            city: data.city,
+            latitude: data.latitude,
+            longitude: data.longitude,
+            timezone: data.timezone?.id ?? data.timezone,
+            postalCode: data.postal,
+          },
+  },
+  {
+    source: 'geojs.io',
+    url: (ip) => `https://get.geojs.io/v1/ip/geo/${encodeURIComponent(ip)}.json`,
+    parse: (data) => {
+      const body = Array.isArray(data) ? data[0] : data;
+      return {
+        ip: body?.ip,
+        country: body?.country,
+        countryCode: body?.country_code,
+        region: body?.region,
+        city: body?.city,
+        latitude: body?.latitude,
+        longitude: body?.longitude,
+        timezone: body?.timezone,
+      };
+    },
+  },
+];
+
+/**
+ * Look an IP up, moving to the next provider whenever one fails *or* answers
+ * without usable coordinates -- an answer with `latitude: undefined` is what
+ * turns into `latitude=NaN` in a forecast URL and comes back as
+ * `400 Bad Request`.
+ */
+async function lookupIp(ip: string): Promise<GeoResult> {
+  const failures: string[] = [];
+
+  for (const provider of IP_LOOKUPS) {
+    try {
+      const body = await grabJson<Record<string, unknown>>(provider.url(ip), `${provider.source} lookup`, {
+        attempts: 2,
+        retryDelay: 250,
+        timeout: 8,
+      });
+      const parsed = provider.parse(body);
+      const coordinates = normalizeCoordinates(parsed.latitude, parsed.longitude);
+      if (!coordinates) {
+        failures.push(`${provider.source}: no coordinates in the response`);
+        continue;
+      }
+
+      return {
+        ...parsed,
+        source: provider.source,
+        ip: parsed.ip ?? ip,
+        timezone: normalizeTimezone(parsed.timezone),
+        ...coordinates,
+      };
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  throw new Error(`IP geolocation failed: ${failures.join('; ')}`);
 }
+
+const json = (body: unknown, status = 200) =>
+  Response.json(body, {
+    status,
+    headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': '*' },
+  });
 
 export default {
   async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
-    const ip = url.searchParams.get('ip');
+    const requestedIp = url.searchParams.get('ip');
+    const clientIp = request.headers.get('CF-Connecting-IP');
 
-    if (ip) {
-      const data = await lookupIpApi(ip);
-      return Response.json(
-        {
-          source: 'ipapi.co',
-          ip: data.ip ?? ip,
-          country: data.country_name,
-          countryCode: data.country_code,
-          region: data.region,
-          city: data.city,
-          latitude: data.latitude,
-          longitude: data.longitude,
-          timezone: data.timezone,
-          org: data.org,
-          asn: data.asn,
-          error: data.error,
-          reason: data.reason,
-        },
-        { headers: { 'Cache-Control': 'no-store' } }
-      );
-    }
+    try {
+      if (requestedIp) return json(await lookupIp(requestedIp));
 
-    const cf = request.cf as CloudflareGeo | undefined;
+      const cf = request.cf as CloudflareGeo | undefined;
+      const coordinates = normalizeCoordinates(cf?.latitude, cf?.longitude);
 
-    return Response.json(
-      {
+      // Cloudflare's own geolocation is free and instant, but it is missing
+      // for some networks. Rather than answer without coordinates, fall back
+      // to the IP lookups so the caller always gets a usable location.
+      if (!coordinates) {
+        if (!clientIp) throw new Error('no Cloudflare geolocation and no client IP to look up');
+        return json({ ...(await lookupIp(clientIp)), source: 'ip-fallback' });
+      }
+
+      return json({
         source: 'cloudflare',
-        ip: request.headers.get('CF-Connecting-IP'),
-        country: request.headers.get('CF-IPCountry'),
+        ip: clientIp,
+        country: request.headers.get('CF-IPCountry') ?? undefined,
         region: cf?.region,
         city: cf?.city,
-        latitude: cf?.latitude,
-        longitude: cf?.longitude,
-        timezone: cf?.timezone,
+        timezone: normalizeTimezone(cf?.timezone),
         postalCode: cf?.postalCode,
-      },
-      { headers: { 'Cache-Control': 'no-store' } }
-    );
+        ...coordinates,
+      } satisfies GeoResult);
+    } catch (error) {
+      // A status the client can classify: the package retries a 502, and
+      // moves on to the next geolocation provider once the retries are spent.
+      return json({ error: true, reason: error instanceof Error ? error.message : String(error) }, 502);
+    }
   },
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
…ck across providers

`Error: Weather request failed: 400 Bad Request` in the widget came from an unvalidated request rather than a bad prop: an IP geolocation upstream answers 200 with no coordinates in the body, `Number(undefined)` becomes `NaN`, and `latitude=NaN` goes out to Open-Meteo. An unknown timezone string or an out-of-range forecast range did the same.

Workarounds, all through `grab-url` (no raw `fetch` left in the package or the worker):

- Validate every input before it goes on the wire: coordinates must be finite and on the globe (rounded to 4 decimals), timezones are canonicalized and dropped when the runtime cannot resolve them, and the forecast range is clamped to the 1-16 days / 1-384 hours the API accepts. A geolocation response without usable coordinates now counts as a failed lookup instead of becoming `NaN`, and unusable lat/lon props fall back to IP geolocation.
- Retry with classified exponential backoff in `grabJson`: a 429, a 5xx, a timeout or a dropped connection is repeated (3 attempts by default, 400ms doubling); a request the server called invalid is not, since replaying it only burns the upstream's rate limit. Duplicate-path cancellation is off, so several widgets on one page no longer abort each other.
- Fallback weather APIs, tried in order: Open-Meteo, its GFS endpoint, met.no and wttr.in. The fallbacks normalize their own condition codes, units and timestamps into the shape Open-Meteo returns, so a failover is invisible in the widget. A 400 from an Open-Meteo endpoint is retried once with the minimal variable set before the chain moves on.
- Fallback IP geolocation APIs: the geo worker (when configured), then ipapi.co, ipwho.is, get.geojs.io and freeipapi.com, with `fallbackLocation` behind all of them.
- Last resort: a cached forecast up to a day old is served rather than throwing, and a failed refetch leaves the previous forecast on screen instead of replacing it with an error. If everything fails, the thrown message lists what each provider said.
- The bundled worker gets the same treatment: it falls back to the IP lookups when Cloudflare's own geolocation carries no coordinates, and answers 502 with a reason instead of a body the caller cannot use.

New options: `weatherProviders`, `geoProviders`, `retryAttempts`, `retryDelay`, `timeout`, `fallbackLocation`, `allowStaleCache`, `onProviderError`.

87 new tests cover the transport, the validation, each provider and the fallback chain; 179 pass, and the package type-checks and builds.


Claude-Session: https://claude.ai/code/session_01NokmyBPHpPJ6ut8FF8uRjo