### PR TITLE
🐛 fix(web): generate the Fumadocs layout CSS so /docs shows its sidebar

### DIFF
--- a/.claude/architecture/documentation.md
+++ b/.claude/architecture/documentation.md
@@ -50,6 +50,34 @@ Consequences worth remembering: the host app **must** register
 `No compiled module for "<path>"`; and MDX rules apply to content — a bare `{` or
 `<` outside a code fence is parsed as JSX.
 
+### The host app must scan `fumadocs-ui/dist` for Tailwind classes
+
+Importing `fumadocs-ui/css/preset.css` is **not** enough to style the docs.
+Fumadocs declares its own utility lists as `@source inline(…)` inside
+`css/generated/*.css`, and `preset.css` `@import`s those files *after* an
+`@plugin` at-rule. Vite resolves CSS `@import`s with postcss-import before
+Tailwind ever sees the file, and postcss-import stops inlining at the first
+non-`@import` at-rule — so all five generated files are dropped with no error.
+
+What survives is only what is plain CSS: the `--color-fd-*` tokens and a handful
+of base rules. Every *class* goes ungenerated — `#nd-notebook-layout`'s grid,
+`--fd-sidebar-width`, `text-fd-muted-foreground`, the sidebar animations — and
+`/docs` renders as a single unstyled column with **no sidebar and no
+navigation**, while the page tree, the routes, the search index and the whole
+test suite stay green.
+
+`apps/qwksearch-web/app/globals.css` compensates by scanning the shipped output
+itself (`dist`, not `src` — fumadocs-ui publishes compiled output only), next to
+the same registration for the docs package's own components:
+
+```css
+@source "../node_modules/fumadocs-ui/dist";
+@source "../../../packages/user-help-docs/src";
+```
+
+`app/docs/__tests__/docs-wiring.test.ts` compiles those registrations through
+Vite and fails if the layout classes stop being generated.
+
 ## Skills (`skills/`)
 
 One [Agent Skill](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)

--- a/apps/qwksearch-web/app/docs/__tests__/docs-wiring.test.ts
+++ b/apps/qwksearch-web/app/docs/__tests__/docs-wiring.test.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
+import { build } from 'vite';
 
 import { source } from 'user-help-docs';
 import { docsConfig } from 'user-help-docs/config';
@@ -117,4 +118,64 @@ describe('the app is configured to render the docs', () => {
     expect(css).toContain('fumadocs-ui/css/neutral.css');
     expect(css).toContain('fumadocs-ui/css/preset.css');
   });
+
+  it('generates the fumadocs layout utilities Tailwind would otherwise skip', async () => {
+    // Importing the preset is not enough. Fumadocs declares its own utility
+    // lists as `@source inline(…)` inside `css/generated/*.css`, which
+    // `preset.css` `@import`s *after* an `@plugin` at-rule — and Vite resolves
+    // CSS imports with postcss-import, which stops inlining at the first
+    // non-`@import` at-rule. Those files are dropped with no error, so every
+    // layout class goes ungenerated and /docs renders as one unstyled column
+    // with no sidebar: the page tree, the routes and the tests all stay green.
+    // `globals.css` compensates by scanning `fumadocs-ui/dist` itself; this
+    // check compiles the registrations it declares and looks for the classes
+    // the notebook layout cannot render without.
+    const css = readAppFile('app', 'globals.css');
+
+    // Reproduce globals.css's fumadocs half without the workspace packages'
+    // prebuilt `style.css` imports, which need `bun run build` to exist.
+    // `@source` paths are relative to the file that declares them, so resolve
+    // them against `app/` before moving the lines to a scratch entry.
+    const entry = [
+      '@import "tailwindcss";',
+      ...css
+        .split('\n')
+        .filter((line) => /^@import\s+"fumadocs-ui\/css\/|^@source\s+"/.test(line.trim()))
+        .map((line) =>
+          line.replace(/^@source\s+"([^"]+)"/, (_match, source: string) =>
+            `@source "${path.resolve(appDir, 'app', source)}"`,
+          ),
+        ),
+    ].join('\n');
+
+    // Inside the app so `fumadocs-ui` and the postcss config both resolve the
+    // way they do for the real build.
+    const entryPath = path.join(appDir, '.docs-css-check.css');
+    fs.writeFileSync(entryPath, entry);
+
+    let compiled: string;
+    try {
+      const result = await build({
+        configFile: false,
+        root: appDir,
+        logLevel: 'silent',
+        build: { write: false, rollupOptions: { input: entryPath } },
+      });
+      const outputs = (Array.isArray(result) ? result[0] : result) as {
+        output: { type: string; fileName: string; source?: unknown }[];
+      };
+      compiled = outputs.output
+        .filter((chunk) => chunk.type === 'asset' && chunk.fileName.endsWith('.css'))
+        .map((chunk) => String(chunk.source))
+        .join('\n');
+    } finally {
+      fs.rmSync(entryPath, { force: true });
+    }
+
+    // The grid container, the sidebar column's width, and one ordinary utility
+    // every Fumadocs surface uses — each absent when the source lists are lost.
+    expect(compiled).toContain('#nd-notebook-layout');
+    expect(compiled).toContain('268px');
+    expect(compiled).toContain('text-fd-muted-foreground');
+  }, 60_000);
 });

