### PR TITLE
🔍 fix(web): make the homepage's silent server-render 500 visible

### DIFF
--- a/apps/qwksearch-web/CLAUDE.md
+++ b/apps/qwksearch-web/CLAUDE.md
@@ -55,3 +55,42 @@ bun run dev        # from the root: turbo dev --filter=qwksearch-web
 bun run build
 bun run test
 ```
+
+## Debugging a server-render 500
+
+A render failure on this stack is silent by default. vinext hands React's
+`onError` to a renderer that only looks for redirect/not-found digests, and
+when the app has no `global-error.tsx` a **shell** error is swallowed into a
+built-in error document with `status: 500`. Cloudflare then records the
+invocation as a bare `GET https://…/ → 500` — no message, no route, no stack.
+
+Four pieces now make that failure legible. Read them together:
+
+| Piece | Catches |
+| --- | --- |
+| `instrumentation.ts` → `onRequestError` | every unhandled render error, **unredacted**, with the route that was rendering |
+| `app/global-error.tsx` | the shell error itself — its existence is what makes vinext rethrow instead of swallowing |
+| `lib/debug/ssr-trace.ts` | `[ssr-trace]` breadcrumbs and `[ssr-error]` failures, on the Worker and in the browser |
+| `lib/debug/marks/*` | import-order markers, so a module that throws *while being evaluated* is named |
+
+How to read a trace:
+
+- Join it to Cloudflare's invocation log by `cf-ray`, which `worker:request`
+  prints first.
+- **Read it by its last line.** A `…:begin` marker with no matching `:end`
+  means a module in that import graph threw while being evaluated — the failure
+  that 500s the whole route before React has a boundary (see #440, #451).
+- A trace that reaches `layout:render:returning-tree` but never `home:page:render`
+  puts the failure in the provider stack, not the page. The
+  `home:stack:use*` breadcrumbs sit between the context hooks for the same
+  reason: the missing one names the hook that threw.
+- The `#N` counter restarts per module graph — the RSC and SSR environments
+  each hold their own copy of the tracer, so one render prints two `#1`s. Order
+  by the `+Nms` stamp, not by the counter.
+- `worker:error-body` quotes the first ~1.2KB of any 5xx body, which tells
+  vinext's built-in error document apart from this app's `global-error.tsx`.
+
+Breadcrumbs are **on by default** — a trace that has to be enabled first is one
+nobody has when it matters. Set the plain Worker Variable `QS_SSR_TRACE=off` in
+the dashboard to silence them without a redeploy; `[ssr-error]` lines are never
+silenced.

--- a/apps/qwksearch-web/app/global-error.tsx
+++ b/apps/qwksearch-web/app/global-error.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { describeError, logSsrError, traceSsr } from '@/lib/debug/ssr-trace';
+
+/**
+ * The root error boundary — and, more to the point, the only place the app can
+ * see a server *shell* error at all.
+ *
+ * vinext decides how to handle a shell error by whether this file exists:
+ *
+ *   no `global-error.tsx`  →  `fallbackToErrorDocumentOnShellError` is true, the
+ *                             throw is swallowed, and the request ends as a
+ *                             built-in error document with `status: 500` and
+ *                             nothing written to the log. That is the state the
+ *                             homepage's mystery 500 was reported in.
+ *   this file              →  the throw is rethrown into
+ *                             `renderAppPageHtmlStreamWithRecovery`, which
+ *                             renders this component with `errorOrigin: "ssr"`
+ *                             — and an SSR-origin error is passed through
+ *                             *unredacted*, so the render below can log the
+ *                             real message and stack.
+ *
+ * An RSC-origin error arrives redacted instead ("The specific message is
+ * omitted in production builds…"), with the original hung off the replacement
+ * under `Symbol.for("vinext.originalServerError")`; `describeError` unwraps it.
+ *
+ * @see node_modules/vinext/dist/server/app-page-stream.js — `fallbackToErrorDocumentOnShellError`
+ * @see node_modules/vinext/dist/server/app-page-boundary-render.js — `errorOrigin === "ssr"`
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: (Error & { digest?: string }) | null | undefined;
+  reset?: () => void;
+}) {
+  // Runs during the server render of the boundary as well as in the browser,
+  // so this one line is what turns a bare `500` in the Cloudflare dashboard
+  // into a message, a stack and a route.
+  logSsrError('global-error:render', error, {
+    digest: error?.digest,
+    hasReset: typeof reset === 'function',
+    href: typeof window === 'undefined' ? undefined : window.location.href,
+  });
+
+  const described = describeError(error);
+
+  return (
+    <html id="__next_error__" lang="en">
+      <head>
+        <title>This page could not load</title>
+        <style
+          dangerouslySetInnerHTML={{
+            __html: [
+              ':root{--bg:#fff;--fg:#171717;--muted:#666;color-scheme:light}',
+              '@media (prefers-color-scheme:dark){:root{--bg:#0a0a0a;--fg:#ededed;--muted:#a0a0a0;color-scheme:dark}}',
+              'body{margin:0;background:var(--bg);color:var(--fg);font-family:system-ui,sans-serif}',
+              '.wrap{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px}',
+              '.card{max-width:32rem;text-align:left}',
+              'h1{font-size:1.5rem;line-height:2rem;margin:0 0 .75rem}',
+              'p{font-size:.875rem;line-height:1.35rem;margin:0 0 1.25rem;color:var(--muted)}',
+              'button{height:2rem;padding:0 .75rem;font:500 .875rem/1.25rem inherit;border-radius:.375rem;',
+              'border:none;cursor:pointer;background:var(--fg);color:var(--bg)}',
+              'code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.75rem;color:var(--muted)}',
+            ].join(''),
+          }}
+        />
+      </head>
+      <body>
+        <div className="wrap">
+          <div className="card">
+            <h1>This page could not load</h1>
+            <p>
+              A server error occurred while rendering this page. Reloading often
+              works; the failure has been written to the server log either way.
+            </p>
+            <button type="button" onClick={() => (reset ? reset() : window.location.reload())}>
+              Reload
+            </button>
+            {described.digest ? (
+              <p style={{ marginTop: '1.25rem' }}>
+                <code>ERROR {described.digest}</code>
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}
+
+traceSsr('module:app/global-error');

--- a/apps/qwksearch-web/app/layout.tsx
+++ b/apps/qwksearch-web/app/layout.tsx
@@ -6,7 +6,16 @@ import 'shadcn-theme-menu/themes.css';
 import { cookies } from "next/headers"
 import { cn } from '@/lib/utils';
 import { config } from '@/lib/config/site';
+// Import-order markers around `Providers`: it pulls the whole
+// `research-agent-ui` shell into the root layout, so a module-scope `document`
+// read anywhere in that graph throws while *this* module is being evaluated —
+// before React has a boundary — and answers every route with a 500. A
+// `layout:import:providers:begin` with no matching `:end` in the log says that
+// is what happened. See lib/debug/marks/README.md.
+import '@/lib/debug/marks/layout-providers-begin';
 import { Providers } from '@/components/layout/Providers';
+import '@/lib/debug/marks/layout-providers-end';
+import { logSsrError, traceSsr } from '@/lib/debug/ssr-trace';
 
 export const metadata: Metadata = {
   title: config.appName + ' - Reimagine the Web as a Self-Organizing Mind Map',
@@ -29,8 +38,25 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookieStore = await cookies();
-  const theme = cookieStore.get("color-theme")?.value || "modern-minimal"
+  traceSsr('layout:render:enter');
+
+  // `cookies()` is a dynamic API: it opts the whole tree out of static
+  // rendering and, outside a request scope, throws. Logging the throw here
+  // separates "the layout could not read the request" from "something below
+  // the layout failed to render", which the bare 500 does not.
+  let theme = 'modern-minimal';
+  try {
+    const cookieStore = await cookies();
+    theme = cookieStore.get("color-theme")?.value || "modern-minimal";
+    traceSsr('layout:cookies:read', { theme });
+  } catch (error) {
+    logSsrError('layout:cookies:threw', error);
+    throw error;
+  }
+
+  // The tree below is returned, not rendered, here: React walks it afterwards.
+  // A trace that stops on this line means the failure is in a descendant.
+  traceSsr('layout:render:returning-tree');
 
   return (
     <html lang="en" suppressHydrationWarning className={`theme-${theme}`}>
@@ -50,3 +76,5 @@ export default async function RootLayout({
     </html>
   );
 }
+
+traceSsr('module:app/layout');

--- a/apps/qwksearch-web/app/page.tsx
+++ b/apps/qwksearch-web/app/page.tsx
@@ -1,9 +1,17 @@
 'use client';
 
 import { HomeScrollStack } from '@/components/layout/HomeScrollStack';
+import { traceSsr } from '@/lib/debug/ssr-trace';
 
 const Home = () => {
+  // The homepage is the route the mystery 500 was reported on, so it gets its
+  // own breadcrumb: a trace that reaches `layout:render:returning-tree` but
+  // never reaches here puts the failure between the two — i.e. in the provider
+  // stack, not in the page.
+  traceSsr('home:page:render');
   return <HomeScrollStack />;
 };
 
 export default Home;
+
+traceSsr('module:app/page');

--- a/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
+++ b/apps/qwksearch-web/components/layout/HomeScrollStack.tsx
@@ -8,7 +8,10 @@ import { useChat, useMainView } from 'research-agent-ui';
 
 import { isHomeLandingState } from '@/lib/home-landing';
 import { cn } from '@/lib/utils';
+import { traceSsr } from '@/lib/debug/ssr-trace';
+import '@/lib/debug/marks/home-workspace-mount-begin';
 import { WorkspaceMount } from '@/components/layout/WorkspaceMount';
+import '@/lib/debug/marks/home-workspace-mount-end';
 
 /**
  * The homepage: the research workspace on the first screen, with the whole
@@ -147,12 +150,23 @@ function ScrollCue({
 }
 
 export function HomeScrollStack() {
+  // One breadcrumb between each hook call rather than a try/catch around them:
+  // a hook that throws must still be *called* on the next render or the hook
+  // order breaks, so the useful signal is which breadcrumb is missing. The
+  // context hooks below come from `research-agent-ui` and read providers
+  // mounted in the root layout — if that stack failed to mount, this is where
+  // the homepage stops, and the last line in the log names the hook.
+  traceSsr('home:stack:render:enter');
+
   const workspaceRef = React.useRef<HTMLDivElement>(null);
   const featuresRef = React.useRef<HTMLDivElement>(null);
   const reducedMotion = usePrefersReducedMotion();
   const pathname = usePathname();
+  traceSsr('home:stack:usePathname', { pathname });
   const { activeView } = useMainView();
+  traceSsr('home:stack:useMainView', { activeView });
   const { chatTurns } = useChat();
+  traceSsr('home:stack:useChat', { chatTurnCount: chatTurns?.length });
 
   // The features slab belongs to the homepage's landing state and nowhere
   // else. The workspace never leaves `/` — chats and REASON documents are tabs
@@ -176,6 +190,8 @@ export function HomeScrollStack() {
 
   // The cue only ever points at the slab, so it lives and dies with it.
   const showCue = showFeatures;
+
+  traceSsr('home:stack:render:resolved', { showFeatures, showingFeatures });
 
   const scrollTo = (ref: React.RefObject<HTMLElement | null>) => {
     ref.current?.scrollIntoView({
@@ -229,3 +245,5 @@ export function HomeScrollStack() {
     </div>
   );
 }
+
+traceSsr('module:components/layout/HomeScrollStack');

--- a/apps/qwksearch-web/components/layout/Providers.tsx
+++ b/apps/qwksearch-web/components/layout/Providers.tsx
@@ -1,9 +1,19 @@
 'use client';
 
+// Import-order markers — see lib/debug/marks/README.md. `research-agent-ui`
+// and the Better Auth client are the two module graphs in this file big enough
+// to fail while being evaluated, which is the failure that costs the whole
+// page a 500 rather than a subtree. A `:begin` with no `:end` names the one
+// that threw.
+import '@/lib/debug/marks/research-agent-ui-begin';
 import { QwkSearchProviders } from 'research-agent-ui';
+import '@/lib/debug/marks/research-agent-ui-end';
+import '@/lib/debug/marks/auth-client-begin';
 import { authClient } from '@/lib/auth/client';
+import '@/lib/debug/marks/auth-client-end';
 import { SettingsModalProvider } from '@/components/Settings/SettingsModal';
 import { config, listFooterLinks } from '@/lib/config/site';
+import { traceSsr } from '@/lib/debug/ssr-trace';
 
 /**
  * The app's root providers. The stack itself — theming, session, chat,
@@ -13,6 +23,11 @@ import { config, listFooterLinks } from '@/lib/config/site';
  * to the web app: its auth client, its site config, and its settings modal.
  */
 export function Providers({ children }: { children: React.ReactNode }) {
+  traceSsr('providers:render', {
+    hasAuthClient: Boolean(authClient),
+    baseUrl: config.baseUrl,
+  });
+
   return (
     <QwkSearchProviders
       authClient={authClient}
@@ -38,3 +53,5 @@ export function Providers({ children }: { children: React.ReactNode }) {
     </QwkSearchProviders>
   );
 }
+
+traceSsr('module:components/layout/Providers');

--- a/apps/qwksearch-web/components/layout/WorkspaceMount.tsx
+++ b/apps/qwksearch-web/components/layout/WorkspaceMount.tsx
@@ -2,6 +2,8 @@
 
 import * as React from 'react';
 
+import { logSsrError, traceSsr } from '@/lib/debug/ssr-trace';
+
 /**
  * The one place the app mounts `research-agent-ui/workspace`.
  *
@@ -27,11 +29,25 @@ import * as React from 'react';
  * in the browser too (an offline navigation, a half-deployed asset), the reader
  * gets a reload prompt rather than a blank screen.
  */
-const ResearchWorkspaceView = React.lazy(() =>
-  import('research-agent-ui/workspace').then((mod) => ({
-    default: mod.ResearchWorkspaceView,
-  })),
-);
+const ResearchWorkspaceView = React.lazy(() => {
+  traceSsr('workspace:chunk:import:begin');
+  return import('research-agent-ui/workspace').then(
+    (mod) => {
+      traceSsr('workspace:chunk:import:end', {
+        hasView: typeof mod.ResearchWorkspaceView === 'function',
+      });
+      return { default: mod.ResearchWorkspaceView };
+    },
+    (error) => {
+      // The whole point of the lazy import is that this failure costs a
+      // skeleton instead of the page — but React only reports it as a
+      // *recoverable* error, which production logs nowhere. Log it here, then
+      // rethrow so the Suspense/error boundary behaviour below is unchanged.
+      logSsrError('workspace:chunk:import:failed', error);
+      throw error;
+    },
+  );
+});
 
 /**
  * Holds the workspace's footprint while its chunk is in flight. The workspace
@@ -75,7 +91,10 @@ class WorkspaceErrorBoundary extends React.Component<
 > {
   state = { failed: false };
 
-  static getDerivedStateFromError() {
+  static getDerivedStateFromError(error: unknown) {
+    // Unlike `componentDidCatch`, this runs during a server render too, so it
+    // is the only hook that reports a workspace failure from inside the Worker.
+    logSsrError('workspace:boundary:derived-state', error);
     return { failed: true };
   }
 
@@ -93,6 +112,8 @@ class WorkspaceErrorBoundary extends React.Component<
 
 /** The research workspace, mounted so that failing to load it is not a 500. */
 export function WorkspaceMount() {
+  traceSsr('workspace:mount:render');
+
   return (
     <WorkspaceErrorBoundary>
       <React.Suspense fallback={<WorkspaceSkeleton />}>
@@ -101,3 +122,5 @@ export function WorkspaceMount() {
     </WorkspaceErrorBoundary>
   );
 }
+
+traceSsr('module:components/layout/WorkspaceMount');

--- a/apps/qwksearch-web/instrumentation.ts
+++ b/apps/qwksearch-web/instrumentation.ts
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview `register()` / `onRequestError()` — the framework's own error
+ * hook, wired to the Worker's console.
+ *
+ * vinext supports Next.js's `instrumentation.ts` convention: `register()` is
+ * baked into the generated RSC entry as a top-level `await`, so it runs inside
+ * the Worker before the first request, and an exported `onRequestError` is
+ * parked on `globalThis` and called for every unhandled server render error —
+ * **with the original error, not the production-redacted one**.
+ *
+ * That last part is why this file is the single most valuable logger in the
+ * app. Without it, vinext's `createRscOnErrorHandler` reports the error to a
+ * reporter that does not exist, declines to `console.error` it because
+ * `NODE_ENV === "production"`, and returns a digest. The request then ends as a
+ * `500` that says nothing.
+ *
+ * @see node_modules/vinext/dist/server/app-rsc-errors.js — `createRscOnErrorHandler`
+ * @see node_modules/vinext/dist/server/instrumentation.js — `reportRequestError`
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation
+ */
+
+import { describeError, isSsrTraceEnabled, logSsrError, traceSsr } from './lib/debug/ssr-trace';
+
+/** Request headers worth keeping. The rest are noise or personal data. */
+const LOGGED_HEADERS = [
+  'accept',
+  'accept-language',
+  'user-agent',
+  'referer',
+  'sec-fetch-dest',
+  'sec-fetch-mode',
+  'sec-ch-ua-mobile',
+  'rsc',
+  'next-router-prefetch',
+  'cf-ray',
+  'cf-ipcountry',
+  'host',
+  'x-forwarded-proto',
+];
+
+type RequestInfo = {
+  path?: string;
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+};
+
+type ErrorContext = {
+  routerKind?: string;
+  routePath?: string;
+  routeType?: string;
+  renderSource?: string;
+  revalidateReason?: string;
+};
+
+/** Header subset, with cookie values reduced to their names. */
+function pickHeaders(headers: RequestInfo['headers']): Record<string, string> {
+  const picked: Record<string, string> = {};
+  if (!headers) return picked;
+  for (const name of LOGGED_HEADERS) {
+    const value = headers[name];
+    if (typeof value === 'string') picked[name] = value;
+    else if (Array.isArray(value)) picked[name] = value.join(', ');
+  }
+  const cookie = headers.cookie;
+  if (typeof cookie === 'string') {
+    // Names only: which cookies arrived decides which code path ran, and no
+    // value here is worth putting in a log.
+    picked['cookie-names'] = cookie
+      .split(';')
+      .map((pair) => pair.split('=')[0]?.trim())
+      .filter(Boolean)
+      .join(',');
+  }
+  return picked;
+}
+
+/**
+ * Runs once per Worker isolate, before any request is served. Prints what the
+ * isolate can see, so a log that starts mid-hunt still says which build and
+ * which configuration produced the lines under it.
+ */
+export function register(): void {
+  traceSsr('instrumentation:register', {
+    nodeEnv: process.env.NODE_ENV,
+    buildId: process.env.__VINEXT_BUILD_ID,
+    baseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+    traceEnabled: isSsrTraceEnabled(),
+  });
+
+  // A promise rejected with nobody awaiting it is otherwise invisible: the
+  // Worker records `outcome: "ok"` and the page still 500s.
+  try {
+    addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+      logSsrError('unhandledrejection', event.reason);
+    });
+    addEventListener('error', (event: ErrorEvent) => {
+      logSsrError('uncaught-error', event.error ?? event.message);
+    });
+  } catch (error) {
+    traceSsr('instrumentation:global-handlers:unavailable', {
+      reason: describeError(error).message,
+    });
+  }
+}
+
+/**
+ * Every unhandled error raised while rendering a route. This is the line to
+ * look for first in the Cloudflare logs: it carries the real message, the real
+ * stack, and the route that was rendering when it threw.
+ */
+export function onRequestError(
+  error: unknown,
+  request: RequestInfo,
+  context: ErrorContext,
+): void {
+  logSsrError('instrumentation:onRequestError', error, {
+    path: request?.path,
+    method: request?.method,
+    routerKind: context?.routerKind,
+    routePath: context?.routePath,
+    routeType: context?.routeType,
+    renderSource: context?.renderSource,
+    revalidateReason: context?.revalidateReason,
+    headers: pickHeaders(request?.headers),
+  });
+}

--- a/apps/qwksearch-web/lib/debug/__tests__/ssr-trace.test.ts
+++ b/apps/qwksearch-web/lib/debug/__tests__/ssr-trace.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SSR_ERROR_PREFIX,
+  SSR_TRACE_PREFIX,
+  describeError,
+  isSsrTraceEnabled,
+  logSsrError,
+  traceSsr,
+} from '../ssr-trace';
+
+const VINEXT_ORIGINAL_SERVER_ERROR = Symbol.for('vinext.originalServerError');
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('isSsrTraceEnabled', () => {
+  it('is on by default, so a production 500 is already traced when it happens', () => {
+    vi.stubEnv('QS_SSR_TRACE', '');
+    expect(isSsrTraceEnabled()).toBe(true);
+  });
+
+  it.each(['off', 'OFF', ' off ', '0', 'false', 'no'])('is off for %o', (value) => {
+    vi.stubEnv('QS_SSR_TRACE', value);
+    expect(isSsrTraceEnabled()).toBe(false);
+  });
+});
+
+describe('traceSsr', () => {
+  it('prints a prefixed, sequenced breadcrumb with its details', () => {
+    vi.stubEnv('QS_SSR_TRACE', 'on');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    traceSsr('layout:render:enter', { theme: 'modern-minimal' });
+
+    expect(log).toHaveBeenCalledTimes(1);
+    const line = log.mock.calls[0]?.[0] as string;
+    expect(line).toContain(SSR_TRACE_PREFIX);
+    expect(line).toContain('layout:render:enter');
+    expect(line).toContain('"theme":"modern-minimal"');
+  });
+
+  it('says nothing once the trace is switched off', () => {
+    vi.stubEnv('QS_SSR_TRACE', 'off');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    traceSsr('layout:render:enter');
+
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it('survives details that do not serialize', () => {
+    vi.stubEnv('QS_SSR_TRACE', 'on');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => traceSsr('worker:request', circular)).not.toThrow();
+    expect(log.mock.calls[0]?.[0]).toContain('[circular]');
+  });
+});
+
+describe('describeError', () => {
+  it('flattens an Error into name, message and stack', () => {
+    const described = describeError(new TypeError('document is not defined'));
+
+    expect(described.name).toBe('TypeError');
+    expect(described.message).toBe('document is not defined');
+    expect(described.stack).toContain('TypeError');
+  });
+
+  it('unwraps vinext’s production redaction to the real error', () => {
+    const original = new ReferenceError('window is not defined');
+    const redacted = new Error('The specific message is omitted in production builds');
+    Object.assign(redacted, { digest: '1234567890' });
+    Object.defineProperty(redacted, VINEXT_ORIGINAL_SERVER_ERROR, {
+      value: original,
+      enumerable: false,
+    });
+
+    const described = describeError(redacted);
+
+    expect(described.message).toBe('window is not defined');
+    expect(described.name).toBe('ReferenceError');
+    expect(described.unwrappedFromVinextDigest).toBe('1234567890');
+  });
+
+  it('follows the cause chain', () => {
+    const described = describeError(
+      new Error('render failed', { cause: new Error('chunk load failed') }),
+    );
+
+    expect(described.cause?.message).toBe('chunk load failed');
+  });
+
+  it('describes a thrown non-Error rather than losing it', () => {
+    expect(describeError('boom').thrownValue).toBe('boom');
+    expect(describeError({ code: 'ENOENT' }).thrownValue).toContain('ENOENT');
+  });
+
+  it('stops following a self-referencing cause chain', () => {
+    const looping = new Error('loop');
+    Object.defineProperty(looping, 'cause', { value: looping });
+
+    expect(() => describeError(looping)).not.toThrow();
+  });
+});
+
+describe('logSsrError', () => {
+  it('prints even when breadcrumbs are switched off', () => {
+    vi.stubEnv('QS_SSR_TRACE', 'off');
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    logSsrError('global-error:render', new Error('boom'), { path: '/' });
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0]?.[0]).toContain(SSR_ERROR_PREFIX);
+    expect(error.mock.calls[0]?.[1]).toContain('"message":"boom"');
+    expect(error.mock.calls[0]?.[1]).toContain('"path":"/"');
+  });
+});

