### PR TITLE
docs: add architecture guides and Claude agent orientation

### DIFF
--- a/.claude/architecture/conventions.md
+++ b/.claude/architecture/conventions.md
@@ -1,0 +1,90 @@
+# Conventions and General Rules
+
+## Language and style
+
+- TypeScript throughout, ESM (`"type": "module"`). Python only in
+  `language-model-training`; Rust only in the Tauri shell.
+- Match the surrounding file's style — naming, import order, comment density.
+  There is no repo-wide formatter enforcing it in CI.
+- **Comments explain why, not what.** The valuable comments in this codebase
+  record a failure and its cause: the error text, why the obvious fix does not
+  work, what broke in production. `worker/index.ts`, `vitest.config.ts` and
+  `src/source.ts` are the house style — copy that register.
+- Keep package boundaries clean: import a sibling from its public entry point,
+  never from its internals or its `src/`.
+
+## Commits
+
+Gitmoji + conventional commits, lowercase subject, imperative mood:
+
+```
+✨ feat(settings): give the two QwkSearch panes their shared controls
+🐛 fix(ci): turn the four chronically red Coverage jobs green
+📝 docs(ci): record the lockfile outage blocking every job
+🔥 chore(worker): delete the unreachable extraction chain
+⏪ revert(research-agent-ui): drop the application sidebar from the app shell
+```
+
+Scope is the package or app name without its prefix. Version-bump commits are
+generated (`chore: bump published package versions [skip ci]`) — do not write them
+by hand.
+
+## Pull requests
+
+- Target `master`. One concern per PR; no drive-by refactors.
+- Say what changed, why, which workspace packages are affected, and whether a
+  published package needs a version bump.
+- Link issues with `Fixes #123`.
+- Include test results; screenshots for UI changes.
+- If you could not run a check, say so and why.
+
+## Tests
+
+- Add or update tests for every behaviour change and bug fix.
+- Run the touched package's own suite first (`cd packages/<name> && bun run test`)
+  — it is far faster than the root run — then `bun run test` from the root.
+- Tests run under Node. Passing tests do **not** prove the code runs on a
+  Cloudflare Worker; see [web-app.md](web-app.md).
+
+## CI
+
+| Workflow | Trigger | What it guards |
+| --- | --- | --- |
+| `test-coverage.yml` | push to master, PR | One matrix job per package, `fail-fast: false`, uploads to Codecov |
+| `test-web-api.yml` | paths under `apps/qwksearch-web` and two packages | The web app's own suite |
+| `lockfile.yml` | push, PR | `bun install --frozen-lockfile` with the pinned bun — this is what the Cloudflare build runs |
+| `npm-publish.yml` | push to master | Publishes changed public packages |
+| `deploy-test-reports.yml` | push to master | Builds the HTML report, deploys `apps/test-reports` |
+| `auto-merge-*.yml` | schedule / PR | Merges PRs that are clean, approved and green |
+
+Coverage jobs build `extract-pdf`, `extract-youtube`, `react-reason-editor` and
+`use-voice-control` explicitly first, because other packages consume them via
+`dist`. A new package that others import via `dist` needs adding to those steps.
+
+## Publishing
+
+Public packages publish from master via `npm-publish.yml`. Version bumps are
+automated; a bump commit lands as `chore: bump published package versions
+[skip ci]`. If you change a published package's public API, say so in the PR so
+the bump is a deliberate choice rather than a patch.
+
+## Security
+
+- Never commit secrets, credentials, API keys, private keys or build output.
+- Worker secrets go through `wrangler secret put`, not `vars` and not the repo.
+  Plaintext dashboard Variables survive deploys only because of `keep_vars` — see
+  [web-app.md](web-app.md).
+- Vulnerabilities are reported privately per `SECURITY.md`, never in a public
+  issue.
+- The license is PROSPER 1.0.0 (`LICENSE.md`); contributions are under it.
+
+## Agent-specific rules
+
+- Read `skills/ask-<name>/SKILL.md` before working in a package. It is written
+  from source and covers the real gotchas.
+- Do not create a root `docs/` folder — see [documentation.md](documentation.md).
+- Do not run `npm`/`yarn`/`pnpm` at the repo root. `packages-lobe/` and
+  `apps/qwksearch-ext` are the exceptions, and they have their own instructions.
+- After changing a package that another package imports, rebuild it before
+  concluding a behaviour is broken — see [monorepo.md](monorepo.md).
+- Update the matching skill and `readme.md` in the same PR as the behaviour change.