--- a/apps/qwksearch-web/app/globals.css
+++ b/apps/qwksearch-web/app/globals.css
@@ -22,8 +22,10 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 /* /docs help site (Fumadocs). `neutral.css`/`preset.css` only define
-   `--color-fd-*` theme tokens and `@source` utility lists — they don't
-   re-import Tailwind, so they load like any other first-party CSS. */
+   `--color-fd-*` theme tokens, base rules and `@source` utility lists — they
+   don't re-import Tailwind, so they load like any other first-party CSS. The
+   utility lists do not survive Vite's CSS import handling; see the
+   `fumadocs-ui/dist` source registration below. */
 @import "fumadocs-ui/css/neutral.css";
 @import "fumadocs-ui/css/preset.css";
 @import "react-native-app-buttons/styles" layer(vendor);
@@ -40,6 +42,22 @@
 @source "../../../packages/research-agent-ui/src";
 @source "../../../packages/reason-editor/src";
 @source "../../../packages/reason-editor-sidebar/src";
+/* Fumadocs ships its own utility lists as `@source inline(…)` inside
+   `css/generated/*.css`, which `preset.css` pulls in — but it `@import`s them
+   *after* an `@plugin` at-rule, and Vite resolves CSS `@import`s with
+   postcss-import before Tailwind ever sees the file. postcss-import stops
+   inlining at the first non-`@import` at-rule, so those five files are dropped
+   silently and every Fumadocs layout class (`#nd-notebook-layout`'s grid,
+   `--fd-sidebar-width`, `text-fd-muted-foreground`, the sidebar animations)
+   goes ungenerated: /docs then renders one unstyled column with no sidebar and
+   no navigation. Scanning the shipped `dist` produces the same utilities the
+   inline lists would have. `app/docs/__tests__/docs-wiring.test.ts` holds this.
+   Note `dist` — not `src`: fumadocs-ui publishes compiled output only. */
+@source "../node_modules/fumadocs-ui/dist";
+/* The docs package's own components (breadcrumb, per-page actions, the theme
+   dropdown) are workspace source, so they need the same explicit registration
+   as the packages above. */
+@source "../../../packages/user-help-docs/src";
 
 @custom-variant dark (&:is(.dark *));
 /* @plugin "@tailwindcss/typography"; */

--- a/packages/user-help-docs/README.md
+++ b/packages/user-help-docs/README.md
@@ -76,12 +76,22 @@ import { helpDocsMdxPlugin } from 'user-help-docs/vite';
 ```
 
 The app must list `user-help-docs` in `next.config`'s `transpilePackages` (it
-ships TypeScript sources, not a build), and import fumadocs' CSS preset:
+ships TypeScript sources, not a build), and wire up four CSS lines:
 
 ```css
