### PR TITLE
🐛 fix(extract-webpage,write-language): load Prism grammars without a load-order gamble

### DIFF
--- a/packages/extract-webpage/CLAUDE.md
+++ b/packages/extract-webpage/CLAUDE.md
@@ -31,6 +31,14 @@ The entire job is parsing pages written by someone else:
 - It also ships as an optional peer of `grab-url` in the sibling GRAB-URL repo
   (behind `grab-url --page`) — it must stay importable without dragging the
   whole app in.
+- **Never `import "prismjs/components/…"`.** Those files read `Prism` off the
+  global object, and nothing in the module graph pins them after whoever
+  publishes it — a bundler that reorders or drops that publication turns the
+  whole chunk into `ReferenceError: Prism is not defined` at load, which is how
+  an embedding app's entire route dies over syntax highlighting. Grammars are
+  loaded through `loadPrismGrammars()` in
+  `src/html-to-content/prism-global.ts`; read the docs at the top of that file
+  before you change it.
 
 ```bash
 cd packages/extract-webpage && bun run test

--- a/packages/extract-webpage/src/html-to-content/html-utils.ts
+++ b/packages/extract-webpage/src/html-to-content/html-utils.ts
@@ -139,26 +139,15 @@ export function convertURLToAbsoluteURL(base, relative) {
 }
 
 import { marked } from "marked";
-// Must precede every `prismjs/components/*` import: the grammar scripts read
-// `Prism` off the global object, which this module publishes (see its docs).
-import Prism from "./prism-global";
-import "prismjs/components/prism-markup.js";
-import "prismjs/components/prism-css.js";
-import "prismjs/components/prism-javascript.js";
-import "prismjs/components/prism-typescript.js";
-import "prismjs/components/prism-jsx.js";
-import "prismjs/components/prism-tsx.js";
-import "prismjs/components/prism-python.js";
-import "prismjs/components/prism-bash.js";
-import "prismjs/components/prism-json.js";
-import "prismjs/components/prism-yaml.js";
-import "prismjs/components/prism-markdown.js";
-import "prismjs/components/prism-sql.js";
-import "prismjs/components/prism-rust.js";
-import "prismjs/components/prism-go.js";
-import "prismjs/components/prism-java.js";
-import "prismjs/components/prism-c.js";
-import "prismjs/components/prism-cpp.js";
+// `prism-global` owns both the Prism instance and the grammars beyond the ones
+// prismjs' entry point bundles; importing `prismjs/components/*` here directly
+// would reintroduce the load-order crash its docs describe.
+import Prism, { loadPrismGrammars } from "./prism-global";
+
+// Start the grammars loading now, and again from the renderer below — the
+// second call is what guarantees they are requested at all, since a bundler is
+// free to drop this one as a side effect of a module it thinks is pure.
+void loadPrismGrammars();
 
 // Configure marked once at module load with Prism.js syntax highlighting.
 // marked v17 removed the `highlight` option from setOptions, so highlighting
@@ -166,6 +155,7 @@ import "prismjs/components/prism-cpp.js";
 marked.use({
   renderer: {
     code({ text, lang }) {
+      void loadPrismGrammars();
       const language = lang && Prism.languages[lang] ? lang : null;
       const highlighted = language
         ? Prism.highlight(text, Prism.languages[language], language)

--- a/packages/extract-webpage/src/html-to-content/prism-global.ts
+++ b/packages/extract-webpage/src/html-to-content/prism-global.ts
@@ -1,22 +1,82 @@
 /**
  * @module html-to-content/prism-global
- * @description Publishes Prism on `globalThis` so the `prismjs/components/*`
- * grammar scripts can find it.
+ * @description Owns the Prism instance: publishes it on `globalThis`, then
+ * registers the language grammars that prismjs' own entry point leaves out —
+ * without ever depending on module evaluation order.
  *
- * Those grammar files are plain browser scripts, not modules — `prism-markup.js`
- * literally opens with `Prism.languages.markup = {...}`, resolving `Prism` as a
- * free variable off the global object. Prism's core only publishes that global
- * when it can see `window` (browser), a `WorkerGlobalScope` `self`, or Node's
- * `global`. On Cloudflare Workers / edge runtimes none of the three exist, so
- * the first grammar file throws `ReferenceError: Prism is not defined` while the
- * module graph is still evaluating, taking the whole SSR render down with it.
+ * The `prismjs/components/*` files are plain browser scripts, not modules:
+ * `prism-markup.js` literally opens with `Prism.languages.markup = {...}`,
+ * resolving `Prism` as a free variable off the global object. Someone has to
+ * put it there first. prismjs' own entry point does that for `window`
+ * (browser) and `global` (Node); on Cloudflare Workers / edge runtimes it sees
+ * neither, which is what the assignment below is for.
  *
- * Import this module *before* any `prismjs/components/*` import. ES modules are
- * evaluated in import order, so this file's body runs — and the global lands —
- * before the grammars reference it.
+ * Publishing it is only half the job, though: it has to happen *before* the
+ * grammar scripts run, and a static `import "prismjs/components/..."` cannot
+ * promise that once a bundler is in the loop. Those files declare no
+ * dependency on Prism — reading a global is invisible to the module graph — so
+ * nothing pins them after whoever publishes it, and a bundler is free to hoist
+ * them, split them into another chunk, or drop the publishing statement as a
+ * dead `globalThis` write. When that happens the chunk dies on load with
+ * `ReferenceError: Prism is not defined`, which takes down the whole route
+ * that lazily imported it rather than just the syntax highlighting.
+ *
+ * So the grammars are loaded with `import()` from inside `loadPrismGrammars()`
+ * instead. The global is published by a statement earlier in that same
+ * function body, which makes the ordering a runtime fact rather than a promise
+ * the bundler has to keep.
  */
 import Prism from "prismjs";
 
