### PR TITLE
📝 docs(packages-lobe): correct the engine job's cache-hit cost with a measurement

### DIFF
--- a/.github/workflows/lobehub-engine.yml
+++ b/.github/workflows/lobehub-engine.yml
@@ -13,8 +13,10 @@ name: LobeHub Engine
 #
 # Path-filtered on purpose: the install is the expensive step (~1 min cold on a
 # runner, a 1.0 GB pnpm store, 4.2 GB of node_modules), so it runs only when the
-# engine actually changed. Measured on the first real run (#452): 3m22s end to
-# end — 1m03s install, 40s type-check, 43s tests, ~25s saving the store cache.
+# engine actually changed. Measured: **3m22s** cold (#452) and **3m36s** on a
+# cache hit (#453) — the store cache is worth ~17s of the install because it
+# removes only the download, while pnpm links 3939 packages either way. Plan on
+# ~3.5 minutes per run whatever the cache does.
 
 on:
   push:

--- a/TODO.md
+++ b/TODO.md
@@ -166,10 +166,18 @@ and not of one machine — which is what makes it usable as a tripwire rather th
 noise. And the **cold install is the whole cost**: on a cache hit the job is
 about two minutes, so the path filter is buying runner slots, not minutes.
 
+**Correction, from the second run.** That last sentence was an inference —
+subtract the install and the cache save — and the measurement disagrees with it.
+#453 hit the store cache on the primary key and took **3m36s**, marginally
+*slower* than the cold 3m22s, with the install going 1m03s → **45.7s**. The
+cache is worth about 17 seconds: it removes the download, but pnpm still links
+3939 packages into `node_modules` on every run, and that is what the install
+actually is. So the job costs ~3.5 minutes every time, which makes the path
+filter worth minutes as well as runner slots. Written up correctly in §5.6.
+
 ### Remaining work
-- **Only ever run on a cache miss.** The first run wrote the store cache; nothing
-  has read one back yet, so the `restore-keys` fallback is unexercised. A bad
-  restore would show up as a slow install rather than a wrong one.
+- **`restore-keys` has still not been taken.** The second run hit the primary
+  key, so the restore path works but the fallback branch is unexercised.
 - **Noticed, not fixed (repo-wide):** every run warns that
   `actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4` and
   `pnpm/action-setup@v4` target Node 20 and are being forced onto Node 24. Every

--- a/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
@@ -608,7 +608,9 @@ cd packages-lobe && bun run type-check:worker
 — the only job in this repository that installs `packages-lobe`. It is
 path-filtered to `packages-lobe/**` and the workflow file, because the install is
 the expensive step (~1 min cold on a runner, 4.2 GB) and nothing outside the
-engine can change either result. **3m22s end to end** on its first real run. What
+engine can change either result. **~3.5 minutes end to end**, cache hit or
+miss — the store cache saves about 17s of a 1-minute install, because pnpm links
+3939 packages either way. What
 it does *not* run is the Worker bundle-size budget; §5.4 of the migration to-do
 records why.
 

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -755,28 +755,6 @@ Blocked on the LobeHub Community License answer, recorded in
     itself.** The install is the expensive step, and nothing outside the engine
     changes either result.
 
