### PR TITLE
🐛 fix(packages-lobe): open the Postgres pool on first query, not on import

### DIFF
--- a/packages-lobe/README.md
+++ b/packages-lobe/README.md
@@ -194,6 +194,15 @@ Project settings for a Workers Builds deploy of this tree:
 | Build command | `pnpm run build:worker` |
 | Deploy command | `pnpm exec wrangler deploy` |
 
+All four have to be entered. The default build command is `npm run build`, which is the Next
+build, not the Worker build: it writes `.next/` and never `dist/worker/index.js`, so the deploy
+step that follows has nothing to upload. It is also how a Workers build ends at `Failed to
+collect page data for /api/auth/resolve-username` — `next build` imports every route to read its
+config, and importing a route that talks to Postgres used to construct the connection pool, which
+throws when `KEY_VAULTS_SECRET` is unset. The pool is now built on first query
+(`packages/database/src/core/db-adaptor.ts`), so neither build needs runtime secrets; `build:worker`
+is still the only one whose output `wrangler deploy` uploads.
+
 The repo root's `packageManager` (`bun@1.4.0`) and this tree's
 (`pnpm@10.33.0`) are both detected and both are installed, and the build image
 picks the repo root's bun unless the install command is set explicitly. Prefer
@@ -268,7 +277,7 @@ LobeHub's Postgres migrations once against the database: `bun run db:migrate` wi
 ## Tests
 
 ```bash
-# Everything QwkSearch added to the engine, in one command -- 579 tests in 37
+# Everything QwkSearch added to the engine, in one command -- 583 tests in 38
 # files, about a minute. This is what CI runs (.github/workflows/lobehub-engine.yml),
 # and the path list lives in the script so the workflow and the docs cannot drift.
 bun run test:qwksearch
@@ -298,7 +307,7 @@ bunx vitest run src/features/Settings/extraction src/features/Settings/search
 bunx vitest run src/spa/router/desktopRouter.sync.test.tsx src/features/NavPanel/routeKey.test.ts
 
 # database bridge
-cd packages/database && bunx vitest run src/core/cloudflare.test.ts
+cd packages/database && bunx vitest run src/core/cloudflare.test.ts src/core/db-adaptor.test.ts
 ```
 
 Coverage includes SPA locale/device/route resolution, the extraction fallback chain, the article and
@@ -310,6 +319,11 @@ rebuilds its route's response from the real resolver.
 ## What changed vs. upstream LobeHub
 
 - `packages/database/src/core/web-server.ts`: Hyperdrive branch (`resolveHyperdriveConnectionString`).
+- `packages/database/src/core/db-adaptor.ts`: `serverDB` is a lazy proxy instead of a
+  `getDBInstance()` call evaluated at module scope, so importing a module cannot build a
+  connection pool. It resolves on first property access, to the one instance `getServerDB()`
+  caches. Upstream's eager export fails any `next build` that runs without `KEY_VAULTS_SECRET`,
+  while it is merely collecting a route's page data.
 - `src/libs/better-auth/utils/config.ts`: KV-backed `secondaryStorage` (`createKVSecondaryStorage`).
 - `apps/server/src/services/email/*`: `cloudflare` provider (Email Routing binding), default on Workers.
 - `apps/server/src/services/search/impls/`: new `qwksearch` provider (`SearchImplType.QwkSearch`),

--- a/packages-lobe/package.json
+++ b/packages-lobe/package.json
@@ -125,7 +125,7 @@
     "start": "next start -p 3210",
     "stylelint": "stylelint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
     "test": "npm run test-app && npm run test-server",