-(globalThis as typeof globalThis & { Prism?: unknown }).Prism ??= Prism;
+/**
+ * The grammars to register, in order — several extend an earlier one, so this
+ * list is loaded sequentially rather than in parallel (`tsx` needs `jsx` and
+ * `typescript`; `cpp` needs `c`). Markup, CSS, C-like and JavaScript are
+ * absent because prismjs' entry point already bundles them.
+ */
+const GRAMMARS: ReadonlyArray<() => Promise<unknown>> = [
+  () => import("prismjs/components/prism-typescript.js"),
+  () => import("prismjs/components/prism-jsx.js"),
+  () => import("prismjs/components/prism-tsx.js"),
+  () => import("prismjs/components/prism-python.js"),
+  () => import("prismjs/components/prism-bash.js"),
+  () => import("prismjs/components/prism-json.js"),
+  () => import("prismjs/components/prism-yaml.js"),
+  () => import("prismjs/components/prism-markdown.js"),
+  () => import("prismjs/components/prism-sql.js"),
+  () => import("prismjs/components/prism-rust.js"),
+  () => import("prismjs/components/prism-go.js"),
+  () => import("prismjs/components/prism-java.js"),
+  () => import("prismjs/components/prism-c.js"),
+  () => import("prismjs/components/prism-cpp.js"),
+];
+
+/** Puts Prism where the grammar scripts look for it. Idempotent. */
+function publishPrismGlobal(): void {
+  (globalThis as typeof globalThis & { Prism?: typeof Prism }).Prism ??= Prism;
+}
+
+publishPrismGlobal();
+
+let loading: Promise<void> | undefined;
+
+/**
+ * Registers the grammars above, once per runtime. Cheap to call repeatedly —
+ * callers are meant to invoke it wherever they are about to highlight, so that
+ * the work does not hinge on a module-level statement surviving tree-shaking.
+ *
+ * Never rejects: a grammar that fails to load just leaves its language out of
+ * `Prism.languages`, which every caller already treats as "render this block
+ * unhighlighted".
+ */
+export function loadPrismGrammars(): Promise<void> {
+  loading ??= (async () => {
+    publishPrismGlobal();
+    for (const load of GRAMMARS) {
+      await load();
+    }
+  })().catch(() => {});
+  return loading;
+}
 
 export default Prism;

