### PR TITLE
📝 docs(packages-lobe): map the old settings surface onto the engine, with a drift guard

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,121 @@
 
 ## Completed
 
+## Map the old settings surface onto the engine as a tested artifact, not a paragraph
+
+**Status:** Completed
+**Source:** Scheduled task — "merge lobehub and qwksearch.com so that lobehub is
+the core engine…, every time it is run make more improvements… keep a to-do list
+of how to migrate and document all lobehub integrations". The LobeHub Migration
+To-Do's own #2 suggested next: § 2.1's settings map, which § 2.4 needs before
+anything in the old surface can be deleted.
+**Branch:** `claude/magical-bohr-0skpwn` (rebased onto `master` at `2b19de7a`)
+**PR:** #458
+**Started:** 2026-09-12
+**Completed:** 2026-09-12
+
+### Goal
+§ 2.1 asks for every section of `research-agent-ui/src/settings/sections.json`
+mapped to its engine equivalent, because § 2.4 may not delete
+`apps/qwksearch-web/components/Settings/**` until each one has somewhere to
+land. The item had sat at ⬜ with a one-line sketch in the to-do page
+(`models → provider + service-model; mcpservers → features/MCP/MCPSettings;
+voice → tts; …`) — which is exactly the shape of thing that is wrong by the time
+someone acts on it.
+
+### The finding worth keeping
+**The sketch was already wrong, and a prose map could not have told anyone.**
+`voice → tts` does not exist: `SettingsTabs.TTS` is deprecated, redirects to
+`ServiceModel` in `SettingsContent.tsx`'s `REDIRECT_MAP`, and
+`src/features/Settings/tts/` has no `index` — only an STT sub-form that
+`service-model` imports. There is no TTS pane to map onto.
+
+So the map shipped as **code with a contract test** rather than as a doc
+section: `legacySettingsMap.ts` (nine sections, 22 fields) plus
+`legacySettingsMap.contract.test.ts`, which reads `sections.json`,
+`search.json`, every named legacy component and `componentMap.ts` off disk and
+fails when either side moves. `retirementBlockers()` answers "may 2.4 run?" from
+code; it returns 9 of 9 today.
+
+Two more findings that change what 2.3 and 2.4 have to do:
+
+- **The old "server" scope was never per-user.** `POST /api/config` is
+  `assertAdmin`-gated, so `searxngURL`, `proxyURL`, `tavilyApiKey` and every
+  provider key are one global D1 row shared by all users. They are operator
+  settings; on the engine they are Worker secrets. 2.3's re-entry announcement
+  therefore covers a *smaller* list than it looked: file-source credentials,
+  per-user provider keys, MCP servers — not the admin row nobody held.
+- **"Search Settings" is not a settings section, it is 22 unrelated fields.**
+  One is already covered (`sourceScrapeTimeout` → the extraction pane's
+  `timeoutSeconds`), one is the agent system role (`ChatSettingsTabs.Prompt`,
+  per-agent rather than global), three become Worker secrets, four have no
+  engine home (follow-up and query-expansion prompts, a TTS voice), and
+  **thirteen are chrome of the old shell** — homepage background art, orb glow,
+  cursor trail, result-card glow, the weather widget (5) and the trending-news
+  widget (4). Mapping the section rather than its fields is what made 2.1 look
+  finished when it was not.
+
+### Scope
+- `packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts` (new) —
+  `LEGACY_SETTINGS_SECTIONS`, `LEGACY_SEARCH_FIELDS`, `retirementBlockers()`,
+  `engineTabsInUse()`.
+- `.../legacySettingsMap.contract.test.ts` (new) — 11 cases.
+- Docs: § 2.1 resolved with a per-section table and the three findings, § 2.3
+  sharpened, § 2.4 re-stated as `retirementBlockers()` returning empty, the
+  snapshot row, the "suggested next" re-ranked, §F5e added to the integrations
+  reference, and `packages-lobe/README.md` § features, § Tests and § What
+  changed.
+
+### Non-goals
+- **Closing any of the nine gaps.** The map records them; deciding which API key
+  the Worker trusts, or whether to write a memories migrator, is each its own
+  change. Three of the cheapest are now the to-do's suggested-next #2.
+- **Touching the legacy surface.** Nothing under `apps/qwksearch-web` changed;
+  2.4 deletes it, and it cannot run yet.
+- **Wiring the map into anything.** It is a migration artifact with a guard, and
+  it is deleted along with the surface it describes.
+
+### What changed
+The map is a plain data module: each section carries `stores` (what actually
+holds its values today), `engineTabs`, `engineFeatures`, a `status` of
+`covered | partial | gap`, and the `gaps` that block deletion. Typing
+`engineTabs` as `SettingsTabs[]` means an upstream enum rename is a compile
+error that `type-check:qwksearch` catches; the rest is the test's job.
+
+The guard reads both sides from disk rather than importing them, and the reason
+is worth keeping: the legacy surface is in the root Bun workspace bundled for
+Next.js, and `componentMap.ts` is thirty `dynamic(() => import(…))` entries that
+would pull half the SPA into the test. It parses `[SettingsTabs.Foo]:` out of the
+registry's source, resolves each name through the real enum, and checks the two
+JSON schemas, every legacy component path and every feature directory. Verified
+by mutation, not assumed: pointing the voice row at `SettingsTabs.TTS` fails with
+`voice → SettingsTabs "tts" is not reachable`, and dropping one field from the
+22 fails the `search.json` coverage case. Both reverted.
+
+### Verification
+- `bunx vitest run src/features/Settings/qwksearch` — **144 passed** (was 133).
+- `bun run test:qwksearch` — **577 + 2 passed, 37 files**, ~1 minute. This is
+  what CI runs.
+- `bun run type-check:qwksearch` — clean.
+- `bun run check --lint <the two files>` — clean after two auto-fix passes; the
+  one remaining warning (`unicorn/import-style` on `node:path`) was fixed by
+  hand, which is also why the test uses `path.join` rather than a named import.
+
+### Notes for the next run
+- **The to-do's suggested-next #1 is still 1.4's parity checklist**, unchanged.
+  #2 is now the three cheapest blockers this map named — where browser-session
+  revocation goes (the engine's `devices` tab manages CLI/desktop devices, not
+  sessions, which is another thing the sketch would have got wrong), whether
+  `SSOProvidersList` can unlink as well as list, and which API key the Worker's
+  `/api/agent/*` routes should trust. The last is a decision, not a build, and
+  it gates deleting the Account section.
+- **`retirementBlockers().length` is asserted to be 9.** That is deliberate: a
+  run that clears a gap has to update the number, which is how it notices the
+  page needs updating too. When it reaches 0, delete the map with the surface.
+- `pnpm install --ignore-scripts` in `packages-lobe` took about two minutes here
+  on a cold store; the suite and the type-check are each about a minute after
+  that, so the whole loop is ~4 minutes.
+
 ## Let CI see `packages-lobe` at all, and widen the type-check to every QwkSearch file
 
 **Status:** Completed

