### PR TITLE
🔧 fix(cloudflare): keep dashboard-set Worker variables across deploys

### DIFF
--- a/.github/workflows/deploy-test-reports.yml
+++ b/.github/workflows/deploy-test-reports.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Deploy to Cloudflare Workers
         working-directory: apps/test-reports
-        run: npx wrangler deploy
+        run: npx wrangler deploy --keep-vars
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/apps/qwksearch-web/wrangler.jsonc
+++ b/apps/qwksearch-web/wrangler.jsonc
@@ -51,7 +51,6 @@
   ],
   "env": {
     "production": {
-      "keep_vars": true,
       "images": {
         "binding": "IMAGES",
       },

--- a/apps/test-reports/wrangler.jsonc
+++ b/apps/test-reports/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "qwksearch-test-reports",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "compatibility_date": "2026-07-29",
   "assets": {
     "directory": "./dist",

--- a/docs/cloudflare-env-vars.md
+++ b/docs/cloudflare-env-vars.md
@@ -1,0 +1,186 @@
+# Cloudflare Workers environment variables
+
+## Symptom
+
+Variables you entered in the Cloudflare dashboard (**Workers & Pages → your
+Worker → Settings → Variables**) disappear after a rebuild or deploy, and the
+Worker starts failing on missing configuration.
+
+## Cause
+
+The rebuild runs Wrangler, and Wrangler treats its own configuration file as the
+source of truth. By default `wrangler deploy` **deletes every plaintext variable
+on the Worker before setting the ones found in `wrangler.toml` /
+`wrangler.jsonc`** — so any variable that exists only in the dashboard is wiped.
+Secrets (`wrangler secret put`) are never deleted by a deploy, with or without
+the flag.
+See [Wrangler commands](https://developers.cloudflare.com/workers/wrangler/commands/workers/)
+and [Source of truth](https://developers.cloudflare.com/workers/wrangler/configuration/#source-of-truth).
+
+## Immediate fix
+
+Deploy with `--keep-vars`:
+
+```bash
+npx wrangler deploy --keep-vars
+```
+
+For version uploads:
+
+```bash
+npx wrangler versions upload --keep-vars
+```
+
+## Permanent fix (what this repo does)
+
+`keep_vars` is set in the Wrangler config, so **every** deploy path — a local
+`wrangler deploy`, Workers Builds, a GitHub Actions job, or a framework wrapper
+such as `opennextjs-cloudflare` / `vinext-cloudflare` — preserves dashboard
+variables without anyone having to remember the flag:
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "keep_vars": true
+}
+```
+
+TOML:
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+keep_vars = true
+```
+
+`keep_vars` is a **top-level-only** key: it applies to the Worker as a whole and
+cannot be set inside a named environment (`env.production`, `env.staging`).
+Wrangler ignores it there and warns about an unexpected field.
+
+## Better long-term setup
+
+Keep one source of truth instead of mixing dashboard variables with CLI
+deployments.
+
+Non-sensitive configuration belongs in the Wrangler config:
+
+```jsonc
+{
+  "vars": {
+    "API_URL": "https://api.example.com",
+    "APP_ENV": "production"
+  }
+}
+```
+
+API keys, database credentials, and tokens belong in secrets:
+
+```bash
+npx wrangler secret put DATABASE_URL
+npx wrangler secret put OPENAI_API_KEY
+```
+
+Cloudflare stores secrets encrypted and does not show their values in the
+dashboard or in Wrangler, but code reads them exactly like ordinary variables
+([Environment variables](https://developers.cloudflare.com/workers/configuration/environment-variables/)):
+
+```js
+export default {
+  async fetch(request, env) {
+    const apiKey = env.OPENAI_API_KEY;
+    const apiUrl = env.API_URL;
+
+    return new Response('ok');
+  },
+};
+```
+
+Read them off `env`, not `process.env`, unless the Worker runs with the relevant
+Node.js compatibility flag.
+
+## Wrangler environments
+
+Variables and bindings are **not inherited** between Wrangler environments —
+Cloudflare treats each one as effectively a separate Worker:
+
+```bash
+npx wrangler deploy
+npx wrangler deploy --env staging
+npx wrangler deploy --env production
+```
+
+Each environment needs its own `vars` block and its own secrets
+([Environments](https://developers.cloudflare.com/workers/wrangler/environments/)):
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "keep_vars": true,
+  "env": {
+    "production": {
+      "vars": { "APP_ENV": "production", "API_URL": "https://api.example.com" }
+    },
+    "staging": {
+      "vars": { "APP_ENV": "staging", "API_URL": "https://staging-api.example.com" }
+    }
+  }
+}
+```
+
+```bash
+npx wrangler secret put OPENAI_API_KEY --env production
+npx wrangler secret put OPENAI_API_KEY --env staging
+```
+
+## Deploying from GitHub Actions
+
+A workflow step that runs bare Wrangler has the same problem:
+
+```yaml
+- name: Deploy Worker
+  run: npx wrangler deploy --keep-vars
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+For production, prefer defining configuration in the Wrangler config and
+uploading secrets from CI rather than depending on dashboard variables:
+
+```bash
+npx wrangler deploy --secrets-file .secrets.json
+```
+
+Never commit `.secrets.json`, `.dev.vars`, or API keys.
+
+## The four things people confuse
+
+| | Where it lives | Survives a Wrangler deploy? |
+| --- | --- | --- |
+| Build variables/secrets | Workers Builds settings | Only used while the framework builds |
+| Worker runtime variables | `vars` in the Wrangler config | Yes — the config is the source of truth |
+| Dashboard variables | Cloudflare dashboard only | **Only with `keep_vars` / `--keep-vars`** |
+| Secrets | `wrangler secret put` | Yes — deploys never delete secrets |
+
+See also
+[Workers Builds configuration](https://developers.cloudflare.com/workers/ci-cd/builds/configuration/).
+
+## Wrangler configs in this repository
+
+Every one of these sets `keep_vars`:
+
+- `apps/qwksearch-web/wrangler.jsonc`
+- `apps/test-reports/wrangler.jsonc`
+- `packages-lobe/apps/share/wrangler.jsonc`
+- `packages-lobe/apps/workbench/wrangler.jsonc`
+- `packages-lobe/wrangler.jsonc`
+- `packages-lobe/wrangler.local.jsonc`
+- `packages-lobe/wrangler.smoke.jsonc`
+- `packages/extract-pdf/server/wrangler.jsonc`
+- `packages/language-model-training/webui/wrangler.json`
+- `packages/react-weather-forecast/worker/wrangler.jsonc`
+- `packages/reason-editor/wrangler.jsonc`
+- `packages/research-agent-ui/wrangler.example.jsonc`
+- `packages/trending-news-api/worker/wrangler.jsonc`

--- a/packages-lobe/apps/share/wrangler.jsonc
+++ b/packages-lobe/apps/share/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "lobehub-share",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "account_id": "d35842305b91be4b48e06ff9a9ad83f5",
   "main": "./workers/app.ts",
   "compatibility_date": "2026-08-01",

--- a/packages-lobe/apps/workbench/wrangler.jsonc
+++ b/packages-lobe/apps/workbench/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "../../node_modules/wrangler/config-schema.json",
   "name": "lobehub-workbench",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "account_id": "d35842305b91be4b48e06ff9a9ad83f5",
   "main": "./workers/app.ts",
   "compatibility_date": "2026-08-01",

--- a/packages-lobe/wrangler.jsonc
+++ b/packages-lobe/wrangler.jsonc
@@ -61,7 +61,6 @@
   },
   "env": {
     "production": {
-      "keep_vars": true,
       "vars": {
         "APP_URL": "https://qwksearch.com",
         "DATABASE_DRIVER": "neon",

--- a/packages-lobe/wrangler.local.jsonc
+++ b/packages-lobe/wrangler.local.jsonc
@@ -3,6 +3,9 @@
 // account; Postgres calls fail until DATABASE_URL points at a reachable database.
 {
   "name": "qwksearch-lobehub-local",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "./dist/worker/index.js",
   "compatibility_date": "2026-03-10",
   "compatibility_flags": ["nodejs_compat"],

--- a/packages-lobe/wrangler.smoke.jsonc
+++ b/packages-lobe/wrangler.smoke.jsonc
@@ -1,5 +1,8 @@
 {
   "name": "qwksearch-lobehub-smoke",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "./dist/worker/index.js",
   "compatibility_date": "2026-03-10",
   "compatibility_flags": ["nodejs_compat"],

--- a/packages/extract-pdf/server/wrangler.jsonc
+++ b/packages/extract-pdf/server/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "pdf-to-html-docling",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "server.js",
   "compatibility_date": "2025-05-01",
   // Required for Node.js built-ins (crypto, stream, path, etc.) used by

--- a/packages/language-model-training/webui/wrangler.json
+++ b/packages/language-model-training/webui/wrangler.json
@@ -1,5 +1,6 @@
 {
   "name": "train-next-word-prediction-webui",
+  "keep_vars": true,
   "type": "javascript",
   "main": "dist/index.js",
   "site": {

--- a/packages/react-weather-forecast/worker/wrangler.jsonc
+++ b/packages/react-weather-forecast/worker/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "../node_modules/wrangler/config-schema.json",
   "name": "react-weather-forecast-geo",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "geo-worker.ts",
   "compatibility_date": "2026-07-06"
 }

--- a/packages/reason-editor/wrangler.jsonc
+++ b/packages/reason-editor/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "react-reason-editor",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "compatibility_date": "2026-07-06",
   "observability": {
     "enabled": true

--- a/packages/research-agent-ui/wrangler.example.jsonc
+++ b/packages/research-agent-ui/wrangler.example.jsonc
@@ -3,6 +3,9 @@
 
 {
   "name": "research-agent-ui",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "type": "service",
   "main": "dist/cloudflare/worker.js",
 

--- a/packages/trending-news-api/worker/wrangler.jsonc
+++ b/packages/trending-news-api/worker/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
   "$schema": "../node_modules/wrangler/config-schema.json",
   "name": "trending-news-api",
+  // Wrangler deletes plaintext Variables set in the Cloudflare dashboard on every
+  // deploy unless keep_vars is set. Secrets are never deleted either way.
+  "keep_vars": true,
   "main": "index.ts",
   "compatibility_date": "2026-07-06"
 }


### PR DESCRIPTION
By default `wrangler deploy` deletes every plaintext variable on the Worker before applying the ones in the Wrangler config, so variables entered only in the Cloudflare dashboard vanish on each rebuild. Secrets are never deleted.

- Set the top-level `keep_vars` key in every Wrangler config, so the behaviour holds for all deploy paths (local CLI, Workers Builds, CI, and framework wrappers such as opennextjs-cloudflare / vinext-cloudflare) without anyone needing to remember the `--keep-vars` flag.
- Pass `--keep-vars` explicitly where CI or scripts invoke wrangler directly.
- Drop `keep_vars` from named environments: it is a top-level-only key, so those entries did nothing and made wrangler warn about an unexpected field.
- Document the failure mode, the flag, and the vars-vs-secrets split.

Claude-Session: https://claude.ai/code/session_01CvwVahdpudNPUPzWHn6N7c