### PR TITLE
📝 docs(packages-lobe): correct three counts inside the legacy settings map

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,10 @@ of how to migrate and document all lobehub integrations". The LobeHub Migration
 To-Do's own #2 suggested next: § 2.1's settings map, which § 2.4 needs before
 anything in the old surface can be deleted.
 **Branch:** `claude/magical-bohr-0skpwn` (rebased onto `master` at `2b19de7a`)
-**PR:** #458
+**PR:** #458, plus #459 — three counts inside the map's own prose were wrong
+(thirteen shell fields written as nine, four server-scoped fields written as
+six, and an unverified "75+" engine count). #458 auto-merged 27 seconds after it
+opened, which is why the correction is its own PR rather than another commit.
 **Started:** 2026-09-12
 **Completed:** 2026-09-12
 

--- a/packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts
+++ b/packages-lobe/src/features/Settings/qwksearch/legacySettingsMap.ts
@@ -149,7 +149,7 @@ export const LEGACY_SETTINGS_SECTIONS: readonly LegacySection[] = [
     engineFeatures: ['search'],
     engineTabs: [SettingsTabs.Search],
     gaps: [
-      'The engine pane selects *categories*; the legacy pane selects *engines within a category* (75+ of them, with favicons and descriptions). No per-engine override exists in UserSearchOverrides.',
+      'The engine pane selects *categories*; the legacy pane selects *individual engines within a category*, listed from GET /api/search/engines with favicons and descriptions. No per-engine override exists in UserSearchOverrides.',
       'No engine equivalent for the live health check: GET /api/search/engines/status and POST /api/search/engines/test run a probe query per engine and disable the ones that fail.',
     ],
     key: 'searchEngines',
@@ -163,7 +163,7 @@ export const LEGACY_SETTINGS_SECTIONS: readonly LegacySection[] = [
     engineTabs: [SettingsTabs.Search, SettingsTabs.Extraction],
     gaps: [
       'This section is 22 unrelated fields with four different destinations — see LEGACY_SEARCH_FIELDS, which maps each one. Only sourceScrapeTimeout lands on a shipped pane today.',
-      'Nine of the 22 are homepage chrome (background art, orb glow, cursor trail, result glow) and homepage widgets (weather ×5, trending news ×4) belonging to a shell the engine replaces.',
+      'Thirteen of the 22 are chrome of a shell the engine replaces: four animations (homepage background art, orb glow, cursor trail, result-card glow) and two homepage widgets (weather ×5, trending news ×4).',
       'Three are operator credentials on a global admin-only row (searxngURL, proxyURL, tavilyApiKey) and become Worker secrets (2.3).',
     ],
     key: 'search',
@@ -171,7 +171,7 @@ export const LEGACY_SETTINGS_SECTIONS: readonly LegacySection[] = [
     name: 'Search Settings',
     status: 'partial',
     stores:
-      'Worker A /api/config for the six scope:"server" fields; localStorage for the other sixteen. Field list: packages/research-agent-ui/src/settings/search.json',
+      'Worker A /api/config for the four scope:"server" fields (searxngURL, proxyURL, tavilyApiKey, sourceScrapeTimeout); localStorage for the other eighteen. Field list: packages/research-agent-ui/src/settings/search.json',
   },
   {
     engineFeatures: [],


### PR DESCRIPTION
Follow-up to #458, which auto-merged 27 seconds after it opened.

The map's *structure* is checked by its contract test — section keys, field
keys, tab registration, feature directories. The prose inside its `gaps` and
`stores` strings is not, and three counts in it were wrong:

| Was | Is |
|---|---|
| "Nine of the 22 are homepage chrome" | **thirteen** — four animations, the weather widget's five fields, the trending-news widget's four. `LEGACY_SEARCH_FIELDS` and the docs already said thirteen; only this sentence disagreed. |
| "the six `scope:"server"` fields … the other sixteen" | **four** (`searxngURL`, `proxyURL`, `tavilyApiKey`, `sourceScrapeTimeout`) and **eighteen**. Now named, since the list is short and it is the list § 2.3 acts on. |
| "75+ of them" for the engines the legacy pane lists | replaced with where the list comes from — `GET /api/search/engines`. The number was never verified in that change. |

Counted from `packages/research-agent-ui/src/settings/search.json` rather than
from memory this time.

No structural change: `bunx vitest run src/features/Settings/qwksearch` is still
144 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013szA4xFV79qK2JWasqN4w6

---
_Generated by [Claude Code](https://claude.ai/code/session_013szA4xFV79qK2JWasqN4w6)_