### PR TITLE
🔧 fix(qwk-in-lobe): target the Wrangler environment explicitly on deploy

### DIFF
--- a/apps/qwk-in-lobe/README.md
+++ b/apps/qwk-in-lobe/README.md
@@ -165,9 +165,20 @@ bun run cf:d1:migrate              # remote
 bun run cf:d1:migrate:dev          # local wrangler dev
 
 # 4. Deploy
-bun run cf:deploy                  # default env
-bun run cf:deploy:production       # `production` env in wrangler.jsonc
+bun run cf:deploy                  # top-level env -> Worker `qwksearch-lobehub`
+bun run cf:deploy:production       # `production` env -> Worker `qwksearch-lobehub-production`
 ```
+
+Both pass `--env` explicitly. `wrangler.jsonc` defines a named `production`
+environment alongside the top-level one, and `wrangler deploy` with no `--env`
+at all warns — *"Multiple environments are defined in the Wrangler configuration
+file, but no target environment was specified"* — and then falls back to the
+top-level environment. That fallback is what this tree wants, but the two
+environments are not interchangeable: the top-level one deploys the Worker
+`qwksearch-lobehub` bound to the `qwksearch-sessions` KV namespace, and
+`--env production` deploys a *separate* Worker, `qwksearch-lobehub-production`,
+bound to `production-qwksearch-sessions`. Passing `--env=""` for the top-level
+environment says so out loud and silences the warning.
 
 Local run: `bun run cf:dev` starts `wrangler dev --local` with `wrangler.local.jsonc` (dummy secrets,
 local D1/KV, no Cloudflare account needed); run `bun run cf:d1:migrate:dev` once to create the D1
@@ -193,9 +204,12 @@ Project settings for a Workers Builds deploy of this tree:
 | Root directory | `apps/qwk-in-lobe` |
 | Install command | `pnpm install --no-frozen-lockfile` |
 | Build command | `pnpm run build:worker` |
-| Deploy command | `pnpm exec wrangler deploy` |
+| Deploy command | `pnpm exec wrangler deploy --env=""` |
 
-Enter all four. The default build command is `npm run build`, which is the Next build, not the
+Enter all four. `--env=""` on the deploy command is the top-level environment,
+the one this project deploys; without it wrangler warns about the `production`
+environment the config also defines and then picks the top-level one anyway (see
+above). The default build command is `npm run build`, which is the Next build, not the
 Worker build: it writes `.next/` and never `dist/worker/index.js`, so the deploy step that follows
 has nothing to upload and fails with `The entry-point file at "dist/worker/index.js" was not
 found`. A deploy left on the defaults now recovers instead of failing: `wrangler.jsonc` declares a

--- a/apps/qwk-in-lobe/package.json
+++ b/apps/qwk-in-lobe/package.json
@@ -59,7 +59,7 @@
     "build:worker:server": "cross-env NODE_OPTIONS=--max-old-space-size=8192 NODE_ENV=production vite build --config vite.worker.config.ts",
     "cf:budget": "tsx scripts/checkWorkerBudget.mts",
     "cf:d1:migrate": "wrangler d1 execute qwksearch-new --remote --file=migrations/d1/0001_qwksearch_tables.sql && wrangler d1 execute qwksearch-new --remote --file=migrations/d1/0002_extraction_settings.sql && wrangler d1 execute qwksearch-new --remote --file=migrations/d1/0003_search_settings.sql",
-    "cf:deploy": "bun run build:worker && wrangler deploy",
+    "cf:deploy": "bun run build:worker && wrangler deploy --env=\"\"",
     "cf:deploy:production": "bun run build:worker && wrangler deploy --env production",
     "cf:dev": "wrangler dev --config wrangler.local.jsonc --local",
     "cf:d1:migrate:dev": "wrangler d1 execute qwksearch-new --local --config wrangler.local.jsonc --file=migrations/d1/0001_qwksearch_tables.sql && wrangler d1 execute qwksearch-new --local --config wrangler.local.jsonc --file=migrations/d1/0002_extraction_settings.sql && wrangler d1 execute qwksearch-new --local --config wrangler.local.jsonc --file=migrations/d1/0003_search_settings.sql",

--- a/apps/qwk-in-lobe/wrangler.jsonc
+++ b/apps/qwk-in-lobe/wrangler.jsonc
@@ -67,6 +67,12 @@
     "head_sampling_rate": 1,
     "logs": { "enabled": true, "invocation_logs": true, "persist": true }
   },
+  // A named environment deploys a *separate* Worker — `qwksearch-lobehub-production`,
+  // bound to the `production-qwksearch-sessions` KV namespace — not a variant of
+  // the one above. Defining it also makes a bare `wrangler deploy` warn that no
+  // target environment was specified before falling back to the top-level one, so
+  // both deploy paths pass `--env` explicitly: `--env=""` for this Worker (the
+  // qwksearch.com deploy), `--env production` for the separate one.
   "env": {
     "production": {
       "vars": {


### PR DESCRIPTION
## What

The Workers Builds deploy of `apps/qwk-in-lobe` ends every run with:

```
▲ [WARNING] Multiple environments are defined in the Wrangler configuration file,
  but no target environment was specified for the deploy command.
```

`wrangler.jsonc` defines a named `production` environment alongside the top-level
one, and `npx wrangler deploy` with no `--env` warns before falling back to the
top-level environment.

That fallback *is* the environment this tree deploys, so nothing is currently
broken — but the two environments are separate Workers, not variants of one:

| | Worker | KV namespace |
| --- | --- | --- |
| top-level (`--env=""`) | `qwksearch-lobehub` | `qwksearch-sessions` (`c53d8944…`) |
| `--env production` | `qwksearch-lobehub-production` | `production-qwksearch-sessions` (`371c242b…`) |

Everything else in `env.production` is a verbatim copy of the top-level block, so
the KV binding is the only functional difference — and one flag decides which
Worker and which session store a deploy lands on. This makes the choice explicit
rather than inherited from a warning.

## Changes

- `apps/qwk-in-lobe/package.json` — `cf:deploy` passes `--env=""`, wrangler's
  spelling for the top-level environment. `cf:deploy:production` was already
  explicit and is unchanged.
- `apps/qwk-in-lobe/README.md` — the Workers Builds "Deploy command" row becomes
  `pnpm exec wrangler deploy --env=""`, and both deploy sections now say which
  Worker and KV namespace each environment maps to.
- `apps/qwk-in-lobe/wrangler.jsonc` — a comment above `env.production` recording
  that it is a separate Worker and why both deploy paths pass `--env`.

## Behaviour

No deploy target changes. This only makes the existing one explicit and silences
the warning.

To pick the fix up on the live deploy, the Workers Builds project's **Deploy
command** setting needs the same flag — `npx wrangler deploy --env=""` — since
that command lives in the Cloudflare dashboard, not in the repo. The README now
documents it.

## Verification

- `package.json` and `wrangler.jsonc` re-parse cleanly; `wrangler.jsonc` still
  resolves to `name: qwksearch-lobehub` with one named env, `production`.
- Docs/config only — no source files touched, so no test or build behaviour changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xi4GWH1ZXBBNpu9f67KidY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xi4GWH1ZXBBNpu9f67KidY)_