### PR TITLE
📝 docs(apps): give every app a README with env vars, setup and deploy

### DIFF
--- a/apps/collaboration-server/README.md
+++ b/apps/collaboration-server/README.md
@@ -15,15 +15,36 @@
 
 # collaboration-server
 
-Hocuspocus server backing the Reason Editor's collaboration rooms for both
-editor engines.
+The [Hocuspocus](https://tiptap.dev/docs/hocuspocus/introduction) WebSocket
+server behind the Reason Editor's collaboration rooms — the thing that makes
+two people editing one document see each other's cursors and keystrokes.
+
+It backs **both** editor engines in `packages/reason-editor`, persists every
+room to SQLite, and verifies who may open which document before the first sync
+frame goes out.
+
+A plain Bun process, not a Worker: Hocuspocus holds long-lived WebSocket
+connections and a SQLite file, neither of which fits the Workers runtime.
+
+## Setup
 
 ```bash
+bun install                      # from the repo root
 cd apps/collaboration-server
-bun run dev          # ws://127.0.0.1:1234
+
+bun run dev                      # ws://127.0.0.1:1234, with --watch
+bun run start                    # the same, without watching
+bun run test                     # vitest
 ```
 
-Point the web app at it with `NEXT_PUBLIC_HOCUSPOCUS_URL`.
+Nothing needs configuring to run it locally. Then point the web app at it:
+
+```bash
+# apps/qwksearch-web/.env
+NEXT_PUBLIC_HOCUSPOCUS_URL=ws://127.0.0.1:1234
+```
+
+Without that variable the editor is single-player and never opens a socket.
 
 ## Rooms
 
@@ -39,18 +60,47 @@ a room: Tiptap stores a ProseMirror document in the Yjs doc and Plate stores a
 Slate document, so the states are not interchangeable. They stay separate until
 there is an explicit document-conversion/export pipeline.
 
-## Environment
+## Environment variables
 
-| Variable | Purpose |
-| --- | --- |
-| `PORT` | Listen port (default `1234`) |
-| `REASON_SQLITE_PATH` | SQLite persistence file (default `./data/reason-editor.sqlite`) |
-| `REASON_AUTH_URL` | Session endpoint that verifies the connection token and returns `{ id, name }` |
-| `REASON_DOCUMENT_ACL_URL` | Endpoint returning `{ role: 'read' \| 'write' }` for a `documentId`/`userId` pair |
+There is no `.env.example` and no API key — every variable here points at
+something you run, so none of them is fetched from a third party.
 
-Without `REASON_AUTH_URL` the server runs in demo mode, where the token *is* the
-user id — fine locally, never in production. Both variables are **required** when
-`NODE_ENV=production`; the server throws rather than accepting unverified tokens
-or granting blanket document access.
+| Variable | Default | Enables | Where to get it |
+| --- | --- | --- | --- |
+| `PORT` | `1234` | The listen port. | Your own choice. |
+| `REASON_SQLITE_PATH` | `./data/reason-editor.sqlite` | Where room state is persisted. | A path on a **persistent** volume — a container's ephemeral filesystem loses every document on restart. |
+| `REASON_AUTH_URL` | — | Verifies the connection token. Called as `GET <url>` with `Authorization: Bearer <token>`; must return `{ id, name }` for a valid token and a non-2xx status otherwise. | An endpoint on your own deployment — for `apps/qwksearch-web`, a route that resolves a better-auth session. |
+| `REASON_DOCUMENT_ACL_URL` | — | Document-level access control. Called as `GET <url>?documentId=…&userId=…`; must return `{ role: "read" \| "write" }`, or a non-2xx status to deny. | The same — an endpoint you write next to your document store. |
 
-For production also terminate TLS and use `wss://`.
+**Both URLs are required when `NODE_ENV=production`.** With `REASON_AUTH_URL`
+unset the server runs in demo mode, where the token *is* the user id — anyone
+can claim any identity — and with `REASON_DOCUMENT_ACL_URL` unset every
+authenticated user gets `write` on every document. Rather than carry either
+into production, the server throws on startup.
+
+## Deploying
+
+```bash
+bun run start
+```
+
+There is no Dockerfile or host config committed here — it is a long-lived Bun
+process, so run it anywhere that gives you one (a VM, a container host, Fly,
+Railway, Render). Whatever you pick:
+
+1. Set `NODE_ENV=production`, then `REASON_AUTH_URL` and
+   `REASON_DOCUMENT_ACL_URL` — the process refuses to start without them, by
+   design.
+2. Mount a persistent volume and point `REASON_SQLITE_PATH` at it. SQLite on an
+   ephemeral disk means every collaborative document disappears on the next
+   deploy.
+3. **Terminate TLS and serve `wss://`.** A page on `https://` cannot open a
+   `ws://` socket, so a plaintext listener does not merely leak — it does not
+   work at all from the deployed web app.
+4. Make sure your proxy passes WebSocket upgrades through and does not cap idle
+   connections at something short; these sockets are meant to stay open.
+5. Set `NEXT_PUBLIC_HOCUSPOCUS_URL` on the web app to the `wss://` origin.
+
+Run one instance. Hocuspocus keeps room state in memory backed by the local
+SQLite file, so two instances behind a round-robin load balancer would give the
+same document two divergent histories.

--- a/apps/qwk-vscode-ext/README.md
+++ b/apps/qwk-vscode-ext/README.md
@@ -188,19 +188,51 @@ Then press **F5** in VS Code (with this folder open) to launch an Extension
 Development Host with QwkSearch loaded, or open the QwkSearch icon in the
 Activity Bar.
 
-### Packaging
+### Packaging and publishing
 
 ```bash
-bun run package      # production build (dist/, webview-ui/dist/, webview-ui-editor/dist/)
-bunx @vscode/vsce package   # produces a .vsix you can install or publish
+bun run package                 # production build (dist/, webview-ui/dist/, webview-ui-editor/dist/)
+bunx @vscode/vsce package       # → qwksearch-vscode-<version>.vsix
 ```
 
+Install the result with **Extensions → … → Install from VSIX**, or
+`code --install-extension qwksearch-vscode-<version>.vsix`.
+
+Publishing to the Marketplace under the `opensourceagi` publisher needs a
+Personal Access Token with the **Marketplace → Manage** scope, created in an
+Azure DevOps organization at [dev.azure.com](https://dev.azure.com) — the
+walkthrough is
+[Publishing Extension](https://code.visualstudio.com/api/working-with-extensions/publishing-extension).
+
+```bash
+bunx @vscode/vsce login opensourceagi   # paste the PAT once
+bunx @vscode/vsce publish               # bump "version" in package.json first
+```
+
+`vscode:prepublish` runs `bun run package`, so both webviews are rebuilt before
+anything ships. The PAT is a credential: leave it in `vsce`'s keychain entry,
+never in the repository.
+
 ## Configuration
+
+**This extension reads no environment variables.** There is no `.env` — every
+knob is a VS Code setting, and the one credential it holds (your QwkSearch API
+key, stored by `QwkSearch: Sign In`) lives in VS Code's
+[SecretStorage](https://code.visualstudio.com/api/references/vscode-api#SecretStorage),
+not in a settings file or this repository.
+
+Change these in **Settings → Extensions → QwkSearch**:
 
 | Setting | Default | Description |
 | --- | --- | --- |
 | `qwksearch.apiBaseUrl` | `https://qwksearch.com` | Base URL of the QwkSearch deployment to use. Point at a self-hosted `qwksearch-web` instance to use your own. |
 | `qwksearch.focusMode` | `webSearch` | Default research focus for new questions: `webSearch` (cited web search) or `writingAssistant` (no search). |
+
+Everything the backend needs — model provider keys, search providers, auth — is
+configured on the `qwksearch-web` deployment that `qwksearch.apiBaseUrl` points
+at, not here. See
+[its README](../qwksearch-web/README.md#environment-variables); point the
+setting at `http://localhost:3000` to develop against a local one.
 
 ## Commands
 

--- a/apps/qwksearch-desktop/README.md
+++ b/apps/qwksearch-desktop/README.md
@@ -1,0 +1,113 @@
+# `qwksearch-desktop`
+
+Select text in any application, press <kbd>Alt</kbd>+<kbd>`</kbd>, and the
+selection opens as a QwkSearch query in your browser. A tray app that stays out
+of the way: the window is 10×10 and hidden, and autostart is enabled on first
+run.
+
+SvelteKit for the (barely visible) UI, **Tauri 2** for everything that matters.
+
+## What it does
+
+| Behaviour | Where it lives |
+| --- | --- |
+| Registers the global `Alt+\`` hotkey | `src-tauri/src/hotkeys.rs` |
+| Reads the current selection from the OS | `src-tauri/src/selection.rs` |
+| Tray icon, window and plugin wiring | `src-tauri/src/setup.rs`, `main.rs` |
+| Opens `https://qwksearch.com/?first=true&q=<selection>` | `hotkeys.rs` |
+| Autostart on login, clipboard fallback | `src/routes/+page.svelte` via the Tauri plugins |
+
+> **The native behaviour is Rust-side, not `src/`.** The hotkey, the tray,
+> autostart and the popup all live in `src-tauri/`. Looking for them in the
+> SvelteKit `src/` is the usual wrong turn.
+
+It renders `packages/research-agent-ui`, so a change there ships here too.
+
+## Configuration
+
+**This app reads no environment variables.** There is no `.env`, no API key and
+no sign-in — it opens a public URL in the user's default browser and holds no
+credentials of its own. Anything you would configure lives in one of two files:
+
+| What | Where | Default |
+| --- | --- | --- |
+| The hotkey | `src-tauri/src/hotkeys.rs` → `gs.register("Alt+\`")` | `Alt+\`` |
+| The search URL | `src-tauri/src/hotkeys.rs`, and `searchEngines` in `src/routes/+page.svelte` | `https://qwksearch.com/?q=` |
+| Bundle targets, identifier, window | [`src-tauri/tauri.conf.json`](./src-tauri/tauri.conf.json) | `deb`, `nsis`, `msi`, `app`, `dmg` · `com.qwksearch.app` |
+| Tauri permissions | `src-tauri/capabilities/` | — |
+
+The `searchEngines` map in `+page.svelte` has Perplexity, Google, DuckDuckGo
+and YouTube commented out — uncomment one to offer it.
+
+## Setup
+
+Unlike the rest of the monorepo, this app needs a **Rust toolchain and the
+platform's native webview libraries**. A machine that builds everything else
+here cannot necessarily build this.
+
+```bash
+bun install                       # from the repo root
+rustup toolchain install stable   # https://rustup.rs
+```
+
+Then the per-OS prerequisites from
+[Tauri's setup guide](https://v2.tauri.app/start/prerequisites/) — on Debian or
+Ubuntu that is `libwebkit2gtk-4.1-dev`, `libgtk-3-dev`,
+`libayatana-appindicator3-dev` and `librsvg2-dev`; the full list is in this
+directory's [`Dockerfile`](./Dockerfile).
+
+```bash
+cd apps/qwksearch-desktop
+bunx tauri dev                    # run it
+bun run test                      # vitest
+```
+
+> `tauri.conf.json` points `beforeDevCommand` and `beforeBuildCommand` at
+> `bun run dev` / `bun run build`, but `package.json` defines neither script.
+> Add them (`vite dev` / `vite build`) before relying on `tauri dev`, or run
+> Vite yourself on port 1420 alongside `tauri dev`.
+
+## Building installers
+
+Native, on the host OS:
+
+```bash
+bun run tauri            # deb, AppImage, nsis, msi, app, dmg — whatever the host supports
+bun run tauri:macos      # just dmg + app
+```
+
+Both set `LINUXDEPLOY_SKIP_STRIP=1` and `NO_STRIP=true`; stripping breaks the
+AppImage bundle.
+
+Reproducibly, in Docker — this is how the Linux and Windows artifacts are
+produced, and it needs no toolchain on the host beyond Docker:
+
+```bash
+bun run docker:build:linux && bun run docker:linux       # → dist/
+bun run docker:windows                                   # builds and runs in one step
+bun run docker:all
+```
+
+Output lands in `dist/`. The Linux image is [`Dockerfile`](./Dockerfile)
+(Ubuntu 22.04, GTK + WebKitGTK); Windows cross-compilation is
+[`Dockerfile.windows`](./Dockerfile.windows).
+
+## Releasing
+
+There is no store submission or auto-updater configured — `tauri.conf.json`
+declares no updater endpoint and no signing keys. Distribution is the bundles
+in `dist/`, attached to a GitHub release. Adding code signing or an updater
+means adding `bundle.createUpdaterArtifacts` and a `plugins.updater` block, and
+holding a signing key per platform; see
+[Tauri distribution](https://v2.tauri.app/distribute/).
+
+## Things that bite
+
+- **A global hotkey is a system-wide grab.** <kbd>`</kbd> is a key people type.
+  The capture must be precise about focus and modifiers, release cleanly, and
+  not swallow the key in other applications.
+- **Per-OS behaviour genuinely differs** — reading the selection needs
+  Accessibility permission on macOS, and tray semantics vary on Linux. A green
+  build on one platform says nothing about the others.
+- `is_registered` only reflects registrations made by this process, so the code
+  registers unconditionally and reports failure rather than pre-checking.

--- a/apps/qwksearch-ext/README.md
+++ b/apps/qwksearch-ext/README.md
@@ -13,17 +13,101 @@
 </p>
 <!-- template-git-repo:badges:end -->
 
-## QwkSearch Tab Manager AI
+# QwkSearch Tab Manager AI
 
-- Vertical Tabs Sidebar with Sorting and Context Menu
-- Search Inside All Open Tabs Page Content
-- Select Text, Press Tab To Search Google, Tab again for First Result
-- Reader Mode to Extract main content text and cite (includes PDF & Youtube)
-- Ask AI about Text Content of Open Tabs & Saved Tabs
+A browser extension (Chrome and Firefox) that turns the sidebar into a tab
+manager and a research assistant over whatever you have open.
+
+- Vertical tabs sidebar with sorting and a context menu
+- Search inside the page content of every open tab
+- Select text, press <kbd>Tab</kbd> to search; <kbd>Tab</kbd> again opens the first result
+- Reader mode that extracts and cites the main content (PDF and YouTube included)
+- Ask AI about the text of open and saved tabs
+
+Open the side panel with <kbd>Ctrl</kbd>+<kbd>Q</kbd>
+(<kbd>Cmd</kbd>+<kbd>B</kbd> on macOS).
 
 ### Screenshot
 
 <img src="https://i.imgur.com/JC1qiRd.png">
+
+## How it is built
+
+[WXT](https://wxt.dev) over Vite and React 19. The UI is
+`packages/research-agent-ui` — the same components the web app renders —
+compiled here through two shims in `lib/`, because an extension has neither
+Next.js nor a local server:
+
+| Shim | Why |
+| --- | --- |
+| `lib/next-navigation-shim.tsx` | `research-agent-ui` imports `next/navigation`, which does not exist outside Next.js. |
+| `lib/grab-url-shim.ts` | Its components call relative paths like `/api/agent/providers`. The shim rewrites anything starting with `/` onto `https://qwksearch.com`. |
+
+`wxt.config.ts` also re-escapes non-ASCII bytes in the content-script bundle
+after Vite's minifier converts `\uXXXX` back to literal characters — Chrome
+rejects content scripts that contain them.
+
+## Setup
+
+```bash
+bun install                 # from the repo root
+cd apps/qwksearch-ext
+
+bun run dev                 # Chrome, with a live-reloading dev profile
+bun run dev:firefox         # Firefox
+bun run test                # vitest
+bun run compile             # tsc --noEmit
+```
+
+`wxt dev` launches a browser with the extension already loaded — there is no
+"load unpacked" step while developing. To load a built extension by hand
+instead: `bun run build`, then `chrome://extensions` → Developer mode → **Load
+unpacked** → `.output/chrome-mv3`.
+
+## Configuration
+
+**This extension reads no environment variables** — there is no `.env`, and no
+API key ships in the bundle. Two things stand in for configuration:
+
+| What | Where | Default |
+| --- | --- | --- |
+| The API host every `/api/*` call is rewritten onto | `API_BASE` in [`lib/grab-url-shim.ts`](./lib/grab-url-shim.ts) | `https://qwksearch.com` |
+| Permissions, keyboard command, search provider, CSP | `manifest` in [`wxt.config.ts`](./wxt.config.ts) | see below |
+
+Point `API_BASE` at `http://localhost:3000` to develop against a local
+`apps/qwksearch-web`. Everything the API itself needs — model keys, auth, search
+providers — is configured on that deployment; see
+[its README](../qwksearch-web/README.md#environment-variables).
+
+The manifest asks for `<all_urls>` host permissions and a wide permission set
+(`tabs`, `history`, `bookmarks`, `sessions`, `downloads`, `scripting`,
+`declarativeNetRequest`, `offscreen`, …). Both stores review those closely, so
+removing one you no longer use is worth doing before a submission rather than
+after a rejection. On Chrome the manifest also overrides the homepage, startup
+page and default search provider; Firefox does not support that subset, so it
+is applied only when `env.browser === 'chrome'`.
+
+## Building and publishing
+
+```bash
+bun run build              # → .output/chrome-mv3/
+bun run build:firefox      # → .output/firefox-mv2/
+bun run zip                # → .output/*.zip, ready to upload
+bun run zip:firefox
+```
+
+Bump `version` in **both** `package.json` and the `manifest` block of
+`wxt.config.ts` — WXT does not derive one from the other, and a store rejects
+an upload whose version is not higher than the last.
+
+| Store | Upload | What you need |
+| --- | --- | --- |
+| Chrome Web Store | [Developer Dashboard](https://chrome.google.com/webstore/devconsole) | A developer account (one-time $5 registration fee) and the `chrome-mv3` zip. |
+| Firefox Add-ons | [addons.mozilla.org/developers](https://addons.mozilla.org/developers/) | A Mozilla account and the `firefox-mv2` zip. Source must be submitted alongside the build, since the bundle is generated. |
+
+Both stores want a privacy policy URL for an extension with these permissions.
+Neither upload needs a secret in this repository — they are interactive, and
+nothing here automates them.
 
 ## Ideas for Future Development
 

--- a/apps/qwksearch-web/README.md
+++ b/apps/qwksearch-web/README.md
@@ -1,0 +1,193 @@
+# `qwksearch-web`
+
+The deployed application: [qwksearch.com](https://qwksearch.com). The chat and
+search UI, the public `/api`, the docs site, the D1 schema, and the Worker that
+serves all of it.
+
+This is the shell the `packages/*` libraries are mounted into — almost no
+behaviour lives here. Search engines, extraction, the editor and the agent
+toolkit are all in packages; find the owning package before editing anything
+in `app/`.
+
+## What it does
+
+| Area | Route | What you get |
+| --- | --- | --- |
+| Research chat | `/`, `/c/[id]` | The agent loop from `packages/chat-agent-toolkit`, over 75+ engines via `packages/search-web-api`, rendered by `packages/research-agent-ui`. |
+| Document editor | `/workspace` | REASON — `packages/reason-editor` and its sidebar, with optional live collaboration. |
+| Library | `/library` | Saved documents, uploads and extractions, backed by D1 and R2. |
+| Extraction | `/api/doc`, `/api/scraper` | URL, PDF and YouTube extraction from `packages/extract-*`. |
+| Search API | `/api/search` | The dedupe-and-rank pipeline, described by `/api/openapi`. |
+| News | `/news` | The trending-news widget, served by `/api/news/trending` so keys stay server-side. |
+| Docs | `/docs` | Fumadocs over `packages/user-help-docs`. |
+| Accounts | `/login`, `/settings` | better-auth — Google, Discord and LinkedIn OAuth, plus email via Resend. |
+| Admin | `/admin` | Gated on `ADMIN_EMAILS`; nobody is an admin when it is unset. |
+| Marketing | `/features`, `/enterprise`, `/legal` | Static pages. |
+
+## Stack
+
+| Layer | Choice |
+| --- | --- |
+| Framework | Next.js App Router, built by [vinext](https://github.com/cloudflare/vinext) (Vite) rather than `next build` |
+| Runtime | Cloudflare Workers (`workerd`) |
+| Database | Cloudflare D1 via Drizzle ORM, with the [D1 Sessions API](https://developers.cloudflare.com/d1/best-practices/read-replication/) for read replication |
+| Storage | R2 (`qwksearch-uploads`) for uploads, KV for caching, Images for transforms |
+| Auth | [better-auth](https://better-auth.com) |
+| Email | Cloudflare Email Workers (`EMAIL` binding) |
+| Tests | Vitest |
+
+## Quick start
+
+From the repository root:
+
+```bash
+bun install                      # never npm or yarn
+cp apps/qwksearch-web/.env.example apps/qwksearch-web/.env
+bun run dev                      # http://localhost:3000
+```
+
+`BETTER_AUTH_SECRET` is the only variable worth setting before your first run —
+generate one with `openssl rand -base64 32`. Everything else is optional and
+disables exactly one feature when missing.
+
+For a local D1 instead of the SQLite fallback:
+
+```bash
+cd apps/qwksearch-web
+bun run db:migrate:local         # applies drizzle/ to the Miniflare D1
+bun run dev:cf                   # vinext build + wrangler dev --local
+```
+
+## Environment variables
+
+Local values go in `apps/qwksearch-web/.env`; the annotated template is
+[`.env.example`](./.env.example). Deployed values go behind
+`wrangler secret put <NAME>` — this app's `wrangler.jsonc` deliberately defines
+no `vars`, and sets `keep_vars: true` so that plaintext variables entered in the
+Cloudflare dashboard survive each deploy.
+
+### App URLs
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `NEXT_PUBLIC_BASE_URL` | Absolute links, OAuth callbacks, OG images. | Your own origin — `http://localhost:3000` in development. |
+| `NEXT_PUBLIC_HOCUSPOCUS_URL` | Live collaborative editing in the workspace. Unset, the editor is single-player. | The URL of your [`apps/collaboration-server`](../collaboration-server/) deployment. |
+
+### Auth
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `BETTER_AUTH_SECRET` | Session signing. Without it nobody stays signed in. | Generate one: `openssl rand -base64 32`. See [better-auth installation](https://www.better-auth.com/docs/installation). |
+| `BETTER_AUTH_TRUSTED_ORIGINS` | Extra comma-separated origins allowed to make authenticated requests. The apex domain, its subdomains and `http://localhost:3000` are trusted already. | Your own preview or custom-domain hosts. |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | "Sign in with Google". | [Google Cloud Console](https://console.cloud.google.com/apis/credentials) → APIs & Services → Credentials → Create Credentials → OAuth client ID. |
+| `AUTH_DISCORD_ID` / `AUTH_DISCORD_SECRET` | "Sign in with Discord". | [discord.com/developers/applications](https://discord.com/developers/applications) → your app → OAuth2 → General Information. |
+| `AUTH_LINKEDIN_ID` / `AUTH_LINKEDIN_SECRET` | "Sign in with LinkedIn". | [linkedin.com/developers](https://www.linkedin.com/developers/) → your app → Auth. |
+| `AUTH_RESEND_KEY` | Verification and magic-link email. | [resend.com/api-keys](https://resend.com/api-keys) |
+| `ADMIN_EMAILS` (legacy `ADMIN_EMAIL` is merged in) | `/admin` and the admin API routes, for the comma-separated addresses listed. Unset, nobody has admin access. | Your own addresses. |
+
+### Model and search providers
+
+At least one model provider is needed for the agent to answer.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `OPENROUTER_API_KEY` | Most models, through one gateway. | [openrouter.ai/keys](https://openrouter.ai/keys) |
+| `ANYAPI_API_KEY` | AnyAPI models. Its free plan gives 100,000 tokens/day with no card. | [anyapi.ai/pricing](https://anyapi.ai/pricing) |
+| `DEEPSEEK_API_KEY` | DeepSeek models. | [platform.deepseek.com](https://platform.deepseek.com/api_keys) |
+| `NVIDIA_API_KEY` | Models on the NVIDIA API catalog. | [build.nvidia.com](https://build.nvidia.com) |
+| `OOMOL_API_KEY` | OOMOL models. | Your OOMOL account dashboard. |
+| `TAVILY_API_KEY` | Tavily as a search backend. The other engines in `packages/search-web-api` need no key. | [app.tavily.com](https://app.tavily.com/) · [docs](https://docs.tavily.com/documentation/quickstart) |
+| `THENEWSAPI_API_KEY` | The homepage trending-news widget. Without it the widget does not render; nothing else changes. | [thenewsapi.com](https://www.thenewsapi.com/) |
+
+### Extraction and storage
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `SCRAPER_URL` / `SCRAPER_API_KEY` | Points extraction at a self-hosted scraper Worker instead of the default. Both optional. | Your own deployment of `packages/render-url-to-html`. |
+| `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` | Uploads over R2's S3-compatible API, used only when the native `R2` binding is unavailable (that is, outside Workers). On Workers the binding handles it and none of these are needed. | [Cloudflare dashboard](https://dash.cloudflare.com) → R2 → **Manage R2 API Tokens** (Object Read & Write); the account ID is in any zone's sidebar. |
+| `R2_UPLOADS_BUCKET` | A bucket other than `qwksearch-uploads`. | The name you created. |
+| `DATABASE_URL` | A libSQL/SQLite file outside Workers. Defaults to `file:./data/qwksearch.db`. On Workers the `DB` binding is used instead. | — |
+
+### D1 read replication
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `D1_SESSION_MODE` | Overrides the per-request replication choice: `auto` (default), `primary`, `unconstrained`, or `off` as a rollback switch. It is a plain Worker variable so it can be flipped in the dashboard without a redeploy. | Your own choice — see [`lib/database/d1-session.ts`](./lib/database/d1-session.ts). |
+| `D1_SESSION_DEBUG` | Logs the bookmark and replica decision per request. | — |
+
+### Bot gate — Cloudflare Turnstile
+
+Optional. With both keys unset the gate never runs. Set both to challenge a
+desktop browser's first HTML page view; phones, crawlers, `/api/*`, assets and
+RSC fetches are never challenged.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` | The gate. | [Cloudflare dashboard](https://dash.cloudflare.com) → Turnstile → Add widget (Managed). |
+| `TURNSTILE_ENABLED` | `"false"` switches it off while keeping the keys. | — |
+| `TURNSTILE_TTL_SECONDS` | How long one pass lasts. Default 604800 (7 days), clamped to 5 minutes – 30 days. | — |
+| `TURNSTILE_COOKIE_DOMAIN` | Shares one pass across subdomains, e.g. `.qwksearch.com`. | — |
+
+## Scripts
+
+Run from the repository root so Turborepo builds the workspace packages first,
+or from this directory with `bun run <script>`.
+
+| Script | What it does |
+| --- | --- |
+| `dev` | `next dev` on port 3000, opening a browser when ready. |
+| `build` | `vinext build` → `dist/client` + the Worker bundle. `prebuild` builds the workspace packages first. |
+| `dev:cf` | Builds, then `wrangler dev --local` — the real Worker with local bindings. |
+| `deploy` / `deploy:staging` | `vinext deploy`, optionally against the `staging` environment. |
+| `db:generate` | Generates a Drizzle migration into `drizzle/`. |
+| `db:migrate` / `db:migrate:local` / `db:migrate:status` | Applies or lists migrations with Wrangler. |
+| `db:studio` | Drizzle Studio. |
+| `test` / `test:coverage` | Vitest. |
+
+## Deploying
+
+Target: Cloudflare Workers. Once, per account:
+
+```bash
+bunx wrangler login
+bunx wrangler d1 create qwksearch-new         # paste the id into wrangler.jsonc
+bunx wrangler r2 bucket create qwksearch-uploads
+bunx wrangler kv namespace create KV          # paste the id into wrangler.jsonc
+bun run db:migrate                            # apply drizzle/ to the remote D1
+```
+
+Then the secrets — only `BETTER_AUTH_SECRET` is needed for a usable deploy:
+
+```bash
+for NAME in BETTER_AUTH_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET \
+            AUTH_RESEND_KEY OPENROUTER_API_KEY TAVILY_API_KEY; do
+  bunx wrangler secret put "$NAME"
+done
+```
+
+Also enable [Email Routing](https://developers.cloudflare.com/email-routing/)
+on the zone and verify the `send_email` destination in
+[`wrangler.jsonc`](./wrangler.jsonc), or outbound mail fails.
+
+Ship it:
+
+```bash
+bun run build
+bun run deploy                 # or deploy:staging for the staging environment
+```
+
+Two constraints worth knowing before a deploy fails on you:
+
+- **`upload_source_maps` is off on purpose.** The unminified rsc/ssr bundles
+  produced ~15.4 MB of maps, over Cloudflare's 15 MB gzipped cap, and the
+  deploy was rejected with API error 10021.
+- **`keep_vars: true` is load-bearing.** This config defines no `vars`, so
+  without it every deploy would delete the plaintext variables set in the
+  dashboard. Secrets survive either way.
+
+## Tests
+
+```bash
+bun run test                                  # this app
+bunx vitest run app/api/__tests__/some.test.ts
+```

--- a/apps/test-reports/README.md
+++ b/apps/test-reports/README.md
@@ -1,0 +1,65 @@
+# `test-reports`
+
+Infrastructure only. A Cloudflare Worker whose entire job is to serve the
+Vitest HTML report at a URL, so a failing suite can be read in a browser
+instead of in CI log scrollback.
+
+**There is no product code here and nothing to test.** If you are here because
+a test is failing, the failure belongs to the package that owns the test.
+Changing this Worker changes where the report is *served*, never what it says.
+
+## What it does
+
+`wrangler.jsonc` declares no `main` — it is a static-assets Worker. Everything
+in `./dist` is served, with `not_found_handling: "single-page-application"` so
+the report's client-side routes resolve.
+
+`dist/` is generated, never committed: the `generate` script runs the repo's
+Vitest suite from the root with `VITEST_HTML_REPORT_DIR` pointed here.
+
+## Setup
+
+```bash
+bun install                  # from the repo root
+cd apps/test-reports
+
+bun run generate             # run the suite, write dist/
+bun run generate:coverage    # the same, with coverage
+bun run preview              # wrangler dev — serve dist/ locally
+```
+
+## Environment variables
+
+**The Worker itself reads none** — it serves static files and runs no code of
+its own. `keep_vars: true` is set only so that a `wrangler deploy` does not
+delete variables someone added in the Cloudflare dashboard.
+
+Deploying needs two credentials, and they belong in your shell or in CI
+secrets, never in `wrangler.jsonc`:
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `CLOUDFLARE_API_TOKEN` | `wrangler deploy` without an interactive login. Needs the **Workers Scripts: Edit** permission. | [Cloudflare → My Profile → API Tokens](https://dash.cloudflare.com/profile/api-tokens) → Create Token → *Edit Cloudflare Workers*. |
+| `CLOUDFLARE_ACCOUNT_ID` | Which account to deploy into. | [Cloudflare dashboard](https://dash.cloudflare.com) → any zone → Account ID in the right-hand sidebar, or `bunx wrangler whoami`. |
+
+Locally you can skip both and use `bunx wrangler login` instead.
+
+## Deploying
+
+```bash
+bun run deploy               # wrangler deploy
+```
+
+In practice you do not run this by hand. `.github/workflows/deploy-test-reports.yml`
+does it on every push to `master` (and on `workflow_dispatch`), reading
+`CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from repository secrets — set
+them under **Settings → Secrets and variables → Actions**.
+
+Two things in that workflow are deliberate and worth keeping:
+
+- The test step uses `continue-on-error`, so a **red suite still publishes its
+  report**. That is the point of the app.
+- A placeholder `dist/index.html` is written when Vitest produced no report.
+  `wrangler deploy` treats a missing `assets.directory` as a hard error, so
+  without it the run would end on a config failure instead of on the test
+  signal.


### PR DESCRIPTION
Part of a pass across all five repos making every `apps/*/README.md` describe what the app does, how to set it up and deploy it, and which environment variables it needs — with a link to the page that issues each one.

Three of the six apps had no README at all, and the three that did stopped short of saying where to obtain a key or how to ship the thing.

## New

**`apps/qwksearch-web`** — the deployed app had no README. Routes and what each serves, a grouped environment-variable reference with a link per row (app URLs, auth across Google/Discord/LinkedIn/Resend, model and search providers, extraction and storage, D1 read replication, Turnstile), the scripts table, and the first-deploy sequence: D1, R2, KV, migrations, secrets, Email Routing. Documents the two deploy traps already explained in `wrangler.jsonc` — `upload_source_maps` is off because the maps exceeded Cloudflare's 15 MB cap (API error 10021), and `keep_vars` is load-bearing because the config defines no `vars`.

**`apps/qwksearch-desktop`** — the Rust-side/Svelte-side split (the hotkey, tray and selection are in `src-tauri/`, not `src/`), the Tauri prerequisites and why this app alone needs a Rust toolchain, native and Docker installer builds, and the fact that it holds no credentials and reads no environment at all. Flags honestly that `tauri.conf.json` points `beforeDevCommand`/`beforeBuildCommand` at `bun run dev` / `bun run build`, which `package.json` does not define.

**`apps/test-reports`** — what a static-assets Worker with no `main` is for, that it reads no environment variables itself, and the two Cloudflare credentials the deploy needs. Records why the CI workflow's `continue-on-error` and placeholder `index.html` are deliberate: a red suite must still publish its report, and a missing `assets.directory` would end the run on a config error instead of the test signal.

## Expanded

**`collaboration-server`** — what Hocuspocus is doing here and why it is a Bun process rather than a Worker, a "where to get it" column with the request/response contract each URL must satisfy, and a deploy section covering `wss://` (a page on `https://` cannot open `ws://` at all), the persistent volume SQLite needs, and why it must run as a single instance.

**`qwksearch-ext`** — had features and a screenshot but no setup at all. Added the build/dev/test commands, the two shims that let `research-agent-ui` compile outside Next.js, where the API host is configured in lieu of env vars (`API_BASE` in `lib/grab-url-shim.ts`), and store submission for both browsers.

**`qwk-vscode-ext`** — states that it reads no environment variables and that the API key lives in VS Code SecretStorage, and documents Marketplace publishing.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kjFYq4o9xD5UQdZ16XctF

---
_Generated by [Claude Code](https://claude.ai/code/session_017kjFYq4o9xD5UQdZ16XctF)_