### PR TITLE
✨ feat: add legal-terms-privacy-policy package

### DIFF
--- a/apps/qwksearch-web/package.json
+++ b/apps/qwksearch-web/package.json
@@ -83,7 +83,7 @@
     "harper.js": "2.7.0",
     "katex": "^0.18.7",
     "kokoro-js": "^1.2.1",
-    "legal-terms-privacy-policy": "^0.1.0",
+    "legal-terms-privacy-policy": "workspace:*",
     "lodash-es": "^4.18.1",
     "lowlight": "^3.3.0",
     "lucide-react": "^1.43.0",

--- a/bun.lock
+++ b/bun.lock
@@ -160,6 +160,7 @@
         "harper.js": "2.7.0",
         "katex": "^0.18.7",
         "kokoro-js": "^1.2.1",
+        "legal-terms-privacy-policy": "workspace:*",
         "lodash-es": "^4.18.1",
         "lowlight": "^3.3.0",
         "lucide-react": "^1.43.0",
@@ -249,7 +250,7 @@
     },
     "packages/chat-agent-toolkit": {
       "name": "chat-agent-toolkit",
-      "version": "1.2.315",
+      "version": "1.2.325",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.50",
         "@ai-sdk/google": "^4.0.65",
@@ -297,7 +298,7 @@
     },
     "packages/domain-rank": {
       "name": "domain-rank",
-      "version": "0.1.304",
+      "version": "0.1.314",
       "dependencies": {
         "fuse.js": "^7.5.0",
         "grab-url": "^1.6.22",
@@ -316,7 +317,7 @@
     },
     "packages/extract-pdf": {
       "name": "extract-pdf",
-      "version": "0.1.299",
+      "version": "0.1.309",
       "dependencies": {
         "grab-url": "^1.6.22",
       },
@@ -341,7 +342,7 @@
     },
     "packages/extract-webpage": {
       "name": "extract-webpage",
-      "version": "1.2.310",
+      "version": "1.2.319",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "ai": "^7.0.94",
@@ -390,7 +391,7 @@
     },
     "packages/extract-youtube": {
       "name": "extract-youtube",
-      "version": "1.0.303",
+      "version": "1.0.313",
       "bin": {
         "extract-youtube": "dist/cli.js",
       },
@@ -428,7 +429,7 @@
     },
     "packages/html-renderer-api": {
       "name": "html-renderer-api",
-      "version": "1.0.187",
+      "version": "1.0.197",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.4.0",
       },
@@ -439,7 +440,7 @@
     },
     "packages/investing": {
       "name": "investing",
-      "version": "0.1.0",
+      "version": "0.1.11",
       "dependencies": {
         "@alpacahq/alpaca-trade-api": "^3.1.3",
         "@langchain/core": "^1.1.8",
@@ -480,9 +481,28 @@
         "drizzle-orm": "^0.45.1",
       },
     },
