### PR TITLE
✨ feat(research-agent-ui): Ctrl-Space spotlight palette that searches the whole app

### DIFF
--- a/.claude/packages/research-agent-ui/CLAUDE.md
+++ b/.claude/packages/research-agent-ui/CLAUDE.md
@@ -24,6 +24,18 @@ are narrow, and neither has the web app's origin.
 
 Import from these, never from `dist/` internals.
 
+## The spotlight palette
+
+`src/components/SpotlightPalette/` is the Ctrl-Space overlay that searches
+chats, pages, settings and actions — ported from CardMirror's quick-card search
+palette in debate-ai, prefix system and ranking included. `QwkSearchProviders`
+mounts it, so all four shells get it; `showSpotlight={false}` opts out.
+
+Keep the split: `spotlightMatch.ts` and `spotlightItems.ts` are pure (a builder
+takes a `SpotlightContext` of callbacks, never a hook), and only
+`SpotlightPalette.tsx` touches React context or the router. That is what lets
+the sources and the ranking be tested without mounting the app.
+
 ## Rules
 
 - Keep it prop-driven and transport-agnostic: `./api` is the seam. A component

--- a/packages/research-agent-ui/README.md
+++ b/packages/research-agent-ui/README.md
@@ -52,6 +52,32 @@ The two editor packages are declared as **optional** peer dependencies:
 installing `research-agent-ui` on its own is enough for the chat-only build,
 and package managers will not warn about the missing peers.
 
+## Spotlight search
+
+`QwkSearchProviders` mounts a macOS-Spotlight-style command palette over the
+whole app. <kbd>Ctrl</kbd> <kbd>Space</kbd> opens it (Cmd-Space belongs to
+macOS), or call `openSpotlight()` from your own chrome. Typing searches past
+chats, app pages, settings sections and actions at once, with "ask the research
+agent this" pinned to the top; a leading letter scopes the search to one source
+— `c ` chats, `t ` pages, `s ` settings, `a ` actions, `w ` ask — and
+<kbd>Tab</kbd> cycles between them.
+
+```tsx
+import { QwkSearchProviders, openSpotlight } from 'research-agent-ui';
+
+<QwkSearchProviders authClient={authClient} showSpotlight>   {/* the default */}
+  <YourApp />
+</QwkSearchProviders>;
+
+// …and from a button somewhere in your own chrome:
+<button onClick={() => openSpotlight()}>Search everything</button>;
+```
+
+Rows that open a chat or a settings section go through `onOpenChat` /
+`onOpenSettings` first, so a host rendering chats inline handles them without
+navigating; returning anything but `true` falls back to `/c/<id>` and
+`/settings/<section>`.
+
 ## Usage
 
 ### The whole app in one component

--- a/packages/research-agent-ui/src/app/CategoryDock.tsx
+++ b/packages/research-agent-ui/src/app/CategoryDock.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image"
 import { usePathname, useRouter } from "next/navigation"
