### PR TITLE
🐛 fix(packages-lobe): pin an exact Node version for Cloudflare Workers Builds

### DIFF
--- a/packages-lobe/.nvmrc
+++ b/packages-lobe/.nvmrc
@@ -1,1 +1,1 @@
-lts/krypton
+24.20.0

--- a/packages-lobe/README.md
+++ b/packages-lobe/README.md
@@ -166,6 +166,27 @@ Verified locally: `/api/version`, `/api/health`, `/api/auth/get-session`, `/trpc
 `/api/v1/docs`, `/api/doc/documents` (D1), `/signin` renders the sign-in SPA in headless Chromium, and
 protected pages redirect to `/signin`.
 
+### Cloudflare Workers Builds
+
+The build image resolves the Node version from `.nvmrc` and installs it by exact
+version, so an nvm alias such as `lts/krypton` fails at `Installing nodejs
+lts/krypton` before a single dependency is fetched. `packages-lobe/.nvmrc` pins
+`24.20.0` (the current Krypton LTS release, so local nvm users stay on the same
+runtime); bump it to another exact version, or override it with a `NODE_VERSION`
+build variable in the project settings.
+
+Project settings for a Workers Builds deploy of this tree:
+
+| Setting | Value |
+| --- | --- |
+| Root directory | `packages-lobe` |
+| Build command | `pnpm run build:worker` |
+| Deploy command | `pnpm exec wrangler deploy` |
+
+The repo root's `packageManager` (`bun@1.4.0`) and this tree's
+(`pnpm@10.33.0`) are both detected, and both are installed — the LobeHub
+workspace still installs with pnpm, and `build:worker` shells out to bun.
+
 ### Required bindings / secrets
 
 Bindings are declared in `wrangler.jsonc` (identical IDs to `apps/qwksearch-web/wrangler.jsonc` for


### PR DESCRIPTION
## Problem

Deploying `packages-lobe` through Cloudflare Workers Builds fails before a single dependency is fetched:

```
Detected the following tools from environment: nodejs@lts/krypton, bun@1.4.0, pnpm@10.33.0
Installing nodejs lts/krypton
Failed: error occurred while installing tools or dependencies
```

`packages-lobe/.nvmrc` contained `lts/krypton`. That is an nvm alias — the Cloudflare build image passes the `.nvmrc` value straight to its tool installer, which only accepts an exact version, so the install step dies on Node. The other two detected tools were fine: `bun@1.4.0` comes from the repo-root `packageManager`, `pnpm@10.33.0` from `packages-lobe/package.json`.

## Change

- `packages-lobe/.nvmrc`: `lts/krypton` → `24.20.0`, the current Krypton LTS release (verified present in the nodejs.org dist index), so local nvm users stay on the same runtime.
- `packages-lobe/README.md`: new **Cloudflare Workers Builds** section recording the exact-version constraint, the `NODE_VERSION` build-variable escape hatch, and the project settings for this tree (root directory `packages-lobe`, build `pnpm run build:worker`, deploy `pnpm exec wrangler deploy`).

The identical bug was already fixed in `vtempest/lobehub-cf-workers` (commit `5152e9b8`); `packages-lobe` is a separate vendored copy of that tree and never received the change.

## How to test

Re-run the Workers Builds deploy for the `packages-lobe` project. The tool-detection line should now read `nodejs@24.20.0` and the install step should proceed past `Installing nodejs` into dependency installation.

To unblock the existing project without waiting on this merge, set a `NODE_VERSION` build variable to `24.20.0` in the Workers Builds settings — it overrides `.nvmrc`.

## Notes for reviewers

Two pre-existing conditions this PR deliberately does **not** change:

- `packages-lobe/pnpm-workspace.yaml` sets `lockfile: false` and `pnpm-lock.yaml` is gitignored, so the CI install is unpinned. No frozen-lockfile failure, but builds are not reproducible.
- `build:worker` shells out to `bun` for the SPA steps, so the build root genuinely needs both bun and pnpm. Cloudflare detects and installs both, so this holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNEgqexWpcyFR9eipPanek


---
_Generated by [Claude Code](https://claude.ai/code/session_01YNEgqexWpcyFR9eipPanek)_