--- a/packages-lobe/README.md
+++ b/packages-lobe/README.md
@@ -122,6 +122,16 @@ data is reused as-is.
   trims. Hosts and credentials appear only as read-only "configured / not configured" rows. Each
   pane's `contract.test.ts` is the drift guard — it imports the real resolver, rebuilds the exact
   document its route returns, and fails if the client's restated types fall behind.
+- **The legacy settings map** (`src/features/Settings/qwksearch/legacySettingsMap.ts`): not a
+  feature — a migration artifact with a test. It carries all nine sections of the old
+  qwksearch.com settings surface (`packages/research-agent-ui/src/settings/sections.json`) and all
+  22 fields of its flat "Search Settings" list, each with what stores it today, the engine tabs
+  that take it over, and what is still missing before the old surface can be deleted.
+  `retirementBlockers()` returns the sections that are not covered yet — nine of nine today — so
+  "may we delete it?" is answerable from code. `legacySettingsMap.contract.test.ts` reads both
+  JSON schemas, the legacy components and `componentMap.ts` from disk and fails when either side
+  moves, which is the difference between a map and a stale paragraph. Both files are deleted along
+  with the surface they describe.
 - **Branding**: `BRANDING_NAME`/`ORG_NAME` = QwkSearch, QwkSearch favicons under `public/`,
   support/social URLs point at qwksearch.com.
 