-import { Settings, LogIn, LogOut, FileText } from "lucide-react"
+import { Settings, LogIn, LogOut, FileText, Search } from "lucide-react"
 import {
   CategoryDock as BaseCategoryDock,
   type DockNavItem,
@@ -14,6 +14,7 @@ import { useSession } from "../hooks/useSession"
 import { useChat } from "../hooks/useChat"
 import { researchAgentUIConfig } from "../config"
 import { useMainView } from "./MainViewProvider"
+import { openSpotlight } from "../components/SpotlightPalette"
 // Both dock marks are SVGs, and next/image refuses to run SVG through the
 // optimizer unless `dangerouslyAllowSVG` is on — the request 400s and the dock
 // renders two broken-image glyphs. They are already tiny inline-able assets, so
@@ -105,6 +106,13 @@ export function CategoryDock() {
       menu: {
         renderContent: () => (
           <>
+            {/* The spotlight palette is keyboard-first, so the dock carries
+                the one pointer-reachable way in — and advertises the chord. */}
+            <DropdownMenuItem onClick={() => openSpotlight()} className="cursor-pointer py-1 h-7">
+              <Search className="mr-2 h-3.5 w-3.5" />
+              <span className="text-sm">Search everything</span>
+              <span className="ml-auto pl-3 text-[10px] text-muted-foreground">Ctrl Space</span>
+            </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => {
                 // Open settings in a modal on large desktop screens; otherwise

--- a/packages/research-agent-ui/src/app/QwkSearchProviders.tsx
+++ b/packages/research-agent-ui/src/app/QwkSearchProviders.tsx
@@ -21,6 +21,7 @@ import { ChatProvider } from '../hooks/useChat';
 import { ExtractPanelProvider } from '../components/ArticleReader/ExtractPanelContext';
 import { CategoryDock } from './CategoryDock';
 import { CookieConsent } from './CookieConsent';
+import { SpotlightPalette } from '../components/SpotlightPalette';
 import { MainViewProvider } from './MainViewProvider';
 import { useChunkErrorReload } from './useChunkErrorReload';
 
@@ -65,6 +66,12 @@ export interface QwkSearchProvidersProps {
   showCookieConsent?: boolean;
   /** Render the `sonner` toaster. Default true. */
   showToaster?: boolean;
+  /**
+   * Mount the Ctrl-Space spotlight palette. Default true. Turn it off in a
+   * shell that already binds that chord (a VS Code webview, say, where the
+   * host may want the keystroke for itself).
+   */
+  showSpotlight?: boolean;
 }
 
 /**
@@ -106,6 +113,7 @@ export function QwkSearchProviders({
   showDock = true,
   showCookieConsent = true,
   showToaster = true,
+  showSpotlight = true,
 }: QwkSearchProvidersProps) {
   // Applied during render rather than from an effect so the very first paint
   // already reflects the host's branding — everything below this point reads
@@ -161,6 +169,10 @@ export function QwkSearchProviders({
               />
             )}
             {showCookieConsent && <CookieConsent />}
+            {/* Outside the scroll root and after the dock: it is an overlay
+                over the whole app, and it reads the chat, session and view
+                contexts it sits inside. */}
+            {showSpotlight && <SpotlightPalette />}
           </ChatProvider>
         </ExtractPanelProvider>
       </SessionProvider>

--- a/packages/research-agent-ui/src/components/SearchConfig/ResearchFocusToggleButton.tsx
+++ b/packages/research-agent-ui/src/components/SearchConfig/ResearchFocusToggleButton.tsx
@@ -2,62 +2,16 @@
  * Popover toggle for selecting the research focus mode: All web, Academic, Writing (no search),
  * Wolfram Alpha, YouTube, or Reddit.
  */
-import {
-  BadgePercent,
-  ChevronDown,
-  Globe,
-  Pencil,
-  ScanEye,
-  SwatchBook,
-} from 'lucide-react';
+import { Globe } from 'lucide-react';
 import { cn } from '../../lib/utils';
 import {
   Popover,
   PopoverTrigger,
   PopoverContent,
 } from '../../ui/popover';
-import { FaReddit, FaYoutube } from 'react-icons/fa';
+import { focusModes } from './focusModes';
 
 import { useChat } from '../../hooks/useChat';
-
-const focusModes = [
-  {
-    key: 'webSearch',
-    title: 'All',
-    description: 'Searches across all of the internet',
-    icon: <Globe size={16} />,
-  },
-  {
-    key: 'academicSearch',
-    title: 'Academic',
-    description: 'Search in published academic papers',
-    icon: <SwatchBook size={16} />,
-  },
-  {
-    key: 'writingAssistant',
-    title: 'Writing',
-    description: 'Chat without searching the web',
-    icon: <Pencil size={16} />,
-  },
-  {
-    key: 'wolframAlphaSearch',
-    title: 'Wolfram Alpha',
-    description: 'Computational knowledge engine',
-    icon: <BadgePercent size={16} />,
-  },
-  {
-    key: 'youtubeSearch',
-    title: 'Youtube',
-    description: 'Search and watch videos',
-    icon: <FaYoutube className="h-[16px] w-auto mr-0.5" />,
-  },
-  {
-    key: 'redditSearch',
-    title: 'Reddit',
-    description: 'Search for discussions and opinions',
-    icon: <FaReddit className="h-[16px] w-auto mr-0.5" />,
-  },
-];
 
 const Focus = () => {
   const { focusMode, setFocusMode } = useChat();

--- a/packages/research-agent-ui/src/components/SearchConfig/focusModes.tsx
+++ b/packages/research-agent-ui/src/components/SearchConfig/focusModes.tsx
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview The research focus modes, as data.
+ *
+ * Shared by the composer's focus popover (`ResearchFocusToggleButton`) and the
+ * spotlight palette's "Focus: …" actions, so a mode added here shows up in
+ * both at once instead of drifting between two hand-kept lists.
+ */
+import { BadgePercent, Globe, Pencil, SwatchBook } from 'lucide-react';
+import { FaReddit, FaYoutube } from 'react-icons/fa';
+import type { ReactNode } from 'react';
+
+export interface FocusMode {
+  /** The value stored in chat state and sent with a search request. */
+  key: string;
+  title: string;
+  description: string;
+  icon: ReactNode;
+}
+
+export const focusModes: FocusMode[] = [
+  {
+    key: 'webSearch',
+    title: 'All',
+    description: 'Searches across all of the internet',
+    icon: <Globe size={16} />,
+  },
+  {
+    key: 'academicSearch',
+    title: 'Academic',
+    description: 'Search in published academic papers',
+    icon: <SwatchBook size={16} />,
+  },
+  {
+    key: 'writingAssistant',
+    title: 'Writing',
+    description: 'Chat without searching the web',
+    icon: <Pencil size={16} />,
+  },
+  {
+    key: 'wolframAlphaSearch',
+    title: 'Wolfram Alpha',
+    description: 'Computational knowledge engine',
+    icon: <BadgePercent size={16} />,
+  },
+  {
+    key: 'youtubeSearch',
+    title: 'Youtube',
+    description: 'Search and watch videos',
+    icon: <FaYoutube className="h-[16px] w-auto mr-0.5" />,
+  },
+  {
+    key: 'redditSearch',
+    title: 'Reddit',
+    description: 'Search for discussions and opinions',
+    icon: <FaReddit className="h-[16px] w-auto mr-0.5" />,
+  },
+];

--- a/packages/research-agent-ui/src/components/SpotlightPalette/SpotlightPalette.tsx
+++ b/packages/research-agent-ui/src/components/SpotlightPalette/SpotlightPalette.tsx
@@ -1,0 +1,432 @@
+'use client';
+
+/**
+ * @fileoverview The Ctrl-Space spotlight palette: one bar, in front of
+ * everything, that searches the whole app.
+ *
+ * Modelled on the CardMirror editor's quick-card search palette in debate-ai
+ * (`packages/debate-editor/src/editor/quick-card-search-ui.ts`) — same
+ * single-letter prefix system, same two-tier ranking (`spotlightMatch.ts`),
+ * same "the keyboard owns it" interaction — re-laid-out as macOS Spotlight:
+ * a rounded card near the top of the window with the query bar on top and the
+ * results under it, rather than CardMirror's results-above-the-bar bar.
+ *
+ * Prefixes (`<letter><space>`; with one present, an empty query browses that
+ * source):
+ *   - `c ` → past chats
+ *   - `t ` → app pages
+ *   - `s ` → settings sections
+ *   - `a ` → actions (new chat, incognito, focus mode, sign in/out…)
+ *   - `w ` → ask the research agent
+ *   - no prefix → everything, with "ask it" pinned to the top as you type
+ *
+ * Mounted once by `QwkSearchProviders`, so all four shells get it. It reads
+ * the chat / session / view contexts it sits inside and needs no props.
+ */
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { useRouter } from 'next/navigation';
+import { Search } from 'lucide-react';
+
+import { cn } from '../../lib/utils';
+import { researchAgentUIConfig } from '../../config';
+import { useChat } from '../../hooks/useChat';
+import { useSession } from '../../hooks/useSession';
+import { useMainView } from '../../app/MainViewProvider';
+import { useRecentChats } from '../ChatHistoryDropdown/useRecentChats';
+import {
+  buildActionItems,
+  buildChatItems,
+  buildPageItems,
+  buildSearchItem,
+  buildSettingItems,
+  type SpotlightContext,
+  type SpotlightItem,
+} from './spotlightItems';
+import {
+  matchSpotlight,
+  parsePrefix,
+  prefixForSource,
+  SPOTLIGHT_PREFIXES,
+  type SpotlightSource,
+} from './spotlightMatch';
+
+/** Fired to open the palette from something that isn't the shortcut — the
+ *  dock's menu, so a pointer-only user can find it too. */
+const OPEN_EVENT = 'qwksearch:open-spotlight';
+
+/** How many past chats the palette loads and searches. */
+const CHAT_LIMIT = 100;
+
+/** Chats listed when nothing has been typed yet. */
+const BROWSE_CHATS = 6;
+
+/** Cap on rendered rows — the list is keyboard-driven, and past this point
+ *  refining the query beats scrolling. */
+const MAX_ROWS = 40;
+
+/** Opens the spotlight palette from anywhere in the tree, without threading
+ *  state through props. A no-op if the palette is not mounted. */
+export function openSpotlight(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(OPEN_EVENT));
+}
+
+/** True for the palette chord: Ctrl-Space. (Cmd-Space never reaches the page
+ *  on macOS — the OS owns it — so this is Ctrl on every platform.) */
+function isSpotlightShortcut(e: KeyboardEvent): boolean {
+  return e.ctrlKey && !e.metaKey && !e.altKey && (e.code === 'Space' || e.key === ' ');
+}
+
+/** Badge text per source, so a row's kind reads at a glance. */
+const SOURCE_LABEL: Record<SpotlightSource, string> = {
+  search: 'ask',
+  chat: 'chat',
+  page: 'page',
+  setting: 'setting',
+  action: 'action',
+};
+
+export function SpotlightPalette() {
+  const [open, setOpen] = useState(false);
+  const [rawQuery, setRawQuery] = useState('');
+  const [selected, setSelected] = useState(0);
+
+  const router = useRouter();
+  const chat = useChat();
+  const { isAuthenticated, signIn, signOut } = useSession();
+  const { docsEnabled, setActiveView, requestFilesSidebar } = useMainView();
+  const { recentChats, load } = useRecentChats(CHAT_LIMIT);
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  // Held in a ref so the open-effect below can depend on `open` alone: `load`
+  // is re-created whenever the session settles, and an effect that re-ran on
+  // its identity would reset the highlighted row mid-typing.
+  const loadRef = useRef(load);
+  useEffect(() => {
+    loadRef.current = load;
+  }, [load]);
+
+  const ctx: SpotlightContext = useMemo(
+    () => ({
+      appName: researchAgentUIConfig.appName,
+      navigate: (href) => router.push(href),
+      openChat: (chatId) => {
+        // The host gets first refusal: shells that render chats inline (the
+        // extension, a tabbed desktop window) handle it without navigating.
+        if (!researchAgentUIConfig.onOpenChat?.(chatId)) router.push(`/c/${chatId}`);
+      },
+      openSettings: (section) => {
+        if (!researchAgentUIConfig.onOpenSettings?.(section))
+          router.push(section ? `/settings/${section}` : '/settings');
+      },
+      // `sendMessage` no-ops without a chat id, and the id a fresh chat gets
+      // is not knowable from here — so the query rides the `?q=` deep link the
+      // chat provider already answers, after `newChat` has cleared the board.
+      ask: (query) => {
+        chat.newChat();
+        router.push(`/?q=${encodeURIComponent(query)}`);
+      },
+      newChat: chat.newChat,
+      focusMode: chat.focusMode,
+      setFocusMode: chat.setFocusMode,
+      incognito: chat.incognito,
+      setIncognito: chat.setIncognito,
+      isAuthenticated,
+      signIn,
+      signOut,
+      docsEnabled,
+      setActiveView,
+      requestFilesSidebar,
+    }),
+    [
+      router,
+      chat.newChat,
+      chat.focusMode,
+      chat.setFocusMode,
+      chat.incognito,
+      chat.setIncognito,
+      isAuthenticated,
+      signIn,
+      signOut,
+      docsEnabled,
+      setActiveView,
+      requestFilesSidebar,
+    ],
+  );
+
+  const { prefix, query } = parsePrefix(rawQuery);
+  const trimmed = query.trim();
+
+  const sources = useMemo(
+    () => ({
+      chat: buildChatItems(recentChats, ctx),
+      page: buildPageItems(ctx),
+      setting: buildSettingItems(ctx),
+      action: buildActionItems(ctx),
+    }),
+    [recentChats, ctx],
+  );
+
+  const results = useMemo(() => {
+    const askRow = buildSearchItem(query, ctx);
+
+    // `w` is the one prefix with no list behind it — the query *is* the row.
+    if (prefix === 'w') return askRow ? [askRow] : [];
+    if (prefix) {
+      const source = SPOTLIGHT_PREFIXES.find((e) => e.prefix === prefix)!.source;
+      return matchSpotlight(sources[source as keyof typeof sources], query)
+        .map((m) => m.item)
+        .slice(0, MAX_ROWS);
+    }
+
+    // No prefix, nothing typed: browse — a few recent chats, then everything
+    // the palette can do, in a fixed order so the list is muscle-memorable.
+    if (!trimmed) {
+      return [
+        ...sources.chat.slice(0, BROWSE_CHATS),
+        ...sources.action,
+        ...sources.page,
+      ].slice(0, MAX_ROWS);
+    }
+
+    // No prefix, something typed: search everything, with "ask it" pinned on
+    // top — the query is always a legitimate thing to ask, even when nothing
+    // in the app matches it.
+    const everything = [...sources.action, ...sources.page, ...sources.setting, ...sources.chat];
+    const matched = matchSpotlight(everything, query).map((m) => m.item);
+    return [...(askRow ? [askRow] : []), ...matched].slice(0, MAX_ROWS);
+  }, [prefix, query, trimmed, sources, ctx]);
+
+  // ── Opening and closing ────────────────────────────────────────────────
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!isSpotlightShortcut(e)) return;
+      e.preventDefault();
+      setOpen((prev) => !prev);
+    };
+    const onOpenEvent = () => setOpen(true);
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener(OPEN_EVENT, onOpenEvent);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener(OPEN_EVENT, onOpenEvent);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setRawQuery('');
+      setSelected(0);
+      return;
+    }
+    setSelected(0);
+    // Fetched on open rather than on mount: an app-wide palette must not cost
+    // every page load a chats request.
+    void loadRef.current();
+    inputRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) close();
+    };
+    document.addEventListener('pointerdown', onPointerDown, true);
+    return () => document.removeEventListener('pointerdown', onPointerDown, true);
+  }, [open, close]);
+
+  // Selection can outrun the list as the query narrows it.
+  useEffect(() => {
+    setSelected((prev) => (prev < results.length ? prev : Math.max(0, results.length - 1)));
+  }, [results.length]);
+
+  useEffect(() => {
+    // Optional call, not just optional chain: `scrollIntoView` is missing in
+    // jsdom and in some embedded webviews, and a palette that throws while
+    // moving the selection is worse than one that doesn't scroll.
+    listRef.current
+      ?.querySelector<HTMLElement>('[data-selected="true"]')
+      ?.scrollIntoView?.({ block: 'nearest' });
+  }, [selected, results.length]);
+
+  // ── Keyboard ───────────────────────────────────────────────────────────
+
+  const activate = useCallback(
+    (item: SpotlightItem | undefined) => {
+      if (!item) return;
+      close();
+      item.run();
+    },
+    [close],
+  );
+
+  /** Tab cycles the bar through the sources, keeping whatever is typed. */
+  const cyclePrefix = useCallback(() => {
+    const order = SPOTLIGHT_PREFIXES.map((e) => e.prefix);
+    const at = prefix ? order.indexOf(prefix) : -1;
+    const next = order[(at + 1) % order.length]!;
+    setRawQuery(`${next} ${query}`);
+    setSelected(0);
+  }, [prefix, query]);
+
+  const onInputKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'Escape':
+        e.preventDefault();
+        close();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        setSelected((i) => (results.length ? (i + 1) % results.length : 0));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSelected((i) => (results.length ? (i - 1 + results.length) % results.length : 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        // Keep it off `document`: an activated row can synchronously open a
+        // modal that installs its own key listener, which would otherwise
+        // catch this very Enter.
+        e.stopPropagation();
+        activate(results[selected]);
+        break;
+      case 'Tab':
+        e.preventDefault();
+        cyclePrefix();
+        break;
+    }
+  };
+
+  if (!open) return null;
+
+  const activeSource = prefix ? SPOTLIGHT_PREFIXES.find((p) => p.prefix === prefix) : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[10000] flex items-start justify-center bg-black/40 backdrop-blur-[2px] px-4 pt-[12vh]"
+      role="presentation"
+    >
+      <div
+        ref={rootRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search everything"
+        className="w-full max-w-xl overflow-hidden rounded-2xl border border-border bg-popover shadow-2xl"
+      >
+        <div className="flex items-center gap-3 border-b border-border px-4">
+          <Search size={18} className="shrink-0 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            value={rawQuery}
+            onChange={(e) => {
+              setRawQuery(e.target.value);
+              setSelected(0);
+            }}
+            onKeyDown={onInputKeyDown}
+            type="text"
+            spellCheck={false}
+            autoComplete="off"
+            aria-label="Search everything"
+            aria-autocomplete="list"
+            aria-controls="spotlight-results"
+            aria-activedescendant={results[selected]?.id}
+            placeholder={
+              activeSource
+                ? `Search ${activeSource.label}…`
+                : 'Search chats, pages, settings — or ask anything'
+            }
+            className="w-full bg-transparent py-4 text-base text-popover-foreground outline-none placeholder:text-muted-foreground"
+          />
+          {activeSource && (
+            <span className="shrink-0 rounded-md bg-secondary px-2 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
+              {activeSource.label}
+            </span>
+          )}
+        </div>
+
+        <div
+          ref={listRef}
+          id="spotlight-results"
+          role="listbox"
+          aria-label="Results"
+          className="max-h-[50vh] overflow-y-auto p-1"
+          // The input owns the keyboard: clicking a row must not move focus to
+          // the scroller, after which arrows would scroll it natively and
+          // Enter would never reach the palette.
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {results.length === 0 ? (
+            <p className="px-3 py-6 text-center text-sm text-muted-foreground">
+              No matches. Press Tab to search another source.
+            </p>
+          ) : (
+            results.map((item, i) => {
+              const Icon = item.icon;
+              return (
+                <div
+                  key={item.id}
+                  id={item.id}
+                  role="option"
+                  aria-selected={i === selected}
+                  data-selected={i === selected}
+                  onMouseMove={() => setSelected(i)}
+                  onClick={() => activate(item)}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2 transition-colors',
+                    i === selected ? 'bg-secondary' : 'hover:bg-secondary/60',
+                  )}
+                >
+                  <Icon
+                    size={16}
+                    className={cn(
+                      'shrink-0',
+                      i === selected ? 'text-primary' : 'text-muted-foreground',
+                    )}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm text-popover-foreground">{item.name}</p>
+                    {item.meta && (
+                      <p className="truncate text-xs text-muted-foreground">{item.meta}</p>
+                    )}
+                  </div>
+                  {item.hint && (
+                    <span className="shrink-0 text-[10px] text-muted-foreground">{item.hint}</span>
+                  )}
+                  <span className="shrink-0 rounded-md bg-secondary px-1.5 py-0 text-[10px] text-muted-foreground">
+                    {SOURCE_LABEL[item.source]}
+                  </span>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+          <span>↑↓ move</span>
+          <span>↵ open</span>
+          <span>⇥ next source</span>
+          <span>esc close</span>
+          <span className="ml-auto">
+            {SPOTLIGHT_PREFIXES.map((p) => `${p.prefix} ${p.label}`).join(' · ')}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SpotlightPalette;

--- a/packages/research-agent-ui/src/components/SpotlightPalette/index.ts
+++ b/packages/research-agent-ui/src/components/SpotlightPalette/index.ts
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview The Ctrl-Space spotlight palette — a single bar that searches
+ * chats, pages, settings and actions, and asks the research agent anything
+ * that matches none of them.
+ */
+export { SpotlightPalette, openSpotlight } from './SpotlightPalette';
+export {
+  buildActionItems,
+  buildChatItems,
+  buildPageItems,
+  buildSearchItem,
+  buildSettingItems,
+} from './spotlightItems';
+export type {
+  SpotlightContext,
+  SpotlightIcon,
+  SpotlightItem,
+} from './spotlightItems';
+export {
+  matchSpotlight,
+  parsePrefix,
+  prefixForSource,
+  SPOTLIGHT_PREFIXES,
+} from './spotlightMatch';
+export type {
+  SpotlightMatch,
+  SpotlightMatchable,
+  SpotlightPrefix,
+  SpotlightSource,
+} from './spotlightMatch';
+export { SPOTLIGHT_LINKS, type SpotlightLink } from './spotlightLinks';

--- a/packages/research-agent-ui/src/components/SpotlightPalette/spotlightItems.ts
+++ b/packages/research-agent-ui/src/components/SpotlightPalette/spotlightItems.ts
@@ -1,0 +1,262 @@
+/**
+ * @fileoverview Builds the palette's rows, one function per source.
+ *
+ * Everything here is pure: a builder takes data plus a {@link SpotlightContext}
+ * of callbacks and returns rows. The component owns the hooks and the
+ * rendering; keeping the sources out of it is what makes the ranking and the
+ * per-source contents testable without mounting the app.
+ */
+import {
+  BookOpen,
+  EyeOff,
+  FileText,
+  Globe,
+  LayoutGrid,
+  LogIn,
+  LogOut,
+  MessageSquare,
+  Plus,
+  Search,
+  Settings as SettingsIcon,
+  SlidersHorizontal,
+  Sparkles,
+} from 'lucide-react';
+import type { ComponentType } from 'react';
+
+import type { Chat } from '../../types/research';
+import { formatTimeDifference } from '../../lib/utils';
+// The section list is read from its JSON source rather than from
+// `../../settings`, whose index also splices in prompt templates from
+// `chat-agent-toolkit` — a runtime import the chat bundle has no other reason
+// to carry. The type still comes from there, and `import type` is erased.
+import sectionsJson from '../../settings/sections.json';
+import type { SettingsSectionSchema } from '../../settings';
+import { focusModes } from '../SearchConfig/focusModes';
+import { SPOTLIGHT_LINKS } from './spotlightLinks';
+import type { SpotlightMatchable, SpotlightSource } from './spotlightMatch';
+
+/** Lucide-style icon component — every row renders one at 16px. */
+export type SpotlightIcon = ComponentType<{ size?: number; className?: string }>;
+
+/** One row of the palette. */
+export interface SpotlightItem extends SpotlightMatchable {
+  /** Stable within a render, and used as the option's DOM id. */
+  id: string;
+  source: SpotlightSource;
+  icon: SpotlightIcon;
+  /** Right-aligned trailing text — a relative timestamp, a state, a count. */
+  hint?: string;
+  /** What Enter (or a click) does. */
+  run: () => void;
+}
+
+/**
+ * The app capabilities the palette drives. Supplied by the component from the
+ * chat / session / view contexts, so nothing in this module reaches for a
+ * hook, a router or an endpoint — which is also what keeps the palette
+ * mountable in the extension and the VS Code webview.
+ */
+export interface SpotlightContext {
+  /** Product name, used in the "Ask …" row. */
+  appName: string;
+  /** Navigate to an in-app route. */
+  navigate: (href: string) => void;
+  /** Open an existing chat (host callback first, route fallback). */
+  openChat: (chatId: string) => void;
+  /** Open settings, optionally deep-linked to a section key. */
+  openSettings: (section?: string) => void;
+  /** Start a fresh chat and ask it something straight away. */
+  ask: (query: string) => void;
+  /** Start a fresh, empty chat. */
+  newChat: () => void;
+  /** Current research focus mode key, and the setter for it. */
+  focusMode: string;
+  setFocusMode: (key: string) => void;
+  incognito: boolean;
+  setIncognito: (value: boolean) => void;
+  isAuthenticated: boolean;
+  signIn: () => void;
+  signOut: () => void;
+  /** Whether this build bundles the REASON editor and its file sidebar. */
+  docsEnabled: boolean;
+  /** Switch the main view between research and documents. */
+  setActiveView: (view: 'research' | 'docs') => void;
+  /** Reveal the REASON files sidebar (docs builds only). */
+  requestFilesSidebar: () => void;
+}
+
+/** Pages (`t `), in the curated order of {@link SPOTLIGHT_LINKS}. */
+export function buildPageItems(ctx: SpotlightContext): SpotlightItem[] {
+  const iconFor = (href: string): SpotlightIcon => {
+    if (href === '/') return Search;
+    if (href === '/workspace') return FileText;
+    if (href === '/settings') return SettingsIcon;
+    if (href === '/docs') return BookOpen;
+    return LayoutGrid;
+  };
+  return SPOTLIGHT_LINKS.filter((link) => !link.docsOnly || ctx.docsEnabled).map((link) => ({
+    id: `page:${link.href}`,
+    source: 'page' as const,
+    name: link.label,
+    meta: link.description,
+    keywords: `${link.keywords ?? ''} ${link.href}`,
+    icon: iconFor(link.href),
+    run: () => ctx.navigate(link.href),
+  }));
+}
+
+/** Past conversations (`c `), newest first — the caller passes them sorted. */
+export function buildChatItems(chats: readonly Chat[], ctx: SpotlightContext): SpotlightItem[] {
+  const now = new Date();
+  return chats.map((chat) => ({
+    id: `chat:${chat.id}`,
+    source: 'chat' as const,
+    name: chat.title || 'Untitled chat',
+    meta: `${chat.messageCount ?? 0} question${(chat.messageCount ?? 0) === 1 ? '' : 's'}`,
+    keywords: chat.focusMode ?? '',
+    icon: MessageSquare,
+    hint: formatTimeDifference(now, chat.lastMessageAt || chat.createdAt),
+    run: () => ctx.openChat(chat.id),
+  }));
+}
+
+/** Settings sections (`s `), deep-linked by section key. */
+export function buildSettingItems(ctx: SpotlightContext): SpotlightItem[] {
+  const sections = sectionsJson as unknown as SettingsSectionSchema[];
+  return sections.map((section) => ({
+    id: `setting:${section.key}`,
+    source: 'setting' as const,
+    name: section.name,
+    meta: section.description,
+    keywords: `settings ${section.key}`,
+    icon: SlidersHorizontal,
+    run: () => ctx.openSettings(section.key),
+  }));
+}
+
+/** Commands (`a `) — the things the palette does rather than navigates to. */
+export function buildActionItems(ctx: SpotlightContext): SpotlightItem[] {
+  const items: SpotlightItem[] = [
+    {
+      id: 'action:new-chat',
+      source: 'action',
+      name: 'New chat',
+      meta: 'Start a fresh conversation',
+      keywords: 'clear reset blank',
+      icon: Plus,
+      run: ctx.newChat,
+    },
+    {
+      id: 'action:settings',
+      source: 'action',
+      name: 'Open settings',
+      meta: 'Models, connectors, search sources and preferences',
+      keywords: 'preferences configure',
+      icon: SettingsIcon,
+      run: () => ctx.openSettings(),
+    },
+    {
+      id: 'action:incognito',
+      source: 'action',
+      name: ctx.incognito ? 'Turn off incognito' : 'Turn on incognito',
+      meta: 'Stop saving this conversation to history',
+      keywords: 'private incognito history off',
+      icon: EyeOff,
+      hint: ctx.incognito ? 'on' : 'off',
+      run: () => ctx.setIncognito(!ctx.incognito),
+    },
+  ];
+
+  // One row per focus mode, so "academic" jumps straight to the right search
+  // scope without going through the composer's popover.
+  for (const mode of focusModes) {
+    items.push({
+      id: `action:focus:${mode.key}`,
+      source: 'action',
+      name: `Focus: ${mode.title}`,
+      meta: mode.description,
+      keywords: `focus mode ${mode.key}`,
+      icon: Globe,
+      hint: ctx.focusMode === mode.key ? 'current' : undefined,
+      run: () => ctx.setFocusMode(mode.key),
+    });
+  }
+
+  if (ctx.docsEnabled) {
+    items.push(
+      {
+        id: 'action:view-docs',
+        source: 'action',
+        name: 'Switch to documents',
+        meta: 'Open the REASON editor view',
+        keywords: 'reason editor write docs',
+        icon: FileText,
+        run: () => ctx.setActiveView('docs'),
+      },
+      {
+        id: 'action:view-research',
+        source: 'action',
+        name: 'Switch to research',
+        meta: 'Back to the search and chat view',
+        keywords: 'chat search',
+        icon: Search,
+        run: () => ctx.setActiveView('research'),
+      },
+      {
+        id: 'action:files-sidebar',
+        source: 'action',
+        name: 'Show files sidebar',
+        meta: 'Browse REASON documents',
+        keywords: 'files documents sidebar',
+        icon: FileText,
+        run: () => {
+          ctx.setActiveView('docs');
+          ctx.requestFilesSidebar();
+        },
+      },
+    );
+  }
+
+  items.push(
+    ctx.isAuthenticated
+      ? {
+          id: 'action:sign-out',
+          source: 'action',
+          name: 'Sign out',
+          meta: 'End this session',
+          keywords: 'logout log out',
+          icon: LogOut,
+          run: ctx.signOut,
+        }
+      : {
+          id: 'action:sign-in',
+          source: 'action',
+          name: 'Sign in',
+          meta: 'Sync chats and settings across devices',
+          keywords: 'login log in account',
+          icon: LogIn,
+          run: ctx.signIn,
+        },
+  );
+
+  return items;
+}
+
+/**
+ * The "ask it" row (`w `) — the one row that is the query rather than a match
+ * for it, so it is built fresh per keystroke and pinned to the top.
+ * Returns null for an empty query, which has nothing to ask.
+ */
+export function buildSearchItem(query: string, ctx: SpotlightContext): SpotlightItem | null {
+  const trimmed = query.trim();
+  if (!trimmed) return null;
+  return {
+    id: 'search:ask',
+    source: 'search',
+    name: trimmed,
+    meta: `Ask ${ctx.appName} — searches the web and answers with sources`,
+    icon: Sparkles,
+    hint: 'Enter',
+    run: () => ctx.ask(trimmed),
+  };
+}

--- a/packages/research-agent-ui/src/components/SpotlightPalette/spotlightLinks.ts
+++ b/packages/research-agent-ui/src/components/SpotlightPalette/spotlightLinks.ts
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview The palette's curated list of app pages (`t ` prefix).
+ *
+ * The package ships the same UI to four shells and has no dependency on any
+ * one of them, so — like CardMirror's `workspace-links.ts`, which this is
+ * modelled on — the list is maintained here by hand rather than derived from
+ * a router. Keep it in sync when `apps/qwksearch-web` gains a major page.
+ */
+
+/** One navigable destination in the app. */
+export interface SpotlightLink {
+  href: string;
+  label: string;
+  description: string;
+  /** Extra search terms that should find this page but aren't worth showing. */
+  keywords?: string;
+  /** Only listed in builds that bundle the REASON editor. */
+  docsOnly?: boolean;
+}
+
+export const SPOTLIGHT_LINKS: SpotlightLink[] = [
+  {
+    href: '/',
+    label: 'Research',
+    description: 'The search and chat window',
+    keywords: 'home chat ask question search',
+  },
+  {
+    href: '/workspace',
+    label: 'REASON Editor',
+    description: 'Write up findings in the document editor',
+    keywords: 'docs document write draft report',
+    docsOnly: true,
+  },
+  {
+    href: '/library',
+    label: 'Library',
+    description: 'Saved chats, uploads and extracted articles',
+    keywords: 'history saved files uploads archive',
+  },
+  {
+    href: '/news',
+    label: 'News',
+    description: 'Trending stories by topic',
+    keywords: 'discover trending headlines',
+  },
+  {
+    href: '/docs',
+    label: 'User Guide',
+    description: 'How every part of the app works',
+    keywords: 'documentation help manual',
+  },
+  {
+    href: '/features',
+    label: 'Features',
+    description: 'Everything the research agent can do',
+    keywords: 'capabilities tour',
+  },
+  {
+    href: '/settings',
+    label: 'Settings',
+    description: 'Models, connectors, search sources and preferences',
+    keywords: 'preferences configure options',
+  },
+  {
+    href: '/enterprise',
+    label: 'Enterprise',
+    description: 'Self-hosting and team plans',
+    keywords: 'business pricing teams',
+  },
+  {
+    href: '/legal/privacy',
+    label: 'Privacy Policy',
+    description: 'What is stored and what is not',
+    keywords: 'legal terms data',
+  },
+];

--- a/packages/research-agent-ui/src/components/SpotlightPalette/spotlightMatch.ts
+++ b/packages/research-agent-ui/src/components/SpotlightPalette/spotlightMatch.ts
@@ -1,0 +1,135 @@
+/**
+ * @fileoverview Spotlight palette matching — the prefix system and the ranker.
+ *
+ * Ported from the CardMirror editor's quick-card search palette in debate-ai
+ * (`packages/debate-editor/src/editor/quick-cards-match.ts`, plus the prefix
+ * parser in `quick-card-search-ui.ts`), because the two palettes want exactly
+ * the same behaviour: order-independent multi-token substring AND-matching in
+ * two tiers — entries whose NAME matches come first, then entries that match
+ * only on their secondary text, carrying a small snippet of the matched
+ * region so it is obvious *why* a row is in the list.
+ *
+ * Deliberately substring matching, not edit-distance fuzz: a chat titled
+ * "Solid-state battery breakthroughs" surfacing for "sled" is noise, and the
+ * palette's whole job is to be predictable enough to use blind.
+ */
+
+/**
+ * A single-letter prefix scoping the query to one source, typed as
+ * `<letter><space>`. With a prefix present an empty query *browses* that
+ * source; with no prefix the palette searches everything.
+ */
+export type SpotlightPrefix = 'c' | 't' | 's' | 'a' | 'w' | null;
+
+/** The kind of thing a palette row points at. */
+export type SpotlightSource = 'chat' | 'page' | 'setting' | 'action' | 'search';
+
+/** Prefix → the source it scopes to, with the hint shown under the bar. */
+export const SPOTLIGHT_PREFIXES: ReadonlyArray<{
+  prefix: Exclude<SpotlightPrefix, null>;
+  source: SpotlightSource;
+  label: string;
+}> = [
+  { prefix: 'c', source: 'chat', label: 'chats' },
+  { prefix: 't', source: 'page', label: 'pages' },
+  { prefix: 's', source: 'setting', label: 'settings' },
+  { prefix: 'a', source: 'action', label: 'actions' },
+  { prefix: 'w', source: 'search', label: 'web' },
+];
+
+/** Split a leading single-letter prefix (`c `/`t `/`s `/`a `/`w `) off the query. */
+export function parsePrefix(raw: string): { prefix: SpotlightPrefix; query: string } {
+  const m = raw.match(/^([a-zA-Z])\s+(.*)$/);
+  if (m) {
+    const p = m[1]!.toLowerCase();
+    const known = SPOTLIGHT_PREFIXES.find((e) => e.prefix === p);
+    if (known) return { prefix: known.prefix, query: m[2]! };
+  }
+  return { prefix: null, query: raw };
+}
+
+/** The prefix that scopes to a given source, for Tab-cycling the bar. */
+export function prefixForSource(source: SpotlightSource): Exclude<SpotlightPrefix, null> {
+  return SPOTLIGHT_PREFIXES.find((e) => e.source === source)!.prefix;
+}
+
+/** The minimum shape the ranker needs: a name, plus optional secondary text. */
+export interface SpotlightMatchable {
+  /** The row's title — the first-tier match target. */
+  name: string;
+  /** Shown under the name; searched in the second tier. */
+  meta?: string;
+  /** Extra searchable text that is never displayed (aliases, synonyms). */
+  keywords?: string;
+}
+
+export interface SpotlightMatch<T extends SpotlightMatchable> {
+  item: T;
+  /** True when the query matched the name; false = secondary-text-only match,
+   *  in which case `snippet` shows the matched region. */
+  matchedName: boolean;
+  snippet: string | null;
+}
+
+/** Chars of context on each side of a secondary-text match (~40 total). */
+const SNIPPET_RADIUS = 18;
+
+/** Everything searchable about an item apart from its name. */
+function secondaryText(item: SpotlightMatchable): string {
+  return `${item.meta ?? ''} ${item.keywords ?? ''}`.toLowerCase();
+}
+
+/**
+ * Ranks `items` against `query`.
+ *
+ * An empty query browses: every item, in the order given (builders already
+ * order their own source — recent chats by recency, pages by the curated
+ * list). A non-empty query keeps only items where EVERY whitespace-separated
+ * token appears somewhere, name matches first.
+ */
+export function matchSpotlight<T extends SpotlightMatchable>(
+  items: readonly T[],
+  query: string,
+): SpotlightMatch<T>[] {
+  const tokens = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0)
+    return items.map((item) => ({ item, matchedName: true, snippet: null }));
+
+  const nameMatches: T[] = [];
+  const secondaryMatches: T[] = [];
+  for (const item of items) {
+    const nameLower = item.name.toLowerCase();
+    if (tokens.every((t) => nameLower.includes(t))) nameMatches.push(item);
+    else {
+      const rest = `${nameLower} ${secondaryText(item)}`;
+      if (tokens.every((t) => rest.includes(t))) secondaryMatches.push(item);
+    }
+  }
+
+  const t0 = tokens[0]!;
+  // Name tier: earliest first-token position wins, so prefix matches float to
+  // the top ("set" puts "Settings" above "Reset chat"). `sort` is stable, so
+  // ties keep the builder's order.
+  nameMatches.sort((a, b) => a.name.toLowerCase().indexOf(t0) - b.name.toLowerCase().indexOf(t0));
+
+  return [
+    ...nameMatches.map((item) => ({ item, matchedName: true, snippet: null as string | null })),
+    ...secondaryMatches.map((item) => ({
+      item,
+      matchedName: false,
+      snippet: makeSnippet(secondaryText(item), t0),
+    })),
+  ];
+}
+
+/** A trimmed, ellipsized window of `textLower` around the first `token` hit. */
+export function makeSnippet(textLower: string, token: string): string {
+  const i = textLower.indexOf(token);
+  if (i < 0) return '';
+  const start = Math.max(0, i - SNIPPET_RADIUS);
+  const end = Math.min(textLower.length, i + token.length + SNIPPET_RADIUS);
+  let s = textLower.slice(start, end).replace(/\s+/g, ' ').trim();
+  if (start > 0) s = '…' + s;
+  if (end < textLower.length) s = s + '…';
+  return s;
+}

--- a/packages/research-agent-ui/src/index.ts
+++ b/packages/research-agent-ui/src/index.ts
@@ -91,6 +91,26 @@ export { default as HistoryDropdown } from './components/ChatHistoryDropdown';
 export { HistoryDialogs } from './components/ChatHistoryDropdown/HistoryDialogs';
 export { useHistoryState } from './components/ChatHistoryDropdown/useHistoryState';
 
+// ============ Spotlight Palette ============
+// The Ctrl-Space overlay that searches chats, pages, settings and actions.
+// `QwkSearchProviders` mounts it already; these exports are for hosts that
+// build their own shell, or want to open it from their own chrome.
+export {
+  SpotlightPalette,
+  openSpotlight,
+  SPOTLIGHT_LINKS,
+  SPOTLIGHT_PREFIXES,
+  matchSpotlight,
+  parsePrefix,
+} from './components/SpotlightPalette';
+export type {
+  SpotlightContext,
+  SpotlightItem,
+  SpotlightLink,
+  SpotlightPrefix,
+  SpotlightSource,
+} from './components/SpotlightPalette';
+
 // ============ Types ============
 export * from './types/chat';
 

--- a/packages/research-agent-ui/test/spotlightItems.test.ts
+++ b/packages/research-agent-ui/test/spotlightItems.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview What each spotlight source puts in the palette, and what
+ * activating a row actually does.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildActionItems,
+  buildChatItems,
+  buildPageItems,
+  buildSearchItem,
+  buildSettingItems,
+  type SpotlightContext,
+} from '../src/components/SpotlightPalette/spotlightItems';
+import type { Chat } from '../src/types/research';
+
+/** A context whose every capability is a spy, overridable per test. */
+function makeContext(overrides: Partial<SpotlightContext> = {}): SpotlightContext {
+  return {
+    appName: 'QwkSearch',
+    navigate: vi.fn(),
+    openChat: vi.fn(),
+    openSettings: vi.fn(),
+    ask: vi.fn(),
+    newChat: vi.fn(),
+    focusMode: 'webSearch',
+    setFocusMode: vi.fn(),
+    incognito: false,
+    setIncognito: vi.fn(),
+    isAuthenticated: false,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    docsEnabled: true,
+    setActiveView: vi.fn(),
+    requestFilesSidebar: vi.fn(),
+    ...overrides,
+  };
+}
+
+const chats: Chat[] = [
+  {
+    id: 'chat-1',
+    title: 'Solid-state battery breakthroughs',
+    createdAt: new Date(Date.now() - 3_600_000).toISOString(),
+    lastMessageAt: new Date(Date.now() - 60_000).toISOString(),
+    focusMode: 'academicSearch',
+    messageCount: 4,
+  },
+];
+
+describe('buildPageItems', () => {
+  it('navigates to the page it lists', () => {
+    const ctx = makeContext();
+    const research = buildPageItems(ctx).find((item) => item.name === 'Research')!;
+
+    research.run();
+
+    expect(ctx.navigate).toHaveBeenCalledWith('/');
+  });
+
+  it('hides the editor page in a build without the editor', () => {
+    const names = buildPageItems(makeContext({ docsEnabled: false })).map((i) => i.name);
+
+    expect(names).not.toContain('REASON Editor');
+    expect(buildPageItems(makeContext()).map((i) => i.name)).toContain('REASON Editor');
+  });
+});
+
+describe('buildChatItems', () => {
+  it('opens the chat it lists, with a question count and a relative time', () => {
+    const ctx = makeContext();
+    const [item] = buildChatItems(chats, ctx);
+
+    expect(item.name).toBe('Solid-state battery breakthroughs');
+    expect(item.meta).toBe('4 questions');
+    expect(item.hint).toMatch(/minute|second/);
+
+    item.run();
+
+    expect(ctx.openChat).toHaveBeenCalledWith('chat-1');
+  });
+
+  it('names an untitled chat rather than rendering a blank row', () => {
+    const [item] = buildChatItems([{ ...chats[0], title: '' }], makeContext());
+
+    expect(item.name).toBe('Untitled chat');
+  });
+});
+
+describe('buildSettingItems', () => {
+  it('deep-links to a settings section', () => {
+    const ctx = makeContext();
+    const models = buildSettingItems(ctx).find((item) => item.name === 'Language Models')!;
+
+    models.run();
+
+    expect(ctx.openSettings).toHaveBeenCalledWith('models');
+  });
+});
+
+describe('buildActionItems', () => {
+  it('offers sign-in when signed out and sign-out when signed in', () => {
+    expect(buildActionItems(makeContext()).map((i) => i.name)).toContain('Sign in');
+    expect(
+      buildActionItems(makeContext({ isAuthenticated: true })).map((i) => i.name),
+    ).toContain('Sign out');
+  });
+
+  it('labels the incognito toggle by what it will do', () => {
+    const ctx = makeContext({ incognito: true });
+    const toggle = buildActionItems(ctx).find((i) => i.id === 'action:incognito')!;
+
+    expect(toggle.name).toBe('Turn off incognito');
+
+    toggle.run();
+
+    expect(ctx.setIncognito).toHaveBeenCalledWith(false);
+  });
+
+  it('lists one row per focus mode and marks the current one', () => {
+    const items = buildActionItems(makeContext({ focusMode: 'academicSearch' }));
+    const academic = items.find((i) => i.id === 'action:focus:academicSearch')!;
+
+    expect(academic.name).toBe('Focus: Academic');
+    expect(academic.hint).toBe('current');
+    expect(items.find((i) => i.id === 'action:focus:webSearch')!.hint).toBeUndefined();
+  });
+
+  it('drops the document actions in a build without the editor', () => {
+    const names = buildActionItems(makeContext({ docsEnabled: false })).map((i) => i.name);
+
+    expect(names).not.toContain('Switch to documents');
+    expect(names).not.toContain('Show files sidebar');
+  });
+
+  it('opens the files sidebar on the document view, not the current one', () => {
+    const ctx = makeContext();
+    buildActionItems(ctx).find((i) => i.id === 'action:files-sidebar')!.run();
+
+    expect(ctx.setActiveView).toHaveBeenCalledWith('docs');
+    expect(ctx.requestFilesSidebar).toHaveBeenCalled();
+  });
+});
+
+describe('buildSearchItem', () => {
+  it('asks the trimmed query', () => {
+    const ctx = makeContext();
+    const item = buildSearchItem('  how do sodium batteries work  ', ctx)!;
+
+    expect(item.name).toBe('how do sodium batteries work');
+    expect(item.meta).toContain('QwkSearch');
+
+    item.run();
+
+    expect(ctx.ask).toHaveBeenCalledWith('how do sodium batteries work');
+  });
+
+  it('has nothing to ask for a blank query', () => {
+    expect(buildSearchItem('   ', makeContext())).toBeNull();
+  });
+});

--- a/packages/research-agent-ui/test/spotlightMatch.test.ts
+++ b/packages/research-agent-ui/test/spotlightMatch.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview The spotlight palette's prefix parser and ranker — the two
+ * pieces that decide what the Ctrl-Space bar shows and in what order.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  makeSnippet,
+  matchSpotlight,
+  parsePrefix,
+  prefixForSource,
+  SPOTLIGHT_PREFIXES,
+} from '../src/components/SpotlightPalette/spotlightMatch';
+
+const items = [
+  { name: 'Settings', meta: 'Models, connectors and preferences' },
+  { name: 'Reset chat', meta: 'Clear the conversation' },
+  { name: 'Library', meta: 'Saved chats and uploads', keywords: 'archive history' },
+];
+
+describe('parsePrefix', () => {
+  it('splits a known single-letter prefix off the query', () => {
+    expect(parsePrefix('c batteries')).toEqual({ prefix: 'c', query: 'batteries' });
+    expect(parsePrefix('S models')).toEqual({ prefix: 's', query: 'models' });
+  });
+
+  it('treats an unknown letter as part of the query', () => {
+    expect(parsePrefix('x batteries')).toEqual({ prefix: null, query: 'x batteries' });
+  });
+
+  it('keeps a bare prefix letter with no trailing space as a query', () => {
+    // Otherwise typing the first letter of a word would silently scope the
+    // search before the user has finished the word.
+    expect(parsePrefix('c')).toEqual({ prefix: null, query: 'c' });
+  });
+
+  it('browses a source when the prefix is followed by nothing', () => {
+    expect(parsePrefix('c ')).toEqual({ prefix: 'c', query: '' });
+  });
+
+  it('maps every source to exactly one prefix', () => {
+    for (const entry of SPOTLIGHT_PREFIXES) {
+      expect(prefixForSource(entry.source)).toBe(entry.prefix);
+    }
+  });
+});
+
+describe('matchSpotlight', () => {
+  it('browses everything, in the given order, for an empty query', () => {
+    const results = matchSpotlight(items, '');
+
+    expect(results.map((r) => r.item.name)).toEqual(['Settings', 'Reset chat', 'Library']);
+    expect(results.every((r) => r.matchedName)).toBe(true);
+  });
+
+  it('ranks name matches above secondary-text matches', () => {
+    const results = matchSpotlight(items, 'chat');
+
+    expect(results.map((r) => r.item.name)).toEqual(['Reset chat', 'Library']);
+    expect(results[0].matchedName).toBe(true);
+    expect(results[1].matchedName).toBe(false);
+    expect(results[1].snippet).toContain('chat');
+  });
+
+  it('floats earlier name hits up within the name tier', () => {
+    const results = matchSpotlight(items, 'set');
+
+    expect(results.map((r) => r.item.name)).toEqual(['Settings', 'Reset chat']);
+  });
+
+  it('requires every token but ignores their order', () => {
+    expect(matchSpotlight(items, 'chat reset').map((r) => r.item.name)).toEqual(['Reset chat']);
+    expect(matchSpotlight(items, 'reset chat').map((r) => r.item.name)).toEqual(['Reset chat']);
+    expect(matchSpotlight(items, 'reset library')).toEqual([]);
+  });
+
+  it('matches undisplayed keywords', () => {
+    expect(matchSpotlight(items, 'archive').map((r) => r.item.name)).toEqual(['Library']);
+  });
+
+  it('does not fuzzy-match across a typo', () => {
+    // Substring matching on purpose: near-miss rows make the list unusable
+    // blind, which is the whole point of a keyboard palette.
+    expect(matchSpotlight(items, 'libary')).toEqual([]);
+  });
+});
+
+describe('makeSnippet', () => {
+  it('windows and ellipsizes around the first hit', () => {
+    const text = 'a'.repeat(60) + ' needle ' + 'b'.repeat(60);
+    const snippet = makeSnippet(text, 'needle');
+
+    expect(snippet.startsWith('…')).toBe(true);
+    expect(snippet.endsWith('…')).toBe(true);
+    expect(snippet).toContain('needle');
+    expect(snippet.length).toBeLessThan(text.length);
+  });
+
+  it('is empty when the token is absent', () => {
+    expect(makeSnippet('nothing here', 'needle')).toBe('');
+  });
+});

--- a/packages/research-agent-ui/test/spotlightPalette.test.tsx
+++ b/packages/research-agent-ui/test/spotlightPalette.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * @fileoverview The palette as the user meets it: the Ctrl-Space chord, the
+ * prefix scoping, keyboard selection, and what Enter does to the app.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+
+const push = vi.fn();
+const newChat = vi.fn();
+const setFocusMode = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/',
+  useParams: () => ({}),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('../src/hooks/useSession', () => ({
+  useSession: () => ({
+    isAuthenticated: false,
+    isLoading: false,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/hooks/useChat', () => ({
+  useChat: () => ({
+    newChat,
+    focusMode: 'webSearch',
+    setFocusMode,
+    incognito: false,
+    setIncognito: vi.fn(),
+  }),
+}));
+
+vi.mock('../src/components/ChatHistoryDropdown/useRecentChats', () => ({
+  useRecentChats: () => ({
+    recentChats: [
+      {
+        id: 'chat-1',
+        title: 'Solid-state battery breakthroughs',
+        createdAt: new Date().toISOString(),
+        lastMessageAt: new Date().toISOString(),
+        messageCount: 4,
+      },
+    ],
+    loading: false,
+    load: vi.fn(),
+  }),
+}));
+
+const { MainViewProvider } = await import('../src/app/MainViewProvider');
+const { SpotlightPalette, openSpotlight } = await import(
+  '../src/components/SpotlightPalette/SpotlightPalette'
+);
+
+function mount() {
+  return render(
+    <MainViewProvider docsEnabled={false}>
+      <SpotlightPalette />
+    </MainViewProvider>,
+  );
+}
+
+/** The Ctrl-Space chord, as the window sees it. */
+function pressShortcut() {
+  act(() => {
+    fireEvent.keyDown(window, { key: ' ', code: 'Space', ctrlKey: true });
+  });
+}
+
+const palette = () => screen.queryByRole('dialog', { name: 'Search everything' });
+const input = () => screen.getByRole('textbox', { name: 'Search everything' }) as HTMLInputElement;
+const options = () => screen.queryAllByRole('option');
+const type = (value: string) => fireEvent.change(input(), { target: { value } });
+
+beforeEach(() => {
+  push.mockClear();
+  newChat.mockClear();
+  setFocusMode.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SpotlightPalette', () => {
+  it('renders nothing until the shortcut is pressed, and toggles back off', () => {
+    mount();
+    expect(palette()).toBeNull();
+
+    pressShortcut();
+    expect(palette()).not.toBeNull();
+
+    pressShortcut();
+    expect(palette()).toBeNull();
+  });
+
+  it('opens from the exported helper, for chrome that has no keyboard', () => {
+    mount();
+
+    act(() => openSpotlight());
+
+    expect(palette()).not.toBeNull();
+  });
+
+  it('browses recent chats and actions before anything is typed', () => {
+    mount();
+    pressShortcut();
+
+    const names = options().map((o) => within(o).getAllByText(/.+/)[0].textContent);
+    expect(names).toContain('Solid-state battery breakthroughs');
+    expect(names).toContain('New chat');
+  });
+
+  it('pins "ask it" to the top of an unscoped query and sends it on Enter', () => {
+    mount();
+    pressShortcut();
+    type('sodium battery cost');
+
+    expect(options()[0].getAttribute('id')).toBe('search:ask');
+
+    fireEvent.keyDown(input(), { key: 'Enter' });
+
+    expect(newChat).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/?q=sodium%20battery%20cost');
+    expect(palette()).toBeNull();
+  });
+
+  it('scopes to one source with a prefix', () => {
+    mount();
+    pressShortcut();
+    type('t library');
+
+    const ids = options().map((o) => o.getAttribute('id'));
+    expect(ids).toEqual(['page:/library']);
+  });
+
+  it('moves the selection with the arrow keys and wraps at the ends', () => {
+    mount();
+    pressShortcut();
+    type('a focus');
+
+    expect(options()[0].getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(input(), { key: 'ArrowDown' });
+    expect(options()[1].getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.keyDown(input(), { key: 'ArrowUp' });
+    fireEvent.keyDown(input(), { key: 'ArrowUp' });
+    expect(options()[options().length - 1].getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('runs the selected action on Enter', () => {
+    mount();
+    pressShortcut();
+    type('a focus academic');
+
+    fireEvent.keyDown(input(), { key: 'Enter' });
+
+    expect(setFocusMode).toHaveBeenCalledWith('academicSearch');
+  });
+
+  it('cycles the scope with Tab, keeping what is typed', () => {
+    mount();
+    pressShortcut();
+    type('battery');
+
+    fireEvent.keyDown(input(), { key: 'Tab' });
+    expect(input().value).toBe('c battery');
+
+    fireEvent.keyDown(input(), { key: 'Tab' });
+    expect(input().value).toBe('t battery');
+  });
+
+  it('closes on Escape and forgets the query', () => {
+    mount();
+    pressShortcut();
+    type('battery');
+    fireEvent.keyDown(input(), { key: 'Escape' });
+
+    expect(palette()).toBeNull();
+
+    pressShortcut();
+    expect(input().value).toBe('');
+  });
+
+  it('says so when nothing matches, instead of an empty box', () => {
+    mount();
+    pressShortcut();
+    type('c zzzzz');
+
+    expect(options()).toHaveLength(0);
+    expect(screen.getByText(/No matches/)).toBeTruthy();
+  });
+});

--- a/packages/user-help-docs/content/docs/chat.mdx
+++ b/packages/user-help-docs/content/docs/chat.mdx
@@ -70,6 +70,31 @@ Privacy mode skips history entirely for that session.
 Hands-free control is packaged separately as
 [`use-voice-control`](https://github.com/OpenSourceAGI/qwksearch-research-agent/tree/master/packages/use-voice-control).
 
+## Spotlight search — <kbd>Ctrl</kbd> <kbd>Space</kbd>
+
+Press <kbd>Ctrl</kbd> <kbd>Space</kbd> anywhere in the app and one bar opens in
+front of everything. Type and it searches your past chats, the app's pages, the
+settings sections and the things the app can do — and whatever you typed is
+always askable from the top row, so a question you meant to ask never turns into
+a dead end.
+
+Start the query with a letter and a space to look in one place only:
+
+| Type | Searches |
+| --- | --- |
+| `c ` | your past chats |
+| `t ` | pages — Library, News, Settings, the REASON editor… |
+| `s ` | settings sections |
+| `a ` | actions — new chat, incognito, focus mode, sign in/out |
+| `w ` | ask the research agent |
+
+<kbd>Tab</kbd> cycles through those scopes without retyping, <kbd>↑</kbd>
+<kbd>↓</kbd> move, <kbd>Enter</kbd> opens and <kbd>Esc</kbd> closes. Matching is
+plain substring matching on every word you type, in any order, so what you see
+is what you asked for. (On a Mac it is Ctrl, not Cmd — macOS keeps
+<kbd>Cmd</kbd> <kbd>Space</kbd> for its own Spotlight.) It's also in the dock's
+settings menu as **Search everything**.
+
 ## Discover
 
 `GET /api/agent/discover` returns curated content by topic — the feed shown on

--- a/packages/user-help-docs/content/docs/features.mdx
+++ b/packages/user-help-docs/content/docs/features.mdx
@@ -19,6 +19,9 @@ icon: "Sparkles"
 - ❓ **Follow-up questions** — generated alongside every answer
 - 🗣️ **Voice** — speak a question (Whisper) and hear the answer (Kokoro or
   Deepgram)
+- ⌨️ **Spotlight search** — <kbd>Ctrl</kbd> <kbd>Space</kbd> opens one bar over
+  the app to jump to a past chat, a page, a setting or an action — or just ask
+  ([details](/docs/chat#spotlight-search--ctrl-space))
 
 ## Content extraction
 

--- a/skills/ask-research-agent-ui/API.md
+++ b/skills/ask-research-agent-ui/API.md
@@ -32,6 +32,18 @@
 | `docsEnabled` | set by the entry point | Whether the REASON surface is in this build |
 | `ChromeProvider` | — | Extra provider mounted inside the dock/view providers |
 | `showDock` / `showCookieConsent` / `showToaster` | `true` | Chrome toggles |
+| `showSpotlight` | `true` | Mount the Ctrl-Space spotlight palette |
+
+## Spotlight palette (`src/components/SpotlightPalette/`)
+
+| Export | Purpose |
+| --- | --- |
+| `SpotlightPalette` | The Ctrl-Space overlay; mounted for you by `QwkSearchProviders` |
+| `openSpotlight()` | Opens it from anywhere (no-op when it is not mounted) |
+| `SPOTLIGHT_PREFIXES`, `SpotlightPrefix`, `SpotlightSource` | The prefix system: `c` chats · `t` pages · `s` settings · `a` actions · `w` ask |
+| `parsePrefix`, `matchSpotlight` | The prefix parser and the two-tier ranker |
+| `SPOTLIGHT_LINKS`, `SpotlightLink` | The hand-kept list of app pages |
+| `SpotlightItem`, `SpotlightContext` | A row, and the callbacks a row's `run()` may use |
 
 ## Configuration
 

--- a/skills/ask-research-agent-ui/SKILL.md
+++ b/skills/ask-research-agent-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ask-research-agent-ui
-description: Guide to research-agent-ui (packages/research-agent-ui), the QwkSearch chat/search UI as a drop-in package — the two entry points (chat-only root vs `/workspace` with the REASON editor), QwkSearchApp and the QwkSearchProviders stack, configureResearchAgentUI, the ChatProvider / SessionProvider / ExtractPanelProvider contexts, the article reader, voice and TTS hooks, and the `/api` dependency-injected route-handler factories. Use when changing anything in the chat window, message composer, search config, article reader, file upload or chat history, when wiring the package into a host app's auth and API routes, or when the editor's dependency tree leaks into a chat-only bundle.
+description: Guide to research-agent-ui (packages/research-agent-ui), the QwkSearch chat/search UI as a drop-in package — the two entry points (chat-only root vs `/workspace` with the REASON editor), QwkSearchApp and the QwkSearchProviders stack, configureResearchAgentUI, the ChatProvider / SessionProvider / ExtractPanelProvider contexts, the article reader, voice and TTS hooks, the Ctrl-Space spotlight palette, and the `/api` dependency-injected route-handler factories. Use when changing anything in the chat window, message composer, search config, article reader, file upload, chat history or the spotlight palette, when wiring the package into a host app's auth and API routes, or when the editor's dependency tree leaks into a chat-only bundle.
 ---
 
 # Working With research-agent-ui
@@ -60,6 +60,7 @@ configured before prompting), `ChromeProvider`, `showDock`, `showCookieConsent`,
 | Copy/share/export actions | `src/components/MessageActions/` |
 | Upload flow, Drive picker | `src/components/FileUpload/` |
 | History dropdown and dialogs | `src/components/ChatHistoryDropdown/` |
+| The Ctrl-Space spotlight palette | `src/components/SpotlightPalette/` |
 | Voice settings, Kokoro voices | `src/components/VoiceSettings/`, `src/hooks/voice/` |
 | Send/stream logic, chat state | `src/hooks/useChat/` (`sendMessage.ts`, `chatMessages.ts`, `buildSections.ts`) |
 | Shell: dock, providers, view switch, tabs | `src/app/` |
@@ -83,6 +84,24 @@ host handled the request in place, and `false`/`undefined` to fall back to navig
 Next.js app. Add an endpoint by adding a handler plus its `*Deps` interface in
 `src/api/types.ts` and exporting it from `src/api/index.ts`.
 
+**The spotlight palette.** `QwkSearchProviders` mounts `SpotlightPalette` (turn it off
+with `showSpotlight={false}`). Ctrl-Space — Cmd-Space belongs to macOS — opens one bar
+over the whole app; `openSpotlight()` does the same from chrome that has no keyboard
+(the dock's Settings menu calls it). It is modelled on CardMirror's quick-card palette
+in debate-ai, prefix system and all: `c ` chats · `t ` pages · `s ` settings sections ·
+`a ` actions · `w ` ask, no prefix searches everything with "ask it" pinned on top. Tab
+cycles the scope, ↑↓ move, Enter runs, Esc closes.
+
+Three files, split so the interesting parts are testable without mounting the app:
+`spotlightMatch.ts` (the prefix parser and the two-tier ranker — name matches first,
+then secondary text with a snippet; substring, never fuzzy), `spotlightItems.ts` (one
+builder per source, each taking a `SpotlightContext` of callbacks so nothing reaches for
+a hook or an endpoint) and `SpotlightPalette.tsx` (the overlay, which supplies that
+context from the chat / session / view contexts it is mounted inside). Add a source by
+writing a builder and giving it a prefix in `SPOTLIGHT_PREFIXES`; add a page by adding
+it to `spotlightLinks.ts`, which is hand-kept because the package has no router to
+derive it from.
+
 **Google Drive picker.** Set both `googleApiKey` and `googleAppId`. The connector holds
 the per-file `drive.file` scope, and Google only releases a picked file when the picker
 knows the app id — with it empty, files come back but downloading them 403s.
@@ -95,6 +114,8 @@ knows the app id — with it empty, files come back but downloading them 403s.
 | `QwkSearchWorkspaceApp` is not exported | You imported the root entry. Use `research-agent-ui/workspace`. |
 | Missing-peer errors for `react-reason-editor` | Those are optional peers of the `/workspace` entry — install them, or use the chat-only entry. |
 | Google One Tap never appears | `googleOneTap` defaults to `'auto'` and stays off unless the backend reports Google as a configured provider. Pass `true` to force it. |
+| Ctrl-Space does nothing | The host mounts its own shell instead of `QwkSearchProviders`, or passes `showSpotlight={false}`. Mount `<SpotlightPalette />` inside the session/chat/view providers — it reads all three. |
+| A palette row navigates when the host wanted to handle it in place | `onOpenChat` / `onOpenSettings` must return `true`; the palette falls back to `/c/<id>` and `/settings/<section>` exactly like the history dropdown. |
 | Settings open as a route when a modal was wanted | `onOpenSettings` must return `true`; anything else falls through to route navigation. |
 | Drive picker returns a file that then 403s | `googleAppId` (the Google Cloud project number) is empty. |
 | Edits don't appear in `apps/qwksearch-web` | It consumes the built `dist/`. `bun run build` here, or run the repo's `.github/scripts/build-workspace-packages.mjs`. |


### PR DESCRIPTION
Adds a macOS-Spotlight-style command palette over the QwkSearch app, ported from CardMirror's quick-card search palette in debate-ai (`packages/debate-editor/src/editor/quick-card-search-ui.ts` + `quick-cards-match.ts`): the same single-letter prefix system and the same two-tier ranking, re-laid out Spotlight-style with the query bar on top and the results under it instead of CardMirror's results-above-the-bar bar.

## What it does

<kbd>Ctrl</kbd> <kbd>Space</kbd> anywhere in the app opens one bar in front of everything. (Ctrl, not Cmd — macOS keeps Cmd-Space for its own Spotlight.)

| Prefix | Searches |
| --- | --- |
| `c ` | past chats |
| `t ` | app pages — Library, News, Settings, the REASON editor… |
| `s ` | settings sections, deep-linked |
| `a ` | actions — new chat, incognito, focus mode, view switch, sign in/out |
| `w ` | ask the research agent |

With no prefix it searches everything at once and pins "ask the agent this" to the top, so a question typed into the palette never dead-ends. <kbd>Tab</kbd> cycles the scope keeping what is typed, arrows move, <kbd>Enter</kbd> runs, <kbd>Esc</kbd> closes. Empty and unscoped it browses: recent chats, then actions, then pages.

## Shape

- **`spotlightMatch.ts`** — the ported prefix parser and ranker. Order-independent multi-token substring AND-matching, name matches first, then secondary-text matches carrying a snippet of the matched region. Substring, never edit-distance fuzz: a keyboard palette has to be predictable enough to use blind.
- **`spotlightItems.ts`** — one builder per source, each taking a `SpotlightContext` of callbacks instead of reaching for a hook, a router or an endpoint. That keeps the sources and the ranking testable without mounting the app, and keeps the package transport-agnostic for the extension and VS Code shells. Chat and settings rows go through `onOpenChat` / `onOpenSettings` before falling back to `/c/<id>` and `/settings/<section>`, exactly like the history dropdown.
- **`SpotlightPalette.tsx`** — the overlay, which supplies that context from the chat / session / view contexts it is mounted inside.
- **`spotlightLinks.ts`** — the hand-kept page list, since the package has no router to derive one from (same reason CardMirror's `workspace-links.ts` is hand-kept).

Mounted once by `QwkSearchProviders` (`showSpotlight`, default on), so all four shells get it; `openSpotlight()` opens it from elsewhere, and the dock's Settings menu now has a **Search everything** entry for pointer-only users.

The composer's focus modes moved to `SearchConfig/focusModes.tsx` so the focus popover and the palette's "Focus: …" rows share one list rather than drifting apart.

## Testing

- `packages/research-agent-ui`: 173 tests pass, including 35 new ones — the ranker and prefix parser, every source builder, and the palette itself (chord toggles it, prefixes scope it, arrows wrap, Enter asks/runs, Tab cycles, Esc closes and forgets).
- `bun run type-check` clean; `bunx turbo run build --filter=research-agent-ui` green.
- Root `bun run test`: 3158 pass. The 14 failures are all in `apps/qwksearch-ext` and pre-existing — WXT's generated `.wxt/tsconfig.json` is missing without `wxt prepare`, unrelated to this change.

## Docs

Package README, its `CLAUDE.md`, the `ask-research-agent-ui` skill and its API map, and the user guide's chat and features pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKnSvtcxLm5rsEC6S3sSAc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KKnSvtcxLm5rsEC6S3sSAc)_