### PR TITLE
Remove e2e workspace from packages-lobe monorepo

### DIFF
--- a/packages-lobe/README.md
+++ b/packages-lobe/README.md
@@ -180,12 +180,22 @@ Project settings for a Workers Builds deploy of this tree:
 | Setting | Value |
 | --- | --- |
 | Root directory | `packages-lobe` |
+| Install command | `pnpm install --no-frozen-lockfile` |
 | Build command | `pnpm run build:worker` |
 | Deploy command | `pnpm exec wrangler deploy` |
 
 The repo root's `packageManager` (`bun@1.4.0`) and this tree's
-(`pnpm@10.33.0`) are both detected, and both are installed — the LobeHub
-workspace still installs with pnpm, and `build:worker` shells out to bun.
+(`pnpm@10.33.0`) are both detected and both are installed, and the build image
+picks the repo root's bun unless the install command is set explicitly. Prefer
+pnpm here: `pnpm-workspace.yaml` carries the `overrides` (react 19.2.4, jose,
+pdfjs-dist) and the `@upstash/qstash` patch that bun does not read, so a bun
+install resolves a different tree than every other consumer of this workspace.
+
+Whichever installer runs, the `workspaces` list in `package.json` has to match
+the directories actually vendored here: bun fails the install outright on a
+literal entry with no directory behind it (`error: Workspace not found "e2e"`),
+where pnpm skips it. The upstream `e2e` tree is not vendored, so neither the
+workspace entry nor its scripts are kept.
 
 ### Required bindings / secrets
 

--- a/packages-lobe/package.json
+++ b/packages-lobe/package.json
@@ -37,7 +37,6 @@
   "workspaces": [
     "packages/*",
     "packages/business/*",
-    "e2e",
     "apps/desktop/src/main",
     "apps/share",
     "apps/workbench"
@@ -96,9 +95,6 @@
     "docs:cdn": "npm run workflow:docs-cdn && npm run lint:mdx",
     "docs:i18n": "lobe-i18n md && npm run lint:mdx",
     "docs:seo": "lobe-seo && npm run lint:mdx",
-    "e2e": "cd e2e && npm run test",
-    "e2e:install": "playwright install",
-    "e2e:ui": "playwright test --ui",
     "fts-search:reindex": "node scripts/elasticsearchReindex/runner.mjs",
     "fts-search:sync": "cross-env MIGRATION_DB=1 bun run scripts/elasticsearchSync/cli.ts",
     "hotfix:branch": "tsx ./scripts/hotfixWorkflow/index.ts",
@@ -129,8 +125,6 @@
     "start": "next start -p 3210",
     "stylelint": "stylelint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "test": "npm run test-app && npm run test-server",
-    "test:e2e": "pnpm --filter @lobechat/e2e-tests test",
-    "test:e2e:smoke": "pnpm --filter @lobechat/e2e-tests test:smoke",
     "test:update": "vitest -u",
     "test-app": "vitest run",
     "test-app:coverage": "vitest --coverage --silent='passed-only'",

--- a/packages-lobe/pnpm-workspace.yaml
+++ b/packages-lobe/pnpm-workspace.yaml
@@ -2,7 +2,6 @@ lockfile: false
 packages:
   - packages/**
   - .
-  - e2e
   - apps/desktop/src/main
   - apps/server
   - apps/share


### PR DESCRIPTION
## Summary
This PR removes the e2e test workspace from the packages-lobe monorepo configuration. The e2e directory is not vendored in this tree, so the workspace entry and its associated scripts have been removed to prevent installation failures and configuration mismatches.

## Key Changes
- Removed `e2e` entry from `pnpm-workspace.yaml` packages list
- Removed `e2e` workspace entry from `package.json` workspaces array
- Removed e2e-related npm scripts from `package.json`:
  - `e2e`: cd into e2e and run tests
  - `e2e:install`: playwright install command
  - `e2e:ui`: playwright UI test command
  - `test:e2e`: pnpm filter for e2e-tests package
  - `test:e2e:smoke`: pnpm filter for e2e-tests smoke tests
- Added explicit `pnpm install --no-frozen-lockfile` install command to Workers Builds configuration
- Updated README documentation to clarify pnpm preference and explain workspace configuration requirements

## Implementation Details
The changes address a critical issue where bun (the repo root's package manager) fails on workspace entries with no corresponding directory, while pnpm silently skips them. By removing the non-existent e2e workspace entry and explicitly configuring pnpm as the install command, the build process now correctly uses pnpm which respects the workspace overrides and patches defined in `pnpm-workspace.yaml`.

https://claude.ai/code/session_01AbC4UZiyTzm7uodRmkb5Xk