@@ -258,7 +268,7 @@ LobeHub's Postgres migrations once against the database: `bun run db:migrate` wi
 ## Tests
 
 ```bash
-# Everything QwkSearch added to the engine, in one command -- 568 tests in 36
+# Everything QwkSearch added to the engine, in one command -- 579 tests in 37
 # files, about a minute. This is what CI runs (.github/workflows/lobehub-engine.yml),
 # and the path list lives in the script so the workflow and the docs cannot drift.
 bun run test:qwksearch
@@ -329,6 +339,9 @@ rebuilds its route's response from the real resolver.
   `languages`/`language`). No upstream file changed for it; the two panes are QwkSearch-added
   files and import it through the barrel. See §F5d of the integrations reference, which also
   records why the language fields use base-ui's `AutoComplete` and not a tags `Select`.
+  `legacySettingsMap.ts` and its contract test live in the same directory and change no upstream
+  file either — they only *read* `componentMap.ts` as text, which is the point: the guard notices
+  when upstream renames or drops a pane the migration was counting on (§F5e).
 - `packages/env/src/email.ts`: accepts `EMAIL_SERVICE_PROVIDER=cloudflare`.
 - `packages/business/const/src/branding.ts`, `packages/const/src/url.ts`: QwkSearch branding.
 - `packages/locales/src/default/{electron,qwksearch}.ts` + `locales/{en-US,zh-CN}`: new keys.

--- a/packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.contract.test.ts
+++ b/packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.contract.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The drift guard for § 2.1's map.
+ *
+ * `legacySettingsMap.ts` describes two codebases it cannot import: the legacy
+ * settings surface, which lives in the root Bun workspace and is bundled for
+ * Next.js, and the engine's own tab registry, which is a module full of
+ * `dynamic()` imports that would pull half the SPA into this test. So both
+ * halves are read from disk as text instead, and every claim the map makes
+ * about a file, a section key or a tab is checked against the thing itself.
+ *
+ * What that buys: the map cannot quietly stop being true. If a tenth section
+ * is added to `sections.json`, if a field is added to `search.json`, if
+ * upstream renames or drops a settings pane, or if one of the legacy
+ * components moves, this fails — instead of 2.4 reading a stale page and
+ * deleting a section that had nowhere to land.
+ *
+ * It deliberately does not check *judgement*: whether a gap is really a gap is
+ * not testable, and re-deciding it is the next run's job.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { SettingsTabs } from '@/store/global/initialState';
+
+import {
+  engineTabsInUse,
+  LEGACY_SEARCH_FIELDS,
+  LEGACY_SETTINGS_SECTIONS,
+  retirementBlockers,
+} from './legacySettingsMap';
+
+/** `src/features/Settings/qwksearch` → `packages-lobe` → the repository root. */
+const REPO_ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '../../../../..');
+const ENGINE_ROOT = path.join(REPO_ROOT, 'packages-lobe');
+const SETTINGS_FEATURES = path.join(ENGINE_ROOT, 'src/features/Settings');
+const SCHEMA_DIR = path.join(REPO_ROOT, 'packages/research-agent-ui/src/settings');
+
+const readJson = <T>(file: string): T => JSON.parse(readFileSync(file, 'utf8')) as T;
+
+const sectionsJson = readJson<{ key: string; name: string }[]>(
+  path.join(SCHEMA_DIR, 'sections.json'),
+);
+const searchJson = readJson<{ key: string }[]>(path.join(SCHEMA_DIR, 'search.json'));
+
+/**
+ * The tabs `componentMap.ts` actually registers, by enum *value*.
+ *
+ * Parsed rather than imported: the module body is `dynamic(() => import(...))`
+ * for thirty panes, and evaluating it here would make this guard cost more
+ * than the suite it lives in. A registration is always spelled
+ * `[SettingsTabs.Foo]:`, so the source is an honest index of what is reachable.
+ */
+const registeredTabs = (): Set<string> => {
+  const source = readFileSync(path.join(SETTINGS_FEATURES, 'features/componentMap.ts'), 'utf8');
+  const names = [...source.matchAll(/\[SettingsTabs\.(\w+)\]:/g)].map(([, name]) => name);
+
+  expect(names.length).toBeGreaterThan(10);
+
+  return new Set(
+    names.map((name) => {
+      const value = (SettingsTabs as Record<string, string>)[name];
+      expect(
+        value,
+        `componentMap registers SettingsTabs.${name}, which is not in the enum`,
+      ).toBeDefined();
+      return value;
+    }),
+  );
+};
+
+describe('the map covers the legacy surface exactly', () => {
+  it('lists every section of sections.json, in order', () => {
+    expect(LEGACY_SETTINGS_SECTIONS.map((section) => section.key)).toEqual(
+      sectionsJson.map((section) => section.key),
+    );
+  });
+
+  it('uses the labels the old surface shows', () => {
+    const names = Object.fromEntries(sectionsJson.map((section) => [section.key, section.name]));
+
+    for (const section of LEGACY_SETTINGS_SECTIONS) {
+      expect(section.name, `${section.key} label`).toBe(names[section.key]);
+    }
+  });
+
+  it('names legacy components that exist', () => {
+    for (const section of LEGACY_SETTINGS_SECTIONS) {
+      expect(
+        existsSync(path.join(REPO_ROOT, section.legacyComponent)),
+        section.legacyComponent,
+      ).toBe(true);
+    }
+  });
+
+  it('maps every field of search.json, in order', () => {
+    expect(LEGACY_SEARCH_FIELDS.map((field) => field.key)).toEqual(
+      searchJson.map((field) => field.key),
+    );
+  });
+});
+
+describe('the map points at engine panes that exist', () => {
+  it('names feature directories that are present', () => {
+    for (const section of LEGACY_SETTINGS_SECTIONS) {
+      for (const feature of section.engineFeatures) {
+        expect(
+          existsSync(path.join(SETTINGS_FEATURES, feature)),
+          `${section.key} → ${feature}`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('only names tabs componentMap registers', () => {
+    const registered = registeredTabs();
+
+    for (const section of LEGACY_SETTINGS_SECTIONS) {
+      for (const tab of section.engineTabs) {
+        expect(registered.has(tab), `${section.key} → SettingsTabs "${tab}" is not reachable`).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it('includes both QwkSearch panes among the tabs in use', () => {
+    // The two panes 2.2 shipped are the reason Phase 2 is not blocked on UI.
+    // If either stops appearing here, the map has lost the work they did.
+    expect(engineTabsInUse()).toEqual(
+      expect.arrayContaining([SettingsTabs.Search, SettingsTabs.Extraction]),
+    );
+  });
+});
+
+describe('status and gaps stay consistent', () => {
+  it('gives every non-covered section at least one gap', () => {
+    for (const section of LEGACY_SETTINGS_SECTIONS) {
+      if (section.status === 'covered') {
+        expect(section.gaps, `${section.key} is covered but lists gaps`).toEqual([]);
+      } else {
+        expect(
+          section.gaps.length,
+          `${section.key} is ${section.status} with no gap recorded`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('leaves engineTabs empty exactly for the sections with no engine home', () => {
+    for (const section of LEGACY_SETTINGS_SECTIONS) {
+      expect(section.engineTabs.length === 0, `${section.key} (${section.status})`).toBe(
+        section.status === 'gap',
+      );
+      expect(section.engineFeatures.length === 0, `${section.key} (${section.status})`).toBe(
+        section.status === 'gap',
+      );
+    }
+  });
+
+  it('reports the sections 2.4 is blocked on', () => {
+    expect(retirementBlockers().map((section) => section.key)).toEqual(
+      LEGACY_SETTINGS_SECTIONS.filter((section) => section.status !== 'covered').map(
+        (section) => section.key,
+      ),
+    );
+  });
+
+  it('is not finished — a run that clears the last blocker should delete this file too', () => {
+    // Phase 2.4 may delete the old surface when this is 0. Until then the
+    // number is the honest answer to "is the map done?", and an assertion is
+    // how a run that clears one notices it has to update the page as well.
+    expect(retirementBlockers().length).toBe(9);
+  });
+});

--- a/packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts
+++ b/packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts
@@ -1,0 +1,363 @@
+/**
+ * § 2.1 of the LobeHub Migration To-Do — the old settings surface mapped onto
+ * this engine — written as data instead of prose.
+ *
+ * Phase 2.4 deletes `apps/qwksearch-web/components/Settings/**`, its
+ * `app/settings/[[...section]]` route and `app/api/config`. It may only do that
+ * once every section of the old surface has somewhere to land, and the thing
+ * that decides "somewhere to land" is this file: each entry names the legacy
+ * section, what actually stores its values today, the engine tab that takes it
+ * over, and — the part that matters — what is still missing before the legacy
+ * section can be deleted.
+ *
+ * Why data and not a doc section. The map is only useful if it is still true
+ * when 2.4 runs, and a prose map decays silently: upstream renames a tab, we
+ * add a pane, someone adds a tenth section to `sections.json`, and the page
+ * still reads as if it were current. `legacySettingsMap.contract.test.ts`
+ * checks this file against both halves it describes — `sections.json` and
+ * `search.json` on the QwkSearch side, `componentMap.ts` and the feature
+ * directories on the engine side — so drift fails a test instead of misleading
+ * a later run. It is the same mechanism the two panes' `contract.test.ts` use
+ * for their routes, one level up.
+ *
+ * Nothing imports this at runtime. It is a migration artifact with a guard,
+ * and it is deleted along with the surface it describes.
+ */
+import { SettingsTabs } from '@/store/global/initialState';
+
+/**
+ * How much of a legacy section the engine can serve today.
+ *
+ * - `covered` — the engine does everything the legacy section does. Nothing
+ *   blocks deleting it.
+ * - `partial` — an engine pane owns the same job, but something the legacy
+ *   section does is missing or unverified. `gaps` says what.
+ * - `gap` — the engine has no equivalent at all. `engineTabs` is empty.
+ */
+export type MigrationStatus = 'covered' | 'gap' | 'partial';
+
+export interface LegacySection {
+  /**
+   * The engine feature directories, relative to `src/features/Settings/`, that
+   * serve this section. Checked for existence by the contract test.
+   */
+  engineFeatures: string[];
+  /**
+   * The engine tabs that take this section over. Every one of these must be
+   * registered in `../features/componentMap.ts`, or it is not reachable and
+   * the contract test fails. Empty exactly when `status` is `gap`.
+   */
+  engineTabs: SettingsTabs[];
+  /**
+   * What must still be built, decided or verified before 2.4 may delete the
+   * legacy section. Empty exactly when `status` is `covered`.
+   */
+  gaps: string[];
+  /** `key` in `packages/research-agent-ui/src/settings/sections.json`. */
+  key: string;
+  /** The component that renders it today, repo-root-relative. */
+  legacyComponent: string;
+  /** `name` in `sections.json` — the label the old surface shows. */
+  name: string;
+  status: MigrationStatus;
+  /** Where the legacy section's values actually live today. */
+  stores: string;
+}
+
+/**
+ * The nine sections of the old surface, in `sections.json` order.
+ *
+ * Read `stores` before `engineTabs`: most of the remaining work in Phase 2 is
+ * not UI — both panes shipped in 2.2 — it is that the legacy values sit in
+ * places the engine does not read. Three distinct stores appear here, and each
+ * implies a different migration:
+ *
+ * - **`/api/config`** — one global D1 config row. Its writes are admin-only
+ *   (`assertAdmin` in `app/api/config/route.ts`), so these were never per-user
+ *   settings; on the engine they are Worker secrets. That is 2.3's "server env
+ *   keys stay Worker secrets".
+ * - **`localStorage`** — per-browser, no server copy, so there is nothing to
+ *   migrate *from* on another device. That is 2.3's "announce a one-time
+ *   re-entry; do not build a migrator", and it includes credentials.
+ * - **Worker A tables** (`/api/user/*`, `/api/agent/*`) — real per-user rows in
+ *   D1, and the only ones where a migrator would even be possible. The engine
+ *   keeps its equivalents in Postgres.
+ */
+export const LEGACY_SETTINGS_SECTIONS: readonly LegacySection[] = [
+  {
+    engineFeatures: ['profile', 'apikey', 'devices', 'appearance'],
+    engineTabs: [
+      SettingsTabs.Profile,
+      SettingsTabs.APIKey,
+      SettingsTabs.Devices,
+      SettingsTabs.Appearance,
+    ],
+    gaps: [
+      'API key: the legacy pane mints and rotates the key the Worker accepts on /api/agent/* (PATCH /api/user). The engine apikey pane issues LobeHub keys from its own table. Decide which key the Worker trusts before deleting — the two are not the same credential.',
+      'Account deletion: DELETE /api/user has no row in the engine profile pane (AvatarRow, EmailRow, FullNameRow, UsernameRow, PasswordRow, InterestsRow, SSOProvidersList, Composio).',
+      'Session revocation has no engine equivalent, despite the devices tab looking like one: the legacy pane lists browser sessions from /api/user/sessions and signs them out, while the engine devices pane manages CLI/desktop device connections and their shares (features/DeviceManager). Different objects, same word.',
+      'Linking/unlinking an OAuth account: engine SSOProvidersList lists providers; unlink parity unverified.',
+    ],
+    key: 'account',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/Account.tsx',
+    name: 'Account',
+    status: 'partial',
+    stores:
+      'Worker A: /api/user, /api/user/accounts, /api/user/sessions, /api/user/password, better-auth client; theme via next-themes in localStorage',
+  },
+  {
+    engineFeatures: ['provider', 'service-model'],
+    engineTabs: [SettingsTabs.Provider, SettingsTabs.ServiceModel],
+    gaps: [
+      'Scope change, not a port: legacy provider keys and base URLs are one admin-only global config row, so every user shares them. The engine keeps provider credentials per user. Cutover means operator keys become Worker secrets and per-user keys are re-entered (2.3).',
+      'The "Test models" round-trip (POST /api/agent/test-models, TestModelsButton.tsx) has no engine equivalent.',
+    ],
+    key: 'models',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/Models/Section.tsx',
+    name: 'Language Models',
+    status: 'partial',
+    stores:
+      'Worker A: GET /api/config (public) + POST /api/config (admin-only), one global D1 row; models resolved through chat-agent-toolkit ModelRegistry',
+  },
+  {
+    engineFeatures: ['connector', 'skill'],
+    engineTabs: [SettingsTabs.Connector, SettingsTabs.Skill],
+    gaps: [
+      'Servers configured in the legacy pane live in Worker A (/api/agent/mcpservers) and the engine reads its own MCP store. Nothing reads both, so this is a re-entry (2.3), not a migrator.',
+      'The engine\'s connector tab is the skill pane in another view mode (ToolSettings viewMode="connector"); which of the two the legacy section maps onto per server type is unverified.',
+    ],
+    key: 'mcpservers',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/MCPServers/Section.tsx',
+    name: 'Connectors',
+    status: 'partial',
+    stores: 'Worker A: /api/agent/mcpservers (list, add, update, delete, toggle)',
+  },
+  {
+    engineFeatures: ['skill', 'memory'],
+    engineTabs: [SettingsTabs.Skill, SettingsTabs.Memory],
+    gaps: [
+      'Memories are per-user rows in Worker A D1 (/api/user/memories) and the engine keeps memory in Postgres. This is the one section where a migrator is possible rather than a re-entry; whether to write one is undecided.',
+      'The legacy skills list is a fixed catalogue of five built-ins toggled through /api/user/enabled-skills. The engine skill pane is a live registry (built-in, MCP, Composio, LobeHub, custom). Map the five onto it, or accept that the toggles do not survive.',
+    ],
+    key: 'skills-memory',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/SkillsAndMemory.tsx',
+    name: 'Skills & Memory',
+    status: 'partial',
+    stores: 'Worker A: /api/user/enabled-skills, /api/user/memories (+ /usage)',
+  },
+  {
+    engineFeatures: ['search'],
+    engineTabs: [SettingsTabs.Search],
+    gaps: [
+      'The engine pane selects *categories*; the legacy pane selects *engines within a category* (75+ of them, with favicons and descriptions). No per-engine override exists in UserSearchOverrides.',
+      'No engine equivalent for the live health check: GET /api/search/engines/status and POST /api/search/engines/test run a probe query per engine and disable the ones that fail.',
+    ],
+    key: 'searchEngines',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/SearchEngines.tsx',
+    name: 'Search Sources',
+    status: 'partial',
+    stores: 'Worker A: /api/search/engines, /api/search/engines/status, /api/search/engines/test',
+  },
+  {
+    engineFeatures: ['search', 'extraction'],
+    engineTabs: [SettingsTabs.Search, SettingsTabs.Extraction],
+    gaps: [
+      'This section is 22 unrelated fields with four different destinations — see LEGACY_SEARCH_FIELDS, which maps each one. Only sourceScrapeTimeout lands on a shipped pane today.',
+      'Nine of the 22 are homepage chrome (background art, orb glow, cursor trail, result glow) and homepage widgets (weather ×5, trending news ×4) belonging to a shell the engine replaces.',
+      'Three are operator credentials on a global admin-only row (searxngURL, proxyURL, tavilyApiKey) and become Worker secrets (2.3).',
+    ],
+    key: 'search',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/Search.tsx',
+    name: 'Search Settings',
+    status: 'partial',
+    stores:
+      'Worker A /api/config for the six scope:"server" fields; localStorage for the other sixteen. Field list: packages/research-agent-ui/src/settings/search.json',
+  },
+  {
+    engineFeatures: [],
+    engineTabs: [],
+    gaps: [
+      'The engine has no file-source concept. Its storage tab manages the local database, not remote buckets, and its creds tab holds model-provider credentials.',
+      'Blocking for 2.3: SSH/S3/R2/B2/Google Docs/Turso credentials sit in localStorage under REASON-file-sources with no server copy, so they cannot be migrated — only re-entered, and only once somewhere exists to enter them.',
+      'Decide whether this belongs to the engine at all or to Phase 3 with the REASON editor and its file browser, which is the only consumer.',
+    ],
+    key: 'fileSources',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/FileSources.tsx',
+    name: 'Cloud Storage',
+    status: 'gap',
+    stores:
+      'localStorage: REASON-file-sources, REASON-active-file-source (packages/research-agent-ui/src/lib/file-sources.ts)',
+  },
+  {
+    engineFeatures: [],
+    engineTabs: [],
+    gaps: [
+      'Phase 3 work: rewrite modes are REASON editor prompts (write-language/rewrite-modes), and REASON is not inside the engine yet. There is no settings tab to map them onto until it is.',
+      'Stored in localStorage, so the custom modes a user added do not survive a cutover unless they are exported first.',
+    ],
+    key: 'aiRewriteModes',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/AIRewriteModes.tsx',
+    name: 'Rewrite Modes',
+    status: 'gap',
+    stores:
+      'localStorage via write-language/rewrite-modes (getRewriteModes / saveRewriteModes / resetRewriteModes)',
+  },
+  {
+    engineFeatures: ['service-model'],
+    engineTabs: [SettingsTabs.ServiceModel],
+    gaps: [
+      "The engine's service-model tab configures STT (tts/features/OpenAI) and model assignments. It has no TTS voice picker: SettingsTabs.TTS is deprecated and redirects to ServiceModel, and src/features/Settings/tts/ has no index — only the STT sub-form service-model imports.",
+      'So Kokoro.js on/off, the speaker choice and voice auto-start have no engine home. Decide adopt-or-port here and in 1.4, which tracks the same question for voice input.',
+    ],
+    key: 'voice',
+    legacyComponent: 'apps/qwksearch-web/components/Settings/Sections/Voice.tsx',
+    name: 'Voice Settings',
+    status: 'partial',
+    stores:
+      'localStorage: useTTSKokoro, ttsSpeaker, voice auto-start (packages/research-agent-ui VoiceSettingsPanel)',
+  },
+];
+
+/**
+ * Where one of the legacy `search` section's fields ends up.
+ *
+ * - `covered` — a shipped engine pane already has this control.
+ * - `operator` — an operator credential or host. It stops being a user setting
+ *   and becomes a Worker secret; the panes report only whether it is
+ *   configured, never its value.
+ * - `gap` — the engine needs it and does not have it.
+ * - `shell` — chrome of the old shell (its homepage, its result cards). The
+ *   engine renders its own; nothing migrates unless the feature is ported.
+ */
+export type FieldDestinationKind = 'covered' | 'gap' | 'operator' | 'shell';
+
+export interface LegacySearchField {
+  /** The engine destination, named precisely enough to act on. */
+  destination: string;
+  /** `key` in `packages/research-agent-ui/src/settings/search.json`. */
+  key: string;
+  kind: FieldDestinationKind;
+}
+
+/**
+ * All 22 fields of `search.json`, which the legacy "Search Settings" section
+ * renders as one flat list.
+ *
+ * The list is flat because the old surface had nowhere else to put things: it
+ * mixes an operator's SearXNG host with a homepage animation toggle and the
+ * agent's system prompt. Mapping it section-by-section is what made 2.1 look
+ * finished when it was not — the section maps onto two panes, and eighteen of
+ * its fields land somewhere else entirely.
+ */
+export const LEGACY_SEARCH_FIELDS: readonly LegacySearchField[] = [
+  {
+    destination: 'QwkSearch homepage background art. The engine has its own homepage.',
+    key: 'showBackgroundArt',
+    kind: 'shell',
+  },
+  { destination: 'QwkSearch homepage orb animation.', key: 'orbHoverGlow', kind: 'shell' },
+  { destination: 'QwkSearch homepage cursor trail.', key: 'cursorGlowTrail', kind: 'shell' },
+  {
+    destination:
+      "QwkSearch search-result source cards. The engine renders the web-browsing tool's own results.",
+    key: 'searchResultGlow',
+    kind: 'shell',
+  },
+  {
+    destination: 'Voice: no engine TTS voice picker (see the voice section).',
+    key: 'ttsSpeaker',
+    kind: 'gap',
+  },
+  {
+    destination:
+      "Agent system role — ChatSettingsTabs.Prompt in the engine's agent settings, which is per-agent rather than one global string.",
+    key: 'systemInstructions',
+    kind: 'covered',
+  },
+  {
+    destination:
+      'Follow-up suggestions. Parity item 1.4 — verify the engine reads QwkSearch results before deciding whether a count control is needed.',
+    key: 'maxFollowupQuestions',
+    kind: 'gap',
+  },
+  {
+    destination:
+      'Follow-up suggestion prompt. Engine equivalent lives in its own prompt, not a user setting (1.4).',
+    key: 'followUpQuestionsPrompt',
+    kind: 'gap',
+  },
+  {
+    destination:
+      'Query expansion prompt, used by the search retriever. No engine control; see packages/builtin-tool-web-browsing (1.4).',
+    key: 'queryExpansionPrompt',
+    kind: 'gap',
+  },
+  {
+    destination:
+      'Worker secret QWKSEARCH_SEARCH_URL / SEARXNG_API_URL. The search pane deliberately drops an endpoint sent by a user.',
+    key: 'searxngURL',
+    kind: 'operator',
+  },
+  {
+    destination:
+      'Worker secret. Surfaced to the extraction pane only as effective.configured.proxy — a proxy URL can carry credentials in its userinfo.',
+    key: 'proxyURL',
+    kind: 'operator',
+  },
+  {
+    destination:
+      'Worker secret. Surfaced to the extraction pane only as effective.configured.tavilyApiKey.',
+    key: 'tavilyApiKey',
+    kind: 'operator',
+  },
+  {
+    destination:
+      'Extraction pane, timeoutSeconds (UserExtractionOverrides) — the same knob, per user instead of global.',
+    key: 'sourceScrapeTimeout',
+    kind: 'covered',
+  },
+  { destination: 'QwkSearch homepage weather widget.', key: 'showWeatherWidget', kind: 'shell' },
+  { destination: 'QwkSearch homepage weather widget.', key: 'weatherLocations', kind: 'shell' },
+  { destination: 'QwkSearch homepage weather widget.', key: 'weatherForecastDays', kind: 'shell' },
+  { destination: 'QwkSearch homepage weather widget.', key: 'weatherForecastHours', kind: 'shell' },
+  {
+    destination: 'QwkSearch homepage weather widget.',
+    key: 'weatherTemperatureUnit',
+    kind: 'shell',
+  },
+  {
+    destination: 'QwkSearch homepage trending-news widget.',
+    key: 'showTrendingNewsWidget',
+    kind: 'shell',
+  },
+  {
+    destination: 'QwkSearch homepage trending-news widget.',
+    key: 'trendingNewsApiUrl',
+    kind: 'shell',
+  },
+  {
+    destination: 'QwkSearch homepage trending-news widget.',
+    key: 'trendingNewsMaxTopics',
+    kind: 'shell',
+  },
+  {
+    destination: 'QwkSearch homepage trending-news widget.',
+    key: 'trendingNewsShowImages',
+    kind: 'shell',
+  },
+];
+
+/**
+ * The sections 2.4 may not delete yet, and why.
+ *
+ * This is the whole point of the file: "can the old settings surface be
+ * deleted?" is `retirementBlockers().length === 0`, and it is answerable from
+ * code rather than from a reading of a doc page.
+ */
+export const retirementBlockers = (): readonly LegacySection[] =>
+  LEGACY_SETTINGS_SECTIONS.filter((section) => section.status !== 'covered');
+
+/** Every engine tab the old surface maps onto, deduped, in first-use order. */
+export const engineTabsInUse = (): SettingsTabs[] => [
+  ...new Set(LEGACY_SETTINGS_SECTIONS.flatMap((section) => section.engineTabs)),
+];