--- a/apps/qwksearch-web/lib/debug/marks/README.md
+++ b/apps/qwksearch-web/lib/debug/marks/README.md
@@ -1,0 +1,20 @@
+# Import-order markers
+
+Each file here logs one `[ssr-trace]` line when it is evaluated, and does
+nothing else. They exist because ES module bodies run *after* every import in
+the file has been evaluated, so a breadcrumb written inside a module can never
+report "I am about to import the heavy thing". A marker placed between two
+`import` statements can: imports are evaluated in source order, so
+
+```ts
+import '@/lib/debug/marks/research-agent-ui-begin';
+import { QwkSearchProviders } from 'research-agent-ui';
+import '@/lib/debug/marks/research-agent-ui-end';
+```
+
+prints `begin`, then the whole `research-agent-ui` module graph evaluates, then
+`end`. A `begin` with no matching `end` in the log means a module inside that
+graph threw while being evaluated — the failure that answers the whole page
+with a 500 before React has a boundary to fall back on (see `#440`, `#451`).
+
+Delete these along with the rest of the tracing once the mystery 500 is closed.

--- a/apps/qwksearch-web/lib/debug/marks/auth-client-begin.ts
+++ b/apps/qwksearch-web/lib/debug/marks/auth-client-begin.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('providers:import:auth-client:begin');