--- a/.claude/architecture/documentation.md
+++ b/.claude/architecture/documentation.md
@@ -1,0 +1,78 @@
+# Documentation — Where It Goes
+
+This repo has **one** home for prose documentation and **one** home for
+agent-facing package reference. Neither of them is a root `docs/` folder.
+
+| Kind of writing | Home |
+| --- | --- |
+| Anything a user or an operator reads | `packages/user-help-docs/content/docs/**` |
+| Package reference written for coding agents | `skills/ask-<name>/SKILL.md` (+ `API.md`) |
+| How to work in this repo, for Claude | `CLAUDE.md` and `.claude/architecture/**` |
+| A package's own public API | that package's `readme.md` |
+
+**Do not create a root `docs/` directory.** One existed and its contents were
+moved into the user guide; a new one splits the documentation in two again and
+ships nothing, because only `user-help-docs` is actually served.
+
+## The user guide (`packages/user-help-docs`)
+
+A **Fumadocs** site served at `/docs` in `apps/qwksearch-web`. Content is MDX under
+`content/docs/`, with an `architecture/` subsection for internal design notes,
+runbooks and migration plans.
+
+To add a page:
+
+1. Write `content/docs/<section>/<slug>.mdx` with frontmatter — `title` required,
+   `description` recommended, optional `icon` (a Lucide name) and `full`.
+   No H1: the frontmatter `title` renders it.
+2. Add the slug to the `pages` array of the `meta.json` in that directory.
+   `test/docs.test.ts` fails if a `meta.json` references a page that does not
+   exist, or if a top-level page is missing from the root `meta.json`.
+3. `cd packages/user-help-docs && bun run test`.
+
+### Why the content pipeline looks unusual
+
+`src/source.ts` inlines every file twice with `import.meta.glob` — `?raw` for the
+search index and the `llms.txt` views, compiled for the rendered page — instead of
+using the `fumadocs-mdx` collections pipeline. Both halves exist because of the
+Workers runtime:
+
+- There is no filesystem on a Worker and no `import.meta.url` to resolve
+  `content/docs` against; resolving one threw at module scope and 500'd every
+  route in the same chunk.
+- The request-time MDX compiler runs its output through `new AsyncFunction(...)`,
+  which Workers forbid (`EvalError: Code generation from strings disallowed`), so
+  the compile happens in the bundler via `helpDocsMdxPlugin` from
+  `user-help-docs/vite`.
+
+Consequences worth remembering: the host app **must** register
+`helpDocsMdxPlugin()` in both its Vite and its Vitest config, or every page throws
+`No compiled module for "<path>"`; and MDX rules apply to content — a bare `{` or
+`<` outside a code fence is parsed as JSX.
+
+## Skills (`skills/`)
+
+One [Agent Skill](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
+per package, each written from the package's **source** rather than its README.
+They are the most detailed documentation in the repo; read the relevant one before
+working in a package.
+
+Start at [`ask-qwksearch-monorepo`](../../skills/ask-qwksearch-monorepo/SKILL.md)
+when you do not yet know which layer owns a behaviour.
+
+Shape of a skill: YAML frontmatter with `name` matching the directory and a
+`description` that names the package and its path, lists what it covers, and ends
+with a `Use when …` clause naming concrete symptoms — that description is the only
+thing an agent sees when deciding to load it. Body: setup → which call to reach
+for → recipes → a symptom/cause/fix table. Exhaustive option, export and prop
+tables go in a sibling `API.md`.
+
+Adding a package means adding its skill, plus rows in `skills/README.md` and in
+`ask-qwksearch-monorepo`'s map.
+
+## Keeping documentation honest
+
+When you change behaviour, update in the same PR: the package `readme.md`, its
+`skills/ask-<name>/SKILL.md`, and any affected `user-help-docs` page. A stale skill
+is worse than a missing one — agents trust it. `packages/readme.md`, for instance,
+still calls the editor Lexical when it is Tiptap; the source is authoritative.

--- a/.claude/architecture/monorepo.md
+++ b/.claude/architecture/monorepo.md
@@ -1,0 +1,104 @@
+# Monorepo Mechanics
+
+Bun workspaces + Turborepo. Most of the friction an agent hits in this repo is one
+of the five things below.
+
+## Workspaces
+
+Declared in the root `package.json`:
+
+```
+packages/*
+packages/render-url-to-html/*     # the two scrapers are their own workspaces
+apps/*
+```
+
+Not covered by that glob, and deliberately separate:
+
+- `packages-lobe/` — its own **pnpm** workspace.
+- `apps/qwksearch-ext` — its own `pnpm-workspace.yaml` and lockfile. A root
+  install does not cover it; install inside it as well.
+
+## Commands
+
+```bash
+bun install                    # bun only — never npm/yarn
+bun run dev                    # turbo dev --filter=qwksearch-web
+bun run dev:editor             # the REASON editor standalone
+bun run build                  # turbo build, whole graph
+bun run test                   # vitest, root config
+bun run test:report            # vitest + HTML reporter into apps/test-reports/dist
+cd packages/<name> && bun run test
+```
+
+`turbo.json` is small on purpose: `build` depends on `^build` and caches
+`dist/`, `.next/`, `.output/`; `test` depends on `^build` and is **not** cached;
+`dev` is persistent and uncached.
+
+## The `dist` trap — read this before debugging a "stale" edit
+
+**Sibling packages are consumed as built `dist/`, not as live source.** Edit
+`packages/foo`, run the web app, see no change: nothing is broken, `foo` was not
+rebuilt.
+
+```bash
+bun run build --filter=<name>            # rebuild the one package
+node scripts/build-workspace-packages.mjs # rebuild all, topological order
+```
+
+That second script is what `apps/qwksearch-web`'s `prebuild` runs.
+
+The related symptom is `Cannot find module 'react-reason-editor/...' or its type
+declarations` — `bun install` symlinks the sibling, but its `exports → types`
+point at a `dist/` that does not exist yet. Same fix.
+
+### Why the script exists instead of just turbo
+
+Turbo treats a dependency as internal only when the declared semver range matches
+the workspace version. When a package asks for `use-voice-control@^0.1.95` and the
+workspace is older, turbo silently drops the edge and builds in the wrong order.
+`scripts/workspace-build-order.mjs` keys edges by package **name**, so the script
+covers what turbo misses. If you add a workspace dependency and the build order
+looks wrong, that mismatch is the first thing to check.
+
+## Tests: three runners, one registry
+
+The root `vitest.config.ts` lists projects **explicitly** — there is no glob, and
+no `vitest.workspace.ts` (Vitest 4 dropped it and silently ignored the file).
+
+Packages on a different runner are intentionally absent from that list and run
+from their own `test` script:
+
+| Package | Runner |
+| --- | --- |
+| `domain-rank`, `extract-pdf` | `bun test` |
+| `extract-youtube` | jest |
+| `language-model-training` | pytest |
+
+**When you add a package**, add its `vitest.config.ts` path to the `projects`
+array in the root config, add a matrix row to
+`.github/workflows/test-coverage.yml`, and give it a skill under
+`skills/ask-<name>/`. Turbo picks it up from the workspace glob on its own.
+
+## Adding a package — checklist
+
+1. `packages/<name>/package.json` (match a sibling's field order and license).
+2. Its own `vitest.config.ts`, registered in the root `vitest.config.ts`.
+3. A matrix row in `.github/workflows/test-coverage.yml`.
+4. `skills/ask-<name>/SKILL.md`, plus rows in `skills/README.md` and in
+   `skills/ask-qwksearch-monorepo/SKILL.md`.
+5. A bullet in the root `README.md` package list.
+6. Run `bun install` and commit the `bun.lock` diff.
+
+## Lockfile
+
+Cloudflare's build runs `bun install --frozen-lockfile` with the bun pinned in
+`packageManager`. A plain `bun install` rewrites `bun.lock` rather than failing, so
+drift only ever surfaces as a deploy failure:
+
+```
+error: lockfile had changes, but lockfile is frozen
+```
+
+The `Lockfile` workflow catches it on every PR. If it goes red: run `bun install`
+and commit the resulting `bun.lock`.

--- a/.claude/architecture/overview.md
+++ b/.claude/architecture/overview.md
@@ -1,0 +1,91 @@
+# Architecture Overview
+
+One product, four shells, twenty-odd libraries. Almost every behaviour a user can
+see is implemented in a `packages/*` library and merely *wired up* by the app that
+renders it. Finding the owning package is the first step of nearly every task here.
+
+## The product
+
+A research assistant with three halves:
+
+- **STREAM** — search across 75+ engines in 10 categories, extract the top results,
+  and answer with citations back to the sentences used.
+- **Tractor** — the extraction pipeline: main-content detection (Readability +
+  Mercury + ~100 site adapters), YouTube transcripts, PDF → structured HTML, and
+  APA citation metadata validated against a 90k-name database.
+- **REASON** — a Tiptap/Plate document editor with a nested document tree, AI
+  rewriting, collaborative editing and Google Docs import/export.
+
+## Request path, end to end
+
+```
+browser / extension / desktop / VS Code
+        │
+        ▼
+apps/qwksearch-web            Next.js on Cloudflare Workers (via vinext)
+  app/api/*                   route handlers — thin
+        │
+        ├─► packages/search-web-api        query 71 engine adapters, dedupe, rank
+        ├─► packages/extract-webpage       URL → cited article
+        │       ├─► packages/extract-pdf       PDF → structured HTML (+ Docling OCR)
+        │       ├─► packages/extract-youtube   transcripts, no browser
+        │       ├─► packages/domain-rank       source label, rank, favicon
+        │       └─► packages/render-url-to-html | html-renderer-api   JS-rendered pages
+        ├─► packages/chat-agent-toolkit    agent orchestration, Mastra, MCP, memory
+        │       └─► packages/write-language    one call across 10+ LLM providers
+        │
+        ▼
+  D1 (Drizzle) · KV · R2 · Better Auth
+```
+
+The UI on top of that is **not** in the app either: `packages/research-agent-ui`
+owns the chat window, result list, reader and uploads; `packages/reason-editor`
+owns the writing surface.
+
+## Product shells (`apps/`)
+
+| App | Stack | Owns |
+| --- | --- | --- |
+| `qwksearch-web` | Next.js + vinext → Cloudflare Workers, D1 via Drizzle | The deployed product: routes, `/api`, auth, DB. See [web-app.md](web-app.md). |
+| `qwksearch-desktop` | SvelteKit + Tauri (`src-tauri/`) | Global hotkey (select text, press `` ` ``), tray, autostart, quick-search popup. Native behaviour is Rust-side, not `src/`. |
+| `qwksearch-ext` | WXT browser extension | `entrypoints/{background,content,popup,sidepanel,offscreen}`. **Own** `pnpm-workspace.yaml` and lockfile — install inside it too. |
+| `qwk-vscode-ext` | esbuild host + two Vite webviews | Host/auth/API proxy in `src/`; chat sidebar in `webview-ui/`; editor in `webview-ui-editor/`. `bun run compile` builds all three. |
+| `collaboration-server` | Hocuspocus + SQLite | The Yjs rooms behind collaborative editing. |
+| `test-reports` | Cloudflare Worker | Static host for the Vitest HTML report. Infra only. |
+
+## Libraries (`packages/`)
+
+**AI and generation** — `write-language` (multi-provider generation),
+`chat-agent-toolkit` (agents, workflows, RAG, evals, MCP sessions, long-term
+memory), `language-model-training` (a GPT on Tinygrad, Python, its own toolchain).
+
+**Search and extraction** — `search-web-api`, `searxng-search-cloudflare`,
+`extract-webpage`, `extract-pdf`, `extract-youtube`, `domain-rank`,
+`render-url-to-html/*` (two self-hosted renderers, each its own workspace),
+`html-renderer-api` (Cloudflare Worker + Durable Object keeping a browser warm).
+
+**Clients and servers** — `qwksearch-api-client` (generated from OpenAPI),
+`qwksearch-mcp-server` (search/extract/render as MCP tools over stdio),
+`notebooklm-api-client` (Worker + sleeping Python container driving NotebookLM).
+
+**UI** — `research-agent-ui`, `reason-editor`, `reason-editor-sidebar`,
+`shadcn-app-dock`, `shadcn-settings`, `react-weather-forecast`,
+`trending-news-api`, `use-voice-control`, `user-help-docs`.
+
+**Vendored** — `investing`, `predictos` (from `ai-broker-investing-agent`).
+
+## `packages-lobe/`
+
+A copy of the [LobeHub](https://github.com/lobehub/lobehub) monorepo adapted to run
+qwksearch.com on the same Cloudflare stack (Workers + D1 + KV + R2 + Email Routing
++ Better Auth), plus the QwkSearch extract side panel and D1-backed docs.
+
+It is a **separate pnpm workspace** with its own rules — do not assume the bun/turbo
+commands above apply inside it. It carries its own `CLAUDE.md` (which delegates to
+`packages-lobe/AGENTS.md`); read that before editing anything in there.
+
+## A trap worth naming
+
+This product has its own, unrelated **Skills & Memory feature** — a per-user toggle
+panel in Settings. When a *user* says "add a skill" they usually mean a tool in
+`chat-agent-toolkit` or an entry in that panel, **not** a file in `skills/`.

--- a/.claude/architecture/web-app.md
+++ b/.claude/architecture/web-app.md
@@ -1,0 +1,108 @@
+# `apps/qwksearch-web` — The Deployed Product
+
+Next.js (App Router) compiled by **vinext** and deployed to a **Cloudflare
+Worker**. This is the only app most changes reach production through, and the
+Workers runtime is the source of most of its surprises.
+
+## Layout
+
+```
+app/                Next.js App Router
+  api/              route handlers — thin wrappers over packages/*
+    agent/ auth/ search/ scraper/ doc/ docs/ speech/ news/
+    notebooklm/ geolocation/ openapi/ admin/ config/ user/
+  docs/             the help site (see documentation.md)
+  admin/ c/ enterprise/ features/ legal/ library/ login/
+  news/ settings/ workspace/
+lib/                the app's own logic
+  auth/             Better Auth setup, session helpers, admin gate
+  database/         Drizzle schema, D1 session wrapper, Turso client
+  cloudflare/ chat/ scraper/ storage/ uploads/ integrations/
+  mcp-servers/ rate-limit/ news/ notebooklm/ config/ hooks/ utils/
+drizzle/            D1 SQL migrations
+worker/index.ts     Cloudflare Worker entry
+wrangler.jsonc      bindings and deploy config
+```
+
+Route handlers should stay thin. If you are writing extraction, search or
+generation logic inside `app/api/`, it belongs in a package instead.
+
+## Bindings
+
+| Binding | What |
+| --- | --- |
+| `DB` | D1, database `qwksearch-new`, migrations in `drizzle/` |
+| `KV` | Cloudflare KV |
+| `R2` | bucket `qwksearch-uploads` |
+| `IMAGES` | Cloudflare Images, used by the Worker's image optimizer |
+| `EMAIL` | Email Routing, sends as `noreply@qwksearch.com` |
+| `ASSETS` | static client bundle, `dist/client` |
+
+A `production` env overrides `KV` (different namespace) and re-declares `DB` and
+`IMAGES`. Bindings are **not** inherited into a named env — anything the
+production Worker needs has to appear there too.
+
+## D1 read replication
+
+The primary lives in WNAM; replicas answer nearby reads. A replica can lag, so
+every request that touches D1 runs inside a **D1 session** carrying a bookmark:
+
+1. `worker/index.ts` opens the scope with `runWithD1Session`, seeded from the
+   bookmark the client returned last time.
+2. `sessionedD1()` wraps the raw binding so every Drizzle statement joins that
+   session.
+3. `applyD1Bookmark` writes the closing bookmark back onto the response.
+
+Outside a session scope (prerender, scripts, unit tests) the wrapper is a
+pass-through. Auth paths opt out of replica reads entirely
+(`PRIMARY_ONLY_PATH_PREFIXES` in `lib/database/d1-session.ts`). Tunable at runtime
+with the `D1_SESSION_MODE` variable (`auto` | `primary` | `unconstrained` | `off`)
+and `D1_SESSION_DEBUG`. Background:
+[user-help-docs → Architecture → D1 Read Replication](../../packages/user-help-docs/content/docs/architecture/d1-read-replication.mdx).
+
+## Auth
+
+**Better Auth** over the Drizzle/D1 adapter, with the `oneTap`, `openAPI`,
+`magicLink` and `anonymous` plugins, plus VPN/location detection on sign-in.
+Trusted origins are compared as bare origins — a trailing slash or a path in a
+configured origin silently never matches.
+
+## Commands
+
+```bash
+bun run dev                # next dev
+bun run build              # vinext build (prebuild rebuilds sibling packages)
+bun run deploy             # vinext deploy
+bun run dev:cf             # build, then wrangler dev --local
+
+bun run db:generate        # drizzle-kit generate — new migration from schema
+bun run db:migrate         # apply to remote D1
+bun run db:migrate:local   # apply to the local D1
+bun run db:migrate:status
+bun run db:studio
+```
+
+Schema changes are: edit `lib/database/schema.ts` → `db:generate` → commit the
+generated SQL in `drizzle/` → `db:migrate`. Never hand-edit an applied migration.
+
+## Workers-runtime rules
+
+These are not style preferences; each one has already broken production here.
+
+- **No filesystem.** No `fs`, no `import.meta.url` path resolution at module
+  scope. Resolving one anyway threw `TypeError: The "path" argument must be of
+  type string or an instance of URL. Received undefined` and took down every
+  route bundled into the same chunk. Inline content at build time instead.
+- **No runtime code generation.** `new Function` / `new AsyncFunction` throws
+  `EvalError: Code generation from strings disallowed for this context`. Anything
+  that compiles at request time has to move into the bundler.
+- **`keep_vars: true` is load-bearing.** This config declares no `vars`, so
+  without it every `wrangler deploy` would delete the plaintext Variables set in
+  the dashboard. It is a top-level-only key — Wrangler ignores it inside a named
+  env. See
+  [user-help-docs → Architecture → Cloudflare Worker Variables](../../packages/user-help-docs/content/docs/architecture/cloudflare-env-vars.mdx).
+- **Source maps stay off** (`upload_source_maps: false`). The unminified rsc/ssr
+  bundles produced ~15.4MB of maps against a 15MB cap and the deploy was rejected
+  with API error 10021.
+- Tests run under Node and will happily pass code that cannot run on Workers.
+  A green suite is not evidence the Worker boots.

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ apps/qwksearch-web/.open-next
 .dev.vars
 .claude/*
 !.claude/skills
+# Architecture notes for Claude agents — checked in on purpose (see CLAUDE.md)
+!.claude/architecture
 .turbo
 
 yarn.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md — QwkSearch Research Agent
+
+Orientation for Claude agents working in this repository. Read this first; the
+detailed notes live in [`.claude/architecture/`](.claude/architecture/) and are
+linked from each section below.
+
+QwkSearch is a **Bun + Turborepo monorepo**. One research assistant — search 75+
+engines, extract and cite articles / PDFs / YouTube, write the result up in the
+REASON editor — shipped as four product shells (web, desktop, browser extension,
+VS Code) built from shared `packages/*`.
+
+## Ground rules
+
+1. **Bun, never npm or yarn.** `packageManager` pins the exact Bun version and
+   Cloudflare's build installs with it. `bun install` — and commit `bun.lock`
+   when it changes, or every Cloudflare build fails on `--frozen-lockfile`.
+2. **Find the owning package before you edit.** Most behaviour lives in
+   `packages/*`, not in the app that renders it. See
+   [`architecture/overview.md`](.claude/architecture/overview.md).
+3. **Read the package's skill first.** Every package has one under
+   [`skills/ask-<name>/SKILL.md`](skills/), written from the source. They are the
+   deepest documentation in the repo — do not re-derive what they already answer.
+4. **Packages are consumed as built `dist/`, not live source.** A package edit
+   that "doesn't show up" almost always means it was not rebuilt. See
+   [`architecture/monorepo.md`](.claude/architecture/monorepo.md).
+5. **Documentation goes in the user guide package**, `packages/user-help-docs`.
+   There is deliberately **no root `docs/` folder** — do not recreate one. See
+   [`architecture/documentation.md`](.claude/architecture/documentation.md).
+6. **Respect package boundaries.** Import from a package's public entry point,
+   never reach into its internals.
+7. **Never commit secrets**, credentials, API keys, build output, or an
+   unrelated `bun.lock` diff.
+
+## Where things live
+
+| You want to change… | Go to |
+| --- | --- |
+| The chat / search UI, results, reader, uploads | `packages/research-agent-ui` |
+| The document editor | `packages/reason-editor` (+ `-sidebar`) |
+| Agent orchestration, MCP, memory, model registry | `packages/chat-agent-toolkit` |
+| One LLM call across 10+ providers | `packages/write-language` |
+| Search engines, dedupe, ranking | `packages/search-web-api` |
+| URL / PDF / YouTube extraction | `packages/extract-*` |
+| Routes, `/api` handlers, auth, D1 schema | `apps/qwksearch-web` |
+| User-facing documentation | `packages/user-help-docs/content/docs` |
+| The qwksearch.com LobeHub build | `packages-lobe/` (separate pnpm workspace) |
+
+Full map: [`architecture/overview.md`](.claude/architecture/overview.md) ·
+[`skills/ask-qwksearch-monorepo`](skills/ask-qwksearch-monorepo/SKILL.md).
+
+## Commands
+
+```bash
+bun install                    # never npm/yarn
+bun run dev                    # turbo dev --filter=qwksearch-web
+bun run build                  # turbo build across the graph
+bun run test                   # vitest, root config
+cd packages/<name> && bun run test    # much faster while iterating
+```
+
+## Before you open a PR
+
+- Run the touched package's own tests, then `bun run test` from the root.
+- Run `bun run build` if you changed anything a sibling package imports.
+- Update the package's `readme.md` and its `skills/ask-<name>/SKILL.md` when
+  behaviour or public API changes.
+- Commit style is **gitmoji + conventional commits**:
+  `✨ feat(scope): what changed`. See
+  [`architecture/conventions.md`](.claude/architecture/conventions.md).
+- Target `master`. Keep the PR focused; no drive-by refactors.
+
+## Detailed notes
+
+| Note | Covers |
+| --- | --- |
+| [overview.md](.claude/architecture/overview.md) | System architecture, the request paths, every package and app |
+| [monorepo.md](.claude/architecture/monorepo.md) | Workspaces, the `dist` trap, turbo, the test runner split |
+| [web-app.md](.claude/architecture/web-app.md) | The deployed Cloudflare app: Worker, D1, auth, deploy, migrations |
+| [documentation.md](.claude/architecture/documentation.md) | Where docs live, the Fumadocs pipeline, the skills convention |
+| [conventions.md](.claude/architecture/conventions.md) | Code style, commits, PRs, CI, publishing, security |

--- a/packages/user-help-docs/content/docs/architecture/cloudflare-env-vars.mdx
+++ b/packages/user-help-docs/content/docs/architecture/cloudflare-env-vars.mdx
@@ -1,4 +1,7 @@
-# Cloudflare Workers environment variables
+---
+title: "Cloudflare Worker Variables"
+description: "Why dashboard-set Worker variables vanish on deploy, and the keep_vars setting this repo uses so they do not."
+---
 
 ## Symptom
 

--- a/packages/user-help-docs/content/docs/architecture/debate-video-category-keywords.mdx
+++ b/packages/user-help-docs/content/docs/architecture/debate-video-category-keywords.mdx
@@ -1,4 +1,7 @@
-# Debate Video Category Keyword Map
+---
+title: "Debate Video Category Keywords"
+description: "Per-category keyword assignments for the policy debate video index, derived from the round title convention."
+---
 
 Per-category keyword assignments for a policy debate video index, derived from the
 naming convention the rounds themselves use. One primary keyword per category, with

--- a/packages/user-help-docs/content/docs/architecture/meta.json
+++ b/packages/user-help-docs/content/docs/architecture/meta.json
@@ -1,12 +1,14 @@
 {
   "title": "Architecture",
-  "description": "Internal design notes and migration plans.",
+  "description": "Internal design notes, operations runbooks and migration plans.",
   "pages": [
     "d1-read-replication",
+    "cloudflare-env-vars",
     "lobehub-core-engine-plan",
     "lobehub-integration-plan",
     "lobe-packages-migration-plan",
     "lobehub-integrations",
-    "lobehub-migration-todo"
+    "lobehub-migration-todo",
+    "debate-video-category-keywords"
   ]
 }


### PR DESCRIPTION
## Summary

Added comprehensive architecture documentation and Claude agent orientation materials to help contributors and AI agents understand the codebase structure, conventions, and workflows.

## Key changes

- **Added `CLAUDE.md`** — Top-level orientation guide for Claude agents covering ground rules, where things live, essential commands, and links to detailed architecture notes
- **Added `.claude/architecture/` directory** with four detailed guides:
  - `overview.md` — System architecture, request paths, all packages and apps, and the product shells
  - `monorepo.md` — Workspace mechanics, the `dist` trap, Turborepo, test runner split, and the build order script
  - `web-app.md` — The deployed Cloudflare Worker app: D1 read replication, auth, bindings, migrations, and Workers runtime rules
  - `conventions.md` — Code style, commit format, PR guidelines, CI workflows, publishing, and security
  - `documentation.md` — Where documentation lives (user guide, skills, package readmes), the Fumadocs pipeline, and why the content inlining is necessary
- **Updated `.gitignore`** — Added `.claude/architecture` to the exclusion list with a comment explaining it is checked in on purpose, and normalized line endings
- **Updated `packages/user-help-docs/content/docs/architecture/meta.json`** — Added `cloudflare-env-vars` to the pages list and updated the section description
- **Renamed and reformatted architecture docs** — Added frontmatter (title, description) to `cloudflare-env-vars.mdx` and `debate-video-category-keywords.mdx` to match Fumadocs conventions

## Implementation details

The architecture guides are written to be read in order (CLAUDE.md → overview.md → specific guides) and cross-reference each other. They document real production gotchas (Workers runtime restrictions, D1 session bookmarks, the `dist` consumption trap) alongside the happy path. The guides are intentionally checked into version control so they stay in sync with the code and are available to Claude agents during analysis.

https://claude.ai/code/session_01Dvhttfj3zusx2tdHxy1FkT