### PR TITLE
📝 docs(packages-lobe): record the engine job's first real run

### DIFF
--- a/.github/workflows/lobehub-engine.yml
+++ b/.github/workflows/lobehub-engine.yml
@@ -11,8 +11,10 @@ name: LobeHub Engine
 # the repository lived in `worker/qwksearch/extract.ts` from the day it was
 # written (see the LobeHub Migration To-Do, §1.3 and §5.5).
 #
-# Path-filtered on purpose: the install is the expensive step (~1.5 min cold,
-# 4.2 GB of node_modules), so it runs only when the engine actually changed.
+# Path-filtered on purpose: the install is the expensive step (~1 min cold on a
+# runner, a 1.0 GB pnpm store, 4.2 GB of node_modules), so it runs only when the
+# engine actually changed. Measured on the first real run (#452): 3m22s end to
+# end — 1m03s install, 40s type-check, 43s tests, ~25s saving the store cache.
 
 on:
   push:
@@ -38,9 +40,8 @@ jobs:
   engine:
     name: QwkSearch type-check + tests
     runs-on: ubuntu-latest
-    # Measured locally at ~1m25s install + ~1m00s type-check + ~1m05s tests.
-    # The cap is generous for a cold runner and exists so a hung install cannot
-    # sit on a runner for six hours.
+    # The job takes ~3.5 minutes cold. The cap is generous and exists so a hung
+    # install cannot sit on a runner for six hours.
     timeout-minutes: 30
 
     steps:

--- a/TODO.md
+++ b/TODO.md
@@ -153,12 +153,28 @@ the expensive step and nothing outside the engine changes either result.
   packages consume as built output, which is exactly what the Coverage workflow
   does before its tests.
 
+### The first real run
+**Green, 3m22s**, on `.nvmrc`'s Node 24.20.0 — faster on a GitHub runner than on
+this box at every step: install **1m03s** (3939 packages), type-check **40s**,
+tests **43s**, plus ~25s saving a **1.0 GB** pnpm store to the cache. Recorded
+in §5.6 in a follow-up, since the PR auto-merged eleven seconds after it opened
+and its own checks finished well after that.
+
+Two things that confirmed more than "it works". The **504 ignored errors are the
+same 504** on Node 24 as on Node 22 here, so that count is a property of the tree
+and not of one machine — which is what makes it usable as a tripwire rather than
+noise. And the **cold install is the whole cost**: on a cache hit the job is
+about two minutes, so the path filter is buying runner slots, not minutes.
+
 ### Remaining work
-- **The job has never run on a GitHub runner.** Everything above was measured on
-  a code-only box with Node 22; the workflow uses `.nvmrc`'s **24.20.0**, which
-  is what the Cloudflare build pins and the deploy runs, but which nothing here
-  could exercise. Its first real run is this PR — read it before building on it,
-  and remember that PRs here auto-merge before checks finish.
+- **Only ever run on a cache miss.** The first run wrote the store cache; nothing
+  has read one back yet, so the `restore-keys` fallback is unexercised. A bad
+  restore would show up as a slow install rather than a wrong one.
+- **Noticed, not fixed (repo-wide):** every run warns that
+  `actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4` and
+  `pnpm/action-setup@v4` target Node 20 and are being forced onto Node 24. Every
+  workflow here uses those actions, so the v5 bump is one repo-wide PR, not a
+  `packages-lobe` one.
 - **An unlockfiled install is not a reproducible one.** `lockfile: false` is
   upstream LobeHub's choice, but it means the job resolves fresh semver on every
   cache miss and can go red for a reason that is not in the diff. If that