--- a/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-integrations.mdx
@@ -78,6 +78,7 @@ then LobeHub's tRPC/webapi/api, then the SPA catch-all.
 | F5b | **Search preferences** — storage and API for F5a's per-user layer | `worker/routes/qwksearch/searchSettings.ts`, `.../qwksearch/searchPreferences.ts` | — | D1 `search_settings` |
 | F5c | **Search & Sources pane** (`/settings/search`) — the form over F5b, inside LobeHub's own settings shell | — | `src/features/Settings/search/` (`index.tsx`, `api.ts`, `formState.ts`, `features/SearchForm.tsx`) | through F5b |
 | F5d | **The panes' shared controls** — ordered drag-sortable lists for `tiers`/`categories`, BCP-47 language fields for `languages`/`language` | — | `src/features/Settings/qwksearch/` (`languageTags.ts`, `OrderedList.tsx`, `OrderedMultiSelect.tsx`, `LanguageSelect.tsx`) | — |
+| F5e | **The legacy settings map** — the old settings surface mapped onto this engine as data, with a guard that fails when either side moves. A migration artifact, not runtime code | — | `src/features/Settings/qwksearch/legacySettingsMap.ts` | — |
 | F6 | **Branding** | `packages/business/const/src/branding.ts`, `packages/const/src/url.ts`, `public/` favicons | — | — |
 | F7 | **Route + nav registration** for `/docs` and the article panel mount | `src/spa/router/desktopRouter.shared.tsx`, `src/features/NavPanel/routeKey.ts`, `src/routes/(main)/_layout/index.tsx` | — | — |
 | F8 | **i18n** | `packages/locales/src/default/qwksearch.ts` + `locales/{en-US,zh-CN}/qwksearch.json` | — | — |
