### PR TITLE
📝 docs(claude): add a CLAUDE.md to every package and app

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bun install)",
+      "Bash(bun run build:*)",
+      "Bash(bun run test:*)",
+      "Bash(bun run dev:*)",
+      "Bash(bunx turbo run:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "Read(./**/.env)",
+      "Read(./**/.env.*)",
+      "Read(./**/.dev.vars)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,11 @@ apps/qwksearch-web/.open-next
 .dev.vars
 .claude/*
 !.claude/skills
-# Architecture notes for Claude agents — checked in on purpose (see CLAUDE.md)
+# Agent docs for Claude Code — checked in on purpose (see CLAUDE.md)
 !.claude/architecture
+!.claude/settings.json
+.claude/settings.local.json
+CLAUDE.local.md
 .turbo
 
 yarn.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ VS Code) built from shared `packages/*`.
 3. **Read the package's skill first.** Every package has one under
    [`skills/ask-<name>/SKILL.md`](skills/), written from the source. They are the
    deepest documentation in the repo — do not re-derive what they already answer.
+   Each package and app also has its own `CLAUDE.md` next to its `readme.md`,
+   carrying the rules and traps specific to working *in* it.
 4. **Packages are consumed as built `dist/`, not live source.** A package edit
    that "doesn't show up" almost always means it was not rebuilt. See
    [`architecture/monorepo.md`](.claude/architecture/monorepo.md).
@@ -62,8 +64,8 @@ cd packages/<name> && bun run test    # much faster while iterating
 
 - Run the touched package's own tests, then `bun run test` from the root.
 - Run `bun run build` if you changed anything a sibling package imports.
-- Update the package's `readme.md` and its `skills/ask-<name>/SKILL.md` when
-  behaviour or public API changes.
+- Update the package's `readme.md`, its `skills/ask-<name>/SKILL.md` and its
+  `CLAUDE.md` when behaviour or public API changes.
 - Commit style is **gitmoji + conventional commits**:
   `✨ feat(scope): what changed`. See
   [`architecture/conventions.md`](.claude/architecture/conventions.md).
@@ -78,3 +80,5 @@ cd packages/<name> && bun run test    # much faster while iterating
 | [web-app.md](.claude/architecture/web-app.md) | The deployed Cloudflare app: Worker, D1, auth, deploy, migrations |
 | [documentation.md](.claude/architecture/documentation.md) | Where docs live, the Fumadocs pipeline, the skills convention |
 | [conventions.md](.claude/architecture/conventions.md) | Code style, commits, PRs, CI, publishing, security |
+
+Per-workspace notes live in each package's and app's own `CLAUDE.md`.

--- a/apps/collaboration-server/CLAUDE.md
+++ b/apps/collaboration-server/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md — `apps/collaboration-server`
+
+Private. The **Hocuspocus** server backing the Reason Editor's Tiptap/Yjs
+collaborative editing, with SQLite persistence. It owns the Yjs rooms.
+
+## What makes this different from a normal server
+
+- **State is CRDT, not rows.** A Yjs document converges from concurrent edits;
+  you cannot "fix" one by overwriting it. Never mutate a stored document outside
+  the Yjs API.
+- **Schema changes in `packages/reason-editor` reach live rooms.** A document
+  written under the old schema still has to load. Test the upgrade path, not
+  just a fresh document.
+- **A room is a permission boundary.** Anyone who can connect to a room can read
+  and write the document — authorize on connect, never only in the UI.
+- Connections are long-lived. A leak here degrades slowly and then all at once;
+  clean up on disconnect, including the error path.
+
+Losing or corrupting a document is the worst outcome this service can produce —
+weigh changes accordingly.

--- a/apps/qwk-vscode-ext/CLAUDE.md
+++ b/apps/qwk-vscode-ext/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md — `apps/qwk-vscode-ext`
+
+The VS Code extension (`qwksearch-vscode`): search, ask and research the web
+from inside the editor.
+
+## Three build targets, one command
+
+| Part | What it is |
+| --- | --- |
+| `src/` | The **extension host** — auth and the API proxy, bundled with esbuild |
+| `webview-ui/` | The chat sidebar (Vite) |
+| `webview-ui-editor/` | The editor webview (Vite) |
+
+`bun run compile` builds all three. A change to one webview that compiles in
+isolation can still break the host contract — build all of it.
+
+## The host boundary
+
+Webviews cannot make network calls or hold credentials. Everything goes through
+the extension host's API proxy. So:
+
+- A component that reaches for `fetch` against an absolute URL, or for browser
+  APIs a webview lacks, works in the web app and fails here.
+- **Credentials stay on the host side.** Never pass a token into a webview.
+- Webview HTML needs a strict CSP and nonce'd scripts — don't loosen it to make
+  something load.
+
+It renders `packages/research-agent-ui` and `packages/reason-editor`; both are
+much narrower here than in the web app.

--- a/apps/qwksearch-desktop/CLAUDE.md
+++ b/apps/qwksearch-desktop/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md — `apps/qwksearch-desktop`
+
+SvelteKit + **Tauri** (`src-tauri/`). The desktop app: select text anywhere,
+press `` ` ``, get a quick-search popup — plus tray, autostart and global
+hotkey.
+
+## The native behaviour is Rust-side, not `src/`
+
+This is the usual wrong turn. The global hotkey, the tray, autostart and the
+popup window all live in **`src-tauri/`**. Looking for them in the SvelteKit
+`src/` wastes an hour.
+
+## Things that bite
+
+- **Rust toolchain required.** A machine that builds the rest of this repo
+  cannot necessarily build this.
+- **A global hotkey is a system-wide grab.** `` ` `` is a key people type. The
+  capture must be precise about focus and modifiers, must release cleanly, and
+  must not swallow the key in other applications.
+- Per-OS behaviour genuinely differs (permissions for reading selected text on
+  macOS, tray semantics on Linux). A green build on one platform says nothing
+  about the others.
+- It renders `packages/research-agent-ui`, so a change there ships here too.

--- a/apps/qwksearch-ext/CLAUDE.md
+++ b/apps/qwksearch-ext/CLAUDE.md
@@ -1,0 +1,26 @@
+# CLAUDE.md — `apps/qwksearch-ext`
+
+The browser extension (WXT). Entrypoints:
+`entrypoints/{background,content,popup,sidepanel,offscreen}`.
+
+## It has its own workspace — install inside it
+
+This app carries its **own `pnpm-workspace.yaml` and lockfile**. A root
+`bun install` is not enough: install inside this directory too, or the build
+fails in ways that look unrelated.
+
+## Extension constraints
+
+- **Manifest permissions are the security surface.** A new host permission or a
+  broad content-script match widens what the extension can read on every page
+  the user visits. Keep them minimal and justify additions in the PR.
+- **No remote code.** Stores reject it; bundle everything.
+- The MV3 background is a **service worker**: torn down and restarted at will.
+  Don't keep state in module scope and expect it to survive.
+- `content` scripts run in someone else's page — never trust the DOM you find,
+  and don't leak the extension's privileges into it.
+- Each entrypoint has a different environment. `offscreen` exists specifically
+  for work the service worker cannot do; don't collapse them.
+
+It renders `packages/research-agent-ui` in the side panel, which is much
+narrower than the web app — check layout there.

--- a/apps/qwksearch-web/CLAUDE.md
+++ b/apps/qwksearch-web/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — `apps/qwksearch-web`
+
+The deployed product: Next.js (App Router) via **vinext** on **Cloudflare
+Workers**, with D1 (Drizzle), KV, R2 and Better Auth. Full notes in
+[`../../.claude/architecture/web-app.md`](../../.claude/architecture/web-app.md).
+
+## Wire up, don't reimplement
+
+Route handlers under `app/api/*` are **thin**: parse, authorize, delegate to a
+`packages/*` library, serialize. The UI is not here either —
+`packages/research-agent-ui` owns the chat window, result list, reader and
+uploads; `packages/reason-editor` owns the writing surface.
+
+If you are writing extraction, ranking, agent or editor logic inside this app,
+it belongs in a package.
+
+## Things that bite
+
+- **Bindings changed → regenerate the Cloudflare types** and commit them.
+- **Never edit an applied migration.** Change the schema, generate, commit the
+  new migration.
+- **Tests run under Node — that does not prove the code runs on a Worker.**
+  Node APIs outside `nodejs_compat`, filesystem assumptions and long CPU work
+  all pass locally and fail in production. See
+  [`web-app.md`](../../.claude/architecture/web-app.md).
+- `worker/index.ts` is documented house style for a reason — read its comments
+  before changing the entrypoint.
+- The `test-web-api.yml` workflow is path-filtered to this app and two packages;
+  a change elsewhere won't run it.
+
+## Commands
+
+```bash
+bun run dev        # from the root: turbo dev --filter=qwksearch-web
+bun run build
+bun run test
+```

--- a/apps/test-reports/CLAUDE.md
+++ b/apps/test-reports/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md — `apps/test-reports`
+
+Private. **Infrastructure only** — a Cloudflare Worker that statically hosts the
+Vitest HTML report, deployed by `deploy-test-reports.yml` on push to `master`.
+
+There is no product code here and no behaviour to test. It exists so the test
+report has a URL.
+
+If you are here because a test is failing, the failure is in the package that
+owns the test — not in this app. Changing this Worker changes where the report
+is *served*, never what it says.

--- a/packages/chat-agent-toolkit/CLAUDE.md
+++ b/packages/chat-agent-toolkit/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — `chat-agent-toolkit`
+
+**Read [`skills/ask-chat-agent-toolkit`](../../skills/ask-chat-agent-toolkit/SKILL.md)
+and its `API.md` first** — they are written from this source and go deeper than
+anything here.
+
+Agent orchestration for the product: agents and workflows, RAG, evals, MCP
+sessions, model registry, and long-term memory. Published to npm. Built —
+consumers get `dist/`, so **rebuild after editing** or the app won't see it.
+
+## Rules
+
+- **One LLM call belongs in `write-language`, not here.** This package
+  orchestrates; `write-language` is the single provider abstraction. Adding a
+  provider branch here means the abstraction leaked.
+- **The model registry is data, not logic.** Adding a model is a registry entry,
+  not a new code path.
+- **MCP sessions are a trust boundary.** Tools come from servers the user
+  configured; treat tool descriptions and results as untrusted input, never as
+  instructions that can redirect the agent.
+- Memory persists across conversations and is user data. Don't widen what gets
+  written, and don't log its contents.
+
+## The naming trap
+
+This product has its own **Skills & Memory feature** — a per-user toggle panel
+in Settings. When a *user* asks to "add a skill", they usually mean a tool here
+or an entry in that panel, **not** a file in the repo's `skills/` directory.
+
+## Entries
+
+`.` · `./connectors` · `./*`
+
+```bash
+cd packages/chat-agent-toolkit && bun run test
+bunx turbo run build --filter=chat-agent-toolkit
+```

--- a/packages/domain-rank/CLAUDE.md
+++ b/packages/domain-rank/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md — `domain-rank`
+
+**Read [`skills/ask-domain-rank`](../../skills/ask-domain-rank/SKILL.md) first.**
+
+Top-million domain ranks, source names, duplicate detection and favicons — what
+turns a bare URL into a labelled, ranked source in search results. Published.
+
+## Rules
+
+- **It is on the hot path of every search.** Lookups must stay cheap and
+  synchronous-ish; a network call per result would be felt on every query.
+- The rank data is a **bundled dataset**. Don't hand-edit it — regenerate it,
+  and remember it ships to consumers, so size is a real cost.
+- Source-name mapping is user-visible: it decides what a result is labelled. A
+  wrong or missing name is a visible quality bug in the product.
+- Duplicate detection feeds dedupe in `search-web-api` — changing normalization
+  changes which results collapse together.
+
+```bash
+cd packages/domain-rank && bun run test
+```

--- a/packages/extract-pdf/CLAUDE.md
+++ b/packages/extract-pdf/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md — `extract-pdf`
+
+**Read [`skills/ask-extract-pdf`](../../skills/ask-extract-pdf/SKILL.md) and its
+`API.md` first.**
+
+PDF (URL or ArrayBuffer) → clean, structured HTML, with Docling OCR for scanned
+documents. Published; built.
+
+## Things that bite
+
+- **A PDF is a layout format, not a document format.** Reading order, column
+  detection, hyphenation across line breaks and table reconstruction are the
+  real work — and the failure mode is plausible-looking scrambled text, not an
+  error. Test with real multi-column and scanned documents.
+- **OCR is a different, much more expensive path.** Don't route a text PDF
+  through it; don't silently skip it for a scanned one.
+- Hostile and corrupt PDFs are expected input: encrypted, truncated, with broken
+  xref tables, or built to expand pathologically. Fail diagnosably.
+- This package is a **coverage-build dependency** in CI — it is one of the
+  packages the coverage jobs build first.
+
+```bash
+cd packages/extract-pdf && bun run test
+```

--- a/packages/extract-webpage/CLAUDE.md
+++ b/packages/extract-webpage/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — `extract-webpage`
+
+**Read [`skills/ask-extract-webpage`](../../skills/ask-extract-webpage/SKILL.md)
+and its `API.md` first.**
+
+URL → cited article. Main-content detection (Readability + Mercury + ~100 site
+adapters), plus APA citation metadata. The centre of the Tractor pipeline, and
+it delegates to `extract-pdf`, `extract-youtube`, `domain-rank` and the
+renderers. Published; built — rebuild after editing.
+
+## Every input is hostile
+
+The entire job is parsing pages written by someone else:
+
+- **Malformed and adversarial HTML is the normal case.** Never let a parse
+  failure escape as an unhandled exception, and never emit unsanitized page
+  content — the output is rendered.
+- Site adapters are per-site workarounds. When a site changes, its adapter
+  breaks; that is expected and should degrade to generic extraction, not fail
+  the request.
+- **Citation metadata is a correctness surface.** A wrong author or date on an
+  APA citation is worse than a missing one — students and researchers cite what
+  this produces.
+
+## Rules
+
+- Fan out to the specialized extractors rather than reimplementing them:
+  `extract-pdf` for PDFs, `extract-youtube` for video, `domain-rank` for the
+  source label and favicon, `render-url-to-html` / `html-renderer-api` for
+  JS-rendered pages.
+- It also ships as an optional peer of `grab-url` in the sibling GRAB-URL repo
+  (behind `grab-url --page`) — it must stay importable without dragging the
+  whole app in.
+
+```bash
+cd packages/extract-webpage && bun run test
+```

--- a/packages/extract-youtube/CLAUDE.md
+++ b/packages/extract-youtube/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md — `extract-youtube`
+
+**Read [`skills/ask-extract-youtube`](../../skills/ask-extract-youtube/SKILL.md)
+and its `API.md` first.**
+
+YouTube transcripts, fast and **with no browser** — serverless-optimized so it
+runs on a Cloudflare Worker. Published; built.
+
+## The no-browser constraint is the package
+
+- **Never add a dependency that needs a DOM, a headless browser, or a
+  long-lived process.** It has to run inside a Worker request. If a page truly
+  needs rendering, that is `render-url-to-html` / `html-renderer-api`'s job, not
+  this one.
+- YouTube changes its internal responses without notice; treat every field as
+  optional and fail with a diagnosable message rather than a destructured
+  `undefined`.
+- Transcripts may be auto-generated, translated, absent, or region-blocked.
+  "No transcript" is a normal outcome, not an error.
+
+This package is also a **coverage-build dependency** in CI.
+
+```bash
+cd packages/extract-youtube && bun run test
+```

--- a/packages/html-renderer-api/CLAUDE.md
+++ b/packages/html-renderer-api/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md — `html-renderer-api`
+
+**Read [`skills/ask-html-renderer-api`](../../skills/ask-html-renderer-api/SKILL.md)
+first.**
+
+A Cloudflare **Worker + Durable Object** that keeps a browser warm and renders
+DOM with Puppeteer, to get HTML from JS-rendered pages and get past
+bot-blocking. Published.
+
+## The Durable Object is the design
+
+- **Its whole purpose is keeping a browser warm.** A change that tears down and
+  relaunches per request removes the reason the package exists.
+- A DO is single-threaded and long-lived: a leaked page, an unawaited
+  navigation, or an unbounded queue wedges it for everyone routed to it.
+  Always close what you open, on the error path too.
+- Browser rendering is billed and rate-limited. Concurrency caps and timeouts
+  are cost control, not politeness — don't relax one to make a slow page work.
+
+## Rules
+
+- It fetches arbitrary user-supplied URLs: block local/private addresses, cap
+  page weight and render time.
+- Never return page-supplied content unsanitized to a caller that renders it.
+- Workers constraints apply — no Node-only APIs, no filesystem. A passing Node
+  test does not prove it runs; exercise it with wrangler.
+
+The self-hosted, non-Worker variants live in `packages/render-url-to-html`.

--- a/packages/investing/CLAUDE.md
+++ b/packages/investing/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md — `investing`
+
+**Read [`skills/ask-investing`](../../skills/ask-investing/SKILL.md) first.**
+
+**Vendored from the sibling repo `ai-broker-investing-agent`.** Alpaca, stock
+data, Polymarket sync over D1, LangGraph debate agents, and the PredictOS
+prediction-market core.
+
+## Two things to know before editing
+
+1. **This is a vendored copy.** Its upstream is
+   `OpenSourceAGI/ai-broker-investing-agent`, where the same package is actively
+   developed. A fix made only here diverges from upstream; prefer fixing it
+   there and re-vendoring, and say in the PR which direction you went.
+2. **`src/predictos/` stays MIT (PredictionXBT).** The former `predictos`
+   package was merged into this one — `packages/predictos` no longer exists.
+   Keep the `NOTICE` file and the upstream attribution intact.
+
+## This code reasons about money
+
+Position sizing, thresholds and risk guards are the product, not obstacles.
+Never weaken one to make a test pass; a threshold change needs a test pinning
+the new number.
+
+## Entries
+
+`.` · `./alpaca` · `./stocks` · `./prediction` · `./trading-agents` ·
+`./predictos` · `./predictos/ai` · `./predictos/agents` ·
+`./predictos/data/kalshi` · `./predictos/data/polymarket` ·
+`./predictos/arbitrage` · `./constants` · `./utils` · `./data/*`
+
+```bash
+cd packages/investing && bun run test
+```

--- a/packages/language-model-training/CLAUDE.md
+++ b/packages/language-model-training/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md — `language-model-training`
+
+**Read [`skills/ask-language-model-training`](../../skills/ask-language-model-training/SKILL.md)
+first.**
+
+**The only Python in this repo** — a GPT trained on Tinygrad, with its own
+toolchain: `pyproject.toml`, `requirements.txt`, `pytest.ini`, `docker/`,
+`scripts/`, and a Fargate deployment example.
+
+## It is outside every JavaScript convention here
+
+- No `package.json`. `bun install`, `bun run test` and turbo never touch it.
+  **Nothing in the root CI covers it.**
+- Tests are **pytest**, not Vitest. Dependencies are pip/`requirements.txt`, not
+  bun.
+- Don't apply the repo's TypeScript conventions to it; follow Python ones
+  (PEP 8, type hints, the existing module layout).
+
+## Rules
+
+- **Training runs cost real money** (`fargate.example.env` is a hint about
+  where). Never commit a change that raises default epochs, model size or
+  instance type without saying so explicitly.
+- Never commit checkpoints, datasets or credentials — they are large and often
+  licensed.
+- Verify with `pytest` from inside this directory, and say in the PR that this
+  is the only check that covers it.

--- a/packages/legal-terms-privacy-policy/CLAUDE.md
+++ b/packages/legal-terms-privacy-policy/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md — `legal-terms-privacy-policy`
+
+**Read [`skills/ask-legal-terms-privacy-policy`](../../skills/ask-legal-terms-privacy-policy/SKILL.md)
+first.**
+
+The shared Terms of Service and Privacy Policy page, as a React component with a
+scannable summary alongside the full text. Published.
+
+## Legal text is not refactorable prose
+
+- **Do not reword, condense or "improve" the legal content** to fit a layout.
+  Structure, tokens and presentation are yours; the wording is not.
+- The summary and the full text must stay in sync — a section removed from one
+  has to be accounted for in the other.
+- An unsubstituted token (company name, jurisdiction, contact) shipping to a
+  live site is the failure mode worth testing for.
+
+**A sibling copy of this package exists in `dev-tools-starter-agent`, and the
+ai-broker app renders its legal pages from that one.** Changing a token name or
+an export here can diverge the two — check before renaming.
+
+```bash
+cd packages/legal-terms-privacy-policy && bun run test
+```

--- a/packages/notebooklm-api-client/CLAUDE.md
+++ b/packages/notebooklm-api-client/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md — `notebooklm-api-client`
+
+**Read [`skills/ask-notebooklm-client`](../../skills/ask-notebooklm-client/SKILL.md)
+first.**
+
+A NotebookLM API client: a Cloudflare **Worker** in front of an **on-demand
+Python container** that drives NotebookLM. Published.
+
+## Two runtimes, one package
+
+The Worker is the front door; the container is a sleeping Python service that
+wakes on demand. Consequences:
+
+- **Cold starts are the normal case.** The first request after a sleep is slow.
+  Timeouts and retries have to assume it; don't tune them against a warm
+  container.
+- Waking a container costs money. Don't wake one speculatively, and don't hold
+  one awake with keepalives that aren't needed.
+- Worker-side code has Workers constraints (no Node builtins, no filesystem);
+  container-side code does not. Know which half you are editing.
+
+## Rules
+
+- It drives an **unofficial surface** of someone else's product. It will break
+  when NotebookLM changes; fail diagnosably and don't retry aggressively into a
+  changed API.
+- Credentials belong in Worker secrets and container environment, never in
+  source.

--- a/packages/qwksearch-api-client/CLAUDE.md
+++ b/packages/qwksearch-api-client/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md — `qwksearch-api-client`
+
+**Read [`skills/ask-qwksearch-api-client`](../../skills/ask-qwksearch-api-client/SKILL.md)
+first.**
+
+The typed API client, **generated from `openapi-docs.yml`**. Published.
+
+## Do not hand-edit generated files
+
+They are output; the next regeneration silently reverts your change. To change
+the client:
+
+1. Change the route in `apps/qwksearch-web/app/api/…`.
+2. Update the OpenAPI spec.
+3. Regenerate, and commit the result with the same change.
+
+Hand-written helpers go in a separate, clearly non-generated file.
+
+Keeping the spec honest matters beyond this package: `qwksearch-mcp-server`
+exposes the same surface.

--- a/packages/qwksearch-mcp-server/CLAUDE.md
+++ b/packages/qwksearch-mcp-server/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md — `qwksearch-mcp-server`
+
+**Read [`skills/ask-qwksearch-mcp-server`](../../skills/ask-qwksearch-mcp-server/SKILL.md)
+first.**
+
+An MCP server exposing web search and content extraction as tools, over
+**stdio**. Published.
+
+## stdio is the transport — stdout is the protocol
+
+- **Never `console.log` to stdout.** A stray log line corrupts the JSON-RPC
+  stream and the client disconnects with a parse error that points nowhere near
+  the cause. Diagnostics go to stderr.
+- Startup must be fast and must not require a browser or a long-lived service —
+  clients spawn and kill this process routinely.
+
+## Tool design
+
+- **Tool names and schemas are the API.** An agent picks a tool from its
+  description; renaming one breaks every configured client, and a vague
+  description is a correctness bug, not a docs bug.
+- Return structured, bounded results. An unbounded extraction dumped into a
+  model's context is a cost and quality problem.
+- Errors are results, not crashes: a failed search should return an error the
+  agent can read, not kill the server.

--- a/packages/react-weather-forecast/CLAUDE.md
+++ b/packages/react-weather-forecast/CLAUDE.md
@@ -1,0 +1,23 @@
+# CLAUDE.md — `use-weather-forecast` (`packages/react-weather-forecast`)
+
+**npm name:** `use-weather-forecast`. **Read
+[`skills/ask-weather-forecast`](../../skills/ask-weather-forecast/SKILL.md)
+first.**
+
+A React weather forecast component backed by **Open-Meteo** and IP geolocation.
+Published.
+
+## Rules
+
+- **Open-Meteo is a free public API.** Cache, don't poll: a component that
+  refetches on every render is abuse. Respect its rate limits and attribution.
+- **IP geolocation is a privacy surface.** Location is inferred, not asked for —
+  never send a user's coordinates anywhere but the forecast call, and don't log
+  them.
+- Geolocation fails often (VPNs, blocked requests, datacenter IPs). A wrong or
+  missing location must degrade to a usable component, not an error state.
+- Units and locale are user-visible: don't hardcode Fahrenheit or English.
+
+```bash
+cd packages/react-weather-forecast && bun run test
+```

--- a/packages/reason-editor-sidebar/CLAUDE.md
+++ b/packages/reason-editor-sidebar/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md — `react-reason-editor-sidebar` (`packages/reason-editor-sidebar`)
+
+**npm name:** `react-reason-editor-sidebar`. **Read
+[`skills/ask-reason-editor-sidebar`](../../skills/ask-reason-editor-sidebar/SKILL.md)
+first.**
+
+The REASON editor's file/folder sidebar, open-tabs pane and document tree.
+Published.
+
+## Rules
+
+- **It is a separate package from `reason-editor` on purpose** — the editor is
+  usable without a sidebar. Don't create a hard dependency from the editor onto
+  this, and keep this one prop-driven rather than reaching into editor
+  internals.
+- The document tree reflects persisted structure. Drag-to-reorder, rename and
+  delete are destructive operations on a user's documents: confirm deletes, make
+  moves undoable, and never let an optimistic UI update diverge from what was
+  actually saved.
+- Open tabs are session state; losing them is annoying, corrupting the tree is
+  not recoverable. Treat them with different levels of care.
+
+```bash
+cd packages/reason-editor-sidebar && bun run test
+```

--- a/packages/reason-editor/CLAUDE.md
+++ b/packages/reason-editor/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md — `react-reason-editor` (`packages/reason-editor`)
+
+**npm name:** `react-reason-editor`. **Read
+[`skills/ask-reason-editor`](../../skills/ask-reason-editor/SKILL.md) and its
+`API.md` first.**
+
+REASON: the WYSIWYG document editor, on Tiptap. Nested document tree, AI
+rewriting, collaborative editing, Google Docs import/export. Published; built.
+
+## The export surface is enormous — and that is deliberate
+
+Sixty-plus subpath exports, most of them one extension each (`./bold`,
+`./table`, `./mermaid`, `./katex`, `./slashcommand`, …), plus `./editor-kit`,
+`./bubble`, `./theme`, `./style.css`, `./reason-docs`, `./docs-agent`.
+
+That shape is the feature: a consumer pays only for the extensions it imports.
+So:
+
+- **Add a new extension as its own subpath export.** Folding it into the barrel
+  makes every consumer carry it.
+- **Never reach past an export into `dist/` internals** — and don't let a
+  consumer do it either.
+- Removing or renaming an export is a breaking change for a published package.
+
+## Rules
+
+- **Document data loss is the worst bug this package can ship.** Anything
+  touching the schema, serialization, or the Docs import/export round-trip needs
+  a round-trip test.
+- Collaborative editing runs through `apps/collaboration-server` (Hocuspocus +
+  Yjs). Schema changes affect live rooms — a Yjs document written by an old
+  schema still has to load.
+- The sidebar is a separate package: `reason-editor-sidebar`.
+- This package is a **coverage-build dependency** in CI (as
+  `react-reason-editor`).
+
+```bash
+cd packages/reason-editor && bun run test
+```

--- a/packages/render-url-to-html/CLAUDE.md
+++ b/packages/render-url-to-html/CLAUDE.md
@@ -1,0 +1,27 @@
+# CLAUDE.md — `render-url-to-html`
+
+**Read [`skills/ask-render-url-to-html`](../../skills/ask-render-url-to-html/SKILL.md)
+first.**
+
+**Not one package — two self-hosted renderers**, each its own workspace:
+
+| Directory | What it is |
+| --- | --- |
+| `scraper-jsdom/` | Lightweight, no browser |
+| `scraper-puppeteer/` | Full browser rendering |
+
+There is no `package.json` at this directory's root. Install, build and test
+inside the renderer you are changing.
+
+## Rules
+
+- **The two exist because they trade off differently** — jsdom is cheap and
+  fails on JS-heavy sites; puppeteer is correct and expensive. Don't converge
+  them, and don't quietly change which one a caller gets.
+- A renderer visits arbitrary user-supplied URLs. Block requests to local and
+  private addresses (SSRF), cap render time and page weight, and never execute
+  page-supplied code in the host context.
+- Puppeteer must not leak browser instances — a renderer that keeps a page open
+  on an error exhausts the host.
+
+For the hosted, always-warm variant see `packages/html-renderer-api`.

--- a/packages/research-agent-ui/CLAUDE.md
+++ b/packages/research-agent-ui/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md — `research-agent-ui`
+
+**Read [`skills/ask-research-agent-ui`](../../skills/ask-research-agent-ui/SKILL.md)
+and its `API.md` first.**
+
+The QwkSearch app UI: the conversation window, search results, the article
+reader, uploads and settings. Published; built.
+
+## The app renders this package — it does not own the UI
+
+`apps/qwksearch-web` wires this up. If you are about to add a component to the
+app that belongs to the chat window, the result list or the reader, it belongs
+here instead. That separation is why the same UI ships in the web app, the
+desktop app, the extension and the VS Code extension.
+
+Consequence: **a change here ships to four shells at once.** Check the ones with
+different constraints — the VS Code webview and the browser extension side panel
+are narrow, and neither has the web app's origin.
+
+## Entries
+
+`.` · `./workspace` · `./config` · `./api` · `./file-sources` · `./settings` ·
+`./settings/*`
+
+Import from these, never from `dist/` internals.
+
+## Rules
+
+- Keep it prop-driven and transport-agnostic: `./api` is the seam. A component
+  that hardcodes an endpoint can't run in the extension.
+- Rendered content (search results, extracted articles, uploads) is untrusted.
+  Sanitize at the boundary.
+- Settings UI comes from `shadcn-settings`; the dock from `shadcn-app-dock`.
+  Compose them rather than reimplementing.
+
+```bash
+cd packages/research-agent-ui && bun run test
+```

--- a/packages/search-web-api/CLAUDE.md
+++ b/packages/search-web-api/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md — `search-web-api`
+
+**Read [`skills/ask-search-web-api`](../../skills/ask-search-web-api/SKILL.md)
+and its `API.md` first.**
+
+70+ search engines across 10 categories, plus dedupe and ranking. Published.
+
+## Engine adapters are the bulk of this package
+
+- **One adapter per engine, isolated.** An engine that changes its HTML or
+  starts rate-limiting must degrade to "this engine returned nothing", never
+  take down the query. Failure of one adapter is normal operation.
+- **Never let an engine's markup reach a consumer unsanitized.** Results are
+  scraped HTML from arbitrary sites.
+- Dedupe and ranking are what make 70 engines useful rather than noisy. A change
+  to either reorders results for every user — pin the behaviour in a test and
+  say so in the PR.
+- `domain-rank` supplies source labels, rank and favicons; don't reimplement
+  them here.
+
+## Rules
+
+- Adding an engine: a new adapter plus its category, nothing else.
+- Respect robots/ToS and rate limits — this is a polite client, not a scraper
+  race.
+- Tests must not depend on a live engine returning particular results. Use
+  fixtures.
+
+```bash
+cd packages/search-web-api && bun run test
+```

--- a/packages/searxng-search-cloudflare/CLAUDE.md
+++ b/packages/searxng-search-cloudflare/CLAUDE.md
@@ -1,0 +1,22 @@
+# CLAUDE.md — `searxng-search-cloudflare`
+
+**Read [`skills/ask-searxng-search`](../../skills/ask-searxng-search/SKILL.md)
+first.**
+
+**Not a Node package** — there is no `package.json`. This is a container
+deployment: `Dockerfile`, `Dockerfile.redis`, and the SearXNG configuration
+(`searxng-settings.yml`, `searxng-engines.yml`).
+
+So nothing at the root installs, builds or tests it. `bun run test` will never
+tell you a change here is wrong.
+
+## Rules
+
+- **The YAML files are the product.** `searxng-engines.yml` decides which
+  engines are queried and how; `searxng-settings.yml` carries instance
+  configuration. A typo is a silently disabled engine, not a crash.
+- Secrets (the SearXNG secret key, any instance credentials) belong in the
+  deployment environment, never in these files.
+- Redis is a separate image (`Dockerfile.redis`) and SearXNG expects it — a
+  change to one usually needs the other.
+- Verify by building and running the containers. There is no other check.

--- a/packages/shadcn-app-dock/CLAUDE.md
+++ b/packages/shadcn-app-dock/CLAUDE.md
@@ -1,0 +1,20 @@
+# CLAUDE.md — `shadcn-app-dock`
+
+**Read [`skills/ask-shadcn-app-dock`](../../skills/ask-shadcn-app-dock/SKILL.md)
+first.**
+
+A prop-driven, macOS-style category dock with magnification. Published.
+
+## Rules
+
+- **Prop-driven and domain-free.** It takes items and renders them; it must not
+  know about QwkSearch's categories. Keep product knowledge in the caller.
+- The magnification animation is the point and it runs on pointer move — keep it
+  off the main thread's critical path, use transforms rather than layout
+  properties, and respect `prefers-reduced-motion`.
+- It must stay usable by keyboard and screen reader; a dock that only works with
+  a hovering pointer excludes people and breaks on touch.
+
+```bash
+cd packages/shadcn-app-dock && bun run test
+```

--- a/packages/shadcn-settings/CLAUDE.md
+++ b/packages/shadcn-settings/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md — `shadcn-settings`
+
+**Read [`skills/ask-shadcn-settings`](../../skills/ask-shadcn-settings/SKILL.md)
+first.**
+
+A prop-driven, **schema-based settings form renderer** on shadcn. Published.
+
+## Schema-driven means the schema is the API
+
+- **A new setting is a schema entry, not a new component.** If a setting needs
+  bespoke rendering, add the field *type* to the renderer so every consumer gets
+  it — one-off components defeat the package.
+- The schema shape is public API for every consumer; changing a field type or a
+  key is a breaking change.
+- **Stay domain-free.** This renders settings; it should not know what
+  QwkSearch's settings mean. Product-specific panels live in
+  `research-agent-ui/settings`.
+
+Both QwkSearch settings panes share these controls, so a styling or layout
+change is visible in more than one place.
+
+```bash
+cd packages/shadcn-settings && bun run test
+```

--- a/packages/trending-news-api/CLAUDE.md
+++ b/packages/trending-news-api/CLAUDE.md
@@ -1,0 +1,21 @@
+# CLAUDE.md — `trending-news-api`
+
+**Read [`skills/ask-trending-news`](../../skills/ask-trending-news/SKILL.md)
+first.**
+
+A React trending-news widget backed by **Wikipedia pageview** data. Published.
+
+## Rules
+
+- **Wikipedia's API is free and rate-limited.** Cache aggressively; send a
+  proper user agent; never fan out one request per item.
+- Pageview spikes are a proxy for "trending", not an editorial judgement. The
+  widget shows what is being read — don't add ranking that implies importance or
+  endorsement.
+- Titles and summaries come from Wikipedia and are user-editable content: treat
+  them as untrusted and sanitize before rendering.
+- Data is per-language-wiki. Don't hardcode English.
+
+```bash
+cd packages/trending-news-api && bun run test
+```

--- a/packages/use-voice-control/CLAUDE.md
+++ b/packages/use-voice-control/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md — `use-voice-control`
+
+**Read [`skills/ask-use-voice-control`](../../skills/ask-use-voice-control/SKILL.md)
+first.**
+
+React voice control: speech transcription, vocalization, and voice commands.
+Published.
+
+## It captures a user's microphone — that governs everything
+
+- **Recording is always explicit and visible.** Never start capture implicitly,
+  never keep the mic open after the interaction ends, and make the active state
+  obvious in the UI.
+- **Never send audio or transcripts anywhere the consumer didn't ask for**, and
+  never log them. Speech is personal data and often captures bystanders.
+- Permission can be denied or revoked mid-session, and the browser may drop the
+  stream when the tab is backgrounded. Both are normal — recover without losing
+  the surrounding UI state.
+- Speech APIs vary a lot by browser. Feature-detect; degrade to a usable
+  keyboard path rather than breaking.
+
+```bash
+cd packages/use-voice-control && bun run test
+```

--- a/packages/user-help-docs/CLAUDE.md
+++ b/packages/user-help-docs/CLAUDE.md
@@ -1,0 +1,24 @@
+# CLAUDE.md — `user-help-docs`
+
+**Read [`skills/ask-user-help-docs`](../../skills/ask-user-help-docs/SKILL.md)
+and [`.claude/architecture/documentation.md`](../../.claude/architecture/documentation.md)
+first.**
+
+Private. The user-facing help documentation, hosted at `/docs` in
+qwksearch.com. Content lives in `content/docs`.
+
+## This is where documentation goes
+
+**There is deliberately no root `docs/` folder in this repo — do not recreate
+one.** User-facing documentation belongs here; package documentation belongs in
+each package's `readme.md` and its `skills/ask-<name>/SKILL.md`; agent
+orientation belongs in `CLAUDE.md` files.
+
+## Rules
+
+- Write for users of the product, not for maintainers.
+- It goes through the Fumadocs pipeline — see
+  [`documentation.md`](../../.claude/architecture/documentation.md) for how it
+  is built and served.
+- Being private and docs-shaped, it is easy to break without any test noticing.
+  Build it before claiming a change works.

--- a/packages/write-language/CLAUDE.md
+++ b/packages/write-language/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md — `write-language`
+
+**Read [`skills/ask-write-language`](../../skills/ask-write-language/SKILL.md)
+and its `API.md` first.**
+
+One LLM call across 10+ providers, on the Vercel AI SDK. Published; built —
+rebuild after editing.
+
+## This package exists so nothing else has to know about providers
+
+That is the whole contract, and it is easy to erode:
+
+- **A provider-specific branch anywhere else in the repo is a bug here.** If a
+  caller needs to know which provider it is talking to, this abstraction is
+  missing something — add it here rather than special-casing at the call site.
+- Keep the failure shape uniform. Providers fail differently (rate limits,
+  content filters, context overflow, truncated streams); callers should see one
+  normalized error, not ten.
+- Streaming, tool calls and structured output must behave the same regardless of
+  provider, or callers end up branching anyway.
+
+## Rules
+
+- **Never log prompts, completions or API keys.** Prompts carry user content.
+- Adding a provider is an entry plus its quirks, not a new public API.
+- Token counting and context limits differ per model — get them from the
+  registry, don't hardcode.
+
+```bash
+cd packages/write-language && bun run test
+```


### PR DESCRIPTION
This repo already had the root `CLAUDE.md` and the `.claude/architecture/` notes — it's the layout the four sibling repos were just brought in line with. This PR completes it with the per-workspace level.

## What's here

- `CLAUDE.md` in all 25 `packages/` directories and all 6 `apps/`
- `.claude/settings.json` pre-approving the repo's own build/test commands and denying reads of `.env` / `.dev.vars`
- Root `CLAUDE.md` now points at the per-workspace files, and the PR checklist asks for them to be updated alongside the `readme.md` and the skill
- `.gitignore` un-ignores `.claude/settings.json` alongside the existing `!.claude/architecture` and `!.claude/skills` lines, and keeps `settings.local.json` / `CLAUDE.local.md` local

## How these differ from the skills

Each file **points at the package's `ask-<name>` skill as the deeper reference rather than restating it**. The skills answer "how do I use this package"; these answer "what do I need to know to work *in* it". So they're short, and they carry things like:

- The three directories under `packages/` with no `package.json`, which nothing at the root installs, builds or tests — `searxng-search-cloudflare` (containers + YAML), `render-url-to-html` (two separate renderer workspaces), and `language-model-training` (the only Python, on pytest, outside every JS convention here).
- `apps/qwksearch-ext` carries its own `pnpm-workspace.yaml` and lockfile — a root `bun install` isn't enough.
- `qwksearch-mcp-server` speaks JSON-RPC over stdio, so a stray `console.log` corrupts the protocol; diagnostics go to stderr.
- `reason-editor`'s sixty-plus one-extension-per-subpath exports are the feature — a new extension is a new subpath, not a barrel addition.
- `packages/investing` is a vendored copy of the `ai-broker-investing-agent` package, with MIT PredictOS code under `src/predictos/` and a `NOTICE` to keep intact.
- `apps/collaboration-server` holds Yjs CRDT state, so a `reason-editor` schema change has to load documents written under the old one.
- `apps/test-reports` is infrastructure only — if you're there because a test is failing, the failure is elsewhere.

The naming trap from `overview.md` (a user saying "add a skill" usually means the product's Skills & Memory panel, not a file in `skills/`) is repeated in `chat-agent-toolkit/CLAUDE.md`, where it's most likely to be hit.

## Notes

Documentation only — no code, config or dependency changes. The `.gitignore` edit is the only change outside `CLAUDE.md`/`.claude/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoGK1G8bnF6riGQekWLtYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoGK1G8bnF6riGQekWLtYr)_