### PR TITLE
✨ feat(react-reason-editor-sidebar): settings icon links to /settings, storage picker moves to the footer

### DIFF
--- a/packages/reason-editor-sidebar/src/Sidebar.tsx
+++ b/packages/reason-editor-sidebar/src/Sidebar.tsx
@@ -41,7 +41,7 @@ export const Sidebar = ({
   onLeftPanelsChange,
   rightPanels,
   onRightPanelsChange,
-  onSettingsClick,
+  settingsHref,
   onRestore,
   newDocumentId,
   showDynamicIsland,
@@ -146,11 +146,6 @@ export const Sidebar = ({
     onAdd,
     onSearchFocus,
     onFileManagerOpen: () => setIsFileManagerOpen(true),
-    sources,
-    activeSource,
-    activeFileSourceId,
-    onFileSourceChange,
-    onSourceSelect: handleSourceSelect,
     allExpanded: expandCycle.isFullyExpanded,
     expandToggleLabel: expandCycle.label,
     // Without a mounted file tree the toggle has nothing to act on; the
@@ -163,7 +158,6 @@ export const Sidebar = ({
     outlineRef,
     deletedDocs,
     onRestore,
-    onSettingsClick,
     showDynamicIsland,
     onToggleDynamicIsland,
     isMobile,
@@ -224,7 +218,13 @@ export const Sidebar = ({
     isMobile,
     deletedDocs,
     onRestore,
-    onSettingsClick,
+    settingsHref,
+    // The storage-source switcher lives in the footer, not the top toolbar.
+    sources,
+    activeSource,
+    activeFileSourceId,
+    onFileSourceChange,
+    onSourceSelect: handleSourceSelect,
   };
 
   // Mobile: render in a drawer

--- a/packages/reason-editor-sidebar/src/SidebarFooter.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarFooter.tsx
@@ -1,7 +1,7 @@
 /**
  * @module SidebarFooter
- * @description Bottom icon bar of the sidebar. Renders trash, settings,
- * and panel view controls.
+ * @description Bottom icon bar of the sidebar. Renders the storage-source
+ * switcher, trash, a settings link, and panel view controls.
  */
 import { Button } from './app-ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './app-ui/tooltip';
@@ -12,17 +12,15 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSeparator,
 } from './app-ui/dropdown-menu';
-import { Settings, Trash2, RotateCcw, Paintbrush, Database, Wand2, Info, LogIn, LogOut } from 'lucide-react';
-
-const settingsNav = [
-  { name: "Appearance", icon: Paintbrush },
-  { name: "Storage Sources", icon: Database },
-  { name: "AI Rewrite Modes", icon: Wand2 },
-  { name: "About", icon: Info },
-];
+import { Settings, Trash2, RotateCcw, Check } from 'lucide-react';
+import type { AnyFileSource } from './app-types/fileSource';
+import { getSourceIcon, getSourceTypeLabel } from './fileSourceUtils';
 import type { Document } from './documents/DocumentTree';
 import type { SidebarPanelType } from './layout/sidebar/types';
 import { SidebarViewMenu } from './SidebarViewMenu';
+
+/** Where the settings button navigates when the host app doesn't override it. */
+const DEFAULT_SETTINGS_HREF = '/settings';
 
 /** Props for the {@link SidebarFooter} component. */
 interface SidebarFooterProps {
@@ -34,47 +32,104 @@ interface SidebarFooterProps {
   rightPanels: SidebarPanelType[];
   /** Changes which panels are visible in the right sidebar. */
   onRightPanelsChange: (panels: SidebarPanelType[]) => void;
-  /** Suppresses the settings button when `true` (mobile layout). */
+  /** Reserved for layout tweaks on the mobile drawer. */
   isMobile?: boolean;
   /** Soft-deleted documents shown in the trash dropdown. */
   deletedDocs: Document[];
   /** Restores a soft-deleted document by ID. */
   onRestore?: (id: string) => void;
-  /** Opens the settings dialog, optionally navigating to a specific section. */
-  onSettingsClick?: (section?: string) => void;
-  /** Logged-in user info, or null/undefined when not authenticated. */
-  user?: { name?: string; email?: string } | null;
-  /** Called when the user clicks "Login". */
-  onLogin?: () => void;
-  /** Called when the user clicks "Sign Out". */
-  onSignOut?: () => void;
+  /** URL the settings button opens. Defaults to `/settings`. */
+  settingsHref?: string;
+  /** Available file source configurations. */
+  sources?: AnyFileSource[];
+  /** The currently active file source object, or `null` if none selected. */
+  activeSource?: AnyFileSource | null;
+  /** ID of the currently active file source. */
+  activeFileSourceId?: string;
+  /** Selects a source by ID and updates the active source state. */
+  onSourceSelect?: (sourceId: string) => void;
+  /** Called when the user selects a different file source; also gates the switcher. */
+  onFileSourceChange?: (sourceId: string) => void;
 }
 
 /**
- * Compact icon row pinned to the bottom of the sidebar. Includes a trash
- * dropdown (restore deleted docs), settings button, and a panel view
- * dropdown.
+ * Compact icon row pinned to the bottom of the sidebar. Includes the storage
+ * source switcher, a trash dropdown (restore deleted docs), a settings link
+ * to the settings page, and a panel view dropdown.
  */
 export const SidebarFooter = ({
   leftPanels,
   onLeftPanelsChange,
   rightPanels,
   onRightPanelsChange,
-  isMobile,
   deletedDocs,
   onRestore,
-  onSettingsClick,
-  user,
-  onLogin,
-  onSignOut,
+  settingsHref = DEFAULT_SETTINGS_HREF,
+  sources = [],
+  activeSource,
+  activeFileSourceId,
+  onSourceSelect,
+  onFileSourceChange,
 }: SidebarFooterProps) => {
   return (
     <div className="border-t border-sidebar-border py-1">
       <TooltipProvider delayDuration={300}>
         <nav className="flex items-center justify-around gap-1">
-          {/* Theme Dropdown */}
-
-
+          {/* Storage Source Dropdown */}
+          {onFileSourceChange && (
+            <DropdownMenu>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-9 w-9 p-0 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                    >
+                      {getSourceIcon(activeSource?.type ?? 'local')}
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  <p>Storage Source: {activeSource?.name || 'Select Source'}</p>
+                </TooltipContent>
+              </Tooltip>
+              <DropdownMenuContent align="start" side="top" className="w-56">
+                {sources.map((source, index) => (
+                  <div key={source.id}>
+                    {index > 0 && sources[index - 1]?.type !== source.type && (
+                      <DropdownMenuSeparator />
+                    )}
+                    <DropdownMenuItem
+                      onClick={() => onSourceSelect?.(source.id)}
+                      className="flex items-center justify-between cursor-pointer"
+                    >
+                      <div className="flex items-center gap-2 flex-1 min-w-0">
+                        {getSourceIcon(source.type)}
+                        <div className="flex flex-col flex-1 min-w-0">
+                          <span className="truncate text-sm">{source.name}</span>
+                          <span className="text-xs text-muted-foreground">
+                            {getSourceTypeLabel(source.type)}
+                          </span>
+                        </div>
+                      </div>
+                      {source.id === activeFileSourceId && (
+                        <Check className="h-4 w-4 ml-2 shrink-0" />
+                      )}
+                    </DropdownMenuItem>
+                  </div>
+                ))}
+                {sources.length === 1 && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem disabled className="text-xs text-center text-muted-foreground">
+                      Add sources in Settings
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
 
           {/* Trash Dropdown */}
           <DropdownMenu>
@@ -124,51 +179,24 @@ export const SidebarFooter = ({
             </DropdownMenuContent>
           </DropdownMenu>
 
-          {/* Settings Dropdown */}
-          {!isMobile && onSettingsClick && (
-            <DropdownMenu>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-9 w-9 p-0 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                    >
-                      <Settings className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  <p>Settings</p>
-                </TooltipContent>
-              </Tooltip>
-              <DropdownMenuContent align="end" className="w-48">
-                {settingsNav.map((item) => (
-                  <DropdownMenuItem
-                    key={item.name}
-                    onClick={() => onSettingsClick(item.name)}
-                    className="flex items-center gap-2"
-                  >
-                    <item.icon className="h-4 w-4 text-muted-foreground" />
-                    <span>{item.name}</span>
-                  </DropdownMenuItem>
-                ))}
-                <DropdownMenuSeparator />
-                {user ? (
-                  <DropdownMenuItem onClick={onSignOut} className="flex items-center gap-2">
-                    <LogOut className="h-4 w-4 text-muted-foreground" />
-                    <span>Sign Out</span>
-                  </DropdownMenuItem>
-                ) : (
-                  <DropdownMenuItem onClick={onLogin} className="flex items-center gap-2">
-                    <LogIn className="h-4 w-4 text-muted-foreground" />
-                    <span>Login</span>
-                  </DropdownMenuItem>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+          {/* Settings — opens the settings page rather than a menu */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                className="h-9 w-9 p-0 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+              >
+                <a href={settingsHref} aria-label="Settings">
+                  <Settings className="h-4 w-4" />
+                </a>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p>Settings</p>
+            </TooltipContent>
+          </Tooltip>
 
           {/* View Options Menu */}
           <SidebarViewMenu

--- a/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
+++ b/packages/reason-editor-sidebar/src/SidebarToolbar.tsx
@@ -1,13 +1,12 @@
 /**
  * @module SidebarToolbar
  * @description Compact icon toolbar rendered at the top of the sidebar. Shows
- * context-sensitive controls based on `leftPanels`: file-source switcher, search,
- * and expand/collapse buttons. The file-tree actions (new file/folder, trash,
- * file manager) render here only when the "Files" panel — which hosts them in
- * its own header — is hidden.
+ * context-sensitive controls based on `leftPanels`: search and expand/collapse
+ * buttons. The storage-source switcher lives in the sidebar footer. The
+ * file-tree actions (new file/folder, trash, file manager) render here only
+ * when the "Files" panel — which hosts them in its own header — is hidden.
  */
 import { RefObject } from 'react';
-import type { AnyFileSource } from './app-types/fileSource';
 import type { DocumentTreeHandle } from './file-tree/filetree';
 import type { OutlineViewHandle } from './search/OutlineView';
 import type { SidebarPanelType, OpenTabItem } from './layout/sidebar/types';
@@ -23,8 +22,7 @@ import {
 } from './app-ui/dropdown-menu';
 import { cn } from './app-utils/utils';
 import { FileTypeIcon } from './app-ui/FileTypeIcon';
-import { Search, FilePlus, FolderPlus, ChevronsDownUp, ChevronsUpDown, Check, Folders, Trash2, RotateCcw, MoreHorizontal, X, MessageSquare } from 'lucide-react';
-import { getSourceIcon, getSourceTypeLabel } from './fileSourceUtils';
+import { Search, FilePlus, FolderPlus, ChevronsDownUp, ChevronsUpDown, Folders, Trash2, RotateCcw, MoreHorizontal, X, MessageSquare } from 'lucide-react';
 import { SidebarViewMenu } from './SidebarViewMenu';
 
 /** Props for the {@link SidebarToolbar} component. */
@@ -45,16 +43,6 @@ interface SidebarToolbarProps {
   onSearchFocus: () => void;
   /** Opens the file manager modal. */
   onFileManagerOpen: () => void;
-  /** Available file source configurations. */
-  sources: AnyFileSource[];
-  /** The currently active file source object, or `null` if none selected. */
-  activeSource: AnyFileSource | null;
-  /** ID of the currently active file source. */
-  activeFileSourceId: string;
-  /** Called when the user selects a different file source from the dropdown. */
-  onFileSourceChange?: (sourceId: string) => void;
-  /** Selects a source by ID and updates the active source state. */
-  onSourceSelect: (sourceId: string) => void;
   /** Whether all tree nodes are currently expanded (drives the toggle icon). */
   allExpanded: boolean;
   /** Tooltip label describing what the expand-all toggle will do next (cycles by folder level). */
@@ -83,9 +71,7 @@ interface SidebarToolbarProps {
   showDynamicIsland?: boolean;
   /** Toggles the floating reading-progress island. */
   onToggleDynamicIsland?: () => void;
-  /** Opens the settings dialog, optionally navigating to a specific section. */
-  onSettingsClick?: (section?: string) => void;
-  /** Suppresses the settings button when `true` (mobile layout). */
+  /** Reserved for layout tweaks on the mobile drawer. */
   isMobile?: boolean;
   /** All currently open tab IDs. */
   openTabs?: string[];
@@ -104,8 +90,7 @@ interface SidebarToolbarProps {
 /**
  * Sidebar toolbar strip. Renders different button sets based on which
  * panels are active in `leftPanels`: the files/open-tabs panel shows
- * file-source, search, file-manager, new-file/folder, and collapse-all
- * buttons; the outline panel additionally shows an expand/collapse toggle.
+ * search, file-manager, new-file/folder, and collapse-all buttons; the outline panel additionally shows an expand/collapse toggle.
  */
 export const SidebarToolbar = ({
   leftPanels,
@@ -116,11 +101,6 @@ export const SidebarToolbar = ({
   onAdd,
   onSearchFocus,
   onFileManagerOpen,
-  sources,
-  activeSource,
-  activeFileSourceId,
-  onFileSourceChange,
-  onSourceSelect,
   allExpanded,
   expandToggleLabel,
   expandToggleDisabled = false,
@@ -133,7 +113,6 @@ export const SidebarToolbar = ({
   onRestore,
   showDynamicIsland = false,
   onToggleDynamicIsland,
-  onSettingsClick,
   isMobile,
   openTabs = [],
   activeTab,
@@ -158,63 +137,7 @@ export const SidebarToolbar = ({
           {/* Show file/folder buttons only when the file tree or open-tabs panel is visible */}
           {(leftPanels.includes('files') || leftPanels.includes('openTabs')) && (
             <>
-              {/* File Source Dropdown */}
-              {onFileSourceChange && (
-                <DropdownMenu>
                   <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="size-8 shrink-0 p-0 text-sidebar-foreground/80 hover:text-sidebar-foreground hover:bg-sidebar-accent"
-                        >
-                          {activeSource && getSourceIcon(activeSource.type)}
-                        </Button>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      <p>Storage Source: {activeSource?.name || 'Select Source'}</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent align="start" className="w-56">
-                    {sources.map((source, index) => (
-                      <div key={source.id}>
-                        {index > 0 && sources[index - 1]?.type !== source.type && (
-                          <DropdownMenuSeparator />
-                        )}
-                        <DropdownMenuItem
-                          onClick={() => onSourceSelect(source.id)}
-                          className="flex items-center justify-between cursor-pointer"
-                        >
-                          <div className="flex items-center gap-2 flex-1 min-w-0">
-                            {getSourceIcon(source.type)}
-                            <div className="flex flex-col flex-1 min-w-0">
-                              <span className="truncate text-sm">{source.name}</span>
-                              <span className="text-xs text-muted-foreground">
-                                {getSourceTypeLabel(source.type)}
-                              </span>
-                            </div>
-                          </div>
-                          {source.id === activeFileSourceId && (
-                            <Check className="h-4 w-4 ml-2 shrink-0" />
-                          )}
-                        </DropdownMenuItem>
-                      </div>
-                    ))}
-                    {sources.length === 1 && (
-                      <>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem disabled className="text-xs text-center text-muted-foreground">
-                          Add sources in Settings
-                        </DropdownMenuItem>
-                      </>
-                    )}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-
-              <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
                     variant="ghost"

--- a/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
+++ b/packages/reason-editor-sidebar/src/layout/sidebar/types.ts
@@ -118,8 +118,9 @@ export interface SidebarProps {
   // rendered outside of Sidebar by ReasonDocs)
   rightPanels: SidebarPanelType[];
   onRightPanelsChange: (panels: SidebarPanelType[]) => void;
-  // Settings
-  onSettingsClick?: (section?: string) => void;
+  // Settings — the footer's settings button is a link to this URL
+  // (defaults to `/settings`), not a menu.
+  settingsHref?: string;
   onInviteClick?: () => void;
   // Trash callbacks
   onRestore?: (id: string) => void;

--- a/packages/reason-editor-sidebar/test/footer/sidebarFooter.test.tsx
+++ b/packages/reason-editor-sidebar/test/footer/sidebarFooter.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The sidebar's bottom icon row. Two things the user sees directly:
+ * settings is a plain link to the settings page (it used to be a dropdown
+ * of settings sections), and the storage-source switcher sits down here
+ * rather than in the top toolbar.
+ */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { Sidebar } from '../../src/Sidebar';
+import type { Document } from '../../src/documents/DocumentTree';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const documents: Document[] = [
+  { id: 'a', title: 'a', content: '', parentId: null, isFolder: false, isExpanded: false },
+];
+
+function renderSidebar(props: Record<string, unknown> = {}) {
+  act(() =>
+    root.render(
+      <Sidebar
+        documents={documents}
+        activeId={null}
+        activeDocument={null}
+        onSelect={() => {}}
+        onAdd={() => {}}
+        onDelete={() => {}}
+        onDuplicate={() => {}}
+        onSetExpandedFolders={() => {}}
+        onMove={() => {}}
+        onRename={() => {}}
+        onSearchFocus={() => {}}
+        isOpen
+        onOpenChange={() => {}}
+        isMobile={false}
+        leftPanels={['files']}
+        onLeftPanelsChange={() => {}}
+        rightPanels={[]}
+        onRightPanelsChange={() => {}}
+        onRestore={() => {}}
+        {...props}
+      />,
+    ),
+  );
+}
+
+/** The footer's settings control, whatever element it renders as. */
+function settingsControl() {
+  return container.querySelector('[aria-label="Settings"]');
+}
+
+/** Buttons in the footer's icon row. */
+function footerButtons() {
+  return Array.from(container.querySelectorAll('nav button'));
+}
+
+describe('sidebar footer', () => {
+  it('opens the settings page instead of a settings menu', () => {
+    renderSidebar();
+
+    const settings = settingsControl();
+    expect(settings).not.toBeNull();
+    expect(settings!.tagName).toBe('A');
+    expect(settings!.getAttribute('href')).toBe('/settings');
+
+    // A link, not a dropdown trigger: Radix marks those with aria-haspopup.
+    expect(settings!.getAttribute('aria-haspopup')).toBeNull();
+  });
+
+  it('lets the host point settings somewhere else', () => {
+    renderSidebar({ settingsHref: '/workspace/settings' });
+
+    expect(settingsControl()!.getAttribute('href')).toBe('/workspace/settings');
+  });
+
+  it('puts the storage-source switcher in the footer, not the toolbar', () => {
+    renderSidebar();
+    const withoutSwitcher = footerButtons().length;
+
+    // The switcher renders only once the host can act on a source change,
+    // and it renders in the footer row — it used to live in the toolbar.
+    renderSidebar({ onFileSourceChange: () => {} });
+    const withSwitcher = footerButtons();
+
+    expect(withSwitcher.length).toBe(withoutSwitcher + 1);
+    expect(withSwitcher[0]?.getAttribute('aria-haspopup')).toBe('menu');
+  });
+});

--- a/packages/reason-editor/src/editor/ReasonDocs.tsx
+++ b/packages/reason-editor/src/editor/ReasonDocs.tsx
@@ -83,6 +83,11 @@ interface ReasonDocsProps {
   /** Called whenever a document/file tab becomes active, so the host can switch away from an extra tab. */
   onFileTabSelect?: () => void;
   /**
+   * URL the sidebar's settings button opens. Defaults to `/settings` — the
+   * button is a plain link to the settings page, not a dropdown menu.
+   */
+  settingsHref?: string;
+  /**
    * Document ID to open as the active document once (e.g. restored from a
    * URL param on load). Applied only on the first render where the document
    * exists — later changes to this prop are ignored, so it never fights with
@@ -144,10 +149,10 @@ const Index = ({
   onGenerateTopics,
   onSearchTopic,
   onSignIn,
+  settingsHref,
 }: ReasonDocsProps) => {
   const { theme, setTheme } = useTheme();
   const state = useReasonDocsState(openFilesSidebarSignal);
-  const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(undefined);
   const [tips, setTips] = useState<string[]>([]);
   const [isTipsLoading, setIsTipsLoading] = useState(false);
   const [topics, setTopics] = useState<string[]>([]);
@@ -331,7 +336,7 @@ const Index = ({
     onLeftPanelsChange: state.setLeftPanels,
     rightPanels: state.rightPanels,
     onRightPanelsChange: state.setRightPanels,
-    onSettingsClick: (section?: string) => { setSettingsInitialSection(section); state.setIsSettingsOpen(true); },
+    settingsHref,
     onInviteClick: () => state.setIsInviteModalOpen(true),
     onRestore: state.handleRestoreDocument,
     onPermanentDelete: state.handlePermanentDelete,
@@ -514,7 +519,6 @@ const Index = ({
         setIsSearchModalOpen={state.setIsSearchModalOpen}
         isSettingsOpen={state.isSettingsOpen}
         setIsSettingsOpen={state.setIsSettingsOpen}
-        settingsInitialSection={settingsInitialSection}
         isTeamsOpen={state.isTeamsOpen}
         setIsTeamsOpen={state.setIsTeamsOpen}
         isInviteModalOpen={state.isInviteModalOpen}

--- a/skills/ask-reason-editor-sidebar/SKILL.md
+++ b/skills/ask-reason-editor-sidebar/SKILL.md
@@ -43,7 +43,7 @@ rather than mutating the array at the call site.
 | The left sidebar | `Sidebar` (`SidebarProps`) |
 | The right panel body | `SidebarContent` (`SidebarContentProps`) |
 | Search box / expand-collapse header | `SidebarToolbar` |
-| Footer | `SidebarFooter` |
+| Footer (storage source, trash, settings link, view menu) | `SidebarFooter` |
 | The panel-toggle menu | `SidebarViewMenu`, `PANEL_OPTIONS`, `togglePanel`, `sortPanels` |
 | The file/folder tree alone | `FileTree`, `DocumentTreeHandle` |
 | Outline of the active document | `OutlineView`, `OutlineViewHandle`, `ActiveHeadingEditorHandle` |
@@ -70,7 +70,9 @@ that callback the stepped state lives only inside the tree and is lost on the ne
 document change.
 
 **File sources.** Seven backends — `local`, `ssh`, `s3`, `r2`, `b2`, `gdocs`, `turso` —
-as a discriminated union on `type`. The CRUD helpers are **localStorage-backed**, so
+as a discriminated union on `type`. The picker lives in `SidebarFooter` (bottom icon
+row), not the toolbar, and renders only when the host passes `onFileSourceChange`.
+The CRUD helpers are **localStorage-backed**, so
 they are per-browser and never reach a server; secrets entered in the file-source dialog
 live in the browser.
 
@@ -89,5 +91,6 @@ same panel.
 | A circular-dependency error appears after an edit | Something in this package imported `react-reason-editor`. The dependency is one-way. |
 | `localStorage is not defined` under SSR | Use `ssrSafeLocalStorage`; the file-source helpers already do. |
 | File-source credentials don't work on another device | They are in `localStorage`, per browser, by design. |
+| The settings button does nothing / 404s | It is a plain link to `settingsHref` (default `/settings`), not a callback — the host must serve that route or pass its own URL. |
 | The tree looks unstyled | Import `react-reason-editor-sidebar/style.css`. |
 | Peer errors on install | `react` and `react-dom` are peers; everything else (headless-tree, radix, svar filemanager, react-split-pane) is a real dependency. |


### PR DESCRIPTION
## What changed

The sidebar footer's gear opened a dropdown of settings sections — Appearance / Storage Sources / AI Rewrite Modes / About — plus a **Login** item that `Sidebar` never wired up (it rendered, clicked, and did nothing). That menu is gone.

- **Settings is now a plain icon link.** It navigates to `settingsHref`, which defaults to `/settings` (the app already serves `/settings/[[...section]]`). Hosts can point it elsewhere.
- **The storage-source (disk) picker moved down to the footer**, ahead of trash and settings, out of the top toolbar.
- The dead `user` / `onLogin` / `onSignOut` props on `SidebarFooter` are removed with the menu.

Footer icon row is now: storage source · trash · settings · view options.

## API changes

| Before | After |
| --- | --- |
| `SidebarProps.onSettingsClick?: (section?: string) => void` | `SidebarProps.settingsHref?: string` (default `/settings`) |
| `SidebarToolbar` took `sources`, `activeSource`, `activeFileSourceId`, `onSourceSelect`, `onFileSourceChange` | `SidebarFooter` takes them; the switcher renders only when `onFileSourceChange` is passed |
| — | `ReasonDocs` gains a `settingsHref?: string` passthrough |

`ReasonDocs` no longer opens the settings dialog from the sidebar, so its `settingsInitialSection` state went with it. The dialog itself is untouched and still reachable through `onOpenSettings`.

## Testing

- New `test/footer/sidebarFooter.test.tsx`: settings renders as an `<a href="/settings">` with no dropdown trigger, honours a host-supplied `settingsHref`, and the source switcher appears in the footer row only when the host passes `onFileSourceChange`.
- `bun run test` in `packages/reason-editor-sidebar` — 9 files, 78 tests, all passing.
- `bunx turbo run build --filter=react-reason-editor-sidebar --filter=react-reason-editor` — clean.
- Root `bun run test` has 22 pre-existing failures on this base (unbuilt workspace `dist/` entries in `extract-*`, `use-voice-control`, the extension app); none are in the touched packages' own suites.
- `skills/ask-reason-editor-sidebar/SKILL.md` updated for the new footer contents and the `settingsHref` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UjzPpYjU8G9nhHk8GnVYP

---
_Generated by [Claude Code](https://claude.ai/code/session_011UjzPpYjU8G9nhHk8GnVYP)_