### PR TITLE
Remove uptime status link from footer and adjust grid layout

### DIFF
--- a/apps/qwksearch-web/lib/config/site.ts
+++ b/apps/qwksearch-web/lib/config/site.ts
@@ -57,11 +57,6 @@ export const listFooterLinks: FooterLink[] = [
   { url: "/legal/privacy", text: "Privacy", icon: "Lock" },
   { url: "https://rights.institute/ethics", text: "Ethics", icon: "Bot" },
   { url: "/enterprise", text: "Enterprise", icon: "Building2" },
-  {
-    url: "https://stats.uptimerobot.com/wgqOZtDv0i",
-    text: "Uptime",
-    icon: "Activity",
-  },
 ];
 
 export const SubscriptionPlans: SubscriptionPlan[] = [

--- a/packages/research-agent-ui/src/components/Footer.tsx
+++ b/packages/research-agent-ui/src/components/Footer.tsx
@@ -116,7 +116,7 @@ export default function Footer({
             <div
                 className={`hidden md:flex absolute bottom-2 left-1/2 -translate-x-1/2 text-slate-200 text-xs z-20 ${optionBackgroundColor} rounded-lg px-2 py-1 shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex-wrap items-center justify-center gap-x-6 max-w-[90vw]`}
             >
-                <div className="max-w-4xl mx-auto grid grid-cols-3 gap-2">
+                <div className="max-w-4xl mx-auto grid grid-cols-4 gap-2">
                     {renderLinks()}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
This PR removes the uptime status link from the footer and adjusts the footer grid layout to accommodate the reduced number of links.

## Key Changes
- Removed the UptimeRobot status link from the footer links configuration in `site.ts`
- Updated the footer grid layout from 3 columns to 4 columns in `Footer.tsx` to better distribute the remaining footer links

## Implementation Details
The uptime monitoring link pointing to `https://stats.uptimerobot.com/wgqOZtDv0i` has been removed from the `listFooterLinks` array. The footer grid layout has been adjusted from `grid-cols-3` to `grid-cols-4` to optimize the visual spacing of the remaining footer navigation items.

https://claude.ai/code/session_016K2hcTAfy6NTcysEHjTxSu