--- a/apps/qwksearch-web/lib/debug/marks/auth-client-end.ts
+++ b/apps/qwksearch-web/lib/debug/marks/auth-client-end.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('providers:import:auth-client:end');

--- a/apps/qwksearch-web/lib/debug/marks/home-workspace-mount-begin.ts
+++ b/apps/qwksearch-web/lib/debug/marks/home-workspace-mount-begin.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('home:import:workspace-mount:begin');

--- a/apps/qwksearch-web/lib/debug/marks/home-workspace-mount-end.ts
+++ b/apps/qwksearch-web/lib/debug/marks/home-workspace-mount-end.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('home:import:workspace-mount:end');

--- a/apps/qwksearch-web/lib/debug/marks/layout-providers-begin.ts
+++ b/apps/qwksearch-web/lib/debug/marks/layout-providers-begin.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('layout:import:providers:begin');

--- a/apps/qwksearch-web/lib/debug/marks/layout-providers-end.ts
+++ b/apps/qwksearch-web/lib/debug/marks/layout-providers-end.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('layout:import:providers:end');

--- a/apps/qwksearch-web/lib/debug/marks/research-agent-ui-begin.ts
+++ b/apps/qwksearch-web/lib/debug/marks/research-agent-ui-begin.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('providers:import:research-agent-ui:begin');