-@import "fumadocs-ui/css/neutral.css";
-@import "fumadocs-ui/css/preset.css";
+@import "fumadocs-ui/css/neutral.css";   /* --color-fd-* tokens */
+@import "fumadocs-ui/css/preset.css";    /* base rules, variants, @source lists */
+@source "../node_modules/fumadocs-ui/dist";       /* the layout classes */
+@source "../../../packages/user-help-docs/src";   /* this package's components */
 ```
+
+Both `@source` lines are load-bearing. Fumadocs declares its utility lists as
+`@source inline(…)` inside `css/generated/*.css`, which `preset.css` `@import`s
+*after* an `@plugin` at-rule — and Vite resolves CSS `@import`s with
+postcss-import, which stops inlining at the first non-`@import` at-rule, so those
+files are dropped with no error. The tokens still land (plain CSS), but every
+class does not: `/docs` then serves every page with no sidebar, no navigation and
+no styling, while the build and the tests stay green.
 
 ## Routes it expects
 

--- a/skills/ask-user-help-docs/SKILL.md
+++ b/skills/ask-user-help-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-user-help-docs
-description: Guide to user-help-docs (packages/user-help-docs), the Fumadocs help site mounted at /docs in qwksearch-web — the content/docs MDX tree and meta.json ordering, the import.meta.glob source that replaces fumadocs-mdx codegen so it runs on Cloudflare Workers, the helpDocsMdxPlugin build-time MDX compile the host has to register, the search index, the llms.mdx / llms-full.txt plain-text views, and docsConfig branding. Use when adding or reordering a help page, when /docs 500s after a content change, when docs search returns nothing, or when wiring the docs routes into a host app.
+description: Guide to user-help-docs (packages/user-help-docs), the Fumadocs help site mounted at /docs in qwksearch-web — the content/docs MDX tree and meta.json ordering, the import.meta.glob source that replaces fumadocs-mdx codegen so it runs on Cloudflare Workers, the helpDocsMdxPlugin build-time MDX compile the host has to register, the search index, the llms.mdx / llms-full.txt plain-text views, the Tailwind sources the host must scan for the Fumadocs layout to be styled at all, and docsConfig branding. Use when adding or reordering a help page, when /docs 500s after a content change, when /docs renders unstyled with no sidebar or navigation, when docs search returns nothing, or when wiring the docs routes into a host app.
 ---
 
 # Working With user-help-docs
@@ -77,6 +77,29 @@ filesystem.
 Every subpath maps to **`src/*.ts(x)` source**, not a build output — this package has no
 `build` script, only `type-check` and `test`.
 
+## Styling the host has to wire up
+
+Two `@import`s and two `@source`s, all four load-bearing, in the host's Tailwind entry
+(`apps/qwksearch-web/app/globals.css`):
+
+```css
+@import "fumadocs-ui/css/neutral.css";   /* --color-fd-* tokens */
+@import "fumadocs-ui/css/preset.css";    /* base rules, variants, @source lists */
+@source "../node_modules/fumadocs-ui/dist";       /* see below */
+@source "../../../packages/user-help-docs/src";   /* this package's own components */
+```
+
+The preset's own utility lists **do not survive a Vite build**. Fumadocs declares them as
+`@source inline(…)` inside `css/generated/*.css` and `preset.css` `@import`s those files
+*after* an `@plugin` at-rule; Vite resolves CSS `@import`s with postcss-import before
+Tailwind sees the file, and postcss-import stops inlining at the first non-`@import`
+at-rule, so all five are dropped with no error. Only the plain CSS survives, which is why
+the tokens look fine while every *class* is missing. Scanning `fumadocs-ui/dist` (the
+published output — this package is source-only, fumadocs-ui is not) regenerates them.
+
+**Symptom to recognise:** `/docs` serves every page, search works, tests pass, and the
+site renders as one unstyled column with no sidebar and no navigation.
+
 ## Recipes
 
 **Plain-text views for LLMs.** `getMarkdownUrl(page)` yields `/docs/llms.mdx/<path>.mdx`
@@ -102,6 +125,8 @@ client-side search UI points there.
 | `/docs` builds but every route in its chunk 500s at runtime | Something reintroduced a filesystem or `import.meta.url` read at module scope. Content must stay inlined via `import.meta.glob`. |
 | `/docs` 500s only once deployed, with `EvalError: Code generation from strings disallowed for this context` | Something compiles MDX at request time again. Workers forbid `new Function`; compile in the bundler instead. |
 | `No compiled module for "<file>"` at startup | The host's Vite or Vitest config is missing `helpDocsMdxPlugin()`. |
+| Every page loads but there is no sidebar, no navigation and no Fumadocs styling — one bare column of text | The host's Tailwind entry is not scanning `fumadocs-ui/dist`. Importing `preset.css` is not enough: its `@source inline(…)` lists are lost to Vite's CSS import handling. See *Styling the host has to wire up*. |
+| The breadcrumb, the per-page actions or the theme dropdown are unstyled while the rest of the docs look right | The host is missing `@source ".../packages/user-help-docs/src"` — those components are workspace source, outside Tailwind's automatic detection. |
 | The app build fails with `Unexpected \`FunctionDeclaration\` in code: only import/exports are supported`, once per page | Two MDX plugins in the chain. vinext auto-injects its own unless it sees a plugin named `@mdx-js/rollup` (or `mdx`), so `helpDocsMdxPlugin()` must keep that name. |
 | A page renders its own frontmatter as body text | `remarkFrontmatter` fell out of `helpDocsMdxPlugin`. |
 | `import.meta.glob is not a function` | The host's bundler does not support it. This package assumes Vite/vinext. |


### PR DESCRIPTION
## The symptom

`/docs` served every page correctly — the page tree, all 24 routes, the search index and `llms-full.txt` were intact — but rendered as a single unstyled column with **no sidebar and no navigation**, so only the page you landed on was reachable.

## The cause

None of Fumadocs' classes were in the built CSS. Checking `dist/client/_next/static/css/index.*.css` from a real `vinext build`:

| Looked for | Before | After |
| --- | --- | --- |
| `#nd-notebook-layout` (the layout grid) | 0 | 1 |
| `268px` (`--fd-sidebar-width` — the sidebar column computed to `0px` without it) | 0 | 1 |
| `grid-area:sidebar` | 0 | 1 |
| `text-fd-muted-foreground` | 0 | 1 |

Only the `--color-fd-*` tokens survived, because those are plain CSS rather than generated utilities — which is why the docs looked themed but had no layout.

Fumadocs declares its utility lists as `@source inline(…)` inside `css/generated/*.css`, and `preset.css` `@import`s those five files **after** an `@plugin` at-rule. Vite resolves CSS `@import`s with postcss-import before Tailwind ever sees the file, and postcss-import stops inlining at the first non-`@import` at-rule — so the lists were dropped with no error, no warning, and a green build.

Reduced to three lines, which reproduces it exactly:

```css
/* imported.css */
@plugin '…/fumadocs-ui/dist/tailwind/typography.js';
@import "./deep.css";   /* its @source inline(…) never reaches Tailwind */
```

Drop the `@plugin` line, or move it below the `@import`, and the classes come back.

## The fix

Scan the shipped `fumadocs-ui/dist` from `app/globals.css` instead of relying on the preset's inline lists, plus `packages/user-help-docs/src` for the docs package's own components (breadcrumb, per-page actions, theme dropdown), which were equally outside Tailwind's automatic detection:

```css
@source "../node_modules/fumadocs-ui/dist";
@source "../../../packages/user-help-docs/src";
```

Verified selector-for-selector against a build where Tailwind resolves the imports itself: the only differences are decimal fragments my comparison regex mis-parsed, plus 116 extra classes contributed by `user-help-docs/src`.

## Tests

`app/docs/__tests__/docs-wiring.test.ts` gains a check that compiles the `@source`/`@import` registrations declared in `globals.css` through Vite and asserts the layout classes are generated. It fails with `expected '/*! tailwindcss v4.3.3 …' to contain '#nd-notebook-layout'` when the `fumadocs-ui/dist` line is removed, and runs in ~870ms.

- `cd apps/qwksearch-web && bun run test` — 12/12 in the docs suite
- `cd packages/user-help-docs && bun run test` — 39/39
- `bun run test` (root) — 3068 passed, 0 failed. 14 test *files* fail to collect, all in `apps/qwksearch-ext`, on a missing generated `apps/qwksearch-ext/.wxt/tsconfig.json` (`wxt prepare` output); unrelated to this change and present before it.
- `bunx vinext build` — succeeds, and the assertions in the table above are taken from its output.

Docs updated in the same change: `.claude/architecture/documentation.md`, `packages/user-help-docs/README.md`, and `skills/ask-user-help-docs/SKILL.md` (including a troubleshooting row for the symptom).

## Noted, not changed

`/docs` renders inside the app shell — `QwkSearchProviders`' `div#app-scroll-root.w-screen.h-screen.overflow-y-auto` and `<main class="min-h-screen">`, with `CategoryDock` above it — while Fumadocs' notebook layout is built to own the viewport (`min-h-[100dvh]` grid, sticky sidebar). Sticky positioning still resolves against `#app-scroll-root`, so it should render, but the dock overlays the docs navbar and there are two nested `next-themes` providers (the app's, and the one `RootProvider` mounts). Left alone to keep this PR focused; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABACvv7fq8VQUPsQvDNjpN

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABACvv7fq8VQUPsQvDNjpN)_