-    "test:qwksearch": "vitest run worker src/features/QwkSearch src/features/Settings/extraction src/features/Settings/search src/features/Settings/qwksearch src/libs/better-auth/utils/kvSecondaryStorage.test.ts src/spa/router/desktopRouter.sync.test.tsx src/features/NavPanel/routeKey.test.ts apps/server/src/services/email/impls/cloudflare apps/server/src/services/search/impls/qwksearch && pnpm --filter @lobechat/database exec vitest run src/core/cloudflare.test.ts",
+    "test:qwksearch": "vitest run worker src/features/QwkSearch src/features/Settings/extraction src/features/Settings/search src/features/Settings/qwksearch src/libs/better-auth/utils/kvSecondaryStorage.test.ts src/spa/router/desktopRouter.sync.test.tsx src/features/NavPanel/routeKey.test.ts apps/server/src/services/email/impls/cloudflare apps/server/src/services/search/impls/qwksearch && pnpm --filter @lobechat/database exec vitest run src/core/cloudflare.test.ts src/core/db-adaptor.test.ts",
     "test:update": "vitest -u",
     "test-app": "vitest run",
     "test-app:coverage": "vitest --coverage --silent='passed-only'",

--- a/packages-lobe/packages/database/src/core/db-adaptor.test.ts
+++ b/packages-lobe/packages/database/src/core/db-adaptor.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LobeChatDatabase } from '../type';
+
+const getDBInstance = vi.hoisted(() => vi.fn());
+
+vi.mock('./web-server', () => ({ getDBInstance }));
+
+/** Re-evaluate the module so each test starts before the instance is cached. */
+const loadAdaptor = async () => {
+  vi.resetModules();
+  return import('./db-adaptor');
+};
+
+const createFakeDB = () => ({
+  marker: 'real instance',
+  select() {
+    return this.marker;
+  },
+});
+
+describe('serverDB', () => {
+  beforeEach(() => {
+    getDBInstance.mockReset();
+    getDBInstance.mockImplementation(() => createFakeDB() as unknown as LobeChatDatabase);
+  });
+
+  it('does not build a database just because a module imported it', async () => {
+    await loadAdaptor();
+
+    expect(getDBInstance).not.toHaveBeenCalled();
+  });
+
+  it('builds the instance once, on first use, and caches it', async () => {
+    const { serverDB } = await loadAdaptor();
+
+    expect(serverDB.select()).toBe('real instance');
+    expect((serverDB as unknown as { marker: string }).marker).toBe('real instance');
+    expect(getDBInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares that one instance with getServerDB()', async () => {
+    const { getServerDB, serverDB } = await loadAdaptor();
+
+    const first = await getServerDB();
+
+    expect(serverDB.select()).toBe('real instance');
+    expect(await getServerDB()).toBe(first);
+    expect(getDBInstance).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports the failure on use rather than on import', async () => {
+    const error = new Error('`KEY_VAULTS_SECRET` is not set');
+    getDBInstance.mockImplementation(() => {
+      throw error;
+    });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Importing is what `next build` does to collect a route's page data.
+    const { getServerDB, serverDB } = await loadAdaptor();
+
+    expect(() => serverDB.select).toThrow(error);
+    await expect(getServerDB()).rejects.toThrow(error);
+
+    consoleError.mockRestore();
+  });
+});

--- a/packages-lobe/packages/database/src/core/db-adaptor.ts
+++ b/packages-lobe/packages/database/src/core/db-adaptor.ts
@@ -7,7 +7,7 @@ import { getDBInstance } from './web-server';
  */
 let cachedDB: LobeChatDatabase | null = null;
 
-export const getServerDB = async (): Promise<LobeChatDatabase> => {
+const resolveDB = (): LobeChatDatabase => {
   // If there's already a cached instance, return it directly
   if (cachedDB) return cachedDB;
 
@@ -21,4 +21,40 @@ export const getServerDB = async (): Promise<LobeChatDatabase> => {
   }
 };
 
-export const serverDB = getDBInstance();
+export const getServerDB = async (): Promise<LobeChatDatabase> => resolveDB();
+
+/**
+ * `serverDB` is a lazy handle, not a connection.
+ *
+ * It used to be `getDBInstance()` evaluated at module scope, so *importing* any
+ * module that touches the database built a connection pool — and threw when
+ * `KEY_VAULTS_SECRET` / `DATABASE_URL` were absent. `next build` imports every
+ * route to collect its page data, so a build without runtime secrets died on
+ * the first route that imports this (see `/api/auth/resolve-username`), even
+ * though no query runs during a build.
+ *
+ * The proxy defers construction to the first property access and shares the one
+ * cached instance with `getServerDB()`, so call sites keep using `serverDB`
+ * exactly as before while a build only needs the secrets it actually reads.
+ */
+export const serverDB = new Proxy({} as LobeChatDatabase, {
+  get: (_target, property) => {
+    const db = resolveDB();
+    const value = Reflect.get(db, property);
+
+    // Methods must keep the real instance as `this`; drizzle reaches for its own
+    // internals (session, dialect, schema) from there.
+    return typeof value === 'function' ? value.bind(db) : value;
+  },
+  getOwnPropertyDescriptor: (_target, property) => {
+    const descriptor = Reflect.getOwnPropertyDescriptor(resolveDB(), property);
+
+    // The proxy target is an empty object, so reporting a non-configurable
+    // property of another object would violate the proxy invariants.
+    return descriptor && { ...descriptor, configurable: true };
+  },
+  getPrototypeOf: () => Reflect.getPrototypeOf(resolveDB()),
+  has: (_target, property) => Reflect.has(resolveDB(), property),
+  ownKeys: () => Reflect.ownKeys(resolveDB()),
+  set: (_target, property, value) => Reflect.set(resolveDB(), property, value),
+});


### PR DESCRIPTION
## The failure

The Cloudflare build ran `npm run build` in `packages-lobe` and died in `next build`:

```
Error: Failed to collect page data for /api/auth/resolve-username
  [cause]: `KEY_VAULTS_SECRET` is not set, please set it in your environment variables.
```

Nothing queries the database during a build. `next build` imports every route to read its config, and `packages/database/src/core/db-adaptor.ts` exported `serverDB = getDBInstance()` — evaluated at module scope. So importing any of the fourteen modules that touch Postgres built a connection pool, and `getDBInstance()` throws when `KEY_VAULTS_SECRET` is unset. `/api/auth/resolve-username` is simply the first such route the collector reached.

## The change

`serverDB` is now a proxy that resolves on first property access, to the same instance `getServerDB()` caches. Methods are bound to the real instance so drizzle still reaches its own session/dialect/schema through `this`. Every call site keeps using `serverDB` unchanged, and a correctly configured deploy behaves exactly as before — the pool is built by the first query instead of by the first import.

## Verification

- `npm run build` in `packages-lobe`, with **no** `KEY_VAULTS_SECRET`, `DATABASE_URL` or `AUTH_SECRET` in the environment — the same condition that failed on Cloudflare — now completes: SPA bundles, page-data collection and the route table, exit 0.
- `bun run test:qwksearch` green: 583 tests in 38 files.
- New `packages/database/src/core/db-adaptor.test.ts` (wired into `test:qwksearch`, so CI runs it) fails three of its four assertions against the eager export and passes against the proxy.
- `bun run check --lint` clean on both changed source files.

## Still needed on the Cloudflare side

This fixes the build error, not the project settings. The build that failed used the defaults (`bun install --frozen-lockfile`, `npm run build`), while a Workers deploy of this tree needs the four settings the README already documents — in particular `pnpm run build:worker`, which is what produces the `dist/worker/index.js` that `wrangler deploy` uploads. `npm run build` is the Next build; it writes `.next/` and leaves the deploy step with nothing. That paragraph is now spelled out next to the settings table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gcjF4Xf9w9wL4XeEVm563

---
_Generated by [Claude Code](https://claude.ai/code/session_012gcjF4Xf9w9wL4XeEVm563)_