--- a/apps/qwksearch-web/lib/debug/marks/research-agent-ui-end.ts
+++ b/apps/qwksearch-web/lib/debug/marks/research-agent-ui-end.ts
@@ -1,0 +1,6 @@
+/**
+ * Import-order marker — see ./README.md. Side effect only, no exports.
+ */
+import { traceSsr } from '../ssr-trace';
+
+traceSsr('providers:import:research-agent-ui:end');

--- a/apps/qwksearch-web/lib/debug/ssr-trace.ts
+++ b/apps/qwksearch-web/lib/debug/ssr-trace.ts
@@ -1,0 +1,213 @@
+/**
+ * @fileoverview Breadcrumbs for the homepage's server-render 500.
+ *
+ * Why this file exists: a render failure on this stack is *silent*. vinext
+ * hands React's `onError` to an error-meta renderer that only looks for
+ * redirect/not-found digests and drops everything else, and when the app has no
+ * `global-error.tsx` a shell error is swallowed into a built-in error document
+ * with `status: 500`. Cloudflare then records the invocation as a bare
+ * `GET https://…/ → 500` with no message, no route and no stack — exactly the
+ * report that started this hunt.
+ *
+ * So the app logs for itself. Two kinds of line, deliberately distinct:
+ *
+ *   `[ssr-trace]`  breadcrumbs — module evaluated, render entered, render left.
+ *                  Chatty, sequence-numbered, silenced by `QS_SSR_TRACE=off`.
+ *   `[ssr-error]`  a failure, with the error unwrapped as far as it goes.
+ *                  Never silenced: an error nobody logs is the bug we are here
+ *                  for.
+ *
+ * The sequence number restarts per module graph, not per request: the RSC and
+ * SSR environments are separate graphs with their own copy of this module, so
+ * a single page render prints two `#1`s. Order lines by the `+Nms` stamp and by
+ * where they sit in the log, never by the counter alone.
+ *
+ * Read a trace by its *last* line. Module-evaluation breadcrumbs are emitted in
+ * import order, so the last `…:module` line before the 500 names the module
+ * whose evaluation threw — the failure mode that took the homepage down in #440
+ * and #451, where the throw happens as the route module loads and React never
+ * gets a boundary to fall back on.
+ *
+ * Everything here is safe on a Worker, in Node and in a browser: no `process`
+ * without a guard, no `window` without a guard, and no throw of its own — a
+ * logger that can fail is one more way to lose the page.
+ */
+
+/** Marks a breadcrumb. Silenced by `QS_SSR_TRACE=off`. */
+export const SSR_TRACE_PREFIX = "[ssr-trace]";
+
+/** Marks a failure. Always printed. */
+export const SSR_ERROR_PREFIX = "[ssr-error]";
+
+/**
+ * vinext replaces a server error with a redacted one before it reaches a
+ * client boundary in production, and hangs the original off the replacement
+ * under this symbol. Reading it back is the only way to see the real message
+ * and stack from inside `global-error.tsx`.
+ *
+ * @see node_modules/vinext/dist/server/app-rsc-errors.js — `sanitizeErrorForClient`
+ */
+const VINEXT_ORIGINAL_SERVER_ERROR = Symbol.for("vinext.originalServerError");
+
+/** How deep to follow `error.cause` before assuming the chain is a cycle. */
+const MAX_CAUSE_DEPTH = 5;
+
+/** Longest stack we print. A Worker log line is truncated well before this. */
+const MAX_STACK_CHARS = 4000;
+
+let sequence = 0;
+const isolateStart = Date.now();
+
+/** `process.env` is only present under `nodejs_compat`, and never in a browser. */
+function readEnv(name: string): string | undefined {
+  try {
+    return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process
+      ?.env?.[name];
+  } catch {
+    return undefined;
+  }
+}
+
+/** Which side of the render a line came from — both go to the same console. */
+export function traceSide(): "server" | "browser" {
+  return typeof window === "undefined" ? "server" : "browser";
+}
+
+/**
+ * Breadcrumbs are on by default: they exist to catch a failure that has so far
+ * only happened in production, and a trace that has to be turned on first is a
+ * trace nobody has when it matters. `QS_SSR_TRACE=off` (a plain Worker
+ * Variable, so it takes effect without a redeploy) turns them off again.
+ */
+export function isSsrTraceEnabled(): boolean {
+  const flag = readEnv("QS_SSR_TRACE")?.trim().toLowerCase();
+  return flag !== "off" && flag !== "0" && flag !== "false" && flag !== "no";
+}
+
+/** JSON that cannot throw, whatever it is handed. */
+function safeJson(value: unknown): string {
+  if (value === undefined) return "";
+  try {
+    const seen = new WeakSet<object>();
+    return JSON.stringify(value, (_key, inner) => {
+      if (typeof inner === "bigint") return `${inner}n`;
+      if (typeof inner === "function") return `[function ${inner.name || "anonymous"}]`;
+      if (typeof inner === "symbol") return inner.toString();
+      if (inner && typeof inner === "object") {
+        if (seen.has(inner as object)) return "[circular]";
+        seen.add(inner as object);
+      }
+      return inner;
+    }) ?? String(value);
+  } catch {
+    return `[unserializable ${typeof value}]`;
+  }
+}
+
+/**
+ * One breadcrumb.
+ *
+ * @param step - Dotted name of the point being passed, e.g. `layout:render:enter`.
+ * @param details - Anything worth carrying; serialized defensively.
+ */
+export function traceSsr(step: string, details?: Record<string, unknown>): void {
+  if (!isSsrTraceEnabled()) return;
+  try {
+    sequence += 1;
+    const suffix = safeJson(details);
+    console.log(
+      `${SSR_TRACE_PREFIX} #${sequence} +${Date.now() - isolateStart}ms ${traceSide()} ${step}${
+        suffix ? ` ${suffix}` : ""
+      }`,
+    );
+  } catch {
+    // A logger that throws would become the outage it is here to explain.
+  }
+}
+
+/** The shape `describeError` returns — a plain object, safe to serialize. */
+export interface DescribedError {
+  name?: string;
+  message?: string;
+  digest?: string;
+  stack?: string;
+  /** Set when the value thrown was not an `Error` at all. */
+  thrownValue?: string;
+  /** Present when vinext's redaction was unwrapped to reach the real error. */
+  unwrappedFromVinextDigest?: string;
+  cause?: DescribedError;
+}
+
+/**
+ * Flattens anything throwable into a loggable object: name, message, digest,
+ * stack, and the `cause` chain behind it.
+ *
+ * Unwraps vinext's production redaction first — without that step every server
+ * error in the log reads "The specific message is omitted in production
+ * builds", which is the opposite of what a debug log is for.
+ */
+export function describeError(error: unknown, depth = 0): DescribedError {
+  if (depth > MAX_CAUSE_DEPTH) return { message: "[cause chain too deep]" };
+
+  if (error && typeof error === "object" && VINEXT_ORIGINAL_SERVER_ERROR in error) {
+    const original = Reflect.get(error, VINEXT_ORIGINAL_SERVER_ERROR);
+    const redactedDigest =
+      "digest" in error && error.digest !== undefined ? String(error.digest) : undefined;
+    return {
+      ...describeError(original, depth + 1),
+      ...(redactedDigest ? { unwrappedFromVinextDigest: redactedDigest } : {}),
+    };
+  }
+
+  if (error instanceof Error) {
+    const described: DescribedError = {
+      name: error.name,
+      message: error.message,
+      stack: error.stack?.slice(0, MAX_STACK_CHARS),
+    };
+    const digest = (error as { digest?: unknown }).digest;
+    if (digest !== undefined) described.digest = String(digest);
+    if (error.cause !== undefined && error.cause !== null) {
+      described.cause = describeError(error.cause, depth + 1);
+    }
+    return described;
+  }
+
+  if (error && typeof error === "object") {
+    const digest = (error as { digest?: unknown }).digest;
+    return {
+      thrownValue: safeJson(error),
+      ...(digest === undefined ? {} : { digest: String(digest) }),
+    };
+  }
+
+  return { thrownValue: String(error) };
+}
+
+/**
+ * One failure. Printed whether or not breadcrumbs are enabled — the whole point
+ * is that this line exists when the next `500` shows up in the dashboard.
+ */
+export function logSsrError(
+  step: string,
+  error: unknown,
+  details?: Record<string, unknown>,
+): void {
+  try {
+    console.error(
+      `${SSR_ERROR_PREFIX} ${traceSide()} ${step}`,
+      safeJson({ ...details, error: describeError(error) }),
+    );
+  } catch {
+    // See `traceSsr`.
+  }
+}
+
+/**
+ * Wraps a module's own evaluation in a breadcrumb pair. Call it as the *last*
+ * statement of a module that is expensive or risky to evaluate; a missing
+ * `…:module` line then means evaluation never finished.
+ */
+export function traceModuleEvaluated(moduleName: string): void {
+  traceSsr(`module:${moduleName}`);
+}