@@ -487,6 +488,57 @@ each render `<Select mode="tags" open={false} tokenSeparators={…} />` with no
 touch, so they are recorded here and not changed — editing them is merge cost
 against upstream and wants its own decision.
 
+### F5e — The legacy settings map
+
+The one entry here that is not wired into anything. It answers a question the
+other entries cannot: **when may the old settings surface be deleted?**
+
+Phase 2.4 of the migration to-do deletes
+`apps/qwksearch-web/components/Settings/**`, `app/settings/[[...section]]` and
+`app/api/config`. Doing that safely needs a per-section answer to "where does
+this land, and what is missing", and that answer has to still be true on the day
+2.4 runs. So it is a module with a contract test rather than a page of prose:
+
+```
+src/features/Settings/qwksearch/
+  legacySettingsMap.ts               LEGACY_SETTINGS_SECTIONS (9) and
+                                     LEGACY_SEARCH_FIELDS (22), plus
+                                     retirementBlockers()
+  legacySettingsMap.contract.test.ts checks every claim against the real files
+```
+
+Each section records four things: what actually stores its values today, the
+engine tabs that take it over, the feature directories behind those tabs, and
+the `gaps` that block deletion. `retirementBlockers()` returns the sections that
+are not yet `covered` — **9 of 9** today — so "may 2.4 run?" is
+`retirementBlockers().length === 0` rather than a reading of a doc page.
+
+**The guard reads both sides from disk** instead of importing them: the legacy
+surface lives in the root Bun workspace and is bundled for Next.js, and
+`componentMap.ts` is thirty `dynamic()` imports that would pull half the SPA
+into the test. So it parses `[SettingsTabs.Foo]:` out of the registry's source,
+resolves each through the real enum, and checks `sections.json`, `search.json`,
+every named legacy component and every named feature directory. Adding a tenth
+section, renaming a pane, or moving a component fails it.
+
+Three things it found, each of which changes the work still to do:
+
+- **The old "server" scope was never per-user.** `POST /api/config` is
+  `assertAdmin`-gated, so the SearXNG URL, the proxy, the Tavily key and the
+  provider keys are one global D1 row. They are operator settings, and on the
+  engine they are Worker secrets — the panes report only `configured: true`.
+- **The "Search Settings" section is 22 fields with four destinations.** One is
+  already covered (`sourceScrapeTimeout` → the extraction pane's
+  `timeoutSeconds`), one is the agent system role, three become Worker secrets,
+  four have no engine home, and thirteen are chrome of the old shell — the
+  homepage animations, the weather widget and the trending-news widget.
+- **`voice → tts` was wrong.** `SettingsTabs.TTS` is deprecated and redirects to
+  `ServiceModel`, and `src/features/Settings/tts/` has no `index` — only the STT
+  sub-form `service-model` imports. Kokoro on/off and the speaker choice have
+  nowhere to land yet.
+
+The map is deleted along with the surface it describes.
+
 ## 3. Shared infrastructure
 
 Both Workers point at the **same** Cloudflare resources, which is what makes a