+    "packages/legal-terms-privacy-policy": {
+      "name": "legal-terms-privacy-policy",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@testing-library/react": "^16.3.3",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.7",
+        "@vitejs/plugin-react": "^6.1.1",
+        "@vitest/coverage-v8": "^5.0.0",
+        "jsdom": "^30.0.1",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "typescript": "^7.0.2",
+        "vitest": "^5.0.0",
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+      },
+    },
     "packages/notebooklm-api-client": {
       "name": "notebooklm-api-client",
-      "version": "0.1.259",
+      "version": "0.1.269",
       "dependencies": {
         "@cloudflare/puppeteer": "^1.4.0",
       },
@@ -518,7 +538,7 @@
     },
     "packages/qwksearch-api-client": {
       "name": "qwksearch-api-client",
-      "version": "0.9.257",
+      "version": "1.0.0",
       "devDependencies": {
         "@hey-api/client-fetch": "^0.13.1",
         "@hey-api/openapi-ts": "^0.99.0",
@@ -532,7 +552,7 @@
     },
     "packages/qwksearch-mcp-server": {
       "name": "qwksearch-mcp-server",
-      "version": "1.0.151",
+      "version": "1.0.161",
       "bin": {
         "qwksearch-mcp": "./bin/qwksearch-mcp.ts",
       },
@@ -549,7 +569,7 @@
     },
     "packages/react-weather-forecast": {
       "name": "use-weather-forecast",
-      "version": "0.1.129",
+      "version": "0.1.139",
       "dependencies": {
         "grab-url": "^1.6.22",
       },
@@ -575,7 +595,7 @@
     },
     "packages/reason-editor": {
       "name": "react-reason-editor",
-      "version": "1.0.117",
+      "version": "1.0.127",
       "dependencies": {
         "@ariakit/react": "^0.4.39",
         "@emoji-mart/data": "1.2.1",
@@ -783,7 +803,7 @@
     },
     "packages/reason-editor-sidebar": {
       "name": "react-reason-editor-sidebar",
-      "version": "0.1.34",
+      "version": "0.1.44",
       "dependencies": {
         "@headless-tree/core": "^1.7.0",
         "@headless-tree/react": "^1.7.0",
@@ -912,7 +932,7 @@
     },
     "packages/research-agent-ui": {
       "name": "research-agent-ui",
-      "version": "0.1.184",
+      "version": "0.1.194",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@radix-ui/react-dialog": "^1.1.23",
@@ -988,7 +1008,7 @@
     },
     "packages/search-web-api": {
       "name": "search-web-api",
-      "version": "1.0.167",
+      "version": "1.0.177",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",
         "@scalar/hono-api-reference": "^0.12.1",
@@ -1008,7 +1028,7 @@
     },
     "packages/shadcn-app-dock": {
       "name": "shadcn-app-dock",
-      "version": "0.1.165",
+      "version": "0.1.175",
       "dependencies": {
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-slot": "^1.3.3",
@@ -1041,7 +1061,7 @@
     },
     "packages/shadcn-settings": {
       "name": "shadcn-settings",
-      "version": "0.1.43",
+      "version": "0.1.53",
       "dependencies": {
         "@radix-ui/react-select": "^2.3.7",
         "@radix-ui/react-switch": "^1.3.7",
@@ -1070,7 +1090,7 @@
     },
     "packages/trending-news-api": {
       "name": "trending-news-api",
-      "version": "0.1.43",
+      "version": "0.1.53",
       "devDependencies": {
         "@cloudflare/workers-types": "^5.20260908.1",
         "@testing-library/react": "^16.3.3",
@@ -1093,7 +1113,7 @@
     },
     "packages/use-voice-control": {
       "name": "use-voice-control",
-      "version": "0.1.124",
+      "version": "0.1.134",
       "bin": {
         "use-voice-control": "bin/use-voice-control.mjs",
       },
@@ -1155,7 +1175,7 @@
     },
     "packages/write-language": {
       "name": "write-language",
-      "version": "0.1.185",
+      "version": "0.1.195",
       "dependencies": {
         "@ai-sdk/amazon-bedrock": "^5.0.78",
         "@ai-sdk/anthropic": "^4.0.50",
@@ -5189,6 +5209,8 @@
 
     "lazy-cache": ["lazy-cache@1.0.4", "", {}, "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="],
 
+    "legal-terms-privacy-policy": ["legal-terms-privacy-policy@workspace:packages/legal-terms-privacy-policy"],
+
     "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
@@ -7651,6 +7673,8 @@
 
     "evp_bytestokey/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "extract-webpage/qwksearch-api-client": ["qwksearch-api-client@0.9.269", "", {}, "sha512-I6saXI0+KZvEa6tvzcF14/QT7pbayivNtHyy2QfDGGDicl3/z7BGyRHZZ9BeUvwsnai55mJxI0UPinpc+tbTCg=="],
+
     "extract-youtube/typescript": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "extract-zip/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -8268,6 +8292,8 @@
     "wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "write-language/qwksearch-api-client": ["qwksearch-api-client@0.9.269", "", {}, "sha512-I6saXI0+KZvEa6tvzcF14/QT7pbayivNtHyy2QfDGGDicl3/z7BGyRHZZ9BeUvwsnai55mJxI0UPinpc+tbTCg=="],
 
     "wsl-utils/is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 

--- a/packages/legal-terms-privacy-policy/README.md
+++ b/packages/legal-terms-privacy-policy/README.md
@@ -1,0 +1,63 @@
+# legal-terms-privacy-policy
+
+The Terms of Service and Privacy Policy page that QwkSearch, Debate AI, AI Broker,
+Grab URL and Rights Institute all publish — one copy, rendered as a React
+component, so the pages cannot drift apart. Each site passes its own name,
+contact address and revision date; every clause is shared.
+
+## Usage
+
+```tsx
+import { LegalTermsPrivacyPolicy } from 'legal-terms-privacy-policy/react';
+
+export default function PrivacyPage() {
+    return (
+        <LegalTermsPrivacyPolicy
+            appName="QwkSearch"
+            contactEmail="support@qwksearch.com"
+            lastRevisedDate="2026-01-15"
+            homeUrl="/"
+            defaultVariant="full"
+        />
+    );
+}
+```
+
+| Prop | Required | Description |
+| --- | --- | --- |
+| `appName` | yes | Product name, woven through the clauses. |
+| `contactEmail` | yes | Address for account closure, deletion requests and questions. |
+| `lastRevisedDate` | yes | Revision date shown under the title, formatted however the site prefers. |
+| `homeUrl` | no | Target of the "Back to Home" link. Omit to leave the link out. |
+| `defaultVariant` | no | `'full'` (default) or `'summary'` — which rendering the page opens on. |
+| `className` | no | Extra class on the page wrapper. |
+
+The page opens on the full legal text, with a switch to a plain-language summary
+of the same clauses; the summary links out to the longer plain-language version
+at [rights.institute/terms-privacy](https://rights.institute/terms-privacy).
+
+The component carries its own stylesheet, inlined into a `<style>` element
+rather than imported as a `.css` file, so it drops into any bundler without
+CSS-in-`node_modules` configuration.
+
+## Entry points
+
+- `legal-terms-privacy-policy` — types and `LEGAL_SUMMARY_URL`, no React import.
+- `legal-terms-privacy-policy/react` — `LegalTermsPrivacyPolicy` and the
+  `FullLegalTerms` / `LegalSummary` halves, should a site want to lay them out
+  itself.
+
+The package ships TypeScript sources, like the other workspace packages here, so
+consumers transpile it. In Next.js that means listing it in
+`transpilePackages`:
+
+```js
+// next.config.mjs
+transpilePackages: ["legal-terms-privacy-policy", /* ... */],
+```
+
+## Changing the text
+
+Edits here change every site's legal page at once, which is the point — and the
+reason to be deliberate. Bump `lastRevisedDate` on the consuming sites when the
+substance changes, not only the wording.

--- a/packages/legal-terms-privacy-policy/package.json
+++ b/packages/legal-terms-privacy-policy/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "legal-terms-privacy-policy",
+  "version": "0.1.0",
+  "description": "Shared Terms of Service and Privacy Policy page, as a React component parameterized by app name, contact address and revision date",
+  "keywords": ["legal", "terms-of-service", "privacy-policy", "react", "component"],
+  "license": "rights.institute/PROSPER",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/qwksearch-research-agent.git",
+    "directory": "packages/legal-terms-privacy-policy"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./react": "./src/react/index.tsx",
+    "./package.json": "./package.json"
+  },
+  "files": ["src", "README.md"],
+  "sideEffects": false,
+  "peerDependencies": {
+    "react": "^18 || ^19"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.3",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.7",
+    "@vitejs/plugin-react": "^6.1.1",
+    "@vitest/coverage-v8": "^5.0.0",
+    "jsdom": "^30.0.1",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "typescript": "^7.0.2",
+    "vitest": "^5.0.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  }
+}

--- a/packages/legal-terms-privacy-policy/src/index.ts
+++ b/packages/legal-terms-privacy-policy/src/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared Terms of Service and Privacy Policy document.
+ *
+ * The clauses are identical across QwkSearch, Debate AI, AI Broker, Grab URL
+ * and Rights Institute; only the app's name, contact address and revision date
+ * differ. Keeping one copy here is what stops the five pages from drifting.
+ *
+ * The document itself is a React component — import it from
+ * `legal-terms-privacy-policy/react`. This entry point carries only the types
+ * and constants, so server code that needs, say, the summary URL does not pull
+ * React in with it.
+ */
+
+/** Which rendering of the document the page opens on. */
+export type LegalVariant = 'full' | 'summary';
+
+/** Plain-language rendering of these same terms, maintained by Rights Institute. */
+export const LEGAL_SUMMARY_URL = 'https://rights.institute/terms-privacy';
+
+export interface LegalTermsPrivacyPolicyProps {
+    /** Product name, woven through the clauses (e.g. "QwkSearch"). */
+    appName: string;
+    /** Address users write to for account closure, deletion requests and questions. */
+    contactEmail: string;
+    /** Revision date shown under the title, formatted however the site prefers. */
+    lastRevisedDate: string;
+    /** Where the "Back to Home" link points. Omit to leave the link out. */
+    homeUrl?: string;
+    /** Rendering to open on. Defaults to the full legal text. */
+    defaultVariant?: LegalVariant;
+    /** Extra class on the page wrapper, for sites that style it further. */
+    className?: string;
+}

--- a/packages/legal-terms-privacy-policy/src/react/full-terms.tsx
+++ b/packages/legal-terms-privacy-policy/src/react/full-terms.tsx
@@ -1,0 +1,195 @@
+import type { ReactNode } from 'react';
+
+export interface FullLegalTermsProps {
+    appName: string;
+    contactEmail: string;
+}
+
+/**
+ * The complete Terms of Service and Privacy Policy, which is the document these
+ * sites have always published. Only the product name and contact address vary.
+ */
+export function FullLegalTerms({ appName, contactEmail }: FullLegalTermsProps): ReactNode {
+    return (
+        <>
+            <h2>1. Introduction</h2>
+            <p>These Terms of Service (&quot;Terms&quot;) govern your use of {appName}&apos;s products and services, along with any associated apps, software, and websites (together, our &quot;Services&quot;). These Terms are a contract between you and {appName}, and they include our Acceptable Use Policy. By accessing our Services, you agree to these Terms.</p>
+
+            <p>This document also describes how {appName} (&quot;we&quot;, &quot;us,&quot; &quot;our&quot;) collects, uses and discloses information about individuals who use our websites, applications, services, tools and features, purchase our products or otherwise interact with us (collectively, the &quot;Services&quot;). For the purposes of this document, &quot;you&quot; and &quot;your&quot; means you as the user of the Services, whether you are a customer, website visitor, job applicant, representative of a company with whom we do business, or another individual whose information we have collected pursuant to this Privacy Policy. Please note that the Services are designed for users in the United States only and are not intended for users located outside the United States.</p>
+
+            <p>Please read this document carefully. By using any of the Services, you agree to the collection, use, and disclosure of your information as described in this document. If you do not agree to these terms, please do not use or access the Services.</p>
+
+            <h2>2. Changes to These Terms</h2>
+            <p>We may revise and update these Terms at our discretion. We may modify this document from time to time, in which case we will update the &quot;Last Updated&quot; date at the top of this document. If we make material changes to the way in which we use or disclose information we collect, we will use reasonable efforts to notify you (such as by emailing you at the last email address you provided us, by posting notice of such changes on the Services, or by other means consistent with applicable law) and will take additional steps as required by applicable law. If you continue to access the Services after we post the updated Terms, you agree to the updated Terms. If you do not agree to any updates to this document, please do not continue using or accessing the Services.</p>
+
+            <h2>3. Artificial Intelligence Ethical Use Policy</h2>
+
+            <h3>3.1 Trust, But Verify Outputs</h3>
+            <p>Artificial intelligence and large language models (LLMs) are frontier technologies that are still improving in accuracy, reliability and safety. When you use our Services, you acknowledge and agree:</p>
+            <ol>
+                <li>Outputs may not always be accurate and may contain material inaccuracies even if they appear accurate because of their level of detail or specificity.</li>
+                <li>You should not rely on any Outputs without independently confirming their accuracy.</li>
+                <li>The Services and any Outputs may not reflect correct, current, or complete information.</li>
+            </ol>
+
+            <h3>3.2 Privacy Protection</h3>
+            <p>Don&apos;t compromise the privacy of others, including:</p>
+            <ol>
+                <li>Collecting, processing, disclosing, inferring or generating personal data without complying with applicable legal requirements</li>
+                <li>Using biometric systems for identification or assessment, including facial recognition</li>
+                <li>Facilitating spyware, communications surveillance, or unauthorized monitoring of individuals</li>
+            </ol>
+
+            <h3>3.3 Safety and Rights Protection</h3>
+            <p>Don&apos;t perform or facilitate activities that may significantly impair the safety, wellbeing, or rights of others, including:</p>
+            <ol>
+                <li>Providing tailored legal, medical/health, or financial advice without review by a qualified professional and disclosure of the use of AI assistance and its potential limitations</li>
+                <li>Making high-stakes automated decisions in domains that affect an individual&apos;s safety, rights or well-being</li>
+                <li>Facilitating real money gambling or payday lending</li>
+                <li>Engaging in political campaigning or lobbying, including generating campaign materials personalized to or targeted at specific demographics</li>
+                <li>Deterring people from participation in democratic processes</li>
+            </ol>
+
+            <h3>3.4 Truthfulness and Transparency</h3>
+            <p>Don&apos;t misuse our platform to cause harm by intentionally deceiving or misleading others, including:</p>
+            <ol>
+                <li>Generating or promoting disinformation, misinformation, or false online engagement</li>
+                <li>Impersonating another individual or organization without consent or legal right</li>
+                <li>Engaging in or promoting academic dishonesty</li>
+                <li>Failing to ensure that automated systems disclose to people that they are interacting with AI, unless it&apos;s obvious from the context</li>
+            </ol>
+
+            <h2>4. Account Creation and Access</h2>
+            <p><strong>Your {appName} Account:</strong> To access our Services, we may ask you to create an Account. You agree to provide correct, current, and complete Account information. You may not share your Account login information with anyone else. You are responsible for all activity occurring under your Account.</p>
+            <p>You may close your Account at any time by contacting us at {contactEmail}.</p>
+
+            <h2>5. Use of Our Services</h2>
+            <p>You may access and use our Services only in compliance with our Terms, our Acceptable Use Policy, and any guidelines or supplemental terms we may post on the Services (the &quot;Permitted Use&quot;).</p>
+            <p>You may not access or use, or help another person to access or use, our Services in any manner that violates these Terms or applicable laws.</p>
+
+            <h2>6. Prompts, Outputs, and Materials</h2>
+            <p>You may be allowed to submit text or other materials to our Services for processing (we call these &quot;Prompts&quot;). Our Services may generate responses based on your Prompts (we call these &quot;Outputs&quot;). Prompts and Outputs collectively are &quot;Materials.&quot;</p>
+            <p>You are responsible for all Prompts you submit to our Services. By submitting Prompts, you represent and warrant that you have all necessary rights and permissions.</p>
+
+            <h2>7. Privacy Policy</h2>
+            <p>When you use or access the Services, we collect certain categories of information about you from a variety of sources.</p>
+
+            <h3>7.1 Information You Provide to Us</h3>
+            <p>Some features of the Services may require you to directly provide us with certain information about yourself. You may elect not to provide this information, but doing so may prevent you from using or accessing these features. Information that you directly submit through our Services includes:</p>
+            <ol>
+                <li>Basic contact details, such as name, address, phone number, and email. We use this information to provide the Services, and to communicate with you (including to tell you about certain promotions or products or services that may be of interest to you).</li>
+                <li>Account information, such as name, username (email) and password. We use this information to provide the Services and to maintain and secure your account with us. If you choose to register an account, you are responsible for keeping your account credentials safe. We recommend you do not share your access details with anyone else. If you believe your account has been compromised, please contact us immediately.</li>
+                <li>Your Input and Output, such as questions, prompts and other content that you input, upload or submit to the Services, and the output that you create. This content may constitute or contain personal information, depending on the substance and how it is associated with your account. We use this information to generate and output new content as part of the Services.</li>
+                <li>Any other information you choose to include in communications with us, for example, when sending a message through the Services or provide your size when purchasing certain products.</li>
+            </ol>
+
+            <h3>7.2 Information We Collect Automatically</h3>
+            <p>We also automatically collect certain information about your interaction with the Services (&quot;Usage Data&quot;). To do this, we may use cookies and other tracking technologies (&quot;Tracking Technologies&quot;). Usage Data includes:</p>
+            <ol>
+                <li>Device information, such as device type, operating system, unique device identifier, and internet protocol (IP) address.</li>
+                <li>Location information, such as approximate location.</li>
+                <li>Other information regarding your interaction with the Services, such as browser type, log data, date and time stamps, clickstream data, interactions with marketing emails, and ad impressions.</li>
+            </ol>
+            <p>We use Usage Data to tailor features and content to you, run analytics and better understand user interaction with the Services. For more information on how we use Tracking Technologies and your choices, see section 8, Cookies and Other Tracking Technologies.</p>
+
+            <h3>7.3 Information Collected From Other Sources</h3>
+            <p>We may obtain information about you from outside sources, including information that we collect directly from third parties and information from third parties that you choose to share with us. Such information includes:</p>
+            <ol>
+                <li>Analytics data we receive from analytics providers such as Google Analytics.</li>
+                <li>Information we receive from consumer marketing databases or other data enrichment companies, which we use to better customize advertising and marketing to you.</li>
+            </ol>
+            <p>Any information we receive from outside sources will be treated in accordance with this document. We are not responsible for the accuracy of the information provided to us by third parties and are not responsible for any third party&apos;s policies or practices. For more information, see section 11, Third Party Websites and Links.</p>
+
+            <p>In addition to the specific uses described above, we may use any of the above information to provide you with and improve the Services and to maintain our business relationship, including by enhancing the safety and security of our Services (e.g., troubleshooting, data analysis, testing, system maintenance, and reporting), providing customer support, sending service and other non-marketing communications, monitoring and analyzing trends, conducting internal research and development, complying with applicable legal obligations, enforcing any applicable terms of service, and protecting the Services, our rights, and the rights of our employees, users or other individuals.</p>
+
+            <p>Finally, we may deidentify or anonymize your information such that it cannot reasonably be used to infer information about you or otherwise be linked to you (&quot;deidentified information&quot;) (or we may collect information that has already been deidentified/anonymized), and we may use such deidentified information for any purpose. To the extent we possess or process any deidentified information, we will maintain and use such information in deidentified/anonymized form and not attempt to re-identify the information, except solely for the purpose of determining whether our deidentification/anonymization process satisfies legal requirements.</p>
+
+            <h2>8. Cookies and Other Tracking Technologies</h2>
+            <p>Most browsers accept cookies automatically, but you may be able to control the way in which your devices permit the use of Tracking Technologies. If you so choose, you may block or delete our cookies from your browser; however, blocking or deleting cookies may cause some of the Services, including certain features and general functionality, to work incorrectly. If you have questions regarding the specific information about you that we process or retain, as well as your choices regarding our collection and use practices, please contact us using the information listed below.</p>
+            <p>To opt out of tracking by Google Analytics, click here: https://tools.google.com/dlpage/gaoptout</p>
+            <p>Your browser settings may allow you to transmit a &quot;do not track&quot; signal, &quot;opt-out preference&quot; signal, or other mechanism for exercising your choice regarding the collection of your information when you visit various websites. Like many websites, our website is not designed to respond to such signals, and we do not use or disclose your information in any way that would legally require us to recognize opt-out preference signals. To learn more about &quot;do not track&quot; signals, you can visit http://www.allaboutdnt.com/.</p>
+
+            <h2>9. Disclosure of Your Information</h2>
+            <p>We may disclose your information to third parties for legitimate purposes subject to this document, including the following categories of third parties:</p>
+            <ol>
+                <li>Company Group: Our affiliates or others within our corporate group.</li>
+                <li>Service Providers: Vendors or other service providers who help us provide the Services, including for system administration, cloud storage, security, customer relationship management, marketing communications, web analytics, payment networks, and payment processing.</li>
+                <li>Other Third Parties: Third parties to whom you request or direct us to disclose information, such as through your use of social media widgets or login integration.</li>
+                <li>Professional advisors: such as auditors, law firms, or accounting firms.</li>
+                <li>Business Transactions: Third parties in connection with or anticipation of an asset sale, merger, or other business transaction, including in the context of a bankruptcy.</li>
+            </ol>
+            <p>We may also disclose your information as needed to comply with applicable law or any obligations thereunder or to cooperate with law enforcement, judicial orders, and regulatory inquiries, to enforce any applicable terms of service, and to ensure the safety and security of our business, employees, and users.</p>
+
+            <h2>10. Social Features</h2>
+            <p>Certain features of the Services may allow you to initiate interactions between the Services and third-party services or platforms, such as social networks (&quot;Social Features&quot;). Social Features include features that allow you to access our pages on third-party platforms, and from there &quot;like&quot; or &quot;share&quot; our content. Use of Social Features may allow a third party to collect and/or use your information. If you use Social Features, information you post or make accessible may be publicly displayed by the third-party service. Both we and the third party may have access to information about you and your use of both the Services and the third-party service. For more information, see section 11, Third Party Websites and Links.</p>
+
+            <h2>11. Third Party Websites and Links</h2>
+            <p>We may provide links to third-party websites or platforms. If you follow links to sites or platforms that we do not control and are not affiliated with us, you should review the applicable privacy notice, policies and other terms. We are not responsible for the privacy or security of, or information found on, these sites or platforms. Information you provide on public or semi-public venues, such as third-party social networking platforms, may also be viewable by other users of the Services and/or users of those third-party platforms without limitation as to its use. Our inclusion of such links does not, by itself, imply any endorsement of the content on such platforms or of their owners or operators.</p>
+
+            <h2>12. Children&apos;s Privacy</h2>
+            <p>Children under the age of 13 are not permitted to use the Services, and we do not seek or knowingly collect any personal information about children under 13 years of age. If we become aware that we have unknowingly collected information about a child under 13 years of age, we will make commercially reasonable efforts to delete such information. If you are the parent or guardian of a child under 13 years of age who has provided us with their personal information, you may contact us using the below information to request that it be deleted.</p>
+
+            <h2>13. Data Security and Retention</h2>
+            <p>Despite our reasonable efforts to protect your information, no security measures are impenetrable, and we cannot guarantee &quot;perfect security.&quot; Any information you send to us electronically, while using the Services or otherwise interacting with us, may not be secure while in transit. We recommend that you do not use unsecure channels to send us sensitive or confidential information.</p>
+            <p>We retain your information for as long as is reasonably necessary for the purposes specified in this document. When determining the length of time to retain your information, we consider various criteria, including whether we need the information to continue to provide you the Services, resolve a dispute, enforce our contractual agreements, prevent harm, promote safety, security and integrity, or protect ourselves, including our rights, property or products.</p>
+            <p>You may opt out of information collection for AI, which would prohibit us from using your search information to improve our AI models in your settings page if you are logged into the Services. If you delete your account, we will delete your personal information from our servers within 30 days. Please contact us at {contactEmail} to request deletion.</p>
+
+            <h2>14. California Residents</h2>
+            <p>This section applies to you only if you are a California resident (&quot;resident&quot; or &quot;residents&quot;). For purposes of this section, references to &quot;personal information&quot; shall include &quot;sensitive personal information,&quot; as these terms are defined under the California Consumer Privacy Act (&quot;CCPA&quot;).</p>
+
+            <h3>14.1 Processing of Personal Information</h3>
+            <p>In the preceding 12 months, we collected and disclosed for a business purpose the following categories of personal information and sensitive personal information (denoted by *) about residents:</p>
+            <ol>
+                <li>Identifiers such as name, e-mail address, IP address</li>
+                <li>Personal information categories listed in the California Customer Records statute such as name, address and telephone number</li>
+                <li>Commercial information such as records of products or services purchased</li>
+                <li>Internet or other similar network activity such as information regarding your interaction with the Platform</li>
+                <li>Geolocation data such as IP address</li>
+                <li>Professional or employment-related information such as title of profession, employer, professional background and other information provided by you when you apply for a job with us</li>
+                <li>Non-public education information collected by certain federally funded institutions such as education records</li>
+                <li>Account access credentials* such as account log-in</li>
+            </ol>
+            <p>The specific business or commercial purposes for which we collect your personal information and the categories of sources from which we collect your personal information are described in section 7, Collection and Use Your Information. We only use and disclose sensitive personal information for the purposes specified in the CCPA. The criteria we use to determine how long to retain your personal information is described in section 13, Data Security and Retention.</p>
+            <p>We disclosed personal information over the preceding 12 months for the following business or commercial purposes:</p>
+            <ol>
+                <li>to communicate with you, provide you with products and services, to market to you, etc.</li>
+                <li>to maintain and secure your account with us</li>
+                <li>to process your payment, to provide you with products or services you have requested</li>
+                <li>to evaluate your candidacy and process your application for employment.</li>
+            </ol>
+
+            <h3>14.2 Selling and/or Sharing of Personal Information</h3>
+            <p>We do not &quot;sell&quot; or &quot;share&quot; (as those terms are defined under the CCPA) personal information, nor have we done so in the preceding 12 months. Further, we do not have actual knowledge that we &quot;sell&quot; or &quot;share&quot; personal information of residents under 16 years of age.</p>
+
+            <h3>14.3 Your California Privacy Rights</h3>
+            <p>As a California resident, you may have the rights listed below in relation to personal information that we have collected about you. However, these rights are not absolute, and in certain cases, we may decline your request as permitted by law.</p>
+            <ol>
+                <li>Right to Know. You have a right to request the following information about our collection, use and disclosure of your personal information:
+                    <ol style={{ listStyleType: 'lower-alpha' }}>
+                        <li>categories of personal information we have collected, disclosed for a business purpose;</li>
+                        <li>categories of sources from which we collected personal information;</li>
+                        <li>the business or commercial purposes for collecting personal information;</li>
+                        <li>categories of third parties to whom the personal information was disclosed for a business purpose; and</li>
+                        <li>specific pieces of personal information we have collected.</li>
+                    </ol>
+                </li>
+                <li>Right to Delete. You have a right to request that we delete personal information we maintain about you.</li>
+                <li>Right to Correct. You have a right to request that we correct inaccurate personal information we maintain about you.</li>
+            </ol>
+            <p>You may exercise any of these rights by contacting us using the information provided below. We will not discriminate against you for exercising any of these rights. We may need to collect information from you to verify your identity, such as your email address and government issued ID, before providing a substantive response to the request. You may designate, in writing or through a power of attorney document, an authorized agent to make requests on your behalf to exercise your rights. Before accepting such a request from an agent, we will require that the agent provide proof you have authorized them to act on your behalf, and we may need you to verify your identity directly with us.</p>
+
+            <h2>15. Feedback</h2>
+            <p>If you provide Feedback to us, you agree that we may use the Feedback however we choose without any obligation or payment to you.</p>
+
+            <h2>16. Disclaimer of Warranties and Limitations of Liability</h2>
+            <p>The services are provided &quot;as is&quot; and &quot;as available&quot; without warranties of any kind. {appName} disclaims all warranties, express or implied.</p>
+            <p>To the fullest extent permissible under applicable law, {appName} shall not be liable for any indirect, incidental, special, consequential, or punitive damages, or any loss of profits or revenues.</p>
+
+            <h2>17. Termination</h2>
+            <p>We may suspend or terminate your access to the Services at any time if we believe that you have breached these Terms, or if we must do so to comply with law.</p>
+
+            <h2>18. How to Contact Us</h2>
+            <p>Should you have any questions about our privacy practices, these Terms of Service, or this document, please email us at {contactEmail}</p>
+        </>
+    );
+}

--- a/packages/legal-terms-privacy-policy/src/react/index.tsx
+++ b/packages/legal-terms-privacy-policy/src/react/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import type { LegalTermsPrivacyPolicyProps, LegalVariant } from '../index';
+import { FullLegalTerms } from './full-terms';
+import { LegalSummary } from './summary';
+import { legalTermsStyles } from './styles';
+
+export type { LegalTermsPrivacyPolicyProps, LegalVariant };
+export { LEGAL_SUMMARY_URL } from '../index';
+export { FullLegalTerms } from './full-terms';
+export { LegalSummary } from './summary';
+export { legalTermsStyles } from './styles';
+
+/**
+ * The shared Terms of Service and Privacy Policy page.
+ *
+ * Renders the full legal text by default, with a switch to a plain-language
+ * summary of the same clauses. Sites pass their own name, contact address and
+ * revision date; everything else is identical across them by design.
+ *
+ * ```tsx
+ * <LegalTermsPrivacyPolicy
+ *     appName="QwkSearch"
+ *     contactEmail="support@qwksearch.com"
+ *     lastRevisedDate="2026-01-15"
+ *     homeUrl="/"
+ * />
+ * ```
+ */
+export function LegalTermsPrivacyPolicy({
+    appName,
+    contactEmail,
+    lastRevisedDate,
+    homeUrl,
+    defaultVariant = 'full',
+    className,
+}: LegalTermsPrivacyPolicyProps): ReactNode {
+    const [variant, setVariant] = useState<LegalVariant>(defaultVariant);
+    const showingSummary = variant === 'summary';
+
+    return (
+        <main className={className ? `legal-terms-page ${className}` : 'legal-terms-page'}>
+            {/* Inlined rather than imported as a .css file so the package drops into
+                any bundler without CSS-in-node_modules configuration. */}
+            <style>{legalTermsStyles}</style>
+
+            <div className="legal-terms-header">
+                {homeUrl ? (
+                    <a href={homeUrl} className="legal-terms-back">
+                        Back to Home
+                    </a>
+                ) : (
+                    <span />
+                )}
+                <button
+                    type="button"
+                    className="legal-terms-switch"
+                    onClick={() => setVariant(showingSummary ? 'full' : 'summary')}
+                    aria-pressed={showingSummary}
+                >
+                    {showingSummary ? 'Read the full legal text' : 'Read the plain-language summary'}
+                </button>
+            </div>
+
+            <h1>{appName} Terms of Service and Privacy Policy</h1>
+            <p>
+                <strong>Revised Date: {lastRevisedDate}</strong>
+            </p>
+
+            {showingSummary ? (
+                <LegalSummary appName={appName} contactEmail={contactEmail} />
+            ) : (
+                <FullLegalTerms appName={appName} contactEmail={contactEmail} />
+            )}
+        </main>
+    );
+}
+
+export default LegalTermsPrivacyPolicy;

--- a/packages/legal-terms-privacy-policy/src/react/styles.ts
+++ b/packages/legal-terms-privacy-policy/src/react/styles.ts
@@ -1,0 +1,116 @@
+/**
+ * The legal page's stylesheet, carried as text rather than a `.css` file so the
+ * package works in any bundler: a published package that `import`s CSS forces
+ * every consumer to configure CSS handling for node_modules, and Next.js, Vite
+ * and the extension builds all handle it differently. The component renders
+ * this into a <style> element instead.
+ *
+ * Class names are prefixed with `legal-terms-` so a host page's own styles
+ * cannot collide with them.
+ */
+export const legalTermsStyles = `
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap');
+
+.legal-terms-page {
+    font-family: 'Lato', Arial, sans-serif;
+    line-height: 1.6;
+    margin: 0 auto;
+    max-width: 800px;
+    padding: 20px;
+    color: #333;
+    overflow-y: auto !important;
+    height: 100%;
+    padding-bottom: 50px;
+    margin-bottom: 50px;
+}
+
+.legal-terms-page h1 {
+    margin: 1rem 0;
+    font-size: 2rem;
+    color: #2c3e50;
+    font-variant: small-caps;
+}
+
+.legal-terms-page h2 {
+    margin: 1.5rem 0 1rem 0;
+    font-size: 1.5rem;
+    color: #34495e;
+    font-variant: small-caps;
+}
+
+.legal-terms-page h3 {
+    margin: 1rem 0;
+    font-size: 1.2rem;
+    color: #7f8c8d;
+    font-variant: small-caps;
+}
+
+.legal-terms-page p {
+    margin: 1rem 0;
+}
+
+.legal-terms-page ol,
+.legal-terms-page ul {
+    padding-left: 20px;
+    margin: 1rem 0;
+}
+
+.legal-terms-page ol {
+    list-style-type: decimal;
+}
+
+.legal-terms-page ol ol {
+    list-style-type: lower-alpha;
+}
+
+.legal-terms-page ul {
+    list-style-type: disc;
+}
+
+.legal-terms-page a {
+    color: #2c5aa0;
+}
+
+.legal-terms-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+    padding-top: 1rem;
+}
+
+.legal-terms-back,
+.legal-terms-switch {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background-color: #f8f9fa;
+    color: #495057;
+    text-decoration: none;
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    font-family: inherit;
+    transition: all 0.2s ease-in-out;
+}
+
+.legal-terms-switch {
+    cursor: pointer;
+}
+
+.legal-terms-back:hover,
+.legal-terms-switch:hover {
+    background-color: #e9ecef;
+    border-color: #adb5bd;
+    color: #212529;
+    text-decoration: none;
+}
+
+.legal-terms-summary-note {
+    font-size: 0.9375rem;
+    color: #6c757d;
+}
+`;

--- a/packages/legal-terms-privacy-policy/src/react/summary.tsx
+++ b/packages/legal-terms-privacy-policy/src/react/summary.tsx
@@ -1,0 +1,129 @@
+import type { ReactNode } from 'react';
+import { LEGAL_SUMMARY_URL } from '../index';
+
+export interface LegalSummaryProps {
+    appName: string;
+    contactEmail: string;
+}
+
+/**
+ * Plain-language summary of the same clauses, section by section, for readers
+ * who want the gist before the legal text. It summarizes; it does not replace
+ * the full document, and the note at the top says so.
+ */
+export function LegalSummary({ appName, contactEmail }: LegalSummaryProps): ReactNode {
+    return (
+        <>
+            <p className="legal-terms-summary-note">
+                A plain-language summary of the full text, written for readability. Where the two
+                differ, the full text is the agreement. A longer plain-language version of these
+                same terms is published at{' '}
+                <a href={LEGAL_SUMMARY_URL} target="_blank" rel="noreferrer noopener">
+                    rights.institute/terms-privacy
+                </a>
+                .
+            </p>
+
+            <h2>The agreement</h2>
+            <ul>
+                <li>Using {appName} — the site, the apps, the APIs — means you accept these terms.</li>
+                <li>We can change the terms. Material changes to how we use or share your
+                    information come with reasonable notice, such as an email or a notice on the
+                    site. Continuing to use {appName} after a change means you accept it.</li>
+                <li>The Services are built for users in the United States.</li>
+            </ul>
+
+            <h2>Using AI responsibly</h2>
+            <ul>
+                <li>AI output can be wrong while sounding confident and specific. Verify anything
+                    you intend to rely on.</li>
+                <li>Don&apos;t use {appName} to erode other people&apos;s privacy: no processing
+                    personal data in breach of the law, no facial recognition or other biometric
+                    identification, no spyware or surveillance.</li>
+                <li>Don&apos;t use it where a wrong answer harms someone: tailored legal, medical or
+                    financial advice without a qualified professional reviewing it and disclosing the
+                    AI&apos;s involvement, high-stakes automated decisions about people, real-money
+                    gambling, payday lending, political campaigning and lobbying, or anything that
+                    discourages people from taking part in democracy.</li>
+                <li>Don&apos;t use it to deceive: no disinformation or fake engagement, no
+                    impersonating people or organizations, no academic dishonesty, and tell people
+                    when they are talking to an AI unless that is already obvious.</li>
+            </ul>
+
+            <h2>Your account and what you submit</h2>
+            <ul>
+                <li>Keep your account details accurate and to yourself — you are responsible for
+                    what happens under your account.</li>
+                <li>What you submit (&quot;Prompts&quot;) and what the Services generate
+                    (&quot;Outputs&quot;) are yours to be responsible for: by submitting something
+                    you confirm you have the rights to it.</li>
+                <li>Close your account any time by writing to {contactEmail}.</li>
+                <li>Feedback you send us, we may use without owing you anything for it.</li>
+            </ul>
+
+            <h2>What we collect</h2>
+            <ul>
+                <li><strong>What you give us:</strong> contact details, account credentials, the
+                    prompts and content you submit and the output you create, and anything else you
+                    put in a message to us.</li>
+                <li><strong>What we collect as you use the site:</strong> device and browser
+                    details, IP address, approximate location, and how you interact with the
+                    Services — gathered with cookies and similar technologies.</li>
+                <li><strong>What others tell us:</strong> analytics data from providers such as
+                    Google Analytics, and marketing data from data enrichment companies.</li>
+            </ul>
+
+            <h2>What we do with it</h2>
+            <ul>
+                <li>Run and improve the Services, support you, keep things secure, communicate with
+                    you, do research and analytics, and meet our legal obligations.</li>
+                <li>We may anonymize information so it can no longer be linked to you, and use it
+                    for any purpose; we don&apos;t try to re-identify it.</li>
+                <li>We share information with our corporate group, with the vendors who help run
+                    the Services, with third parties you direct us to, with professional advisers,
+                    and in a merger or similar transaction — plus where the law or law enforcement
+                    requires it.</li>
+                <li>We do not sell or share your personal information in the sense the California
+                    Consumer Privacy Act gives those words.</li>
+            </ul>
+
+            <h2>Your choices</h2>
+            <ul>
+                <li>Your browser can block or delete cookies, though parts of the Services may then
+                    misbehave. Google Analytics has its own opt-out at{' '}
+                    <a
+                        href="https://tools.google.com/dlpage/gaoptout"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                    >
+                        tools.google.com/dlpage/gaoptout
+                    </a>
+                    . The site does not act on &quot;do not track&quot; signals.</li>
+                <li>If you are logged in, your settings page has a switch that stops your searches
+                    being used to improve our AI models.</li>
+                <li>Delete your account and we remove your personal information from our servers
+                    within 30 days — write to {contactEmail} to ask for that.</li>
+                <li>California residents can ask what we collected, have it corrected, or have it
+                    deleted, and we won&apos;t treat you differently for asking. We may need to
+                    verify who you are first.</li>
+            </ul>
+
+            <h2>Limits</h2>
+            <ul>
+                <li>Under-13s may not use the Services, and we don&apos;t knowingly collect their
+                    information. Tell us if we have, and we will delete it.</li>
+                <li>We protect your information as best we reasonably can, but no system is
+                    impenetrable — don&apos;t send secrets over insecure channels.</li>
+                <li>Third-party sites we link to have their own policies; we are not responsible
+                    for them.</li>
+                <li>The Services come with no warranties, and our liability for indirect or
+                    consequential losses is excluded as far as the law allows.</li>
+                <li>We can suspend or end your access if you break these terms or if the law
+                    requires it.</li>
+            </ul>
+
+            <h2>Questions</h2>
+            <p>Write to {contactEmail}.</p>
+        </>
+    );
+}

--- a/packages/legal-terms-privacy-policy/test/legal-terms-privacy-policy.test.tsx
+++ b/packages/legal-terms-privacy-policy/test/legal-terms-privacy-policy.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LegalTermsPrivacyPolicy } from '../src/react';
+import { LEGAL_SUMMARY_URL } from '../src/index';
+
+const props = {
+    appName: 'QwkSearch',
+    contactEmail: 'support@qwksearch.com',
+    lastRevisedDate: '2026-01-15',
+    homeUrl: '/',
+};
+
+describe('LegalTermsPrivacyPolicy', () => {
+    it('opens on the full legal text, titled and dated for the app', () => {
+        render(<LegalTermsPrivacyPolicy {...props} />);
+
+        expect(
+            screen.getByRole('heading', {
+                level: 1,
+                name: 'QwkSearch Terms of Service and Privacy Policy',
+            }),
+        ).toBeTruthy();
+        expect(screen.getByText('Revised Date: 2026-01-15')).toBeTruthy();
+        expect(screen.getByRole('heading', { level: 2, name: '1. Introduction' })).toBeTruthy();
+        expect(screen.getByRole('heading', { level: 2, name: '14. California Residents' })).toBeTruthy();
+    });
+
+    it('weaves the app name and contact address through the clauses', () => {
+        render(<LegalTermsPrivacyPolicy {...props} />);
+
+        expect(screen.getAllByText(/QwkSearch/).length).toBeGreaterThan(1);
+        expect(screen.getAllByText(/support@qwksearch\.com/).length).toBeGreaterThan(1);
+    });
+
+    it('switches to the plain-language summary and back', () => {
+        render(<LegalTermsPrivacyPolicy {...props} />);
+
+        fireEvent.click(screen.getByRole('button', { name: /plain-language summary/i }));
+
+        expect(screen.queryByRole('heading', { level: 2, name: '1. Introduction' })).toBeNull();
+        expect(screen.getByRole('heading', { level: 2, name: 'What we collect' })).toBeTruthy();
+        expect(screen.getByRole('link', { name: /rights\.institute\/terms-privacy/ }).getAttribute('href')).toBe(
+            LEGAL_SUMMARY_URL,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: /full legal text/i }));
+
+        expect(screen.getByRole('heading', { level: 2, name: '1. Introduction' })).toBeTruthy();
+    });
+
+    it('can open on the summary instead', () => {
+        render(<LegalTermsPrivacyPolicy {...props} defaultVariant="summary" />);
+
+        expect(screen.getByRole('heading', { level: 2, name: 'The agreement' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /full legal text/i })).toBeTruthy();
+    });
+
+    it('leaves the home link out when no homeUrl is given', () => {
+        const { homeUrl: _omitted, ...withoutHome } = props;
+        render(<LegalTermsPrivacyPolicy {...withoutHome} />);
+
+        expect(screen.queryByRole('link', { name: 'Back to Home' })).toBeNull();
+    });
+});

--- a/packages/legal-terms-privacy-policy/tsconfig.json
+++ b/packages/legal-terms-privacy-policy/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/packages/legal-terms-privacy-policy/vitest.config.ts
+++ b/packages/legal-terms-privacy-policy/vitest.config.ts
@@ -1,0 +1,19 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom', // the package renders React components
+    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+    restoreMocks: true,
+    unstubGlobals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      include: ['src/**/*.ts', 'src/**/*.tsx'],
+      exclude: ['node_modules/**', 'src/**/*.d.ts', '**/*.test.ts', '**/*.test.tsx'],
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
       'packages/chat-agent-toolkit',
       'packages/extract-webpage',
       'packages/html-renderer-api',
+      'packages/legal-terms-privacy-policy',
       'packages/notebooklm-api-client',
       'packages/qwksearch-api-client',
       'packages/qwksearch-mcp-server',


### PR DESCRIPTION
## Summary

Introduces a new `legal-terms-privacy-policy` package that provides a shared, reusable React component for Terms of Service and Privacy Policy pages. This allows QwkSearch, Debate AI, AI Broker, Grab URL, and Rights Institute to maintain a single source of truth for their legal documents while parameterizing only the app name, contact email, and revision date.

## Key Changes

- **New package structure** (`packages/legal-terms-privacy-policy/`):
  - `src/index.ts` — Types and constants (entry point for non-React consumers)
  - `src/react/index.tsx` — Main `LegalTermsPrivacyPolicy` component with full/summary toggle
  - `src/react/full-terms.tsx` — Complete Terms of Service and Privacy Policy text (~195 lines)
  - `src/react/summary.tsx` — Plain-language summary of the same clauses (~129 lines)
  - `src/react/styles.ts` — Inlined stylesheet (avoids CSS-in-node_modules configuration issues)

- **Component features**:
  - Renders full legal text by default with a button to switch to plain-language summary
  - Parameterized by `appName`, `contactEmail`, `lastRevisedDate`, and optional `homeUrl`
  - Includes comprehensive AI ethical use policy (sections 3.1–3.4)
  - Privacy policy covers data collection, cookies, tracking, CCPA compliance, and data sharing
  - Summary links to longer plain-language version at `rights.institute/terms-privacy`

- **Testing and configuration**:
  - Full test suite (`test/legal-terms-privacy-policy.test.tsx`) covering rendering, switching variants, and prop handling
  - TypeScript configuration with strict mode
  - Vitest setup with jsdom environment for React component testing
  - Package exports both main entry point (types only) and `/react` entry point (component)

- **Integration**:
  - Updated `apps/qwksearch-web/package.json` to use workspace dependency
  - Added package to root `vitest.config.ts` transpile list for monorepo builds

## Implementation Details

- Stylesheet is inlined as a `<style>` element rather than imported as `.css` to avoid requiring CSS-in-node_modules configuration in consuming bundlers (Next.js, Vite, extension builds all handle it differently)
- Class names prefixed with `legal-terms-` to prevent style collisions with host pages
- Component uses React hooks (`useState`) for variant switching and is marked with `'use client'` for Next.js compatibility
- Deidentification/anonymization clause included to clarify data handling practices
- Document emphasizes that AI outputs can be inaccurate and should be verified before reliance

https://claude.ai/code/session_01XC25RWVoJFXVMRrMhhXAu5