--- a/apps/qwksearch-web/lib/turnstile/gate.ts
+++ b/apps/qwksearch-web/lib/turnstile/gate.ts
@@ -35,6 +35,7 @@ import {
 import { renderChallengePage } from "./challenge-page";
 import { decideChallenge } from "./request-filter";
 import { buildPassCookie, mintPassToken, readCookie, verifyPassToken } from "./session";
+import { traceSsr } from "../debug/ssr-trace";
 
 /** Name of the cookie carrying a verified pass. */
 export const TURNSTILE_COOKIE_NAME = "qs_human";
@@ -54,7 +55,10 @@ export async function handleTurnstileGate(
   env: TurnstileEnv | undefined | null,
 ): Promise<Response | null> {
   const config = resolveTurnstileConfig(env);
-  if (!config) return null;
+  if (!config) {
+    traceSsr("turnstile:unconfigured");
+    return null;
+  }
 
   const url = new URL(request.url);
 
@@ -65,12 +69,16 @@ export async function handleTurnstileGate(
     return handleVerification(request, url, config);
   }
 
-  if (!decideChallenge(request, url).challenge) return null;
+  const decision = decideChallenge(request, url);
+  traceSsr("turnstile:decision", { path: url.pathname, ...decision });
+  if (!decision.challenge) return null;
 
   if (await verifyPassToken(config.secretKey, readCookie(request, TURNSTILE_COOKIE_NAME))) {
+    traceSsr("turnstile:pass-accepted", { path: url.pathname });
     return null;
   }
 
+  traceSsr("turnstile:challenge-served", { path: url.pathname });
   return renderChallengePage({
     siteKey: config.siteKey,
     redirectTo: safeRedirectTarget(`${url.pathname}${url.search}`),

--- a/apps/qwksearch-web/vitest.config.ts
+++ b/apps/qwksearch-web/vitest.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['lib/**/__tests__/**/*.test.ts', 'app/**/__tests__/**/*.test.ts'],
+    // Breadcrumbs are on by default in the app (see lib/debug/ssr-trace.ts);
+    // in a suite they are just noise between the assertions. The tracer's own
+    // tests stub this back on.
+    env: { QS_SSR_TRACE: 'off' },
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,

--- a/apps/qwksearch-web/worker/index.ts
+++ b/apps/qwksearch-web/worker/index.ts
@@ -10,6 +10,7 @@ import type { ImageConfig } from "vinext/server/image-optimization";
 import handler from "vinext/server/app-router-entry";
 import { applyD1Bookmark, runWithD1Session } from "../lib/database/d1-session";
 import { handleTurnstileGate, type TurnstileEnv } from "../lib/turnstile";
+import { describeError, isSsrTraceEnabled, logSsrError, traceSsr } from "../lib/debug/ssr-trace";
 
 interface Env extends TurnstileEnv {
   ASSETS: Fetcher;
@@ -42,50 +43,189 @@ interface ExecutionContext {
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
+    const startedAt = Date.now();
 
-    // Cloudflare Turnstile, in front of everything else: a desktop browser's
-    // first HTML page view is answered with a "just a moment" check until it
-    // carries a pass this Worker signed. Returns null — and costs one HMAC
-    // verify — for every other request, and for all of them when the
-    // TURNSTILE_* variables are unset. See lib/turnstile/gate.ts.
-    const gated = await handleTurnstileGate(request, env);
-    if (gated) return gated;
+    // One line per request, before anything can throw. It is the anchor every
+    // other line of the trace is read against: the same `cf-ray` appears in
+    // Cloudflare's own invocation log, so a bare `500` there can be joined to
+    // the breadcrumbs here.
+    traceSsr("worker:request", describeRequest(request, url));
 
-    // Image optimization via Cloudflare Images binding.
-    // The parseImageParams validation inside handleImageOptimization
-    // normalizes backslashes and validates the origin hasn't changed.
-    if (isImageOptimizationPath(url.pathname)) {
-      const allowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
-      return handleImageOptimization(request, {
-        fetchAsset: (path) => env.ASSETS.fetch(new Request(new URL(path, request.url))),
-        transformImage: async (body, { width, format, quality }) => {
-          const result = await env.IMAGES.input(body).transform(width > 0 ? { width } : {}).output({ format, quality });
-          return result.response();
-        },
-      }, allowedWidths);
-    }
+    // Which bindings and variables this deployment actually has. The report
+    // that opened this hunt came from `opensourceagi.app`, served by a Worker
+    // whose script name is not the one `wrangler.jsonc` deploys — so "the same
+    // code with a binding missing" is a live hypothesis, and a missing binding
+    // is invisible until something dereferences it. Names and presence only;
+    // no secret is read here.
+    traceSsr("worker:env", describeEnv(env));
 
-    // Delegate everything else to vinext, forwarding ctx so that
-    // ctx.waitUntil() is available to background cache writes and
-    // other deferred work via getRequestExecutionContext().
-    //
-    // The whole request runs inside one D1 read-replication session
-    // (lib/database/d1-session.ts): reads can be answered by the nearest
-    // replica, while the session's bookmark keeps them sequentially
-    // consistent. The closing bookmark rides back on the response so the
-    // client's next request never sees an older version of the database.
-    return runWithD1Session(request, env.D1_SESSION_MODE, async () => {
+    try {
+      // Cloudflare Turnstile, in front of everything else: a desktop browser's
+      // first HTML page view is answered with a "just a moment" check until it
+      // carries a pass this Worker signed. Returns null — and costs one HMAC
+      // verify — for every other request, and for all of them when the
+      // TURNSTILE_* variables are unset. See lib/turnstile/gate.ts.
+      //
+      // It also runs before the framework, so an exception here is one of the
+      // few ways to 500 a page without the app ever being asked to render it.
+      let gated: Response | null;
       try {
-        const response = await handler.fetch(request, env, ctx);
-        if (response.status >= 500) reportServerError(request, url, response.status);
-        return applyD1Bookmark(response, { debug: Boolean(env.D1_SESSION_DEBUG) });
+        gated = await handleTurnstileGate(request, env);
       } catch (error) {
-        reportServerError(request, url, 500, error);
+        logSsrError("worker:turnstile:threw", error, { path: url.pathname });
         throw error;
       }
-    });
+      if (gated) {
+        traceSsr("worker:turnstile:served", { status: gated.status, path: url.pathname });
+        return gated;
+      }
+
+      // Image optimization via Cloudflare Images binding.
+      // The parseImageParams validation inside handleImageOptimization
+      // normalizes backslashes and validates the origin hasn't changed.
+      if (isImageOptimizationPath(url.pathname)) {
+        traceSsr("worker:image-optimization", { path: url.pathname });
+        const allowedWidths = [...DEFAULT_DEVICE_SIZES, ...DEFAULT_IMAGE_SIZES];
+        return handleImageOptimization(request, {
+          fetchAsset: (path) => env.ASSETS.fetch(new Request(new URL(path, request.url))),
+          transformImage: async (body, { width, format, quality }) => {
+            const result = await env.IMAGES.input(body).transform(width > 0 ? { width } : {}).output({ format, quality });
+            return result.response();
+          },
+        }, allowedWidths);
+      }
+
+      // Delegate everything else to vinext, forwarding ctx so that
+      // ctx.waitUntil() is available to background cache writes and
+      // other deferred work via getRequestExecutionContext().
+      //
+      // The whole request runs inside one D1 read-replication session
+      // (lib/database/d1-session.ts): reads can be answered by the nearest
+      // replica, while the session's bookmark keeps them sequentially
+      // consistent. The closing bookmark rides back on the response so the
+      // client's next request never sees an older version of the database.
+      return await runWithD1Session(request, env.D1_SESSION_MODE, async () => {
+        traceSsr("worker:handler:enter", {
+          path: url.pathname,
+          d1SessionMode: env.D1_SESSION_MODE ?? "auto",
+        });
+        try {
+          const response = await handler.fetch(request, env, ctx);
+          traceSsr("worker:handler:exit", {
+            path: url.pathname,
+            status: response.status,
+            contentType: response.headers.get("content-type") ?? undefined,
+            ms: Date.now() - startedAt,
+          });
+          const withBookmark = applyD1Bookmark(response, { debug: Boolean(env.D1_SESSION_DEBUG) });
+          if (response.status >= 500) {
+            reportServerError(request, url, response.status);
+            return describeErrorResponseBody(withBookmark, url, ctx);
+          }
+          return withBookmark;
+        } catch (error) {
+          reportServerError(request, url, 500, error);
+          throw error;
+        }
+      });
+    } catch (error) {
+      // `runWithD1Session` and the phases above it are outside the inner
+      // try/catch; without this one, a throw from any of them reaches
+      // Cloudflare as an unhandled exception with no context attached.
+      logSsrError("worker:fetch:threw", error, {
+        ...describeRequest(request, url),
+        ms: Date.now() - startedAt,
+      });
+      throw error;
+    }
   },
 };
+
+/** Which bindings are wired up, and how the tunable Variables are set. */
+function describeEnv(env: Env): Record<string, unknown> {
+  const bindings: Record<string, boolean> = {};
+  for (const name of ["ASSETS", "IMAGES", "KV", "DB", "R2", "EMAIL"]) {
+    bindings[name] = (env as unknown as Record<string, unknown>)[name] !== undefined;
+  }
+  return {
+    bindings,
+    d1SessionMode: env.D1_SESSION_MODE ?? "(unset)",
+    d1SessionDebug: Boolean(env.D1_SESSION_DEBUG),
+    turnstileConfigured: Boolean(env.TURNSTILE_SITE_KEY && env.TURNSTILE_SECRET_KEY),
+  };
+}
+
+/** The parts of a request that decide which code path it takes. */
+function describeRequest(request: Request, url: URL): Record<string, unknown> {
+  return {
+    method: request.method,
+    path: url.pathname,
+    search: url.search || undefined,
+    host: url.host,
+    ray: request.headers.get("cf-ray") ?? undefined,
+    country: request.headers.get("cf-ipcountry") ?? undefined,
+    accept: request.headers.get("accept") ?? undefined,
+    secFetchDest: request.headers.get("sec-fetch-dest") ?? undefined,
+    secFetchMode: request.headers.get("sec-fetch-mode") ?? undefined,
+    rsc: request.headers.get("rsc") ?? undefined,
+    prefetch: request.headers.get("next-router-prefetch") ?? undefined,
+    userAgent: request.headers.get("user-agent") ?? undefined,
+    // Names only — which cookies arrived changes the render, the values are
+    // nobody's business in a log.
+    cookieNames: (request.headers.get("cookie") ?? "")
+      .split(";")
+      .map((pair) => pair.split("=")[0]?.trim())
+      .filter(Boolean)
+      .join(",") || undefined,
+  };
+}
+
+/** How much of a 5xx body to quote. Enough to recognise which shell it is. */
+const ERROR_BODY_SAMPLE_CHARS = 1200;
+
+/**
+ * Logs the first part of a 5xx body, and returns a response that still streams
+ * the original bytes to the client.
+ *
+ * The point is to tell the two failure shapes apart from the log alone:
+ * vinext's built-in error document (a shell error it swallowed), this app's
+ * `app/global-error.tsx` (a shell error it rethrew and we logged), or an
+ * error from a route handler that never involved the renderer at all. The body
+ * is teed rather than read, so nothing is buffered on the way to the reader.
+ */
+function describeErrorResponseBody(response: Response, url: URL, ctx: ExecutionContext): Response {
+  if (!isSsrTraceEnabled() || !response.body) return response;
+
+  let forClient: ReadableStream<Uint8Array>;
+  let forLog: ReadableStream<Uint8Array>;
+  try {
+    [forClient, forLog] = response.body.tee();
+  } catch (error) {
+    traceSsr("worker:error-body:tee-failed", { reason: describeError(error).message });
+    return response;
+  }
+
+  ctx.waitUntil(
+    (async () => {
+      try {
+        const sample = await new Response(forLog).text();
+        traceSsr("worker:error-body", {
+          path: url.pathname,
+          status: response.status,
+          bodyStart: sample.slice(0, ERROR_BODY_SAMPLE_CHARS),
+        });
+      } catch (error) {
+        traceSsr("worker:error-body:unreadable", { reason: describeError(error).message });
+      }
+    })(),
+  );
+
+  return new Response(forClient, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
 
 /**
  * Put a 5xx in the Worker's logs with something to act on.
@@ -96,6 +236,10 @@ export default {
  * dashboard as a bare `500` with no cause, no route and no stack. This adds one
  * line naming the path, the status and (when the exception did escape) its
  * stack, so the next report starts from the error rather than from a guess.
+ *
+ * The cause itself comes from inside the app: `instrumentation.ts`'s
+ * `onRequestError` and `app/global-error.tsx` log the error the framework
+ * caught, which is the half this function cannot see.
  */
 function reportServerError(request: Request, url: URL, status: number, error?: unknown) {
   console.error(


### PR DESCRIPTION
## The problem

The reported failure is `GET https://opensourceagi.app/ → 500` with **no message, no route and no stack** — just Cloudflare's invocation log. That is not bad luck; the stack swallows the error on purpose. Reading `vinext@1.0.0-beta.9`'s server code:

- `entries/app-ssr-entry.js` hands React's SSR `onError` to `createSsrErrorMetaRenderer`, which only looks for redirect/not-found digests and **drops everything else**.
- `server/app-page-stream.js` sets `fallbackToErrorDocumentOnShellError` to `hasCustomGlobalError === false`. This app had no `app/global-error.tsx`, so a **shell** error was swallowed into a built-in error document with `status: 500` and nothing written anywhere.
- `server/app-rsc-errors.js` declines to `console.error` when `NODE_ENV === "production"` and instead reports to the `onRequestError` instrumentation hook — which the app never defined.

Three independent paths, all ending in silence. `worker/index.ts` couldn't see any of it: the framework catches the error long before the entrypoint.

## What this adds

| Piece | Catches |
| --- | --- |
| `instrumentation.ts` → `onRequestError` | every unhandled render error, **unredacted**, with the route that was rendering |
| `app/global-error.tsx` | the shell error itself — its existence is what makes vinext rethrow instead of swallow |
| `lib/debug/ssr-trace.ts` | `[ssr-trace]` breadcrumbs and `[ssr-error]` failures, on the Worker and in the browser |
| `lib/debug/marks/*` | import-order markers, so a module that throws *while being evaluated* is named |

`describeError` unwraps vinext's `Symbol.for("vinext.originalServerError")`, so an RSC error logs its real message and stack instead of "The specific message is omitted in production builds".

Breadcrumbs run through the whole path: the Worker entry (request shape, which **bindings** this deployment actually has, the Turnstile decision, handler status, and a quote of any 5xx body so vinext's error document is distinguishable from this app's), the root layout's `cookies()` read, the provider stack, the homepage's context hooks **one by one**, and the workspace chunk import.

The import-order markers exist because a module body runs *after* its imports, so a breadcrumb inside a module can never say "about to import the heavy thing". A `:begin` with no matching `:end` names the module graph that threw during evaluation — the failure that 500s a route before React has a boundary (#440, #451).

## Reading a trace

- Join it to Cloudflare's log by `cf-ray`, printed first by `worker:request`.
- **Read by the last line.** Reaching `layout:render:returning-tree` but not `home:page:render` puts the failure in the provider stack, not the page.
- The `#N` counter restarts per module graph (RSC and SSR are separate) — order by the `+Nms` stamp.

## Behaviour change

`app/global-error.tsx` replaces vinext's built-in error document on a shell error. The status stays 500; the reader gets a themed page instead of the framework's, and the server gets a log line. Everything else is additive logging.

Breadcrumbs are **on by default** — a trace that has to be enabled first is one nobody has when it matters. `QS_SSR_TRACE=off` (a plain Worker Variable) silences them with no redeploy; `[ssr-error]` lines are never silenced. Test runs set it to `off` so suites stay readable.

## Verification

- `bun run build` succeeds against the real vite/rolldown production build.
- `hasCustomGlobalError: Boolean(global_error_default…)` confirmed in `dist/server/index.js` — the swallow path is genuinely off now.
- `onRequestError` and `ensureInstrumentationRegistered` confirmed bundled into the RSC entry.
- Ran the built app (`node dist/standalone/server.js`) and requested `/`: 200, with the full trace printed from `worker:request` → `worker:env` → `turnstile:unconfigured` → `layout:*` → `providers:render` → `home:stack:use*` → `workspace:chunk:import:end`.
- `bun run test` in `apps/qwksearch-web`: **897 passed (63 files)**, including 13 new tests for the tracer. Root `bun run test`: **3123 passed**; the 14 failing *files* are `apps/qwksearch-ext` missing its generated `.wxt/tsconfig.json` (no `wxt prepare` in this environment) and are untouched by this change.

## Next step

This does not fix the 500 — it makes the next one say what it is. Once a request to `/` on the affected host lands with this deployed, the `[ssr-error]` line names the cause and the fix follows from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEtXmxJAVLip8AVJPvmqD4

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEtXmxJAVLip8AVJPvmqD4)_