@@ -547,7 +599,7 @@ the script so this page, `packages-lobe/README.md` and the workflow cannot drift
 apart:
 
 ```bash
-cd packages-lobe && bun run test:qwksearch    # 568 cases, 36 files, ~1 min
+cd packages-lobe && bun run test:qwksearch    # 579 cases, 37 files, ~1 min
 ```
 
 The individual recipes below are for iterating on one seam. They are the same
@@ -582,7 +634,8 @@ bunx vitest run apps/server/src/services/search
 bunx vitest run src/features/Settings/extraction src/features/Settings/search
 
 # The panes' shared controls (F5d), including the language drift guard that
-# runs one corpus through both routes' normalizers and this module (133 cases)
+# runs one corpus through both routes' normalizers and this module, and the
+# legacy settings map with its own guard (F5e) — 144 cases
 bunx vitest run src/features/Settings/qwksearch
 
 # Route/nav registration touched by /docs

--- a/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
+++ b/packages/user-help-docs/content/docs/architecture/lobehub-migration-todo.mdx
@@ -16,7 +16,7 @@ The map of what already connects is
 
 **Legend** — ✅ done · 🚧 in progress · ⬜ not started · 🔒 blocked
 
-Last updated: 2026-09-11.
+Last updated: 2026-09-12.
 
 ## Snapshot
 