--- a/packages/extract-webpage/test/html-utils.test.ts
+++ b/packages/extract-webpage/test/html-utils.test.ts
@@ -10,6 +10,7 @@ import {
   convertURLToAbsoluteURL,
   copyHTMLToClipboard,
 } from '../src/html-to-content/html-utils';
+import { loadPrismGrammars } from '../src/html-to-content/prism-global';
 
 describe('convertURLSafeHTMLToHTML', () => {
   it('decodes named entities', () => {
@@ -130,6 +131,15 @@ describe('convertMarkdownToHTML', () => {
     const html = convertMarkdownToHTML('```js\nconst a = 1;\n```') as string;
 
     expect(html).toContain('class="language-js"');
+    expect(html).toContain('token');
+  });
+
+  it('highlights a language that only arrives with the loaded grammars', async () => {
+    await loadPrismGrammars();
+
+    const html = convertMarkdownToHTML('```python\nx = 1\n```') as string;
+
+    expect(html).toContain('class="language-python"');
     expect(html).toContain('token');
   });
 

--- a/packages/write-language/CLAUDE.md
+++ b/packages/write-language/CLAUDE.md
@@ -25,6 +25,12 @@ That is the whole contract, and it is easy to erode:
 - Adding a provider is an entry plus its quirks, not a new public API.
 - Token counting and context limits differ per model — get them from the
   registry, don't hardcode.
+- **Never `import "prismjs/components/…"`.** Those files read `Prism` off the
+  global object, and nothing in the module graph pins them after whoever
+  publishes it — a bundler that reorders or drops that publication turns the
+  whole chunk into `ReferenceError: Prism is not defined` at load. Grammars are
+  loaded through `loadPrismGrammars()` in `src/utils/prism-global.ts`, which
+  reads the docs at the top of that file before you change it.
 
 ```bash
 cd packages/write-language && bun run test

--- a/packages/write-language/src/utils/prism-global.ts
+++ b/packages/write-language/src/utils/prism-global.ts
@@ -1,21 +1,81 @@
 /**
- * @fileoverview Publishes Prism on `globalThis` so the `prismjs/components/*`
- * grammar scripts can find it.
+ * @fileoverview Owns the Prism instance: publishes it on `globalThis`, then
+ * registers the language grammars that prismjs' own entry point leaves out —
+ * without ever depending on module evaluation order.
  *
- * Those grammar files are plain browser scripts, not modules — `prism-markup.js`
- * literally opens with `Prism.languages.markup = {...}`, resolving `Prism` as a
- * free variable off the global object. Prism's core only publishes that global
- * when it can see `window` (browser), a `WorkerGlobalScope` `self`, or Node's
- * `global`. On Cloudflare Workers / edge runtimes none of the three exist, so
- * the first grammar file throws `ReferenceError: Prism is not defined` while the
- * module graph is still evaluating, taking the whole SSR render down with it.
+ * The `prismjs/components/*` files are plain browser scripts, not modules:
+ * `prism-markup.js` literally opens with `Prism.languages.markup = {...}`,
+ * resolving `Prism` as a free variable off the global object. Someone has to
+ * put it there first. prismjs' own entry point does that for `window`
+ * (browser) and `global` (Node); on Cloudflare Workers / edge runtimes it sees
+ * neither, which is what the assignment below is for.
  *
- * Import this module *before* any `prismjs/components/*` import. ES modules are
- * evaluated in import order, so this file's body runs — and the global lands —
- * before the grammars reference it.
+ * Publishing it is only half the job, though: it has to happen *before* the
+ * grammar scripts run, and a static `import "prismjs/components/..."` cannot
+ * promise that once a bundler is in the loop. Those files declare no
+ * dependency on Prism — reading a global is invisible to the module graph — so
+ * nothing pins them after whoever publishes it, and a bundler is free to hoist
+ * them, split them into another chunk, or drop the publishing statement as a
+ * dead `globalThis` write. When that happens the chunk dies on load with
+ * `ReferenceError: Prism is not defined`, which takes down the whole route
+ * that lazily imported it rather than just the syntax highlighting.
+ *
+ * So the grammars are loaded with `import()` from inside `loadPrismGrammars()`
+ * instead. The global is published by a statement earlier in that same
+ * function body, which makes the ordering a runtime fact rather than a promise
+ * the bundler has to keep.
  */
 import Prism from "prismjs";
 
-(globalThis as typeof globalThis & { Prism?: unknown }).Prism ??= Prism;
+/**
+ * The grammars to register, in order — several extend an earlier one, so this
+ * list is loaded sequentially rather than in parallel (`tsx` needs `jsx` and
+ * `typescript`; `cpp` needs `c`). Markup, CSS, C-like and JavaScript are
+ * absent because prismjs' entry point already bundles them.
+ */
+const GRAMMARS: ReadonlyArray<() => Promise<unknown>> = [
+  () => import("prismjs/components/prism-typescript.js"),
+  () => import("prismjs/components/prism-jsx.js"),
+  () => import("prismjs/components/prism-tsx.js"),
+  () => import("prismjs/components/prism-python.js"),
+  () => import("prismjs/components/prism-bash.js"),
+  () => import("prismjs/components/prism-json.js"),
+  () => import("prismjs/components/prism-yaml.js"),
+  () => import("prismjs/components/prism-markdown.js"),
+  () => import("prismjs/components/prism-sql.js"),
+  () => import("prismjs/components/prism-rust.js"),
+  () => import("prismjs/components/prism-go.js"),
+  () => import("prismjs/components/prism-java.js"),
+  () => import("prismjs/components/prism-c.js"),
+  () => import("prismjs/components/prism-cpp.js"),
+];
+
+/** Puts Prism where the grammar scripts look for it. Idempotent. */
+function publishPrismGlobal(): void {
+  (globalThis as typeof globalThis & { Prism?: typeof Prism }).Prism ??= Prism;
+}
+
+publishPrismGlobal();
+
+let loading: Promise<void> | undefined;
+
+/**
+ * Registers the grammars above, once per runtime. Cheap to call repeatedly —
+ * callers are meant to invoke it wherever they are about to highlight, so that
+ * the work does not hinge on a module-level statement surviving tree-shaking.
+ *
+ * Never rejects: a grammar that fails to load just leaves its language out of
+ * `Prism.languages`, which every caller already treats as "render this block
+ * unhighlighted".
+ */
+export function loadPrismGrammars(): Promise<void> {
+  loading ??= (async () => {
+    publishPrismGlobal();
+    for (const load of GRAMMARS) {
+      await load();
+    }
+  })().catch(() => {});
+  return loading;
+}
 
 export default Prism;

--- a/packages/write-language/src/utils/prism.ts
+++ b/packages/write-language/src/utils/prism.ts
@@ -1,30 +1,17 @@
 /**
- * @fileoverview Configures Prism.js with a fixed set of language grammars and exposes
- * a small `highlightCode` helper used by markdown-to-html.ts for code-block syntax
- * highlighting.
+ * @fileoverview Exposes a small `highlightCode` helper used by
+ * markdown-to-html.ts for code-block syntax highlighting. The Prism instance
+ * and its language grammars are owned by `prism-global.ts`.
  */
-// Must precede every `prismjs/components/*` import: the grammar scripts read
-// `Prism` off the global object, which this module publishes (see its docs).
-import Prism from "./prism-global";
-import "prismjs/components/prism-markup";
-import "prismjs/components/prism-css";
-import "prismjs/components/prism-javascript";
-import "prismjs/components/prism-typescript";
-import "prismjs/components/prism-jsx";
-import "prismjs/components/prism-tsx";
-import "prismjs/components/prism-python";
-import "prismjs/components/prism-bash";
-import "prismjs/components/prism-json";
-import "prismjs/components/prism-yaml";
-import "prismjs/components/prism-markdown";
-import "prismjs/components/prism-sql";
-import "prismjs/components/prism-rust";
-import "prismjs/components/prism-go";
-import "prismjs/components/prism-java";
-import "prismjs/components/prism-c";
-import "prismjs/components/prism-cpp";
+import Prism, { loadPrismGrammars } from "./prism-global";
+
+// Start the grammars loading now, and again from `highlightCode` below — the
+// second call is what guarantees they are requested at all, since a bundler is
+// free to drop this one as a side effect of a module it thinks is pure.
+void loadPrismGrammars();
 
 export function highlightCode(code: string, lang: string): string | null {
+  void loadPrismGrammars();
   const grammar = Prism.languages[lang];
   if (!grammar) return null;
   return Prism.highlight(code, grammar, lang);

--- a/packages/write-language/test/prism.test.ts
+++ b/packages/write-language/test/prism.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Unit tests for the Prism wiring behind `highlightCode`.
+ */
+import { describe, expect, it } from "vitest";
+import { highlightCode } from "../src/utils/prism";
+import { loadPrismGrammars } from "../src/utils/prism-global";
+
+describe("highlightCode", () => {
+  it("highlights a language prismjs' entry point already bundles", () => {
+    expect(highlightCode("const a = 1;", "javascript")).toContain("token");
+  });
+
+  it("returns null for a language Prism does not know", () => {
+    expect(highlightCode("x", "notalanguage")).toBeNull();
+  });
+
+  it("highlights a language that only arrives with the loaded grammars", async () => {
+    await loadPrismGrammars();
+
+    expect(highlightCode("x = 1", "python")).toContain("token");
+  });
+
+  it("publishes Prism on the global object for the grammar scripts to find", () => {
+    expect(
+      (globalThis as typeof globalThis & { Prism?: unknown }).Prism,
+    ).toBeDefined();
+  });
+});

--- a/packages/write-language/vite.config.js
+++ b/packages/write-language/vite.config.js
@@ -3,6 +3,24 @@ import { resolve } from "path";
 import dts from "vite-plugin-dts";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
 
+/** Bare specifiers left to the consumer to resolve rather than bundled in. */
+const EXTERNAL_PACKAGES = [
+  "ai",
+  "@ai-sdk/openai",
+  "@ai-sdk/anthropic",
+  "@ai-sdk/groq",
+  "@ai-sdk/google",
+  "@ai-sdk/google-vertex",
+  "@ai-sdk/xai",
+  "@ai-sdk/amazon-bedrock",
+  "@ai-sdk/mcp",
+  "@openrouter/ai-sdk-provider",
+  "prismjs",
+  "html-entities",
+  "marked",
+  "qwksearch-api-client",
+];
+
 export default defineConfig({
   plugins: [
     nodePolyfills({
@@ -22,22 +40,13 @@ export default defineConfig({
       fileName: (format) => `write-language.${format === "es" ? "es" : "cjs"}.js`,
     },
     rollupOptions: {
-      external: [
-        "ai",
-        "@ai-sdk/openai",
-        "@ai-sdk/anthropic",
-        "@ai-sdk/groq",
-        "@ai-sdk/google",
-        "@ai-sdk/google-vertex",
-        "@ai-sdk/xai",
-        "@ai-sdk/amazon-bedrock",
-        "@ai-sdk/mcp",
-        "@openrouter/ai-sdk-provider",
-        "prismjs",
-        "html-entities",
-        "marked",
-        "qwksearch-api-client",
-      ],
+      // `prismjs/components/*` is matched by prefix, not listed: the grammars
+      // are pulled in with `import()` (see src/utils/prism-global.ts) and a
+      // bundled dynamic import would split this single-file lib build into
+      // extra chunks. Left external, they stay `import()` calls the consumer
+      // resolves.
+      external: (id) =>
+        id.startsWith("prismjs/") || EXTERNAL_PACKAGES.includes(id),
       output: {
         codeSplitting: false,
       },

--- a/skills/ask-write-language/API.md
+++ b/skills/ask-write-language/API.md
@@ -79,5 +79,5 @@ the reply into `result.extract`.
 | --- | --- |
 | `extractJSONFromLanguageReply(reply)` | Pull a JSON object out of a fenced or prose-wrapped reply |
 | `convertMarkdownToHTMLEscaped(md)` / `markdownToHTML` | Markdown → escaped HTML (marked) |
-| `highlightCode`, `Prism` | Syntax highlighting used by the HTML output |
+| `highlightCode`, `Prism` | Syntax highlighting used by the HTML output. Markup/CSS/C-like/JavaScript highlight immediately; the other grammars are registered asynchronously by `loadPrismGrammars()` (`src/utils/prism-global.ts`), so a block rendered in that first gap comes back unhighlighted rather than broken |
 | `getRewriteModes`, `saveRewriteModes`, `resetRewriteModes`, `DEFAULT_REWRITE_MODES` | The rewrite-mode presets (`src/rewrite-modes.ts`) |


### PR DESCRIPTION
## The bug

Embedding apps that lazily load the research UI die on the chunk with:

```
ReferenceError: Prism is not defined
    at ResearchAgentEmbed-C-89k_gD.js:51:511
```

That is debate-ai.com's `/doc`, which mounts `research-agent-ui` →
`extract-webpage/html-to-content/html-utils`. The route renders nothing but its
error boundary — the whole workspace is gone, over syntax highlighting.

## Why

`prismjs/components/*` are plain browser scripts, not modules. `prism-markup.js`
literally opens with `Prism.languages.markup = {...}`, resolving `Prism` as a
free variable off the global object. Something has to put it there first —
prismjs' own entry point does it for `window`/`global`, and our
`globalThis.Prism ??= Prism` did it for edge runtimes.

Publishing it is only half the job: it has to happen **before** the grammar
scripts run, and a static `import "prismjs/components/…"` cannot guarantee that
once a bundler is in the loop. Reading a global is an edge no bundler can see,
so nothing in the module graph pins those files after whoever publishes it.
Rolldown (Vite 8) then:

- hoists and re-groups them freely once the code lands in a lazily-loaded chunk, and
- drops `globalThis.Prism ??= Prism` as a dead `globalThis` write, while **keeping**
  the grammar files — they mutate an unresolved global, which can throw, so they
  look load-bearing.

Either way the chunk throws while it is still evaluating, which takes the route
down rather than just the highlighting.

## The fix

Load the grammars with `import()` from inside `loadPrismGrammars()`. The global
is published by a statement earlier in that same function body, so the ordering
is a runtime fact rather than a promise the bundler has to keep. Callers invoke
it where they highlight (`highlightCode`, the `marked` code renderer) as well as
at module load, so the work no longer hinges on a top-level statement surviving
tree-shaking.

Markup, CSS, C-like and JavaScript are dropped from the grammar list — prismjs'
entry point already bundles them — so the common languages highlight
synchronously and a grammar that arrives a tick late leaves its block
unhighlighted instead of broken. `loadPrismGrammars()` never rejects: a grammar
that fails to load just stays out of `Prism.languages`, which every call site
already treats as "render this plain".

After the change both dists contain **zero** static grammar imports and zero
free `Prism` references.

## Also

- `write-language`'s lib build externalises `prismjs/*` by prefix, keeping the
  new dynamic imports out of its single-file dist — which halves it, 92 KB → 50 KB.
- Both packages' `CLAUDE.md` gain a "never `import "prismjs/components/…"`" rule.

## Testing

- `packages/extract-webpage`: 419 passed (was 418; one new test covers a
  language that only arrives with the loaded grammars). The one failing file,
  `url-to-content`, fails identically on `master` — an unbuilt `extract-youtube`
  sibling, unrelated to this change.
- `packages/write-language`: 82 passed, including a new `test/prism.test.ts`.
- `bun run build` green in both packages; dist output inspected as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YDTg9zfXG2LPzWnUm6HRXh

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDTg9zfXG2LPzWnUm6HRXh)_