--- a/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
@@ -606,10 +606,11 @@ cd packages-lobe && bun run type-check:worker
 **Both of the above now run in CI**, in
 [`.github/workflows/lobehub-engine.yml`](https://github.com/OpenSourceAGI/qwksearch-research-agent/blob/master/.github/workflows/lobehub-engine.yml)
 — the only job in this repository that installs `packages-lobe`. It is
-path-filtered to `packages-lobe/**` and the workflow file, because the install
-is the expensive step (~1.5 min cold, 4.2 GB) and nothing outside the engine can
-change either result. What it does *not* run is the Worker bundle-size budget;
-§5.4 of the migration to-do records why.
+path-filtered to `packages-lobe/**` and the workflow file, because the install is
+the expensive step (~1 min cold on a runner, 4.2 GB) and nothing outside the
+engine can change either result. **3m22s end to end** on its first real run. What
+it does *not* run is the Worker bundle-size budget; §5.4 of the migration to-do
+records why.
 
 ## 7. Not yet integrated
 

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -753,7 +753,30 @@ Blocked on the LobeHub Community License answer, recorded in
     the same mechanism as the panes' `contract.test.ts`.
   - **Path-filtered to everything under `packages-lobe/`, plus the workflow file
     itself.** The install is the expensive step, and nothing outside the engine
-    changes either result. Whole job: ~4 minutes cold.
+    changes either result.
+
+  **First real run: green, in 3m22s** (#452, `f3b37e85`). Every step was faster
+  on a GitHub runner than on the box these numbers were estimated from:
+
+  | Step | On a runner, cold cache |
+  |---|---|
+  | `pnpm install --ignore-scripts` | **1m03s**, 3939 packages |
+  | `pnpm run type-check:qwksearch` | **40s** → clean |
+  | `pnpm run test:qwksearch` | **43s**, 568 passed |
+  | Saving the pnpm store to the cache | ~25s, **1.0 GB** |
+
+  Two things that run confirmed beyond "it works". The **504 ignored errors are
+  the same 504** on the runner's Node 24.20.0 as on Node 22 here, so the filter's
+  count is a property of the tree rather than of one machine — which is what
+  makes it usable as a tripwire. And the **cold install is the whole cost**: on a
+  cache hit the job is roughly two minutes, so the path filter is about runner
+  slots, not minutes.
+
+  One warning on every run, and not this job's: `actions/checkout@v4`,
+  `actions/setup-node@v4`, `actions/cache@v4` and `pnpm/action-setup@v4` all
+  target Node 20 and are being forced onto Node 24. Every workflow in this
+  repository uses those actions, so the v5 bump is a repo-wide change, not a
+  `packages-lobe` one.
   - **Three details are specific to this workspace**, and each one is a way the
     obvious workflow would have failed: `pnpm/action-setup` reads the *repo
     root* `package.json` by default, which pins **bun**, so it has to be pointed
@@ -771,10 +794,13 @@ Blocked on the LobeHub Community License answer, recorded in
     means this job resolves fresh semver on every cache miss and can go red for
     a reason that is not in the diff. If that happens, the store cache key
     (the manifests) is the first thing to read.
-  - ⬜ **Never yet run on a GitHub runner.** Everything above was measured on a
-    code-only box with Node 22; the job uses `.nvmrc`'s **24.20.0**, which is
-    what the Cloudflare build pins and what the deploy actually runs, but which
-    nothing here could exercise.
+  - ✅ **Confirmed on a GitHub runner**, on `.nvmrc`'s **24.20.0** — the version
+    the Cloudflare build pins and the deploy runs, which nothing local could
+    exercise. See the table above.
+  - ⬜ **The job has only ever run on a cache miss.** Its first run wrote the
+    store cache; nothing has yet read one back. If a restore is ever partial or
+    stale, the symptom will be an install that is slow rather than wrong, but
+    the `restore-keys` fallback is unexercised.
 
 ## How to pick up the next item
 


### PR DESCRIPTION
#452 auto-merged eleven seconds after it opened, so its own checks — including the first ever run of the CI job it adds — finished long after the docs describing that job were written. Those docs estimated; this replaces the estimates with measurements, and closes the "never yet run on a GitHub runner" follow-up it had to leave open.

## The run

**Green in 3m22s**, on `.nvmrc`'s Node 24.20.0 — the version the Cloudflare build pins and the deploy runs, which nothing local could exercise. Every step was *faster* on a GitHub runner than on the box the estimates came from:

| Step | On a runner, cold cache | Estimated from local |
|---|---|---|
| `pnpm install --ignore-scripts` | **1m03s**, 3939 packages | ~1m25s |
| `pnpm run type-check:qwksearch` | **40s** → clean | ~1m00s |
| `pnpm run test:qwksearch` | **43s**, 568 passed | ~1m05s |
| Saving the pnpm store to the cache | ~25s, **1.0 GB** | not measured |

## Two results worth more than the timings

- **The 504 ignored type errors are the same 504** on the runner's Node 24 as on Node 22 here. That count is a property of the tree, not of one machine — which is what makes it usable as a tripwire rather than noise, and means a change in it is a signal.
- **The cold install is the whole cost.** On a cache hit the job is roughly two minutes, so the path filter is buying runner slots, not minutes.

## Also noted, and not this job's

Every run warns that `actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4` and `pnpm/action-setup@v4` target Node 20 and are being forced onto Node 24. Every workflow in this repository uses those actions, so the v5 bump is one repo-wide PR rather than a `packages-lobe` change. Recorded in `TODO.md`, not acted on here.

## Still open

The job has only ever run on a cache *miss* — its first run wrote the store cache and nothing has read one back, so the `restore-keys` fallback is unexercised. A bad restore would surface as a slow install rather than a wrong one.

## Changed

Docs and comments only, no behaviour: §5.6 of the migration to-do, §6 of the integrations reference, the header comment and `timeout-minutes` note in `lobehub-engine.yml`, and the run's entry in `TODO.md`.

Verified: `packages/user-help-docs` suite (renders every MDX page) 39 passed; the workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAtFqNquimVeZacbQX4jKM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAtFqNquimVeZacbQX4jKM)_