### PR TITLE
🐛 fix(web): mount the research workspace so its chunk can fail without a 500

### DIFF
--- a/apps/qwksearch-web/CLAUDE.md
+++ b/apps/qwksearch-web/CLAUDE.md
@@ -23,6 +23,12 @@ it belongs in a package.
   Node APIs outside `nodejs_compat`, filesystem assumptions and long CPU work
   all pass locally and fail in production. See
   [`web-app.md`](../../.claude/architecture/web-app.md).
+- **Mount the research workspace through `components/layout/WorkspaceMount`**,
+  never by importing `research-agent-ui/workspace` into a route. That entry
+  carries the REASON editor's whole dependency tree, and a static import of it
+  turns one dependency's module-scope `document` read into a 500 for the entire
+  page. The mount loads it lazily inside a Suspense boundary, so the same
+  failure costs a flash of skeleton instead.
 - `worker/index.ts` is documented house style for a reason — read its comments
   before changing the entrypoint.
 - The `test-web-api.yml` workflow is path-filtered to this app and two packages;

--- a/apps/qwksearch-web/app/__tests__/workspace-mount.test.ts
+++ b/apps/qwksearch-web/app/__tests__/workspace-mount.test.ts
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { renderToReadableStream } from 'react-dom/server.browser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `/` and `/workspace` both mount the research workspace, and that entry
+ * (`research-agent-ui/workspace`) drags the REASON editor's whole dependency
+ * tree in with it. A dependency that reads `document` while its module is being
+ * evaluated therefore used to take the *response* down, not just the subtree:
+ * the import threw as the route module loaded, before React had a boundary, and
+ * the server answered with Next's error shell and a 500 (see #440, and the
+ * homepage 500 that followed it).
+ *
+ * `WorkspaceMount` is the fix, so this holds the property that matters: when
+ * loading that entry throws, server rendering still produces the page with a
+ * placeholder in the workspace's place and hands the subtree to the client.
+ */
+async function renderMount() {
+  const { WorkspaceMount } = await import('@/components/layout/WorkspaceMount');
+  const errors: string[] = [];
+
+  const stream = await renderToReadableStream(React.createElement(WorkspaceMount), {
+    onError(error: unknown) {
+      errors.push(error instanceof Error ? error.message : String(error));
+    },
+  });
+
+  return { html: await new Response(stream).text(), errors };
+}
+
+describe('WorkspaceMount', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('renders the workspace when its chunk loads', async () => {
+    vi.doMock('research-agent-ui/workspace', () => ({
+      ResearchWorkspaceView: () =>
+        React.createElement('main', { 'data-testid': 'workspace' }, 'workspace'),
+    }));
+
+    const { html, errors } = await renderMount();
+
+    expect(html).toContain('data-testid="workspace"');
+    expect(errors).toEqual([]);
+  });
+
+  it('still renders a page when loading the workspace throws', async () => {
+    vi.doMock('research-agent-ui/workspace', () => {
+      // What a DOM-only dependency does to this entry on a server.
+      throw new ReferenceError('document is not defined');
+    });
+
+    const { html, errors } = await renderMount();
+
+    // The response is the page plus a placeholder — not an error shell.
+    expect(html).toContain('data-testid="workspace-skeleton"');
+    expect(html).not.toContain('data-testid="workspace"');
+    // React reported the failure as recoverable and deferred to the client
+    // rather than letting it escape the render. (Vitest rewrites the message of
+    // an error thrown out of a mock factory, so only the count is asserted.)
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/apps/qwksearch-web/app/workspace/page.tsx
+++ b/apps/qwksearch-web/app/workspace/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { ResearchWorkspaceView } from 'research-agent-ui/workspace'
+import { WorkspaceMount } from '@/components/layout/WorkspaceMount'
 
 export default function Page() {
-  return <ResearchWorkspaceView />
+  return <WorkspaceMount />
 }

--- a/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
+++ b/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
@@ -6,9 +6,9 @@ import { usePathname } from 'next/navigation';
 import { ChevronDown } from 'lucide-react';
 import { useChat, useMainView } from 'research-agent-ui';
 
-import { ResearchWorkspaceView } from 'research-agent-ui/workspace';
 import { isHomeLandingState } from '@/lib/home-landing';
 import { cn } from '@/lib/utils';
+import { WorkspaceMount } from '@/components/layout/WorkspaceMount';
 
 /**
  * The homepage: the research workspace on the first screen, with the whole
@@ -191,7 +191,7 @@ export function HomeScrollStack() {
           turn it into a containing block and re-anchor the app's `fixed` and
           `absolute` chrome (popovers, dialogs, the dock) to it. */}
       <div ref={workspaceRef} className="h-screen">
-        <ResearchWorkspaceView />
+        <WorkspaceMount />
       </div>
 
       {showCue && (

--- a/apps/qwksearch-web/components/layout/WorkspaceMount.tsx
+++ b/apps/qwksearch-web/components/layout/WorkspaceMount.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import * as React from 'react';
+
+/**
+ * The one place the app mounts `research-agent-ui/workspace`.
+ *
+ * Why it exists: that entry pulls in the REASON editor and, through it, a few
+ * hundred transitive modules. If *any* of them touches `document` or `window`
+ * while being evaluated, a static `import` of this entry throws
+ * `ReferenceError: document is not defined` as the route module loads — before
+ * React has a boundary to fall back to — so the server answers the whole
+ * request with Next's error shell and a 500. That is exactly what took the
+ * homepage (and `/workspace`) down in #440, and the cause there was a
+ * dependency's *build*, not this repo's code: nothing in the app can promise it
+ * will not happen again on the next dependency bump.
+ *
+ * So the import is lazy and lives inside a Suspense boundary. The module is
+ * then evaluated *during render* rather than at module load, which makes a
+ * throw an ordinary render error in a subtree React knows how to give up on:
+ * it streams this fallback instead, marks the subtree for client rendering, and
+ * the response stays a 200 carrying the real page shell. The browser — where
+ * `document` exists — renders the workspace a moment later, so a DOM-only
+ * dependency costs a flash of skeleton rather than the entire site.
+ *
+ * The error boundary above the Suspense is the second line: if the chunk fails
+ * in the browser too (an offline navigation, a half-deployed asset), the reader
+ * gets a reload prompt rather than a blank screen.
+ */
+const ResearchWorkspaceView = React.lazy(() =>
+  import('research-agent-ui/workspace').then((mod) => ({
+    default: mod.ResearchWorkspaceView,
+  })),
+);
+
+/**
+ * Holds the workspace's footprint while its chunk is in flight. The workspace
+ * is a fixed 100vh app shell, so the placeholder is one too — anything shorter
+ * would let the content stacked beneath it (the features slab on the homepage)
+ * jump up into the first screen and back down again.
+ */
+function WorkspaceSkeleton() {
+  return (
+    <div
+      className="bg-background flex h-screen w-full items-center justify-center"
+      aria-busy="true"
+      aria-label="Loading the research workspace"
+      data-testid="workspace-skeleton"
+    >
+      <div className="border-muted-foreground/30 border-t-foreground/60 size-8 animate-spin rounded-full border-2" />
+    </div>
+  );
+}
+
+function WorkspaceUnavailable() {
+  return (
+    <div className="bg-background flex h-screen w-full flex-col items-center justify-center gap-4 px-6 text-center">
+      <p className="text-muted-foreground text-sm">
+        The research workspace could not be loaded.
+      </p>
+      <button
+        type="button"
+        onClick={() => window.location.reload()}
+        className="hover:bg-accent rounded-full border px-4 py-2 text-sm font-medium"
+      >
+        Reload
+      </button>
+    </div>
+  );
+}
+
+class WorkspaceErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    // Surfaces in the browser console and in whatever error reporting the page
+    // installs; the server-side attempt is already reported by React as a
+    // recoverable error.
+    console.error('[workspace] failed to mount', error);
+  }
+
+  render() {
+    return this.state.failed ? <WorkspaceUnavailable /> : this.props.children;
+  }
+}
+
+/** The research workspace, mounted so that failing to load it is not a 500. */
+export function WorkspaceMount() {
+  return (
+    <WorkspaceErrorBoundary>
+      <React.Suspense fallback={<WorkspaceSkeleton />}>
+        <ResearchWorkspaceView />
+      </React.Suspense>
+    </WorkspaceErrorBoundary>
+  );
+}

--- a/apps/qwksearch-web/vitest.config.ts
+++ b/apps/qwksearch-web/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       'extract-webpage': resolve(__dirname, '../../packages/extract-webpage/src'),
       'research-agent-ui/api': resolve(__dirname, '../../packages/research-agent-ui/src/api/index.ts'),
       'research-agent-ui/settings': resolve(__dirname, '../../packages/research-agent-ui/src/settings/index.ts'),
+      'research-agent-ui/workspace': resolve(__dirname, '../../packages/research-agent-ui/src/workspace.ts'),
       'research-agent-ui': resolve(__dirname, '../../packages/research-agent-ui/src/index.ts'),
       'domain-rank': resolve(__dirname, '../../packages/domain-rank'),
       'search-web-api': resolve(__dirname, '../../packages/search-web-api/src'),

--- a/apps/qwksearch-web/worker/index.ts
+++ b/apps/qwksearch-web/worker/index.ts
@@ -66,8 +66,37 @@ export default {
     // consistent. The closing bookmark rides back on the response so the
     // client's next request never sees an older version of the database.
     return runWithD1Session(request, env.D1_SESSION_MODE, async () => {
-      const response = await handler.fetch(request, env, ctx);
-      return applyD1Bookmark(response, { debug: Boolean(env.D1_SESSION_DEBUG) });
+      try {
+        const response = await handler.fetch(request, env, ctx);
+        if (response.status >= 500) reportServerError(request, url, response.status);
+        return applyD1Bookmark(response, { debug: Boolean(env.D1_SESSION_DEBUG) });
+      } catch (error) {
+        reportServerError(request, url, 500, error);
+        throw error;
+      }
     });
   },
 };
+
+/**
+ * Put a 5xx in the Worker's logs with something to act on.
+ *
+ * Cloudflare's invocation log records only `GET <url>` and the status, and a
+ * render error never reaches this handler — the framework catches it and
+ * answers with its error shell — so an SSR failure otherwise reaches the
+ * dashboard as a bare `500` with no cause, no route and no stack. This adds one
+ * line naming the path, the status and (when the exception did escape) its
+ * stack, so the next report starts from the error rather than from a guess.
+ */
+function reportServerError(request: Request, url: URL, status: number, error?: unknown) {
+  console.error(
+    `[worker] ${request.method} ${url.pathname} -> ${status}`,
+    JSON.stringify({
+      host: url.host,
+      search: url.search || undefined,
+      ray: request.headers.get("cf-ray") ?? undefined,
+      error: error instanceof Error ? `${error.name}: ${error.message}` : error ? String(error) : undefined,
+      stack: error instanceof Error ? error.stack : undefined,
+    }),
+  );
+}


### PR DESCRIPTION
## The report

`GET http://opensourceagi.app/` → `500`, logged by the `qwksearch-research-agent`
Worker with `outcome: ok` — i.e. nothing was thrown at the Worker entry; the
framework caught a render error and answered with its own error shell.

## What I could and could not reproduce

I built the deployed commit (`df05212`, the version live when the log was taken)
and served it two ways — `dist/standalone` under Node, and the Worker bundle
under `wrangler dev` (workerd, real bindings in local mode) — replaying the
reported request verbatim: `Host: opensourceagi.app`, `x-forwarded-proto: http`,
`cf-visitor: {"scheme":"http"}`, the same iPhone UA, `accept-encoding: gzip`, no
cookies. **`/` returns 200 with the real page in both runtimes.** The lockfile is
unchanged, so the dependency tree matches what Cloudflare builds.

So the 500 is not reproducible from this commit's source. It points at the
deployed artifact or its environment rather than at the code — and the log has no
cause in it to narrow that down, which is the second thing this PR fixes.

## What this changes

**1. A workspace chunk failure can no longer 500 the page.**

`/` and `/workspace` both imported `research-agent-ui/workspace` statically, and
that entry carries the REASON editor's whole dependency tree. A dependency that
reads `document` while its module is evaluated throws as the *route module loads*
— before React has a boundary — so the entire response becomes an error page
instead of one broken subtree. That is exactly how the homepage went down in
#440, and the cause there was a dependency's own build, not this repo's code:
nothing here can promise the next bump won't do it again.

Both routes now mount it through `components/layout/WorkspaceMount`:

- `React.lazy` + `Suspense` moves module evaluation into render, where a throw is
  an ordinary render error React knows how to abandon. It streams the skeleton,
  marks the subtree for client rendering, and the response stays a **200 carrying
  the real page shell**. The browser — which has a `document` — renders the
  workspace a moment later.
- An error boundary above the Suspense covers a failure in the browser too (an
  offline navigation, a half-deployed asset) with a reload prompt rather than a
  blank screen.

Cost: none measured. `/` and `/workspace` still server-render the workspace
exactly as before (byte-identical rendered markers; the HTML differs only by
React's boundary comments).

**2. A 5xx now arrives with something to act on.** Cloudflare's invocation log
records only `GET <url>` and the status. The Worker entry logs one line per 5xx
it returns or exception it sees — method, path, host, `cf-ray`, and the stack
when the exception did escape.

## Verification

- `dist/standalone` (Node) and `wrangler dev` (workerd): `/` → 200, `/workspace`
  → 200, workspace server-rendered, replayed production request.
- `app/__tests__/workspace-mount.test.ts` (new): renders the mount with that
  import throwing `ReferenceError: document is not defined` and asserts the page
  still renders, with the placeholder in the workspace's place and the failure
  reported as recoverable.
- `bunx vitest run` in `apps/qwksearch-web`: 61 files, 849 tests green.
- `bun run test` at the root: 3069 passed. The 14 failing files are all
  `apps/qwksearch-ext`, failing to load on a missing generated
  `.wxt/tsconfig.json` — pre-existing and unrelated.
- `tsc --noEmit`: 68 errors before the change, the same 68 after.

## Follow-up if `/` is still 500ing after this deploys

The new log line will name the route and carry the stack. Worth checking
alongside it: the Worker in `wrangler.jsonc` is named `qwksearch`, but the Worker
actually serving the domain is `qwksearch-research-agent`, and no `qwksearch`
Worker exists in the account — so the deploy is renaming the script somewhere
outside this repo, which is worth confirming points where it should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VW6ks5xpZy44HA2NVL89ET

---
_Generated by [Claude Code](https://claude.ai/code/session_01VW6ks5xpZy44HA2NVL89ET)_