### PR TITLE
✨ feat(web): gate first page loads behind Cloudflare Turnstile

### DIFF
--- a/.claude/architecture/web-app.md
+++ b/.claude/architecture/web-app.md
@@ -60,6 +60,27 @@ with the `D1_SESSION_MODE` variable (`auto` | `primary` | `unconstrained` | `off
 and `D1_SESSION_DEBUG`. Background:
 [user-help-docs → Architecture → D1 Read Replication](../../packages/user-help-docs/content/docs/architecture/d1-read-replication.mdx).
 
+## Turnstile first-load gate
+
+`worker/index.ts` calls `handleTurnstileGate` (`apps/qwksearch-web/lib/turnstile/`) before
+anything else. A desktop browser's **first** HTML page view is answered with a
+Cloudflare Turnstile check; the Worker validates the token server-side against
+`siteverify` and sets an HMAC-signed pass cookie (7 days by default), so nobody
+is challenged twice.
+
+Never challenged: phones (`Sec-CH-UA-Mobile`, falling back to the user-agent),
+search-engine and link-preview crawlers, `/api/*`, `/_next/*`, `/_vinext/*`,
+static assets, RSC payload fetches (`RSC: 1`, `?_rsc=`), `robots.txt` /
+`sitemap.xml` / manifests / health checks, and every non-`GET` request. A new
+machine-facing path outside `/api/*` has to be added to
+`lib/turnstile/request-filter.ts`.
+
+The gate is **off until configured and fails open**: with `TURNSTILE_SITE_KEY` /
+`TURNSTILE_SECRET_KEY` unset it returns `null` for every request, which is what
+keeps local dev, previews and CI unchallenged. `TURNSTILE_ENABLED=false` turns
+it off with the keys still in place. Full write-up:
+[user-help-docs → Architecture → Turnstile first-load gate](../../packages/user-help-docs/content/docs/architecture/turnstile-bot-gate.mdx).
+
 ## Auth
 
 **Better Auth** over the Drizzle/D1 adapter, with the `oneTap`, `openAPI`,

--- a/apps/qwksearch-web/.env.example
+++ b/apps/qwksearch-web/.env.example
@@ -140,3 +140,25 @@ TAVILY_API_KEY=your_tavily_api_key
 # Get it from:
 # https://www.thenewsapi.com/
 THENEWSAPI_API_KEY=your_thenewsapi_api_key
+
+# ============================================================================
+# Cloudflare Turnstile (first-load bot gate)
+# ============================================================================
+
+# Optional. With both keys unset the gate never runs and the app behaves
+# exactly as before. Set both to challenge a desktop browser's first HTML page
+# view once; phones, crawlers, /api/*, assets and RSC fetches are never
+# challenged. See the "Turnstile first-load gate" architecture doc.
+# Create a Managed widget at https://dash.cloudflare.com → Turnstile.
+# TURNSTILE_SITE_KEY=
+# TURNSTILE_SECRET_KEY=
+
+# Optional. "false" switches the gate off while keeping the keys in place.
+# TURNSTILE_ENABLED=
+
+# Optional. How long one pass lasts, in seconds. Default 604800 (7 days),
+# clamped to 5 minutes - 30 days.
+# TURNSTILE_TTL_SECONDS=
+
+# Optional. Share one pass across subdomains, e.g. .qwksearch.com
+# TURNSTILE_COOKIE_DOMAIN=

--- a/apps/qwksearch-web/CLAUDE.md
+++ b/apps/qwksearch-web/CLAUDE.md
@@ -31,6 +31,12 @@ it belongs in a package.
   failure costs a flash of skeleton instead.
 - `worker/index.ts` is documented house style for a reason — read its comments
   before changing the entrypoint.
+- **The Turnstile gate runs first in `worker/index.ts`** (`lib/turnstile`). It
+  only ever interrupts a desktop browser's first HTML page view, and it is a
+  no-op until `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` are set. Adding a
+  path that must answer machines — a webhook, a feed, a health check — outside
+  `/api/*` means adding it to the exempt list in
+  `lib/turnstile/request-filter.ts`.
 - The `test-web-api.yml` workflow is path-filtered to this app and two packages;
   a change elsewhere won't run it.
 

--- a/apps/qwksearch-web/lib/turnstile/__tests__/turnstile.test.ts
+++ b/apps/qwksearch-web/lib/turnstile/__tests__/turnstile.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveTurnstileConfig, TURNSTILE_VERIFY_PATH } from "../config";
+import { handleTurnstileGate, safeRedirectTarget, TURNSTILE_COOKIE_NAME } from "../gate";
+import { decideChallenge, isCrawlerRequest, isMobileRequest } from "../request-filter";
+import { buildPassCookie, mintPassToken, readCookie, verifyPassToken } from "../session";
+
+const SECRET = "0x4AAAAAAAsecret";
+const SITE_KEY = "0x4AAAAAAAsitekey";
+const ENV = { TURNSTILE_SITE_KEY: SITE_KEY, TURNSTILE_SECRET_KEY: SECRET };
+
+const DESKTOP_HEADERS = {
+  "user-agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0 Safari/537.36",
+  "sec-fetch-dest": "document",
+  "sec-fetch-mode": "navigate",
+  accept: "text/html,application/xhtml+xml",
+};
+
+const PHONE_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1";
+
+function pageRequest(path = "/", headers: Record<string, string> = {}) {
+  return new Request(`https://example.com${path}`, { headers: { ...DESKTOP_HEADERS, ...headers } });
+}
+
+/** Stubs the siteverify call so no test reaches the network. */
+function stubSiteverify(body: Record<string, unknown>, ok = true) {
+  const fetchMock = vi.fn(async () => new Response(JSON.stringify(body), { status: ok ? 200 : 500 }));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function verifyRequest(fields: Record<string, string>) {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) form.append(key, value);
+  return new Request(`https://example.com${TURNSTILE_VERIFY_PATH}`, { method: "POST", body: form });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("resolveTurnstileConfig", () => {
+  it("is off until both keys are present", () => {
+    expect(resolveTurnstileConfig(undefined)).toBeNull();
+    expect(resolveTurnstileConfig({})).toBeNull();
+    expect(resolveTurnstileConfig({ TURNSTILE_SITE_KEY: SITE_KEY })).toBeNull();
+    expect(resolveTurnstileConfig({ TURNSTILE_SECRET_KEY: SECRET })).toBeNull();
+    expect(resolveTurnstileConfig(ENV)).not.toBeNull();
+  });
+
+  it("can be switched off without removing the keys", () => {
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_ENABLED: "false" })).toBeNull();
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_ENABLED: "OFF" })).toBeNull();
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_ENABLED: "true" })).not.toBeNull();
+  });
+
+  it("clamps the TTL and falls back to a week on junk", () => {
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_TTL_SECONDS: "nonsense" })?.ttlSeconds).toBe(604_800);
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_TTL_SECONDS: "1" })?.ttlSeconds).toBe(300);
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_TTL_SECONDS: "99999999" })?.ttlSeconds).toBe(2_592_000);
+    expect(resolveTurnstileConfig({ ...ENV, TURNSTILE_TTL_SECONDS: "3600" })?.ttlSeconds).toBe(3600);
+  });
+});
+
+describe("pass token", () => {
+  it("round-trips a token it signed itself", async () => {
+    const token = await mintPassToken(SECRET, 60);
+    await expect(verifyPassToken(SECRET, token)).resolves.toBe(true);
+  });
+
+  it("rejects a token signed with another secret", async () => {
+    const token = await mintPassToken(SECRET, 60);
+    await expect(verifyPassToken("other-secret", token)).resolves.toBe(false);
+  });
+
+  it("rejects a hand-written or tampered token", async () => {
+    await expect(verifyPassToken(SECRET, "1")).resolves.toBe(false);
+    await expect(verifyPassToken(SECRET, "v1.9999999999.nonce.signature")).resolves.toBe(false);
+
+    const token = await mintPassToken(SECRET, 60);
+    const [version, expiry, nonce, signature] = token.split(".");
+    // Extending the expiry must invalidate the signature that covers it.
+    await expect(verifyPassToken(SECRET, `${version}.${Number(expiry) + 86_400}.${nonce}.${signature}`)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("rejects an expired token", async () => {
+    const now = 1_700_000_000;
+    const token = await mintPassToken(SECRET, 60, now);
+    await expect(verifyPassToken(SECRET, token, now + 30)).resolves.toBe(true);
+    await expect(verifyPassToken(SECRET, token, now + 61)).resolves.toBe(false);
+  });
+
+  it("reads its cookie back out of a Cookie header", () => {
+    const request = new Request("https://example.com/", {
+      headers: { cookie: `other=1; ${TURNSTILE_COOKIE_NAME}=abc.def; another=2` },
+    });
+    expect(readCookie(request, TURNSTILE_COOKIE_NAME)).toBe("abc.def");
+    expect(readCookie(request, "missing")).toBeNull();
+  });
+
+  it("marks the cookie HttpOnly and drops Secure off plain http", () => {
+    const https = buildPassCookie({ name: "p", token: "t", ttlSeconds: 60, secure: true });
+    expect(https).toContain("HttpOnly");
+    expect(https).toContain("SameSite=Lax");
+    expect(https).toContain("Secure");
+    expect(buildPassCookie({ name: "p", token: "t", ttlSeconds: 60, secure: false })).not.toContain("Secure");
+    expect(buildPassCookie({ name: "p", token: "t", ttlSeconds: 60, secure: true, domain: ".example.com" })).toContain(
+      "Domain=.example.com",
+    );
+  });
+});
+
+describe("decideChallenge", () => {
+  const decide = (request: Request) => decideChallenge(request, new URL(request.url));
+
+  it("challenges a desktop browser's first page view", () => {
+    expect(decide(pageRequest("/search"))).toEqual({ challenge: true, reason: "challenge" });
+  });
+
+  it("never challenges a phone", () => {
+    expect(decide(pageRequest("/", { "user-agent": PHONE_UA })).reason).toBe("mobile");
+    expect(decide(pageRequest("/", { "sec-ch-ua-mobile": "?1" })).reason).toBe("mobile");
+    // A Chromium desktop sends the same hint with ?0 and is still challenged.
+    expect(decide(pageRequest("/", { "sec-ch-ua-mobile": "?0" })).challenge).toBe(true);
+  });
+
+  it("never challenges a search-engine or link-preview crawler", () => {
+    expect(decide(pageRequest("/", { "user-agent": "Mozilla/5.0 (compatible; Googlebot/2.1)" })).reason).toBe(
+      "crawler",
+    );
+    expect(decide(pageRequest("/", { "user-agent": "facebookexternalhit/1.1" })).reason).toBe("crawler");
+  });
+
+  it("never challenges API calls, assets or well-known paths", () => {
+    for (const path of [
+      "/api/agent/chat",
+      "/_next/static/chunk.js",
+      "/_vinext/image",
+      "/.well-known/security.txt",
+      "/robots.txt",
+      "/sitemap.xml",
+      "/favicon.ico",
+      "/manifest.webmanifest",
+      "/sw.js",
+      "/logo.svg",
+    ]) {
+      expect(decide(pageRequest(path)).reason, path).toBe("exempt-path");
+    }
+  });
+
+  it("never challenges a non-document fetch", () => {
+    expect(decide(pageRequest("/", { "sec-fetch-dest": "empty", "sec-fetch-mode": "cors" })).reason).toBe(
+      "not-a-document",
+    );
+    expect(decide(pageRequest("/", { rsc: "1" })).reason).toBe("not-a-document");
+    expect(decide(pageRequest("/dashboard?_rsc=abc123")).reason).toBe("not-a-document");
+    expect(decide(pageRequest("/", { "next-router-prefetch": "1" })).reason).toBe("not-a-document");
+  });
+
+  it("never challenges a write", () => {
+    const post = new Request("https://example.com/settings", { method: "POST", headers: DESKTOP_HEADERS });
+    expect(decide(post).reason).toBe("unsafe-method");
+  });
+
+  it("falls back to Accept when the browser sends no Sec-Fetch headers", () => {
+    const legacy = new Request("https://example.com/", {
+      headers: { "user-agent": DESKTOP_HEADERS["user-agent"], accept: "text/html" },
+    });
+    expect(decide(legacy).challenge).toBe(true);
+
+    const json = new Request("https://example.com/", {
+      headers: { "user-agent": DESKTOP_HEADERS["user-agent"], accept: "application/json" },
+    });
+    expect(decide(json).reason).toBe("not-a-document");
+  });
+
+  it("treats a Cloudflare-verified bot as a crawler", () => {
+    const request = pageRequest("/", { "user-agent": "SomethingUnlisted/1.0" });
+    Object.defineProperty(request, "cf", { value: { verifiedBotCategory: "Search Engine Crawler" } });
+    expect(isCrawlerRequest(request)).toBe(true);
+    expect(isMobileRequest(request)).toBe(false);
+  });
+});
+
+describe("safeRedirectTarget", () => {
+  it("keeps same-origin paths", () => {
+    expect(safeRedirectTarget("/search?q=hello")).toBe("/search?q=hello");
+  });
+
+  it("refuses anything that could leave the origin", () => {
+    expect(safeRedirectTarget("//evil.example")).toBe("/");
+    expect(safeRedirectTarget("/\\evil.example")).toBe("/");
+    expect(safeRedirectTarget("https://evil.example")).toBe("/");
+    expect(safeRedirectTarget("")).toBe("/");
+    expect(safeRedirectTarget(`/x${String.fromCharCode(13)}${String.fromCharCode(10)}Set-Cookie: a=b`)).toBe("/");
+    expect(safeRedirectTarget(`/${"x".repeat(4000)}`)).toBe("/");
+    // Bouncing back to the verify endpoint would be a dead end.
+    expect(safeRedirectTarget(TURNSTILE_VERIFY_PATH)).toBe("/");
+  });
+});
+
+describe("handleTurnstileGate", () => {
+  it("passes everything through when unconfigured", async () => {
+    await expect(handleTurnstileGate(pageRequest("/"), {})).resolves.toBeNull();
+    await expect(handleTurnstileGate(pageRequest("/"), undefined)).resolves.toBeNull();
+  });
+
+  it("serves the challenge page on a first desktop page view", async () => {
+    const response = await handleTurnstileGate(pageRequest("/search?q=a"), ENV);
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get("cache-control")).toContain("no-store");
+    expect(response?.headers.get("x-robots-tag")).toContain("noindex");
+
+    const html = await response!.text();
+    expect(html).toContain(`data-sitekey="${SITE_KEY}"`);
+    expect(html).toContain(`action="${TURNSTILE_VERIFY_PATH}"`);
+    expect(html).toContain('value="/search?q=a"');
+    // The secret must never reach the browser.
+    expect(html).not.toContain(SECRET);
+  });
+
+  it("escapes the redirect it echoes back into the form", async () => {
+    // A redirect read off the URL arrives percent-encoded by `URL` itself...
+    const fromUrl = await handleTurnstileGate(pageRequest("/a?q=%22%3E%3Cscript%3E"), ENV);
+    expect(await fromUrl!.text()).toContain('value="/a?q=%22%3E%3Cscript%3E"');
+
+    // ...but the one posted back to the verify endpoint is raw form text, so
+    // the page has to escape it before echoing it into the hidden input.
+    const retry = await handleTurnstileGate(
+      verifyRequest({ redirect: '/a"><script>alert(1)</script>' }),
+      ENV,
+    );
+    const html = await retry!.text();
+    expect(retry?.status).toBe(400);
+    expect(html).not.toContain("<script>alert(1)");
+    expect(html).toContain("&quot;&gt;&lt;script&gt;alert(1)");
+  });
+
+  it("lets a verified browser straight through", async () => {
+    const token = await mintPassToken(SECRET, 3600);
+    const request = pageRequest("/", { cookie: `${TURNSTILE_COOKIE_NAME}=${token}` });
+    await expect(handleTurnstileGate(request, ENV)).resolves.toBeNull();
+  });
+
+  it("challenges a browser carrying a forged cookie", async () => {
+    const forged = await mintPassToken("not-the-secret", 3600);
+    const request = pageRequest("/", { cookie: `${TURNSTILE_COOKIE_NAME}=${forged}` });
+    const response = await handleTurnstileGate(request, ENV);
+    expect(response?.status).toBe(200);
+    expect(await response!.text()).toContain("cf-turnstile");
+  });
+
+  it("verifies the token server-side and sets a signed cookie", async () => {
+    const fetchMock = stubSiteverify({ success: true, hostname: "example.com" });
+
+    const response = await handleTurnstileGate(
+      verifyRequest({ "cf-turnstile-response": "token-from-widget", redirect: "/search?q=a" }),
+      ENV,
+    );
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [verifyUrl, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(verifyUrl).toBe("https://challenges.cloudflare.com/turnstile/v0/siteverify");
+    expect((init.body as FormData).get("secret")).toBe(SECRET);
+    expect((init.body as FormData).get("response")).toBe("token-from-widget");
+
+    expect(response?.status).toBe(303);
+    expect(response?.headers.get("location")).toBe("/search?q=a");
+
+    const setCookie = response!.headers.get("set-cookie")!;
+    expect(setCookie).toContain(`${TURNSTILE_COOKIE_NAME}=`);
+    const minted = setCookie.slice(setCookie.indexOf("=") + 1, setCookie.indexOf(";"));
+    await expect(verifyPassToken(SECRET, minted)).resolves.toBe(true);
+  });
+
+  it("refuses a redirect that would leave the site", async () => {
+    stubSiteverify({ success: true, hostname: "example.com" });
+    const response = await handleTurnstileGate(
+      verifyRequest({ "cf-turnstile-response": "t", redirect: "//evil.example" }),
+      ENV,
+    );
+    expect(response?.headers.get("location")).toBe("/");
+  });
+
+  it("sets no cookie when siteverify rejects the token", async () => {
+    stubSiteverify({ success: false, "error-codes": ["invalid-input-response"] });
+    const response = await handleTurnstileGate(verifyRequest({ "cf-turnstile-response": "bad" }), ENV);
+    expect(response?.status).toBe(403);
+    expect(response?.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("sets no cookie when the token was solved for another site", async () => {
+    stubSiteverify({ success: true, hostname: "evil.example" });
+    const response = await handleTurnstileGate(verifyRequest({ "cf-turnstile-response": "t" }), ENV);
+    expect(response?.status).toBe(403);
+    expect(response?.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("accepts a token solved on a sibling hostname of the widget's domain", async () => {
+    stubSiteverify({ success: true, hostname: "www.example.com" });
+    const response = await handleTurnstileGate(verifyRequest({ "cf-turnstile-response": "t" }), ENV);
+    expect(response?.status).toBe(303);
+  });
+
+  it("re-challenges rather than 500s when siteverify is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    const response = await handleTurnstileGate(verifyRequest({ "cf-turnstile-response": "t" }), ENV);
+    expect(response?.status).toBe(502);
+    expect(await response!.text()).toContain("cf-turnstile");
+  });
+
+  it("rejects a submission with no token without calling siteverify", async () => {
+    const fetchMock = stubSiteverify({ success: true });
+    const response = await handleTurnstileGate(verifyRequest({ redirect: "/" }), ENV);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response?.status).toBe(400);
+  });
+
+  it("answers a GET on the verify endpoint with 405", async () => {
+    const response = await handleTurnstileGate(
+      new Request(`https://example.com${TURNSTILE_VERIFY_PATH}`, { headers: DESKTOP_HEADERS }),
+      ENV,
+    );
+    expect(response?.status).toBe(405);
+  });
+});

--- a/apps/qwksearch-web/lib/turnstile/challenge-page.ts
+++ b/apps/qwksearch-web/lib/turnstile/challenge-page.ts
@@ -1,0 +1,187 @@
+/**
+ * @fileoverview The interstitial served in place of a first page load.
+ *
+ * Self-contained on purpose: inline CSS, one inline script, and Cloudflare's
+ * widget loader. It renders before the app's own JS, CSS or fonts exist for
+ * this visitor, so it cannot depend on any of them — and it must stay small,
+ * because it is on the critical path of the very first impression.
+ *
+ * The widget auto-submits the form from its success callback, so in Turnstile's
+ * Managed mode most visitors see a spinner resolve on its own and never click
+ * anything. The submit button is the fallback for the interactive case and for
+ * `noscript`.
+ */
+
+const WIDGET_SCRIPT_URL = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+
+export interface ChallengePageOptions {
+  siteKey: string;
+  /** Same-origin path to return to once the token checks out. */
+  redirectTo: string;
+  /** Where the page POSTs its token. */
+  verifyPath: string;
+  /** Shown above the widget when a previous attempt failed. */
+  error?: string;
+  status?: number;
+}
+
+/** Escapes a value for interpolation into an HTML attribute or text node. */
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+export function renderChallengePage(options: ChallengePageOptions): Response {
+  const siteKey = escapeHtml(options.siteKey);
+  const redirectTo = escapeHtml(options.redirectTo);
+  const verifyPath = escapeHtml(options.verifyPath);
+  const error = options.error ? escapeHtml(options.error) : "";
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="robots" content="noindex, nofollow" />
+<meta name="referrer" content="no-referrer" />
+<title>Just a moment — QwkSearch</title>
+<script src="${WIDGET_SCRIPT_URL}" async defer></script>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f6f7f9;
+    --card: #ffffff;
+    --fg: #14161a;
+    --muted: #5c636e;
+    --border: #e3e6ea;
+    --accent: #2563eb;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0c0e12;
+      --card: #14171d;
+      --fg: #eef1f5;
+      --muted: #9aa3b0;
+      --border: #252a33;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: var(--bg);
+    color: var(--fg);
+    font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  }
+  main {
+    width: 100%;
+    max-width: 420px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 32px 28px;
+    text-align: center;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 12px 32px rgba(0, 0, 0, 0.06);
+  }
+  .brand {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 18px;
+  }
+  h1 { font-size: 19px; font-weight: 600; margin: 0 0 8px; }
+  p { margin: 0 0 22px; color: var(--muted); font-size: 14px; }
+  .widget { display: flex; justify-content: center; min-height: 65px; }
+  .error {
+    margin: 0 0 18px;
+    padding: 10px 12px;
+    border-radius: 9px;
+    background: rgba(204, 45, 45, 0.1);
+    color: #cc2d2d;
+    font-size: 13px;
+    text-align: left;
+  }
+  button {
+    margin-top: 18px;
+    width: 100%;
+    padding: 10px 16px;
+    border: 0;
+    border-radius: 9px;
+    background: var(--accent);
+    color: #fff;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  button:hover { filter: brightness(1.08); }
+  .foot { margin: 20px 0 0; font-size: 12px; color: var(--muted); }
+  noscript p { margin-top: 16px; }
+</style>
+</head>
+<body>
+<main>
+  <p class="brand">QwkSearch</p>
+  <h1>Just a moment</h1>
+  <p>We're checking that you're a person before loading the page. This happens once.</p>
+  ${error ? `<p class="error">${error}</p>` : ""}
+  <form id="turnstile-form" method="POST" action="${verifyPath}">
+    <input type="hidden" name="redirect" value="${redirectTo}" />
+    <div class="widget">
+      <div class="cf-turnstile"
+           data-sitekey="${siteKey}"
+           data-callback="onTurnstileSuccess"
+           data-theme="auto"
+           data-appearance="always"></div>
+    </div>
+    <button type="submit">Continue</button>
+  </form>
+  <noscript>
+    <p>JavaScript is required to complete this check.</p>
+  </noscript>
+  <p class="foot">Protected by Cloudflare Turnstile</p>
+</main>
+<script>
+  // Defined on window (not module-scoped) because the widget resolves
+  // data-callback by name off the global object.
+  window.onTurnstileSuccess = function () {
+    var form = document.getElementById("turnstile-form");
+    if (form) form.submit();
+  };
+</script>
+</body>
+</html>`;
+
+  return new Response(html, {
+    status: options.status ?? 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // The pass is carried by a cookie, so a cached copy of this page (or of
+      // the page behind it) would be served to the wrong visitor.
+      "cache-control": "no-store, must-revalidate",
+      vary: "Cookie",
+      // Belt and braces alongside the meta tag: crawlers are exempt from the
+      // gate, but a challenge page that somehow reached one must not be indexed.
+      "x-robots-tag": "noindex, nofollow",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+    },
+  });
+}

--- a/apps/qwksearch-web/lib/turnstile/config.ts
+++ b/apps/qwksearch-web/lib/turnstile/config.ts
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Configuration for the first-load Cloudflare Turnstile gate.
+ *
+ * The gate is **opt-in and fail-open**: with no `TURNSTILE_SITE_KEY` /
+ * `TURNSTILE_SECRET_KEY` set on the Worker, `resolveTurnstileConfig` returns
+ * `null` and the Worker serves the app exactly as it did before. That keeps
+ * local `vite dev`, preview deploys and the test suite unchallenged, and makes
+ * the feature switchable from the Cloudflare dashboard alone — set the two
+ * values to turn it on, set `TURNSTILE_ENABLED=false` to turn it back off
+ * without deleting them.
+ *
+ * The site key is public (it ships in the challenge page's HTML); the secret
+ * key is server-only. It is used for two things: calling Cloudflare's
+ * siteverify endpoint, and as the HMAC key that signs the "this browser passed"
+ * cookie — so no *second* secret has to be provisioned for the gate to be
+ * tamper-proof. See `session.ts`.
+ *
+ * @see https://developers.cloudflare.com/turnstile/get-started/
+ */
+
+/** The subset of Worker bindings this feature reads. */
+export interface TurnstileEnv {
+  /** Public Turnstile site key, rendered into the challenge page. */
+  TURNSTILE_SITE_KEY?: string;
+  /** Turnstile secret key — siteverify + the cookie's HMAC key. Never sent to the browser. */
+  TURNSTILE_SECRET_KEY?: string;
+  /** Set to "false"/"0"/"off" to disable the gate while keeping the keys in place. */
+  TURNSTILE_ENABLED?: string;
+  /** How long one pass is good for, in seconds. Default 7 days. */
+  TURNSTILE_TTL_SECONDS?: string;
+  /** Optional cookie `Domain=`, e.g. `.example.com` to share a pass across subdomains. */
+  TURNSTILE_COOKIE_DOMAIN?: string;
+}
+
+export interface TurnstileConfig {
+  siteKey: string;
+  secretKey: string;
+  ttlSeconds: number;
+  cookieDomain?: string;
+}
+
+/** Where the challenge page POSTs its token. Must never itself be gated. */
+export const TURNSTILE_VERIFY_PATH = "/__turnstile/verify";
+
+/** Cloudflare's token validation endpoint. */
+export const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/** One week: long enough that a returning reader is only ever challenged once. */
+const DEFAULT_TTL_SECONDS = 7 * 24 * 60 * 60;
+const MIN_TTL_SECONDS = 300;
+const MAX_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+const FALSEY = new Set(["false", "0", "off", "no", "disabled"]);
+
+/**
+ * Reads the gate's configuration off the Worker environment, or returns `null`
+ * when the gate should not run at all. Callers treat `null` as "pass every
+ * request straight through" — a missing key must never mean a locked-out site.
+ */
+export function resolveTurnstileConfig(env: TurnstileEnv | undefined | null): TurnstileConfig | null {
+  if (!env) return null;
+
+  const enabled = env.TURNSTILE_ENABLED?.trim().toLowerCase();
+  if (enabled && FALSEY.has(enabled)) return null;
+
+  const siteKey = env.TURNSTILE_SITE_KEY?.trim();
+  const secretKey = env.TURNSTILE_SECRET_KEY?.trim();
+  if (!siteKey || !secretKey) return null;
+
+  const cookieDomain = env.TURNSTILE_COOKIE_DOMAIN?.trim();
+
+  return {
+    siteKey,
+    secretKey,
+    ttlSeconds: resolveTtlSeconds(env.TURNSTILE_TTL_SECONDS),
+    ...(cookieDomain ? { cookieDomain } : {}),
+  };
+}
+
+/**
+ * A dashboard-entered TTL is a string typed by a human, so anything unparseable
+ * falls back to the default rather than producing a cookie that expires
+ * immediately (`NaN` → always challenged) or never.
+ */
+function resolveTtlSeconds(raw: string | undefined): number {
+  const parsed = Number.parseInt(raw?.trim() ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TTL_SECONDS;
+  return Math.min(Math.max(parsed, MIN_TTL_SECONDS), MAX_TTL_SECONDS);
+}

--- a/apps/qwksearch-web/lib/turnstile/gate.ts
+++ b/apps/qwksearch-web/lib/turnstile/gate.ts
@@ -1,0 +1,190 @@
+/**
+ * @fileoverview The first-load Cloudflare Turnstile gate.
+ *
+ * One call at the top of the Worker's `fetch`:
+ *
+ *     const gated = await handleTurnstileGate(request, env);
+ *     if (gated) return gated;
+ *
+ * It returns a `Response` only when it has something of its own to serve — the
+ * challenge page, or the result of the verification POST — and `null` for every
+ * request the app should handle as usual, which is all of them once the visitor
+ * holds a valid pass (and all of them always, when the feature is unconfigured).
+ *
+ * The flow:
+ *
+ *   1. A desktop browser asks for a page and carries no pass cookie.
+ *   2. The Worker answers with the challenge page instead of the app.
+ *   3. Turnstile solves in the browser and the page POSTs its token here.
+ *   4. This Worker — not the browser — calls Cloudflare's siteverify endpoint
+ *      with the secret key. A token is single-use and short-lived, and nothing
+ *      is trusted until siteverify says `success`.
+ *   5. A signed pass cookie is set and the visitor is redirected to where they
+ *      were going. Subsequent loads skip all of the above.
+ *
+ * @see https://developers.cloudflare.com/turnstile/get-started/
+ */
+
+import {
+  SITEVERIFY_URL,
+  TURNSTILE_VERIFY_PATH,
+  resolveTurnstileConfig,
+  type TurnstileConfig,
+  type TurnstileEnv,
+} from "./config";
+import { renderChallengePage } from "./challenge-page";
+import { decideChallenge } from "./request-filter";
+import { buildPassCookie, mintPassToken, readCookie, verifyPassToken } from "./session";
+
+/** Name of the cookie carrying a verified pass. */
+export const TURNSTILE_COOKIE_NAME = "qs_human";
+
+interface SiteverifyResult {
+  success: boolean;
+  hostname?: string;
+  "error-codes"?: string[];
+}
+
+/**
+ * Runs the gate for one request. Returns a `Response` to short-circuit with, or
+ * `null` to let the app serve the request.
+ */
+export async function handleTurnstileGate(
+  request: Request,
+  env: TurnstileEnv | undefined | null,
+): Promise<Response | null> {
+  const config = resolveTurnstileConfig(env);
+  if (!config) return null;
+
+  const url = new URL(request.url);
+
+  if (url.pathname === TURNSTILE_VERIFY_PATH) {
+    if (request.method !== "POST") {
+      return new Response("Method Not Allowed", { status: 405, headers: { allow: "POST" } });
+    }
+    return handleVerification(request, url, config);
+  }
+
+  if (!decideChallenge(request, url).challenge) return null;
+
+  if (await verifyPassToken(config.secretKey, readCookie(request, TURNSTILE_COOKIE_NAME))) {
+    return null;
+  }
+
+  return renderChallengePage({
+    siteKey: config.siteKey,
+    redirectTo: safeRedirectTarget(`${url.pathname}${url.search}`),
+    verifyPath: TURNSTILE_VERIFY_PATH,
+  });
+}
+
+/** Handles the POST from the challenge page. */
+async function handleVerification(request: Request, url: URL, config: TurnstileConfig): Promise<Response> {
+  let token: string | null = null;
+  let redirectTo = "/";
+
+  try {
+    const form = await request.formData();
+    const rawToken = form.get("cf-turnstile-response");
+    token = typeof rawToken === "string" ? rawToken : null;
+    const rawRedirect = form.get("redirect");
+    redirectTo = safeRedirectTarget(typeof rawRedirect === "string" ? rawRedirect : "/");
+  } catch {
+    // A body that is not form-encoded is not a browser submitting this page.
+    return challengeAgain(config, redirectTo, "That submission could not be read. Please try again.", 400);
+  }
+
+  if (!token) {
+    return challengeAgain(config, redirectTo, "The check did not complete. Please try again.", 400);
+  }
+
+  let result: SiteverifyResult;
+  try {
+    result = await callSiteverify(token, config.secretKey, request.headers.get("cf-connecting-ip"));
+  } catch (error) {
+    console.error("[turnstile] siteverify request failed", error);
+    return challengeAgain(config, redirectTo, "We could not reach the verification service. Please try again.", 502);
+  }
+
+  if (!result.success) {
+    console.warn("[turnstile] verification rejected", JSON.stringify({ codes: result["error-codes"] ?? [] }));
+    return challengeAgain(config, redirectTo, "That check could not be verified. Please try again.", 403);
+  }
+
+  // Defence in depth: a token solved against some other site's widget must not
+  // open this one. The comparison allows apex/subdomain pairs so a widget
+  // registered for the apex still passes visitors on `www.`.
+  if (result.hostname && !hostnamesMatch(result.hostname, url.hostname)) {
+    console.warn(
+      "[turnstile] hostname mismatch",
+      JSON.stringify({ solvedFor: result.hostname, requested: url.hostname }),
+    );
+    return challengeAgain(config, redirectTo, "That check was issued for a different site. Please try again.", 403);
+  }
+
+  const pass = await mintPassToken(config.secretKey, config.ttlSeconds);
+  return new Response(null, {
+    status: 303,
+    headers: {
+      location: redirectTo,
+      "set-cookie": buildPassCookie({
+        name: TURNSTILE_COOKIE_NAME,
+        token: pass,
+        ttlSeconds: config.ttlSeconds,
+        secure: url.protocol === "https:",
+        ...(config.cookieDomain ? { domain: config.cookieDomain } : {}),
+      }),
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/** POSTs the token to Cloudflare for validation. The secret never leaves here. */
+async function callSiteverify(
+  token: string,
+  secret: string,
+  remoteIp: string | null,
+): Promise<SiteverifyResult> {
+  const body = new FormData();
+  body.append("secret", secret);
+  body.append("response", token);
+  if (remoteIp) body.append("remoteip", remoteIp);
+
+  const response = await fetch(SITEVERIFY_URL, { method: "POST", body });
+  if (!response.ok) {
+    throw new Error(`siteverify responded ${response.status}`);
+  }
+  return (await response.json()) as SiteverifyResult;
+}
+
+/** Re-serves the challenge page with an explanation after a failed attempt. */
+function challengeAgain(config: TurnstileConfig, redirectTo: string, error: string, status: number): Response {
+  return renderChallengePage({
+    siteKey: config.siteKey,
+    redirectTo,
+    verifyPath: TURNSTILE_VERIFY_PATH,
+    error,
+    status,
+  });
+}
+
+/**
+ * Narrows a client-supplied redirect to a same-origin path, so the challenge
+ * page can never be turned into an open redirect. Anything else lands on `/`.
+ */
+export function safeRedirectTarget(raw: string): string {
+  if (!raw || raw.length > 2048) return "/";
+  // Reject protocol-relative (`//evil.com`), backslash-smuggled (`/\evil.com`)
+  // and control-character values outright rather than trying to repair them.
+  if (!raw.startsWith("/") || raw.startsWith("//") || raw.startsWith("/\\")) return "/";
+  if (/[\u0000-\u001f\u007f]/.test(raw)) return "/";
+  if (raw === TURNSTILE_VERIFY_PATH) return "/";
+  return raw;
+}
+
+/** True for identical hostnames, or an apex/subdomain pair. */
+function hostnamesMatch(solvedFor: string, requested: string): boolean {
+  const a = solvedFor.toLowerCase();
+  const b = requested.toLowerCase();
+  return a === b || a.endsWith(`.${b}`) || b.endsWith(`.${a}`);
+}

--- a/apps/qwksearch-web/lib/turnstile/index.ts
+++ b/apps/qwksearch-web/lib/turnstile/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Public entry point for the first-load Turnstile gate. The Worker imports
+ * `handleTurnstileGate` from here; the rest is exported for the tests and for
+ * anything that needs to reason about the gate's decisions.
+ */
+export { handleTurnstileGate, safeRedirectTarget, TURNSTILE_COOKIE_NAME } from "./gate";
+export {
+  resolveTurnstileConfig,
+  TURNSTILE_VERIFY_PATH,
+  type TurnstileConfig,
+  type TurnstileEnv,
+} from "./config";
+export {
+  decideChallenge,
+  isCrawlerRequest,
+  isDocumentNavigation,
+  isExemptPath,
+  isMobileRequest,
+} from "./request-filter";
+export { buildPassCookie, mintPassToken, readCookie, verifyPassToken } from "./session";

--- a/apps/qwksearch-web/lib/turnstile/request-filter.ts
+++ b/apps/qwksearch-web/lib/turnstile/request-filter.ts
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview Decides which requests the Turnstile gate is allowed to stop.
+ *
+ * The gate is a *first-load* check, so it only ever interrupts a top-level
+ * HTML navigation. Everything else — API calls, the framework's own RSC
+ * fetches, static assets, webhooks, health checks, crawlers, and anything from
+ * a phone — passes straight through. Challenging any of those would break the
+ * app rather than protect it: an interstitial served in place of a JSON
+ * response is just a parse error with extra steps, and an interstitial served
+ * to Googlebot is a deindexed site.
+ */
+
+/**
+ * Mobile is exempt by product decision: the interstitial costs a phone user an
+ * extra tap on a connection where the page load is already the slow part.
+ *
+ * Detection prefers the `Sec-CH-UA-Mobile` client hint, which Chromium sends on
+ * every request and which is not a string-matching guess, and falls back to the
+ * user-agent for Safari and Firefox. iPadOS deliberately presents itself as
+ * desktop Safari and is not detectable here — an iPad gets the challenge.
+ */
+const MOBILE_UA_PATTERN =
+  /Android|iPhone|iPod|iPad|Windows Phone|IEMobile|BlackBerry|BB10|Opera Mini|Opera Mobi|webOS|Mobile Safari|Silk\//i;
+
+/**
+ * Search-engine and link-preview crawlers, allowed through so the site stays
+ * indexable and its links keep unfurling.
+ *
+ * This is a deliberately *narrow* list of named agents rather than a match on
+ * "bot", which anything could claim. A user-agent is still self-reported and
+ * therefore spoofable: this list is an SEO guarantee, not a security control.
+ * Real enforcement against agents that lie about who they are belongs in
+ * Cloudflare's Bot Management / verified-bot WAF rules, in front of this Worker.
+ */
+const CRAWLER_UA_PATTERN =
+  /(googlebot|google-inspectiontool|storebot-google|google-extended|bingbot|bingpreview|slurp|duckduckbot|baiduspider|yandex(bot|images)|sogou|exabot|applebot|petalbot|facebookexternalhit|facebookcatalog|twitterbot|linkedinbot|slackbot|discordbot|telegrambot|whatsapp|redditbot|pinterest(bot|\/)|embedly|quora link preview|skypeuripreview|vkshare|w3c_validator|ia_archiver|archive\.org_bot|gptbot|oai-searchbot|chatgpt-user|claudebot|claude-web|anthropic-ai|perplexitybot|amazonbot|bytespider|ccbot|semrushbot|ahrefsbot|mj12bot|screaming frog)/i;
+
+/** Path prefixes the gate never touches. */
+const EXEMPT_PREFIXES = [
+  "/api/",
+  "/_next/",
+  "/_vinext/",
+  "/__vinext/",
+  "/assets/",
+  "/static/",
+  "/fonts/",
+  "/images/",
+  "/icons/",
+  "/.well-known/",
+  "/cdn-cgi/",
+  "/monitoring",
+];
+
+/** Exact paths the gate never touches. */
+const EXEMPT_PATHS = new Set([
+  "/favicon.ico",
+  "/favicon.svg",
+  "/apple-touch-icon.png",
+  "/apple-touch-icon-precomposed.png",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/ads.txt",
+  "/llms.txt",
+  "/opensearch.xml",
+  "/manifest.json",
+  "/manifest.webmanifest",
+  "/site.webmanifest",
+  "/sw.js",
+  "/service-worker.js",
+  "/health",
+  "/healthz",
+  "/status",
+]);
+
+/** File extensions that mark a request as an asset fetch, not a page view. */
+const ASSET_EXTENSION_PATTERN =
+  /\.(?:js|mjs|cjs|css|map|json|xml|txt|ico|png|jpe?g|gif|svg|webp|avif|bmp|woff2?|ttf|otf|eot|mp[34]|m4a|webm|ogg|wav|pdf|zip|wasm|csv)$/i;
+
+export interface ChallengeDecision {
+  challenge: boolean;
+  /** Why the request was let through, for logging and for the tests. */
+  reason:
+    | "challenge"
+    | "not-a-document"
+    | "unsafe-method"
+    | "exempt-path"
+    | "mobile"
+    | "crawler";
+}
+
+/** True when the client hints or the user-agent say this is a phone. */
+export function isMobileRequest(request: Request): boolean {
+  const hint = request.headers.get("sec-ch-ua-mobile");
+  if (hint) return hint.trim() === "?1";
+  return MOBILE_UA_PATTERN.test(request.headers.get("user-agent") ?? "");
+}
+
+/** True for a crawler Cloudflare itself verified, or one naming itself in the list above. */
+export function isCrawlerRequest(request: Request): boolean {
+  const verifiedCategory = (request as { cf?: { verifiedBotCategory?: string } }).cf?.verifiedBotCategory;
+  if (verifiedCategory) return true;
+  return CRAWLER_UA_PATTERN.test(request.headers.get("user-agent") ?? "");
+}
+
+/**
+ * True only for a top-level HTML navigation.
+ *
+ * `Sec-Fetch-Dest` is authoritative where the browser sends it (every current
+ * browser does) and cleanly separates a navigation from the framework's own
+ * `fetch` for an RSC payload. Where it is absent, the `Accept` header carries
+ * the same signal well enough: a document request asks for `text/html`, a data
+ * fetch does not.
+ */
+export function isDocumentNavigation(request: Request, url: URL): boolean {
+  // Next.js/vinext fetch RSC payloads from an already-rendered page. They are
+  // same-URL GETs that would otherwise look exactly like a navigation, and
+  // answering one with an HTML interstitial breaks client-side routing.
+  if (request.headers.get("rsc") === "1") return false;
+  if (request.headers.get("next-router-prefetch")) return false;
+  if (url.searchParams.has("_rsc")) return false;
+
+  const dest = request.headers.get("sec-fetch-dest");
+  if (dest) return dest === "document";
+
+  const mode = request.headers.get("sec-fetch-mode");
+  if (mode) return mode === "navigate";
+
+  return (request.headers.get("accept") ?? "").includes("text/html");
+}
+
+/** True when the path is one the gate must never interrupt. */
+export function isExemptPath(pathname: string): boolean {
+  if (EXEMPT_PATHS.has(pathname)) return true;
+  if (EXEMPT_PREFIXES.some((prefix) => pathname.startsWith(prefix))) return true;
+  return ASSET_EXTENSION_PATTERN.test(pathname);
+}
+
+/**
+ * The single decision the Worker asks for: may this request be interrupted by
+ * the challenge page?
+ */
+export function decideChallenge(request: Request, url: URL): ChallengeDecision {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return { challenge: false, reason: "unsafe-method" };
+  }
+  if (isExemptPath(url.pathname)) {
+    return { challenge: false, reason: "exempt-path" };
+  }
+  if (!isDocumentNavigation(request, url)) {
+    return { challenge: false, reason: "not-a-document" };
+  }
+  if (isMobileRequest(request)) {
+    return { challenge: false, reason: "mobile" };
+  }
+  if (isCrawlerRequest(request)) {
+    return { challenge: false, reason: "crawler" };
+  }
+  return { challenge: true, reason: "challenge" };
+}

--- a/apps/qwksearch-web/lib/turnstile/session.ts
+++ b/apps/qwksearch-web/lib/turnstile/session.ts
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview The "this browser already passed" cookie.
+ *
+ * Rendering the Turnstile widget is not protection, and neither is a cookie
+ * that merely *says* `verified=1` — a bot can set that with one `document.cookie`
+ * write, or one `curl -b`. So the pass this module mints is an HMAC-SHA-256
+ * token over its own expiry and a random nonce, keyed by `TURNSTILE_SECRET_KEY`
+ * (which never leaves the Worker):
+ *
+ *     v1.<expiry-unix-seconds>.<nonce>.<base64url HMAC of "v1.<expiry>.<nonce>">
+ *
+ * Forging one requires the secret; replaying one is bounded by the expiry; and
+ * verification is a single WebCrypto call with no storage behind it, so the
+ * happy path — every request after the first — costs no KV read and no D1 query.
+ *
+ * A KV- or Durable-Object-backed session would additionally allow *revoking* an
+ * individual pass. That is deliberately not built: this gate exists to stop
+ * cheap unattended scraping of a first page load, not to carry a security
+ * boundary, and the app's real authentication is untouched by it.
+ */
+
+const TOKEN_VERSION = "v1";
+const NONCE_BYTES = 16;
+
+/**
+ * WebCrypto key import is not free, and one Worker isolate serves many
+ * requests with the same secret, so the derived key is memoised per secret
+ * string rather than re-imported per request.
+ */
+const keyCache = new Map<string, Promise<CryptoKey>>();
+
+function hmacKey(secret: string): Promise<CryptoKey> {
+  let key = keyCache.get(secret);
+  if (!key) {
+    key = crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign", "verify"],
+    );
+    keyCache.set(secret, key);
+  }
+  return key;
+}
+
+function base64UrlEncode(bytes: ArrayBuffer | Uint8Array): string {
+  const view = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  let binary = "";
+  for (const byte of view) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64UrlDecode(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  try {
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mints a pass valid for `ttlSeconds` from now.
+ *
+ * @param nowSeconds injectable clock, so the tests can assert expiry without
+ *   waiting a week for one.
+ */
+export async function mintPassToken(
+  secret: string,
+  ttlSeconds: number,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Promise<string> {
+  const expiry = nowSeconds + ttlSeconds;
+  const nonce = base64UrlEncode(crypto.getRandomValues(new Uint8Array(NONCE_BYTES)));
+  const payload = `${TOKEN_VERSION}.${expiry}.${nonce}`;
+  const signature = await crypto.subtle.sign("HMAC", await hmacKey(secret), new TextEncoder().encode(payload));
+  return `${payload}.${base64UrlEncode(signature)}`;
+}
+
+/**
+ * True only for a token this Worker signed, that is not past its expiry and
+ * whose signature covers the very expiry being checked.
+ *
+ * The comparison goes through `crypto.subtle.verify` rather than `===` so a
+ * forged signature cannot be recovered byte-by-byte from response timing.
+ */
+export async function verifyPassToken(
+  secret: string,
+  token: string | null | undefined,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): Promise<boolean> {
+  if (!token) return false;
+
+  const parts = token.split(".");
+  if (parts.length !== 4) return false;
+
+  const [version, expiryRaw, nonce, signatureRaw] = parts;
+  if (version !== TOKEN_VERSION || !nonce) return false;
+
+  const expiry = Number.parseInt(expiryRaw, 10);
+  if (!Number.isFinite(expiry) || expiry <= nowSeconds) return false;
+
+  const signature = base64UrlDecode(signatureRaw);
+  if (!signature) return false;
+
+  const payload = new TextEncoder().encode(`${version}.${expiryRaw}.${nonce}`);
+  try {
+    // `signature` is a Uint8Array view; pass its backing buffer slice so the
+    // runtime never sees a detached or over-long BufferSource.
+    return await crypto.subtle.verify("HMAC", await hmacKey(secret), signature as unknown as BufferSource, payload);
+  } catch {
+    return false;
+  }
+}
+
+/** Reads one cookie out of a request's `Cookie` header. */
+export function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get("cookie");
+  if (!header) return null;
+  for (const pair of header.split(";")) {
+    const index = pair.indexOf("=");
+    if (index === -1) continue;
+    if (pair.slice(0, index).trim() !== name) continue;
+    return decodeURIComponent(pair.slice(index + 1).trim());
+  }
+  return null;
+}
+
+/**
+ * Builds the `Set-Cookie` value for a freshly minted pass.
+ *
+ * `HttpOnly` keeps it away from page scripts, `SameSite=Lax` lets it ride a
+ * top-level navigation in from a search result (which is exactly the first load
+ * being protected) while staying off cross-site subresource requests, and
+ * `Secure` is attached on https only so a plain-http local dev server can still
+ * complete the flow.
+ */
+export function buildPassCookie(options: {
+  name: string;
+  token: string;
+  ttlSeconds: number;
+  secure: boolean;
+  domain?: string;
+}): string {
+  const attributes = [
+    `${options.name}=${options.token}`,
+    "Path=/",
+    `Max-Age=${options.ttlSeconds}`,
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (options.domain) attributes.push(`Domain=${options.domain}`);
+  if (options.secure) attributes.push("Secure");
+  return attributes.join("; ");
+}

--- a/apps/qwksearch-web/worker/index.ts
+++ b/apps/qwksearch-web/worker/index.ts
@@ -9,8 +9,9 @@ import { handleImageOptimization, DEFAULT_DEVICE_SIZES, DEFAULT_IMAGE_SIZES, isI
 import type { ImageConfig } from "vinext/server/image-optimization";
 import handler from "vinext/server/app-router-entry";
 import { applyD1Bookmark, runWithD1Session } from "../lib/database/d1-session";
+import { handleTurnstileGate, type TurnstileEnv } from "../lib/turnstile";
 
-interface Env {
+interface Env extends TurnstileEnv {
   ASSETS: Fetcher;
   // See lib/database/d1-session.ts — "auto" (default), "primary",
   // "unconstrained" or "off". Settable as a plain Variable in the dashboard.
@@ -41,6 +42,14 @@ interface ExecutionContext {
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
+
+    // Cloudflare Turnstile, in front of everything else: a desktop browser's
+    // first HTML page view is answered with a "just a moment" check until it
+    // carries a pass this Worker signed. Returns null — and costs one HMAC
+    // verify — for every other request, and for all of them when the
+    // TURNSTILE_* variables are unset. See lib/turnstile/gate.ts.
+    const gated = await handleTurnstileGate(request, env);
+    if (gated) return gated;
 
     // Image optimization via Cloudflare Images binding.
     // The parseImageParams validation inside handleImageOptimization

--- a/packages/user-help-docs/content/docs/architecture/meta.json
+++ b/packages/user-help-docs/content/docs/architecture/meta.json
@@ -9,6 +9,7 @@
     "lobe-packages-migration-plan",
     "lobehub-integrations",
     "lobehub-migration-todo",
-    "debate-video-category-keywords"
+    "debate-video-category-keywords",
+    "turnstile-bot-gate"
   ]
 }

--- a/packages/user-help-docs/content/docs/architecture/turnstile-bot-gate.mdx
+++ b/packages/user-help-docs/content/docs/architecture/turnstile-bot-gate.mdx
@@ -1,0 +1,147 @@
+---
+title: "Turnstile first-load gate"
+description: "The Cloudflare Turnstile check in front of a visitor's first page view: what it challenges, what it never challenges, and how to turn it on."
+---
+
+A desktop browser's **first** HTML page view of QwkSearch is answered with a
+short "just a moment" check instead of the page. Once it passes, the Worker sets
+a signed cookie and the visitor is never challenged again for the life of that
+cookie (a week by default). Phones are exempt, and so is everything that is not
+a top-level page view.
+
+The whole feature lives in `apps/qwksearch-web/lib/turnstile/` and is called from one
+place — the top of the Worker's `fetch` in `apps/qwksearch-web/worker/index.ts`:
+
+```ts
+const gated = await handleTurnstileGate(request, env);
+if (gated) return gated;
+```
+
+## Why a Worker gate and not a widget on a form
+
+[Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/get-started/)
+issues a token in the browser, but **rendering the widget is not protection**.
+The token means nothing until a server exchanges it, with the secret key, at
+Cloudflare's `siteverify` endpoint — which is what this Worker does, on a request
+the browser cannot skip, before the app renders anything.
+
+The cookie that records the result is signed for the same reason. A plain
+`verified=1` cookie would be a one-line bypass (`curl -b verified=1`), so the
+pass is an HMAC-SHA-256 token over its own expiry and a random nonce, keyed by
+`TURNSTILE_SECRET_KEY`:
+
+```text
+v1.<expiry>.<nonce>.<HMAC of "v1.<expiry>.<nonce>">
+```
+
+Forging one needs the secret; replaying one is bounded by the expiry; verifying
+one is a single WebCrypto call with no KV or D1 read behind it, so every request
+after the first costs microseconds.
+
+## What gets challenged
+
+Only a request that is **all** of the following:
+
+- `GET` or `HEAD`,
+- a top-level document navigation (`Sec-Fetch-Dest: document`, or `Accept:
+  text/html` on older browsers),
+- not from a phone,
+- not from a search-engine or link-preview crawler,
+- not on an exempt path,
+- and not already carrying a valid pass cookie.
+
+Everything else goes straight to the app. That list is not politeness — an
+interstitial served in place of a JSON response is a parse error, and one served
+to Googlebot is a deindexed site.
+
+### Never challenged
+
+| | Why |
+| --- | --- |
+| Phones | Product decision: the extra tap lands on the connection where the page load is already slow. Detected from `Sec-CH-UA-Mobile`, falling back to the user-agent. iPadOS presents itself as desktop Safari and is not detectable — an iPad gets the check. |
+| Crawlers | Googlebot, Bingbot, Applebot, `facebookexternalhit`, Slackbot, GPTBot and friends, plus anything Cloudflare itself marks with `cf.verifiedBotCategory`. |
+| `/api/*` | The public API, webhooks and anything with its own auth. |
+| `/_next/*`, `/_vinext/*`, assets | Scripts, styles, images, fonts — by prefix and by file extension. |
+| RSC payload fetches | `RSC: 1`, `?_rsc=`, `Next-Router-Prefetch`. Answering one with HTML breaks client-side routing. |
+| `/robots.txt`, `/sitemap.xml`, `/favicon.ico`, manifests, `/health` | Machine endpoints and crawler contracts. |
+| Non-`GET` requests | Form posts and API writes carry their own protection. |
+
+The crawler list matches on the user-agent, which is self-reported and therefore
+spoofable. That is a deliberate trade: it guarantees the site stays indexable,
+and it is not the layer that stops a determined agent. Enforcement against
+clients that lie about who they are belongs in Cloudflare Bot Management and WAF
+rules in front of this Worker.
+
+## The round trip
+
+1. A desktop browser asks for a page and carries no pass cookie.
+2. The Worker answers with the challenge page (`200`, `Cache-Control: no-store`,
+   `X-Robots-Tag: noindex`) carrying the widget and the path to return to.
+3. Turnstile solves in the browser. In Managed mode most visitors see a spinner
+   resolve on its own; the widget's success callback submits the form.
+4. The page `POST`s the token to `/__turnstile/verify`.
+5. The Worker calls `siteverify` with the secret key and the visitor's IP.
+6. On success it checks the hostname the token was solved for, mints the pass,
+   and answers `303` back to the original path with `Set-Cookie`.
+
+Failures re-serve the same page with an explanation rather than a dead end: a
+missing token is `400`, a rejected token or a hostname mismatch is `403`, and an
+unreachable `siteverify` is `502` — all of them retryable by the visitor.
+
+The redirect target is always narrowed to a same-origin path, so the check page
+can never be turned into an open redirect.
+
+## Turning it on
+
+The gate is **off until it is configured**, and fails open: with no keys set,
+`handleTurnstileGate` returns `null` for every request and the Worker serves the
+app exactly as it did before. Local dev, preview deploys and CI are unaffected
+without doing anything.
+
+1. Create a **Managed** widget in the Cloudflare dashboard under **Turnstile**,
+   with `qwksearch.com` (and any other hostname the app answers on) in its
+   allowed list.
+2. Put the secret key in the Worker's secrets:
+
+   ```bash
+   bunx wrangler secret put TURNSTILE_SECRET_KEY
+   ```
+
+3. Set the site key as a plaintext Variable on the Worker (it is public — it
+   ships in the challenge page's HTML), or add it to `wrangler.jsonc` `vars`.
+
+| Variable | Required | Meaning |
+| --- | --- | --- |
+| `TURNSTILE_SITE_KEY` | yes | Public widget key rendered into the check page. |
+| `TURNSTILE_SECRET_KEY` | yes | Secret key. Validates tokens **and** signs the pass cookie. Never sent to the browser. |
+| `TURNSTILE_ENABLED` | no | `false` / `0` / `off` switches the gate off without removing the keys. |
+| `TURNSTILE_TTL_SECONDS` | no | How long one pass lasts. Default `604800` (7 days), clamped to 5 minutes–30 days. |
+| `TURNSTILE_COOKIE_DOMAIN` | no | e.g. `.qwksearch.com` to share one pass across subdomains. |
+
+<Callout type="warn">
+  `TURNSTILE_SECRET_KEY` is the cookie's signing key as well as the siteverify
+  credential. Rotating it invalidates every outstanding pass — visitors get the
+  check once more, which is the intended behaviour, not a bug.
+</Callout>
+
+## Local development
+
+Leave the variables unset and the gate never runs. To exercise it locally, add
+`localhost` to the widget's hostname list and put both keys in `.dev.vars`;
+`Secure` is dropped from the cookie on plain `http` so the flow completes.
+Cloudflare also publishes
+[testing keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/)
+that always pass or always fail.
+
+## Content Security Policy
+
+The check page loads `https://challenges.cloudflare.com/turnstile/v0/api.js` and
+the widget talks back to the same host. If a CSP is ever added to this app, that
+origin needs to be allowed for `script-src`, `frame-src` and `connect-src`.
+
+## Tests
+
+`apps/qwksearch-web/lib/turnstile/__tests__/turnstile.test.ts` covers the decision
+matrix (phone, crawler, asset, RSC, API, write), token forging and expiry, the
+siteverify exchange, hostname mismatch, open-redirect refusal, and the
+fails-open behaviour when unconfigured.


### PR DESCRIPTION
A desktop browser's **first** HTML page view is now answered with a Cloudflare Turnstile check instead of the page. The Worker validates the token server-side and sets an HMAC-signed pass cookie, so a visitor is only ever challenged once (7 days by default). Phones are exempt, as the ask specified.

## Why a Worker gate

Rendering the widget is not protection — the token means nothing until a server exchanges it, with the secret key, at Cloudflare's `siteverify` endpoint. That happens in `worker/index.ts`, on a request the browser cannot skip, before the app renders anything.

A plain `verified=1` cookie would be a one-line bypass (`curl -b verified=1`), so the pass is an HMAC-SHA-256 token over its own expiry and a random nonce, keyed by `TURNSTILE_SECRET_KEY`:

```
v1.<expiry>.<nonce>.<HMAC of "v1.<expiry>.<nonce>">
```

Forging one needs the secret; replaying one is bounded by the expiry; verifying one is a single WebCrypto call with no KV or D1 read behind it, so every request after the first costs microseconds.

## What is never challenged

| | Why |
| --- | --- |
| Phones | Per the ask. `Sec-CH-UA-Mobile` first, falling back to the user-agent. iPadOS presents as desktop Safari and is not detectable server-side — an iPad gets the check. |
| Crawlers | Googlebot, Bingbot, Applebot, `facebookexternalhit`, Slackbot, GPTBot and friends, plus anything Cloudflare marks with `cf.verifiedBotCategory`. An interstitial served to Googlebot is a deindexed site. |
| `/api/*` | The public agent API that external sites embed `research-agent-ui` against, plus every other handler with its own auth. |
| `/_next/*`, `/_vinext/*`, assets | By prefix and by file extension. |
| RSC payload fetches | `RSC: 1`, `?_rsc=`, `Next-Router-Prefetch` — answering one with HTML breaks client-side routing. |
| `robots.txt`, `sitemap.xml`, manifests, `/health` | Machine endpoints and crawler contracts. |
| Non-`GET` requests | Form posts and API writes carry their own protection. |

The crawler list matches on the user-agent, which is self-reported and therefore spoofable. That is a deliberate trade — it guarantees the site stays indexable, and it is not the layer meant to stop a determined agent. Enforcement against clients that lie belongs in Cloudflare Bot Management / WAF rules in front of this Worker.

## Rollout — nothing changes until you configure it

The gate is **off until configured and fails open**: with `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` unset, `handleTurnstileGate` returns `null` for every request and the Worker behaves exactly as before. Local dev, preview deploys and CI are unaffected by this merge.

To turn it on:

1. Create a **Managed** widget under **Turnstile** in the Cloudflare dashboard with `qwksearch.com` (and any other hostname the app answers on) allowed.
2. `bunx wrangler secret put TURNSTILE_SECRET_KEY`
3. Set `TURNSTILE_SITE_KEY` as a plaintext Worker Variable (it is public — it ships in the check page's HTML).

`TURNSTILE_ENABLED=false` switches it off again with the keys still in place. `TURNSTILE_TTL_SECONDS` and `TURNSTILE_COOKIE_DOMAIN` are optional.

## The round trip

Challenge page (`200`, `no-store`, `noindex`) → widget solves → `POST /__turnstile/verify` → `siteverify` with the secret and the visitor's IP → hostname check → mint pass → `303` back to the original path with `Set-Cookie`. Failures re-serve the same page with an explanation rather than a dead end (`400` missing token, `403` rejected or wrong hostname, `502` siteverify unreachable), all retryable. The redirect target is always narrowed to a same-origin path, so the check page cannot become an open redirect.

## Files

- `apps/qwksearch-web/lib/turnstile/` — `config` (env, fail-open), `session` (HMAC pass), `request-filter` (the decision matrix), `challenge-page` (self-contained interstitial), `gate` (the flow).
- `apps/qwksearch-web/worker/index.ts` — three lines at the top of `fetch`, ahead of the D1 session scope since a challenged request never reaches the database.
- Docs: `packages/user-help-docs/content/docs/architecture/turnstile-bot-gate.mdx`, plus `.claude/architecture/web-app.md`, the app's `CLAUDE.md` and `.env.example`.

## Testing

- `apps/qwksearch-web/lib/turnstile/__tests__/turnstile.test.ts` — 32 tests: the decision matrix (phone, crawler, asset, RSC, API, write, legacy `Accept` fallback), token forging/tamper/expiry, the siteverify exchange, hostname mismatch, open-redirect refusal, HTML escaping, and the fails-open behaviour when unconfigured. All pass.
- `bun run test` from the root: 3000 tests pass. 22 files in `extract-webpage`, `qwksearch-extension-wxt`, `react-reason-editor` and `use-weather-forecast` fail to resolve unbuilt package `dist` entries — the documented `dist` trap, identical on `master` and untouched by this change.
- `tsc --noEmit` on the app: 128 errors before this change, 128 after, none in `lib/turnstile/` or `worker/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ECTHZkb7vdiErUcLLGgPZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01ECTHZkb7vdiErUcLLGgPZY)_