@@ -24,7 +24,7 @@ Last updated: 2026-09-11.
 |---|---|
 | 0. Baseline — LobeHub builds and deploys on Workers | ✅ |
 | 1. Chat mode on the engine (staging) | 🚧 search and extraction wired, both with a settings layer, a pane and shared controls; the Worker's one unreachable chain deleted; parity open |
-| 2. Settings as the single system of record | 🚧 Both panes shipped end to end and their controls finished (2.2 done); key migration and retiring the old surface remain |
+| 2. Settings as the single system of record | 🚧 Both panes shipped and their controls finished (2.2), and the old surface is now mapped section by section as a tested artifact (2.1); the key migration and the deletion remain, with 9 of 9 sections still blocking it |
 | 3. REASON docs inside the engine | ⬜ |
 | 4. Public cutover | 🔒 needs the license answer |
 | 5. Decommission + satellites + ops gaps | 🚧 `worker/` type-checks clean and CI finally installs this workspace (5.5, 5.6); packages, satellites and the ops gaps untouched |
@@ -574,10 +574,50 @@ Reproduce today's chat-mode behavior on the engine and record each gap:
 
 ## Phase 2 — Settings: one system of record
 
-- ⬜ **2.1 Map every section** of `research-agent-ui/src/settings/sections.json`
-  to its engine equivalent: models → `Settings/provider` + `service-model`;
-  mcpservers → `features/MCP/MCPSettings`; voice → `tts`; skills-memory →
-  `skill` + `memory`; account/storage → `profile` / `storage`.
+- ✅ **2.1 Map every section** of `research-agent-ui/src/settings/sections.json`
+  to its engine equivalent. Done, and done as **code rather than as this
+  paragraph**: `packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts`
+  carries all nine sections with, for each, what stores its values today, the
+  engine tabs that take it over, and what is still missing before 2.4 may delete
+  it. `legacySettingsMap.contract.test.ts` checks every claim against the thing
+  itself — `sections.json` and `search.json` on the QwkSearch side,
+  `componentMap.ts` and the feature directories on the engine side — so the map
+  fails a test instead of going quietly stale. `retirementBlockers()` is the
+  answer to "may 2.4 run yet?"; it returns **9 of 9** today.
+
+  | Legacy section | Engine tabs | State |
+  |---|---|---|
+  | Account | `profile`, `apikey`, `devices`, `appearance` | 🚧 which API key the Worker trusts; account deletion; browser-session revocation (the `devices` tab is CLI/desktop devices, not sessions) |
+  | Language Models | `provider`, `service-model` | 🚧 global admin row → per-user vault; no "test models" |
+  | Connectors | `connector`, `skill` | 🚧 servers live in Worker A, engine reads its own store |
+  | Skills & Memory | `skill`, `memory` | 🚧 memories are D1 rows vs engine Postgres — the one migrator that is possible |
+  | Search Sources | `search` | 🚧 pane picks categories, legacy picks engines *within* a category + health test |
+  | Search Settings | `search`, `extraction` | 🚧 22 fields, four destinations — see below |
+  | Cloud Storage | — | ⬜ no engine equivalent; credentials in `localStorage` |
+  | Rewrite Modes | — | ⬜ Phase 3: REASON is not in the engine yet |
+  | Voice Settings | `service-model` | 🚧 STT only; `SettingsTabs.TTS` is deprecated and `tts/` has no pane |
+
+  Three findings the map exists to record, because each changes what 2.3 and 2.4
+  have to do:
+
+  - **The old "server" scope was never per-user.** `POST /api/config` is
+    `assertAdmin`-gated, so `searxngURL`, `proxyURL`, `tavilyApiKey` and the
+    provider keys are one global D1 row shared by everyone. On the engine they
+    are Worker secrets — which is what 2.3 already says, but the reason is that
+    they were operator settings all along, not that per-user storage was lost.
+  - **The "Search Settings" section is not one setting.** Its 22 fields have
+    four different destinations, mapped field by field in `LEGACY_SEARCH_FIELDS`:
+    **1** is already on a shipped pane (`sourceScrapeTimeout` → the extraction
+    pane's `timeoutSeconds`), **1** is the agent system role
+    (`ChatSettingsTabs.Prompt`, per-agent rather than global), **3** become
+    Worker secrets, **4** are follow-up/query-expansion prompts and a TTS voice
+    with no engine home, and **13** are chrome of the old shell — homepage
+    background art, orb and cursor glow, result-card glow, the weather widget
+    (5) and the trending-news widget (4).
+  - **`voice → tts` was wrong**, which is the kind of thing a prose map hides:
+    `SettingsTabs.TTS` is deprecated and redirects to `ServiceModel`, and
+    `src/features/Settings/tts/` has no `index` — only an STT sub-form that
+    `service-model` imports. There is no TTS voice pane to map onto.
 - ✅ **2.2 Add the two missing panes**, following the existing tab conventions
   (`src/features/Settings/<tab>/` + route segment + keys in
   `packages/locales/src/default/qwksearch.ts`): **Search & Sources** (engine and
@@ -599,7 +639,16 @@ Reproduce today's chat-mode behavior on the engine and record each gap:
 - ⬜ **2.3 Key migration.** Server env keys stay Worker secrets. Per-user keys
   live in `localStorage` today and have no server copy — announce a one-time
   re-entry into the engine's key vault; do not build a migrator.
-- ⬜ **2.4 Retire the old surface** only after the map is covered: delete
+
+  2.1's map sharpens the list. What actually has to be re-entered is: the
+  **file-source credentials** (SSH / S3 / R2 / B2 / Google Docs / Turso under
+  `REASON-file-sources`, and there is nowhere on the engine to enter them yet),
+  **per-user model provider keys**, and **MCP servers**. What does *not* need
+  announcing is the admin-only global row — those become Worker secrets and no
+  user ever held them. The one place a migrator is even possible is
+  `/api/user/memories`, which is server-side; whether to write one is undecided.
+- ⬜ **2.4 Retire the old surface** when `retirementBlockers()` (2.1) returns
+  empty — it returns all nine sections today. Then delete
   `apps/qwksearch-web/components/Settings/**`, `app/settings/[[...section]]`,
   `app/api/config`, and drop `shadcn-settings` from the prebuild chain. Never run
   two settings stores at once.
@@ -748,7 +797,7 @@ Blocked on the LobeHub Community License answer, recorded in
     drift guards, the shared controls, the Cloudflare adapters, the search
     provider, and the Hyperdrive bridge in `packages/database` (a separate
     vitest project, because the root config excludes `**/packages/**`).
-    **568 tests in 36 files, ~1 minute.** The path list living in the script is
+    **579 tests in 37 files, ~1 minute.** The path list living in the script is
     what stops the workflow, the README and the reference from drifting apart —
     the same mechanism as the panes' `contract.test.ts`.
   - **Path-filtered to everything under `packages-lobe/`, plus the workflow file
@@ -821,8 +870,14 @@ credentials:
    with the two items that are pure verification against the wired-up engine —
    search-cited answers with follow-ups, and file-upload Q&A — and record each
    gap before deciding to adopt or port.
-2. **2.1's settings map**, which is pure reading, and which 2.4 needs before
-   anything in the old surface can be deleted.
+2. **The cheapest blockers 2.1 just named.** The map turned "retire the old
+   surface" into nine specific questions, and three of them are code-only and
+   small: where browser-session revocation goes now that the `devices` tab turns
+   out to manage CLI/desktop devices rather than sessions; whether
+   `SSOProvidersList` can unlink as well as list; and which API key the Worker's
+   `/api/agent/*` routes should trust once the legacy minting UI is gone (that
+   one is a decision, not a build, and it gates deleting the Account section).
+   Each clears a `gaps` entry in `legacySettingsMap.ts` and its test.
 3. **5.4's bundle budget in CI**, which is now purely a minutes decision: 5.6's
    job exists to hang it on, and the measurement exists (`bun run cf:budget`).
    What it needs that 5.6 does not is a full install and a Worker build — see
@@ -853,7 +908,7 @@ Then, for whichever you pick:
    + auto-discovered related tests in one pass) available, which is the workflow
    `packages-lobe/AGENTS.md` documents. Prefer it unless the change is
    `worker/`-only. With it, `bun run test:qwksearch` runs the whole integration
-   surface — 568 tests — in about a minute; that is what CI runs, so a green run
+   surface — 579 tests — in about a minute; that is what CI runs, so a green run
    of it locally is the same signal.
 
    **`bun run build:worker:server` cannot finish after an `--ignore-scripts`


### PR DESCRIPTION
§ 2.1 of the LobeHub Migration To-Do: every section of the old qwksearch.com
settings surface mapped to its engine equivalent. 2.4 may not delete
`apps/qwksearch-web/components/Settings/**` until each section has somewhere to
land, and the item had sat at ⬜ behind a one-line sketch.

**The sketch was already wrong, and a prose map could not have said so.**
`voice → tts` does not exist: `SettingsTabs.TTS` is deprecated, redirects to
`ServiceModel` in `SettingsContent.tsx`'s `REDIRECT_MAP`, and
`src/features/Settings/tts/` has no pane — only the STT sub-form that
`service-model` imports.

So the map ships as data with a contract test rather than as a doc section.

## What's in it

- `packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts` — all
  nine sections of `sections.json` with what stores their values today, the
  engine tabs and feature directories that take them over, and the `gaps` that
  block deletion; all 22 fields of the flat "Search Settings" list with their
  four different destinations; `retirementBlockers()`, which answers "may 2.4
  run yet?" from code and returns **9 of 9** today.
- `legacySettingsMap.contract.test.ts` — 11 cases. Both halves are read from
  disk rather than imported (the legacy surface is in the root Bun workspace;
  `componentMap.ts` is thirty `dynamic()` imports). It parses
  `[SettingsTabs.Foo]:` out of the registry, resolves each through the real
  enum, and checks `sections.json`, `search.json`, every named legacy component
  and every named feature directory. Adding a section, renaming a pane or moving
  a component fails it.

## Findings that change what 2.3 and 2.4 have to do

- **The old "server" scope was never per-user.** `POST /api/config` is
  `assertAdmin`-gated, so `searxngURL`, `proxyURL`, `tavilyApiKey` and the
  provider keys are one global D1 row. They are operator settings and become
  Worker secrets, which makes 2.3's re-entry list smaller than it looked:
  file-source credentials, per-user provider keys, MCP servers.
- **"Search Settings" is 22 unrelated fields**, not a settings section. One is
  already covered (`sourceScrapeTimeout` → the extraction pane's
  `timeoutSeconds`), one is the agent system role, three become Worker secrets,
  four have no engine home, and thirteen are chrome of the old shell — homepage
  animations, the weather widget and the trending-news widget.
- **The `devices` tab is not session management.** It manages CLI/desktop device
  connections and their shares; browser-session revocation (`/api/user/sessions`)
  has no engine equivalent.

## Scope

Additive only — no upstream LobeHub file changed. The guard merely *reads*
`componentMap.ts` as text, which is how it notices upstream dropping a pane the
migration was counting on.

Docs updated in the same change: § 2.1 resolved with a per-section table, § 2.3
sharpened, § 2.4 restated as `retirementBlockers()` returning empty, the
snapshot row, the re-ranked "suggested next", §F5e in the integrations
reference, and `packages-lobe/README.md` (features, Tests, What changed).

## Verification

| Check | Result |
|---|---|
| `bunx vitest run src/features/Settings/qwksearch` | 144 passed (was 133) |
| `bun run test:qwksearch` | 577 + 2 passed, 37 files, ~1 min — what CI runs |
| `bun run type-check:qwksearch` | clean |
| `bun run check --lint` on both new files | clean |
| Both changed `.mdx` files compiled with `@mdx-js/mdx` | OK |

The guard was verified by mutation, not assumed: pointing the voice row at
`SettingsTabs.TTS` fails with `voice → SettingsTabs "tts" is not reachable`, and
dropping one of the 22 fields fails the `search.json` coverage case. Both
reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013szA4xFV79qK2JWasqN4w6

---
_Generated by [Claude Code](https://claude.ai/code/session_013szA4xFV79qK2JWasqN4w6)_