### PR TITLE
✨ feat(qwksearch-web): deep-linkable feature sections and a comparison table title

### DIFF
--- a/apps/qwksearch-web/components/features/FeaturesView.tsx
+++ b/apps/qwksearch-web/components/features/FeaturesView.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import OrbitingCirclesGlobe from "@/components/ui/orbiting-circles-02";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+  AnchorLink,
   AuroraBackdrop,
   CountUp,
   Marquee,
@@ -46,11 +47,18 @@ import {
 import { config } from "@/lib/config/site";
 import { cn } from "@/lib/utils";
 
+/**
+ * Section title with a deep-linkable heading. The `id` is the section's hash:
+ * hovering the title reveals a link icon that copies `…/features#<id>`, and
+ * `scroll-mt-28` keeps the eyebrow pill in frame when you arrive on one.
+ */
 function SectionHeading({
+  id,
   eyebrow,
   title,
   blurb,
 }: {
+  id: string;
   eyebrow: string;
   title: React.ReactNode;
   blurb?: string;
@@ -58,8 +66,12 @@ function SectionHeading({
   return (
     <Reveal className="mx-auto mb-12 max-w-2xl text-center">
       <Pill className="mb-4">{eyebrow}</Pill>
-      <h2 className="text-3xl font-bold tracking-tight text-balance sm:text-4xl">
+      <h2
+        id={id}
+        className="group scroll-mt-28 text-3xl font-bold tracking-tight text-balance sm:text-4xl"
+      >
         {title}
+        <AnchorLink id={id} label={eyebrow} />
       </h2>
       {blurb && (
         <p className="text-muted-foreground mt-4 text-base leading-relaxed text-pretty">
@@ -287,6 +299,7 @@ function BentoGrid() {
     <section className="relative px-4 py-20 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <SectionHeading
+          id="the-loop"
           eyebrow="The loop"
           title="Ask, search, read, cite, write — without leaving the tab"
           blurb="Most research tools stop at a list of links. This one carries a question all the way to a finished, sourced document."
@@ -415,6 +428,7 @@ function Comparison() {
     <section className="relative px-4 py-20 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <SectionHeading
+          id="how-it-compares"
           eyebrow="How it compares"
           title="The only open-source research IDE"
           blurb="Search breadth, cited answers, document ingestion, and a real writing editor — side by side with the closed alternatives."
@@ -423,8 +437,24 @@ function Comparison() {
         <Reveal>
           <div className="qs-border-beam relative isolate overflow-hidden rounded-3xl p-px">
             <div className="bg-card/80 relative z-10 overflow-hidden rounded-[calc(1.5rem-1px)] border backdrop-blur-sm">
+              {/* Title sits outside the scroll container so it stays put
+                  while the 1080px-wide table is panned sideways; the <table>
+                  carries the same text as its accessible name. */}
+              <div className="border-b px-4 py-4 sm:px-6">
+                <h3 className="text-base font-semibold tracking-tight">
+                  {config.appName} vs. other research tools
+                </h3>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Feature by feature, as each product ships it today.
+                </p>
+              </div>
+
               <div className="overflow-x-auto">
                 <table className="w-full min-w-[1080px] border-collapse text-sm">
+                  <caption className="sr-only">
+                    {config.appName} vs. other research tools, feature by
+                    feature.
+                  </caption>
                   <thead>
                     <tr className="border-b">
                       <th
@@ -540,6 +570,7 @@ function Pipeline() {
     <section className="relative px-4 py-20 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <SectionHeading
+          id="how-it-works"
           eyebrow="How it works"
           title="How a question becomes a cited answer"
           blurb="Five stages, each one a package you can use on its own."
@@ -583,6 +614,7 @@ function FeatureExplorer() {
     <section className="relative px-4 py-20 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <SectionHeading
+          id="every-feature"
           eyebrow="Every feature"
           title="Four surfaces, one stack"
           blurb="Pick a surface to see everything it ships with today."

--- a/apps/qwksearch-web/components/features/effects.tsx
+++ b/apps/qwksearch-web/components/features/effects.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import * as React from "react";
+import { Check, Link2 } from "lucide-react";
+
 import { cn } from "@/lib/utils";
 
 /**
@@ -262,6 +264,99 @@ export function Pill({
       )}
     >
       {children}
+    </span>
+  );
+}
+
+/**
+ * GitHub-style anchor affordance for a section heading: hidden until the
+ * heading is hovered (or the link itself focused), and copies that section's
+ * fully-qualified `#hash` URL to the clipboard when clicked.
+ *
+ * It stays a real `<a href="#id">`, so middle-click, "copy link address" and
+ * keyboard activation keep working, and modified clicks are left alone. The
+ * click handler only takes over when the async clipboard is actually
+ * available — it is not on plain HTTP — otherwise the browser just follows
+ * the anchor. Touch devices never hover, so the icon is always shown there.
+ */
+export function AnchorLink({
+  id,
+  label,
+  className,
+}: {
+  /** Target element's `id`; also the hash that gets copied. */
+  id: string;
+  /** What the section is, for the screen-reader label. */
+  label?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = React.useState(false);
+  const timer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(
+    () => () => {
+      if (timer.current) clearTimeout(timer.current);
+    },
+    [],
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const clipboard =
+      typeof navigator === "undefined" ? undefined : navigator.clipboard;
+    if (!clipboard?.writeText) return;
+
+    event.preventDefault();
+    const { origin, pathname, search } = window.location;
+
+    clipboard.writeText(`${origin}${pathname}${search}#${id}`).then(
+      () => {
+        // Put the hash in the address bar without re-triggering a scroll —
+        // the heading the link belongs to is already on screen.
+        window.history.replaceState(null, "", `#${id}`);
+        setCopied(true);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), 1600);
+      },
+      () => {
+        // Clipboard refused (permissions, focus) — fall back to navigating.
+        window.location.hash = id;
+      },
+    );
+  };
+
+  return (
+    <span className="relative ml-2 inline-flex align-middle">
+      <a
+        href={`#${id}`}
+        onClick={handleClick}
+        aria-label={
+          copied ? "Link copied" : `Copy link to ${label ?? "this section"}`
+        }
+        className={cn(
+          "text-muted-foreground/60 hover:text-foreground hover:bg-muted/60 focus-visible:ring-ring inline-flex size-8 -translate-y-[0.08em] items-center justify-center rounded-lg opacity-0 transition-[color,background-color,opacity] group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none [@media(hover:none)]:opacity-100",
+          className,
+        )}
+      >
+        {copied ? (
+          <Check className="size-4" aria-hidden />
+        ) : (
+          <Link2 className="size-4" aria-hidden />
+        )}
+      </a>
+
+      {copied && (
+        <span className="bg-card pointer-events-none absolute -top-8 left-1/2 -translate-x-1/2 rounded-md border px-2 py-1 text-[11px] font-medium whitespace-nowrap shadow-sm">
+          Copied!
+        </span>
+      )}
+
+      {/* Announced on a mouse click, when the link itself never takes focus
+          and the swapped `aria-label` would go unnoticed. */}
+      <span role="status" aria-live="polite" className="sr-only">
+        {copied ? "Link copied" : ""}
+      </span>
     </span>
   );
 }


### PR DESCRIPTION
## What

Two changes to `/features`:

**1. Every section title is now deep-linkable.** Hovering a section heading reveals a small link icon; clicking it copies that section's fully-qualified `#hash` URL to the clipboard, so a section can be shared directly.

Anchors added: `#the-loop`, `#how-it-compares`, `#how-it-works`, `#every-feature`.

**2. The comparison table has a title.** "QwkSearch vs. other research tools", with a one-line subtitle, sitting above the table.

## How

- New `AnchorLink` primitive in `components/features/effects.tsx`. It stays a real `<a href="#id">`, so middle-click, right-click → "copy link address" and keyboard activation all keep working, and modified clicks (⌘/Ctrl/Shift/Alt) fall through untouched. The click handler only takes over when the async clipboard is actually available — it is not on plain HTTP — otherwise the browser just follows the anchor. On success it copies the URL, updates the address bar with `history.replaceState` (no scroll jump, since the heading is already on screen), and shows a "Copied!" bubble for 1.6s.
- Accessibility: the icon is revealed on `group-hover` *and* `focus-visible`, is always visible under `@media (hover: none)` where there is no hover at all, and the copy is announced through a polite live region for mouse users who never focus the link.
- `SectionHeading` takes an `id`, applies it to the `<h2>`, and gets `scroll-mt-28` so the eyebrow pill stays in frame when you land on a section from a hash.
- The comparison table's title sits *outside* the `overflow-x-auto` container so it does not pan sideways with the 1080px-wide table; the `<table>` carries the same text as a `<caption class="sr-only">` for its accessible name.

## Testing

- `bunx tsc --noEmit` in `apps/qwksearch-web` — no errors in the touched files (the pre-existing failures are unbuilt package `dist` resolution, unrelated).
- `bun run test` from the root — 3019 passed, 2 skipped. The 22 failing suites are pre-existing import-resolution failures in the extension and editor workspaces; none are in `apps/qwksearch-web` and none import the features page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pxk4e5CNqGYvgm2DAFob44

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pxk4e5CNqGYvgm2DAFob44)_