-  **First real run: green, in 3m22s** (#452, `f3b37e85`). Every step was faster
-  on a GitHub runner than on the box these numbers were estimated from:
-
-  | Step | On a runner, cold cache |
-  |---|---|
-  | `pnpm install --ignore-scripts` | **1m03s**, 3939 packages |
-  | `pnpm run type-check:qwksearch` | **40s** → clean |
-  | `pnpm run test:qwksearch` | **43s**, 568 passed |
-  | Saving the pnpm store to the cache | ~25s, **1.0 GB** |
-
-  Two things that run confirmed beyond "it works". The **504 ignored errors are
-  the same 504** on the runner's Node 24.20.0 as on Node 22 here, so the filter's
-  count is a property of the tree rather than of one machine — which is what
-  makes it usable as a tripwire. And the **cold install is the whole cost**: on a
-  cache hit the job is roughly two minutes, so the path filter is about runner
-  slots, not minutes.
-
-  One warning on every run, and not this job's: `actions/checkout@v4`,
-  `actions/setup-node@v4`, `actions/cache@v4` and `pnpm/action-setup@v4` all
-  target Node 20 and are being forced onto Node 24. Every workflow in this
-  repository uses those actions, so the v5 bump is a repo-wide change, not a
-  `packages-lobe` one.
   - **Three details are specific to this workspace**, and each one is a way the
     obvious workflow would have failed: `pnpm/action-setup` reads the *repo
     root* `package.json` by default, which pins **bun**, so it has to be pointed
@@ -787,6 +765,43 @@ Blocked on the LobeHub Community License answer, recorded in
     the install is `--ignore-scripts` like every other recipe here, which is
     also what keeps 5.4's bundle budget out of this job.
 
+  **Both runs so far: green**, on `.nvmrc`'s Node 24.20.0 — the version the
+  Cloudflare build pins and the deploy runs, which nothing local could exercise.
+  #452 (`f3b37e85`) missed the store cache and wrote it; #453 (`3c8839f6`) hit it
+  on the primary key:
+
+  | Step | Cold (#452) | Cache hit (#453) |
+  |---|---|---|
+  | `pnpm install --ignore-scripts` | 1m03s, 3939 packages | **45.7s** |
+  | `pnpm run type-check:qwksearch` | 40s → clean | 47s → clean |
+  | `pnpm run test:qwksearch` | 43s, 568 passed | 56s, 568 passed |
+  | The pnpm store | ~25s to save, **1.0 GB** | hit, nothing saved |
+  | **Whole job** | **3m22s** | **3m36s** |
+
+  Three things those runs settled:
+
+  - **The 504 ignored errors are the same 504** on the runner's Node 24 as on
+    Node 22 here, so the filter's count is a property of the tree rather than of
+    one machine. That is what makes it usable as a tripwire: a change in it is
+    a signal, not a machine difference.
+  - **The store cache is worth about 17 seconds, and that is all.** #452's
+    write-up guessed that a cache hit would take the job to "roughly two
+    minutes"; the measured hit is 3m36s, *slower* than the cold run, within
+    runner variance either way. The cache only removes the download — pnpm still
+    links 3939 packages into `node_modules` every time, and that is the install.
+    Keep the cache (17s and a gentler registry) but do not plan around it: this
+    job costs ~3.5 minutes on every run, which makes the path filter worth
+    minutes and not just runner slots.
+  - **`restore-keys` is no longer unexercised.** The second run hit the primary
+    key, so the fallback branch specifically still has not been taken, but the
+    restore path itself works.
+
+  One warning on every run, and not this job's: `actions/checkout@v4`,
+  `actions/setup-node@v4`, `actions/cache@v4` and `pnpm/action-setup@v4` all
+  target Node 20 and are being forced onto Node 24. Every workflow in this
+  repository uses those actions, so the v5 bump is a repo-wide change, not a
+  `packages-lobe` one.
+
   Follow-ups:
 
   - ⬜ **An unlockfiled install is not a reproducible one.** `lockfile: false`
@@ -794,13 +809,6 @@ Blocked on the LobeHub Community License answer, recorded in
     means this job resolves fresh semver on every cache miss and can go red for
     a reason that is not in the diff. If that happens, the store cache key
     (the manifests) is the first thing to read.
-  - ✅ **Confirmed on a GitHub runner**, on `.nvmrc`'s **24.20.0** — the version
-    the Cloudflare build pins and the deploy runs, which nothing local could
-    exercise. See the table above.
-  - ⬜ **The job has only ever run on a cache miss.** Its first run wrote the
-    store cache; nothing has yet read one back. If a restore is ever partial or
-    stale, the symptom will be an install that is slow rather than wrong, but
-    the `restore-keys` fallback is unexercised.
 
 ## How to pick up the next item
 


### PR DESCRIPTION
#453 claimed that a pnpm store cache hit would take the LobeHub Engine job to "roughly two minutes". That was an inference — subtract the install and the cache save from the cold run — and #453's own CI run disagrees with it.

## The measurement

| Step | Cold (#452, `f3b37e85`) | Cache hit (#453, `3c8839f6`) |
|---|---|---|
| `pnpm install --ignore-scripts` | 1m03s, 3939 packages | **45.7s** |
| `pnpm run type-check:qwksearch` | 40s → clean | 47s → clean |
| `pnpm run test:qwksearch` | 43s, 568 passed | 56s, 568 passed |
| The pnpm store | ~25s to save, 1.0 GB | hit on the primary key, nothing saved |
| **Whole job** | **3m22s** | **3m36s** |

The cache hit was *slower*, within runner variance either way. **The store cache is worth about 17 seconds** — it removes the download, but pnpm still links 3939 packages into `node_modules` on every run, and that linking is what the install actually is.

Keep the cache (17s, and a gentler registry), but don't plan around it: this job costs ~3.5 minutes per run regardless, which makes the path filter worth minutes as well as runner slots. The conclusion #453 drew survives; the number it rested on does not.

## Also

- Closes the "only ever run on a cache miss" follow-up — the restore path works. The `restore-keys` *fallback* specifically still hasn't been taken, since this hit was on the primary key, and that stays noted.
- §5.6's runs are now one table rather than a paragraph of estimates, and a bullet that had been left orphaned below the prose is back inside its list.

Both runs were green, on `.nvmrc`'s Node 24.20.0, with the same 504 ignored type errors as on Node 22 locally.

## Changed

Docs and one workflow comment, no behaviour: §5.6 of the migration to-do, §6 of the integrations reference, the header comment in `lobehub-engine.yml`, and the run's entry in `TODO.md`.

Verified: `packages/user-help-docs` suite (renders every MDX page) 40 passed; the workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAtFqNquimVeZacbQX4jKM

---
_Generated by [Claude Code](https://claude.ai/code/session_01LAtFqNquimVeZacbQX4jKM)_